### PR TITLE
Add MediaButton

### DIFF
--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -6,3 +6,24 @@ package com.google.android.horologist.mediaui {
 
 }
 
+package com.google.android.horologist.mediaui.components.controls {
+
+  public final class MediaButtonKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void MediaButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, boolean enabled, androidx.compose.ui.graphics.vector.ImageVector icon, String contentDescription, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);
+  }
+
+}
+
+package com.google.android.horologist.mediaui.components.semantics {
+
+  @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public final class CustomSemanticsProperties {
+    method public androidx.compose.ui.graphics.vector.ImageVector getIconImageVector(androidx.compose.ui.semantics.SemanticsPropertyReceiver);
+    method public androidx.compose.ui.semantics.SemanticsPropertyKey<androidx.compose.ui.graphics.vector.ImageVector> getIconImageVectorKey();
+    method public void setIconImageVector(androidx.compose.ui.semantics.SemanticsPropertyReceiver, androidx.compose.ui.graphics.vector.ImageVector iconImageVector);
+    property public final androidx.compose.ui.semantics.SemanticsPropertyKey<androidx.compose.ui.graphics.vector.ImageVector> IconImageVectorKey;
+    property public final androidx.compose.ui.graphics.vector.ImageVector iconImageVector;
+    field public static final com.google.android.horologist.mediaui.components.semantics.CustomSemanticsProperties INSTANCE;
+  }
+
+}
+

--- a/media-ui/build.gradle
+++ b/media-ui/build.gradle
@@ -36,10 +36,15 @@ android {
 
     buildFeatures {
         buildConfig false
+        compose true
     }
 
     kotlinOptions {
         jvmTarget = '1.8'
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion libs.versions.compose.get()
     }
 
     lintOptions {
@@ -73,6 +78,17 @@ project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile.class).co
 
 dependencies {
     implementation libs.kotlin.stdlib
+    implementation libs.androidx.wear
+    implementation libs.wearcompose.material
+    implementation libs.wearcompose.foundation
+    implementation libs.compose.ui.tooling
+    implementation libs.compose.material.iconscore
+    implementation libs.compose.material.iconsext
+
+    debugImplementation libs.androidx.customview
+    debugImplementation libs.androidx.customview.pooling
+    debugImplementation libs.compose.ui.test.manifest
+    debugImplementation libs.compose.ui.toolingpreview
 
     testImplementation libs.junit
 

--- a/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/MediaButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/MediaButtonPreview.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalMediaUiApi::class)
+
+package com.google.android.horologist.mediaui.components.controls
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
+
+@Preview(name = "Play - Enabled")
+@Composable
+fun MediaButtonPreviewPlayEnabled() {
+    MediaButton(
+        onClick = {},
+        enabled = true,
+        icon = Icons.Default.PlayArrow,
+        "Play"
+    )
+}
+
+@Preview("Pause - Disabled")
+@Composable
+fun MediaButtonPreviewPauseDisabled() {
+    MediaButton(
+        onClick = {},
+        enabled = false,
+        icon = Icons.Default.Pause,
+        "Pause"
+    )
+}

--- a/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/MediaButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/MediaButton.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediaui.components.controls
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.semantics
+import androidx.wear.compose.material.Button
+import androidx.wear.compose.material.ButtonColors
+import androidx.wear.compose.material.ButtonDefaults
+import androidx.wear.compose.material.Icon
+import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
+import com.google.android.horologist.mediaui.components.semantics.CustomSemanticsProperties.iconImageVector
+
+/**
+ * A base button for media controls.
+ */
+@ExperimentalMediaUiApi
+@Composable
+public fun MediaButton(
+    onClick: () -> Unit,
+    enabled: Boolean,
+    icon: ImageVector,
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+    colors: ButtonColors = ButtonDefaults.iconButtonColors(),
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        colors = colors,
+    ) {
+        Icon(
+            modifier = Modifier
+                .size(ButtonDefaults.SmallButtonSize)
+                .semantics { iconImageVector = icon },
+            imageVector = icon,
+            contentDescription = contentDescription
+        )
+    }
+}

--- a/media-ui/src/main/java/com/google/android/horologist/mediaui/components/semantics/CustomSemanticsProperties.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/mediaui/components/semantics/CustomSemanticsProperties.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediaui.components.semantics
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
+
+/**
+ * Custom semantic properties, mainly used for accessibility and testing.
+ */
+@ExperimentalMediaUiApi
+public object CustomSemanticsProperties {
+
+    public val IconImageVectorKey: SemanticsPropertyKey<ImageVector> =
+        SemanticsPropertyKey("IconImageVector")
+    public var SemanticsPropertyReceiver.iconImageVector: ImageVector by IconImageVectorKey
+}


### PR DESCRIPTION
#### WHAT
Add `MediaButton`.

![Screen Shot 2022-04-12 at 16 38 44](https://user-images.githubusercontent.com/878134/163000563-25dda91d-3e44-4a30-8122-544598a46cd6.png)

#### WHY
In order to be used as a base button for other media controls.

#### HOW
- Add `MediaButton` implementation;
- Add required compose and wear dependencies to module;
- Add preview in `debug` build source folder;
- Add custom semantics property `iconImageVector` to be used in tests;

#### Checklist :clipboard:
- [x] Added explicit visibility modifier and explicit return types for public declarations
- [x] Updated metalava's signature text files
