### PR TITLE
Only release release.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,7 @@ allprojects {
 
     plugins.withId("com.vanniktech.maven.publish") {
         mavenPublish {
+            androidVariantToPublish = "release"
             sonatypeHost = "DEFAULT"
         }
     }


### PR DESCRIPTION
Reverts this for now as source doesn't load in Android Studio in apps

https://github.com/vanniktech/gradle-maven-publish-plugin/blob/master/CHANGELOG.md#version-0190-2022-02-26

> Behavior Change: When using version 7.1.0 or newer of the Android Gradle Plugin we will now publish all variants of a library unless androidVariantToPublish was set in the DSL. This means that for example both debug and release or all flavors.