### PR TITLE
Simplify nav scaffold view model.

### DIFF
--- a/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/WearNavScaffold.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/WearNavScaffold.kt
@@ -75,10 +75,7 @@ public fun WearNavScaffold(
     val currentBackStackEntry: NavBackStackEntry? by navController.currentBackStackEntryAsState()
 
     val viewModel: NavScaffoldViewModel? = currentBackStackEntry?.let {
-        viewModel(
-            viewModelStoreOwner = it,
-            factory = NavScaffoldViewModel.Factory
-        )
+        viewModel(viewModelStoreOwner = it)
     }
 
     Scaffold(
@@ -274,7 +271,7 @@ public fun NavGraphBuilder.wearNavComposable(
     content: @Composable (NavBackStackEntry, NavScaffoldViewModel) -> Unit
 ) {
     composable(route, arguments, deepLinks) {
-        val viewModel: NavScaffoldViewModel = viewModel(factory = NavScaffoldViewModel.Factory)
+        val viewModel: NavScaffoldViewModel = viewModel()
 
         content(it, viewModel)
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -39,8 +39,6 @@ android {
             manifestPlaceholders.schemeSuffix = "-debug"
         }
         release {
-            isDefault = true
-
             manifestPlaceholders.schemeSuffix = ""
 
             minifyEnabled true

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -39,6 +39,8 @@ android {
             manifestPlaceholders.schemeSuffix = "-debug"
         }
         release {
+            isDefault = true
+
             manifestPlaceholders.schemeSuffix = ""
 
             minifyEnabled true


### PR DESCRIPTION
NavBackStackEntry defaults to a factory that can build this.

```
    private val defaultFactory by lazy { SavedStateViewModelFactory() }
```

So remove the code and use default.