### PR TITLE
Catch request focus exception

### DIFF
--- a/audio-ui/src/main/java/com/google/android/horologist/audioui/VolumeScreen.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audioui/VolumeScreen.kt
@@ -110,7 +110,6 @@ internal fun VolumeScreen(
     focusRequester: FocusRequester = remember { FocusRequester() },
     scrollableState: ScrollableState? = null
 ) {
-
     Box(
         modifier = modifier.fillMaxSize().run {
             if (scrollableState != null) {

--- a/compose-layout/api/current.api
+++ b/compose-layout/api/current.api
@@ -19,6 +19,7 @@ package com.google.android.horologist.compose.navscaffold {
     method public final androidx.compose.foundation.gestures.ScrollableState? getScrollableState();
     method public final com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel.TimeTextMode getTimeTextMode();
     method public final com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel.VignetteMode getVignettePosition();
+    method public final void requestFocus();
     method public final void setPositionIndicatorMode(com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel.PositionIndicatorMode positionIndicatorMode);
     method public final void setTimeTextMode(com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel.TimeTextMode timeTextMode);
     method public final void setVignettePosition(com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel.VignetteMode vignettePosition);

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/NavScaffoldViewModel.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/NavScaffoldViewModel.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.horologist.compose.navscaffold
 
+import android.util.Log
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.gestures.ScrollableState
 import androidx.compose.foundation.lazy.LazyListState
@@ -150,6 +151,16 @@ public open class NavScaffoldViewModel(
         }
 
         return _scrollableState as LazyListState
+    }
+
+    public fun requestFocus() {
+        if (focusRequested) {
+            try {
+                focusRequester.requestFocus()
+            } catch (ise: IllegalStateException) {
+                Log.w("horologist", "Focus Requestor not installed", ise)
+            }
+        }
     }
 
     internal enum class ScrollType {

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/WearNavScaffold.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/WearNavScaffold.kt
@@ -183,10 +183,8 @@ public fun NavGraphBuilder.scalingLazyColumnComposable(
 
         content(ScaffoldContext(it, scrollState, viewModel))
 
-        if (viewModel.focusRequested) {
-            LaunchedEffect(Unit) {
-                viewModel.focusRequester.requestFocus()
-            }
+        LaunchedEffect(Unit) {
+            viewModel.requestFocus()
         }
     }
 }
@@ -210,10 +208,8 @@ public fun NavGraphBuilder.scrollStateComposable(
 
         content(ScaffoldContext(it, scrollState, viewModel))
 
-        if (viewModel.focusRequested) {
-            LaunchedEffect(Unit) {
-                viewModel.focusRequester.requestFocus()
-            }
+        LaunchedEffect(Unit) {
+            viewModel.requestFocus()
         }
     }
 }
@@ -237,10 +233,8 @@ public fun NavGraphBuilder.lazyListComposable(
 
         content(ScaffoldContext(it, scrollState, viewModel))
 
-        if (viewModel.focusRequested) {
-            LaunchedEffect(Unit) {
-                viewModel.focusRequester.requestFocus()
-            }
+        LaunchedEffect(Unit) {
+            viewModel.requestFocus()
         }
     }
 }


### PR DESCRIPTION
Apps using NavScaffold may be ignoring the focusRequestor.  If not attached then using it fails badly.

This is a temporary fix, we should make it near impossible to request a focusRequestor without using it, but that means API changes.