### PR TITLE
Add module for Media UI library

### DIFF
--- a/media-ui/README.md
+++ b/media-ui/README.md
@@ -1,0 +1,1 @@
+# Media UI library

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -1,0 +1,8 @@
+// Signature format: 4.0
+package com.google.android.horologist.mediaui {
+
+  @kotlin.RequiresOptIn(message="Horologist Media is experimental. The API may be changed in the future.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention) public @interface ExperimentalMediaUiApi {
+  }
+
+}
+

--- a/media-ui/build.gradle
+++ b/media-ui/build.gradle
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+}
+
+android {
+    compileSdkVersion 31
+
+    defaultConfig {
+        minSdk 26
+        targetSdk 30
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    buildFeatures {
+        buildConfig false
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
+    lintOptions {
+        textReport true
+        textOutput 'stdout'
+        // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
+        checkReleaseBuilds false
+    }
+
+    packagingOptions {
+        // Some of the META-INF files conflict with coroutines-test. Exclude them to enable
+        // our test APK to build (has no effect on our AARs)
+        excludes += "/META-INF/AL2.0"
+        excludes += "/META-INF/LGPL2.1"
+    }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+        animationsDisabled true
+    }
+}
+
+project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile.class).configureEach { task ->
+    // Workaround for https://youtrack.jetbrains.com/issue/KT-37652
+    if (!task.name.endsWith("TestKotlin") && !task.name.startsWith("compileDebug")) {
+        task.kotlinOptions.freeCompilerArgs.add("-Xexplicit-api=strict")
+    }
+}
+
+dependencies {
+    implementation libs.kotlin.stdlib
+
+    testImplementation libs.junit
+
+    androidTestImplementation libs.compose.ui.test.junit4
+}

--- a/media-ui/gradle.properties
+++ b/media-ui/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=horologist-media-ui
+POM_NAME=Horologist Media UI library
+POM_PACKAGING=aar

--- a/media-ui/src/main/AndroidManifest.xml
+++ b/media-ui/src/main/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2022 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.google.android.horologist.media.ui">
+
+    <uses-feature android:name="android.hardware.type.watch" />
+</manifest>

--- a/media-ui/src/main/java/com/google/android/horologist/mediaui/ExperimentalMediaUiApi.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/mediaui/ExperimentalMediaUiApi.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediaui
+
+@RequiresOptIn(
+    message = "Horologist Media is experimental. The API may be changed in the future."
+)
+@Retention(AnnotationRetention.BINARY)
+public annotation class ExperimentalMediaUiApi

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,6 +30,7 @@ include ':compose-layout'
 include ':audio'
 include ':audio-ui'
 include ':tiles'
+include ':media-ui'
 
 // Enable Gradle's version catalog support
 // https://docs.gradle.org/current/userguide/platforms.html


### PR DESCRIPTION
#### WHAT
Add a module for Media UI library

#### WHY
In order to include UI components related to media and publish them as an individual library.

#### HOW
- Add a new android ui module with same setup as other modules from the project;
- Add maven publish plugin configuration to the module;
- Add annotation `ExperimentalMediaUiApi`;
- Add metalava generated API file;