### PR TITLE
Use debug as default again.

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -39,8 +39,6 @@ android {
             manifestPlaceholders.schemeSuffix = "-debug"
         }
         release {
-            isDefault = true
-
             manifestPlaceholders.schemeSuffix = ""
 
             minifyEnabled true


### PR DESCRIPTION
Was to make sure we ran fast on device, but it breaks previews and tests in Android Studio.