### PR TITLE
Update audio output repository to use media router instead

### DIFF
--- a/audio-ui/api/current.api
+++ b/audio-ui/api/current.api
@@ -21,7 +21,7 @@ package com.google.android.horologist.audioui {
   }
 
   @com.google.android.horologist.audioui.ExperimentalAudioUiApi public class VolumeViewModel extends androidx.lifecycle.ViewModel {
-    ctor public VolumeViewModel(com.google.android.horologist.audio.VolumeRepository volumeRepository, com.google.android.horologist.audio.AudioOutputRepository audioOutputRepository);
+    ctor public VolumeViewModel(com.google.android.horologist.audio.VolumeRepository volumeRepository, com.google.android.horologist.audio.AudioOutputRepository audioOutputRepository, optional kotlin.jvm.functions.Function0<kotlin.Unit> onCleared);
     method public final void decreaseVolume();
     method public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.AudioOutput> getAudioOutput();
     method public final com.google.android.horologist.audioui.VolumeScrollableState getVolumeScrollableState();

--- a/audio-ui/src/debug/java/com/google/android/horologist/audioui/VolumeScreenPreview.kt
+++ b/audio-ui/src/debug/java/com/google/android/horologist/audioui/VolumeScreenPreview.kt
@@ -45,7 +45,7 @@ import com.google.android.horologist.audio.VolumeState
 @Composable
 fun VolumeScreenPreview() {
     val volume = VolumeState(5, 0, 10, isMute = false)
-    val audioOutput = AudioOutput.BluetoothHeadset(id = 1, name = "EarBuds")
+    val audioOutput = AudioOutput.BluetoothHeadset(id = "1", name = "EarBuds")
 
     VolumeScreen(
         volume = { volume },

--- a/audio/api/current.api
+++ b/audio/api/current.api
@@ -66,7 +66,7 @@ package com.google.android.horologist.audio {
   }
 
   @com.google.android.horologist.audio.ExperimentalAudioApi public final class SystemAudioOutputRepository implements com.google.android.horologist.audio.AudioOutputRepository {
-    ctor public SystemAudioOutputRepository(android.media.AudioManager audioManager, android.content.Context application);
+    ctor public SystemAudioOutputRepository(android.content.Context application, androidx.mediarouter.media.MediaRouter mediaRouter, optional androidx.mediarouter.media.MediaRouteSelector selector);
     method public void close();
     method public kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.AudioOutput> getAudioOutput();
     method public kotlinx.coroutines.flow.StateFlow<java.util.List<com.google.android.horologist.audio.AudioOutput>> getAvailable();
@@ -78,6 +78,9 @@ package com.google.android.horologist.audio {
 
   public static final class SystemAudioOutputRepository.Companion {
     method public com.google.android.horologist.audio.SystemAudioOutputRepository fromContext(android.content.Context application);
+  }
+
+  public final class SystemAudioOutputRepositoryKt {
   }
 
   @com.google.android.horologist.audio.ExperimentalAudioApi public final class SystemVolumeRepository implements com.google.android.horologist.audio.VolumeRepository {

--- a/audio/api/current.api
+++ b/audio/api/current.api
@@ -2,50 +2,50 @@
 package com.google.android.horologist.audio {
 
   @com.google.android.horologist.audio.ExperimentalAudioApi public interface AudioOutput {
-    method public Integer? getId();
+    method public String getId();
     method public String getName();
-    property public abstract Integer? id;
+    property public abstract String id;
     property public abstract String name;
   }
 
   public static final class AudioOutput.BluetoothHeadset implements com.google.android.horologist.audio.AudioOutput {
-    ctor public AudioOutput.BluetoothHeadset(int id, String name);
-    method public int component1();
+    ctor public AudioOutput.BluetoothHeadset(String id, String name);
+    method public String component1();
     method public String component2();
-    method public com.google.android.horologist.audio.AudioOutput.BluetoothHeadset copy(int id, String name);
-    method public int getId();
+    method public com.google.android.horologist.audio.AudioOutput.BluetoothHeadset copy(String id, String name);
+    method public String getId();
     method public String getName();
-    property public int id;
+    property public String id;
     property public String name;
   }
 
   public static final class AudioOutput.None implements com.google.android.horologist.audio.AudioOutput {
-    method public Integer? getId();
+    method public String getId();
     method public String getName();
-    property public Integer? id;
+    property public String id;
     property public String name;
     field public static final com.google.android.horologist.audio.AudioOutput.None INSTANCE;
   }
 
   public static final class AudioOutput.Unknown implements com.google.android.horologist.audio.AudioOutput {
-    ctor public AudioOutput.Unknown(int id, String name);
-    method public int component1();
+    ctor public AudioOutput.Unknown(String id, String name);
+    method public String component1();
     method public String component2();
-    method public com.google.android.horologist.audio.AudioOutput.Unknown copy(int id, String name);
-    method public int getId();
+    method public com.google.android.horologist.audio.AudioOutput.Unknown copy(String id, String name);
+    method public String getId();
     method public String getName();
-    property public int id;
+    property public String id;
     property public String name;
   }
 
   public static final class AudioOutput.WatchSpeaker implements com.google.android.horologist.audio.AudioOutput {
-    ctor public AudioOutput.WatchSpeaker(int id, String name);
-    method public int component1();
+    ctor public AudioOutput.WatchSpeaker(String id, String name);
+    method public String component1();
     method public String component2();
-    method public com.google.android.horologist.audio.AudioOutput.WatchSpeaker copy(int id, String name);
-    method public int getId();
+    method public com.google.android.horologist.audio.AudioOutput.WatchSpeaker copy(String id, String name);
+    method public String getId();
     method public String getName();
-    property public int id;
+    property public String id;
     property public String name;
   }
 

--- a/audio/api/current.api
+++ b/audio/api/current.api
@@ -9,15 +9,12 @@ package com.google.android.horologist.audio {
   }
 
   public static final class AudioOutput.BluetoothHeadset implements com.google.android.horologist.audio.AudioOutput {
-    ctor public AudioOutput.BluetoothHeadset(int id, String name, optional android.media.AudioDeviceInfo? audioDevice);
+    ctor public AudioOutput.BluetoothHeadset(int id, String name);
     method public int component1();
     method public String component2();
-    method public android.media.AudioDeviceInfo? component3();
-    method public com.google.android.horologist.audio.AudioOutput.BluetoothHeadset copy(int id, String name, android.media.AudioDeviceInfo? audioDevice);
-    method public android.media.AudioDeviceInfo? getAudioDevice();
+    method public com.google.android.horologist.audio.AudioOutput.BluetoothHeadset copy(int id, String name);
     method public int getId();
     method public String getName();
-    property public final android.media.AudioDeviceInfo? audioDevice;
     property public int id;
     property public String name;
   }
@@ -31,29 +28,23 @@ package com.google.android.horologist.audio {
   }
 
   public static final class AudioOutput.Unknown implements com.google.android.horologist.audio.AudioOutput {
-    ctor public AudioOutput.Unknown(int id, String name, optional android.media.AudioDeviceInfo? audioDevice);
+    ctor public AudioOutput.Unknown(int id, String name);
     method public int component1();
     method public String component2();
-    method public android.media.AudioDeviceInfo? component3();
-    method public com.google.android.horologist.audio.AudioOutput.Unknown copy(int id, String name, android.media.AudioDeviceInfo? audioDevice);
-    method public android.media.AudioDeviceInfo? getAudioDevice();
+    method public com.google.android.horologist.audio.AudioOutput.Unknown copy(int id, String name);
     method public int getId();
     method public String getName();
-    property public final android.media.AudioDeviceInfo? audioDevice;
     property public int id;
     property public String name;
   }
 
   public static final class AudioOutput.WatchSpeaker implements com.google.android.horologist.audio.AudioOutput {
-    ctor public AudioOutput.WatchSpeaker(int id, String name, optional android.media.AudioDeviceInfo? audioDevice);
+    ctor public AudioOutput.WatchSpeaker(int id, String name);
     method public int component1();
     method public String component2();
-    method public android.media.AudioDeviceInfo? component3();
-    method public com.google.android.horologist.audio.AudioOutput.WatchSpeaker copy(int id, String name, android.media.AudioDeviceInfo? audioDevice);
-    method public android.media.AudioDeviceInfo? getAudioDevice();
+    method public com.google.android.horologist.audio.AudioOutput.WatchSpeaker copy(int id, String name);
     method public int getId();
     method public String getName();
-    property public final android.media.AudioDeviceInfo? audioDevice;
     property public int id;
     property public String name;
   }

--- a/audio/build.gradle
+++ b/audio/build.gradle
@@ -98,6 +98,7 @@ dependencies {
     implementation libs.androidx.lifecycle.runtime
 
     androidTestImplementation libs.androidx.lifecycle.testing
+    androidTestImplementation libs.androidx.test.rules
     androidTestImplementation libs.truth
     androidTestImplementation libs.compose.ui.test.junit4
     debugImplementation libs.compose.ui.test.manifest

--- a/audio/build.gradle
+++ b/audio/build.gradle
@@ -94,6 +94,7 @@ project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile.class).co
 dependencies {
     implementation libs.kotlin.stdlib
 
+    implementation libs.androidx.mediarouter
     implementation libs.androidx.wear
     implementation libs.androidx.lifecycle.runtime
 

--- a/audio/src/androidTest/java/com/google/android/horologist/audio/AudioOutputRepositoryTest.kt
+++ b/audio/src/androidTest/java/com/google/android/horologist/audio/AudioOutputRepositoryTest.kt
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.compose.layout
+package com.google.android.horologist.audio
 
 import androidx.test.platform.app.InstrumentationRegistry
-import com.google.android.horologist.audio.AudioOutput
-import com.google.android.horologist.audio.ExperimentalAudioApi
-import com.google.android.horologist.audio.SystemAudioOutputRepository
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 

--- a/audio/src/androidTest/java/com/google/android/horologist/audio/AudioOutputRepositoryTest.kt
+++ b/audio/src/androidTest/java/com/google/android/horologist/audio/AudioOutputRepositoryTest.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.horologist.audio
 
+import androidx.test.annotation.UiThreadTest
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
@@ -23,6 +24,7 @@ import org.junit.Test
 @OptIn(ExperimentalAudioApi::class)
 class AudioOutputRepositoryTest {
     @Test
+    @UiThreadTest
     fun testAudioOutputRepository() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
 

--- a/audio/src/androidTest/java/com/google/android/horologist/audio/SystemAudioOutputRepositoryTest.kt
+++ b/audio/src/androidTest/java/com/google/android/horologist/audio/SystemAudioOutputRepositoryTest.kt
@@ -22,7 +22,7 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 @OptIn(ExperimentalAudioApi::class)
-class AudioOutputRepositoryTest {
+class SystemAudioOutputRepositoryTest {
     @Test
     @UiThreadTest
     fun testAudioOutputRepository() {

--- a/audio/src/androidTest/java/com/google/android/horologist/audio/VolumeRepositoryTest.kt
+++ b/audio/src/androidTest/java/com/google/android/horologist/audio/VolumeRepositoryTest.kt
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.compose.layout
+package com.google.android.horologist.audio
 
 import androidx.test.platform.app.InstrumentationRegistry
-import com.google.android.horologist.audio.ExperimentalAudioApi
-import com.google.android.horologist.audio.SystemVolumeRepository
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 

--- a/audio/src/main/java/com/google/android/horologist/audio/AudioOutput.kt
+++ b/audio/src/main/java/com/google/android/horologist/audio/AudioOutput.kt
@@ -26,7 +26,7 @@ public interface AudioOutput {
     /**
      * A unique audio output id.
      */
-    public val id: Int?
+    public val id: String
 
     /**
      * The user meaningful display name for the device.
@@ -38,14 +38,14 @@ public interface AudioOutput {
      */
     public object None : AudioOutput {
         override val name: String = "None"
-        override val id: Int? = null
+        override val id: String = "None"
     }
 
     /**
      * A bluetooth headset paired with the watch.
      */
     public data class BluetoothHeadset(
-        override val id: Int,
+        override val id: String,
         override val name: String
     ) : AudioOutput
 
@@ -53,7 +53,7 @@ public interface AudioOutput {
      * The one device watch speaker.
      */
     public data class WatchSpeaker(
-        override val id: Int,
+        override val id: String,
         override val name: String
     ) : AudioOutput
 
@@ -61,7 +61,7 @@ public interface AudioOutput {
      * An unknown audio output device
      */
     public data class Unknown(
-        override val id: Int,
+        override val id: String,
         override val name: String
     ) : AudioOutput
 }

--- a/audio/src/main/java/com/google/android/horologist/audio/AudioOutput.kt
+++ b/audio/src/main/java/com/google/android/horologist/audio/AudioOutput.kt
@@ -16,9 +16,6 @@
 
 package com.google.android.horologist.audio
 
-import android.media.AudioDeviceInfo
-import android.media.AudioManager
-
 /**
  * A device capable of playing audio.
  *
@@ -27,7 +24,7 @@ import android.media.AudioManager
 @ExperimentalAudioApi
 public interface AudioOutput {
     /**
-     * The id from [AudioManager] if applicable.
+     * A unique audio output id.
      */
     public val id: Int?
 
@@ -49,8 +46,7 @@ public interface AudioOutput {
      */
     public data class BluetoothHeadset(
         override val id: Int,
-        override val name: String,
-        val audioDevice: AudioDeviceInfo? = null
+        override val name: String
     ) : AudioOutput
 
     /**
@@ -58,16 +54,14 @@ public interface AudioOutput {
      */
     public data class WatchSpeaker(
         override val id: Int,
-        override val name: String,
-        val audioDevice: AudioDeviceInfo? = null
+        override val name: String
     ) : AudioOutput
 
     /**
-     * An unknown device provided by the [AudioManager]
+     * An unknown audio output device
      */
     public data class Unknown(
         override val id: Int,
-        override val name: String,
-        val audioDevice: AudioDeviceInfo? = null
+        override val name: String
     ) : AudioOutput
 }

--- a/audio/src/main/java/com/google/android/horologist/audio/SystemAudioOutputRepository.kt
+++ b/audio/src/main/java/com/google/android/horologist/audio/SystemAudioOutputRepository.kt
@@ -119,15 +119,13 @@ public class SystemAudioOutputRepository(
                 return when (type) {
                     AudioDeviceInfo.TYPE_BUILTIN_SPEAKER -> AudioOutput.WatchSpeaker(
                         audioDevice.id,
-                        name,
-                        audioDevice
+                        name
                     )
                     AudioDeviceInfo.TYPE_BLUETOOTH_A2DP -> AudioOutput.BluetoothHeadset(
                         audioDevice.id,
-                        name,
-                        audioDevice
+                        name
                     )
-                    else -> AudioOutput.Unknown(audioDevice.id, name, audioDevice)
+                    else -> AudioOutput.Unknown(audioDevice.id, name)
                 }
             }
 

--- a/audio/src/main/java/com/google/android/horologist/audio/SystemAudioOutputRepository.kt
+++ b/audio/src/main/java/com/google/android/horologist/audio/SystemAudioOutputRepository.kt
@@ -66,7 +66,7 @@ public class SystemAudioOutputRepository(
         val currentAvailable = _available.value.toMutableList()
 
         removedDevices.forEach { audioDevice ->
-            changed = changed or currentAvailable.removeIf { it.id == audioDevice.id }
+            changed = changed or currentAvailable.removeIf { it.id == audioDevice.id.toString() }
         }
 
         if (changed) {
@@ -118,14 +118,14 @@ public class SystemAudioOutputRepository(
                 val name = audioDevice.productName.toString()
                 return when (type) {
                     AudioDeviceInfo.TYPE_BUILTIN_SPEAKER -> AudioOutput.WatchSpeaker(
-                        audioDevice.id,
+                        audioDevice.id.toString(),
                         name
                     )
                     AudioDeviceInfo.TYPE_BLUETOOTH_A2DP -> AudioOutput.BluetoothHeadset(
-                        audioDevice.id,
+                        audioDevice.id.toString(),
                         name
                     )
-                    else -> AudioOutput.Unknown(audioDevice.id, name)
+                    else -> AudioOutput.Unknown(audioDevice.id.toString(), name)
                 }
             }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ androidx-lifecycle-testing = { module = "androidx.lifecycle:lifecycle-runtime-te
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidxNavigation" }
 androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidxNavigation" }
+androidx-test-rules = "androidx.test:rules:1.4.0"
 androidx-test-ext = "androidx.test.ext:junit:1.1.3"
 androidx-test-ext-ktx = "androidx.test.ext:junit-ktx:1.1.3"
 androidx-wear = { module = "androidx.wear:wear", version.ref = "androidxWear" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-kt
 androidx-lifecycle-service = { module = "androidx.lifecycle:lifecycle-service", version.ref = "androidxLifecycle" }
 androidx-lifecycle-testing = { module = "androidx.lifecycle:lifecycle-runtime-testing", version.ref = "androidxLifecycle" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
+androidx-mediarouter = "androidx.mediarouter:mediarouter:1.2.6"
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidxNavigation" }
 androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidxNavigation" }
 androidx-test-rules = "androidx.test:rules:1.4.0"


### PR DESCRIPTION
The current implementation of `AudioOutputRepository` uses `AudioManager` to show what outputs are available and what output is connected. The implementation is assuming that if there is an A2DP device available that this is the connected output. Even if this is highly likely this is in my understanding not always correct. A media application can choose to select another media route using `androidx.mediarouter.media.MediaRouter`, even if Bluetooth is connected.

This change modifies the `AudioOutputRepository` to instead use `androidx.mediarouter.media.MediaRouter` to track what output is used. As a consequence the `AudioOutput` model can no longer have dependencies to `AudioManager` classes/data. This change also removes the dependency from the model so we're free to use whatever implementation we want.

An additional advantage of using `MediaRouter` is that any registered non-system routes would now work with the `AudioOutputRepository`. After this change they will show up as `AudioOutput#Unknown` devices, but in the future this interface can be expanded to cover more specific non-system route use-cases.

Lastly the change also contains a commits that prepares for this change. For this reason change is most likely best to review commit by commit.