### PR TITLE
Add PlayButton

### DIFF
--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -16,6 +16,10 @@ package com.google.android.horologist.mediaui.components.controls {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void PauseButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, boolean enabled, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);
   }
 
+  public final class PlayButtonKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void PlayButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, boolean enabled, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);
+  }
+
 }
 
 package com.google.android.horologist.mediaui.components.semantics {

--- a/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/PlayButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/PlayButtonPreview.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalMediaUiApi::class)
+
+package com.google.android.horologist.mediaui.components.controls
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
+
+@Preview(name = "Enabled")
+@Composable
+fun PlayButtonPreviewEnabled() {
+    PlayButton(
+        onClick = {},
+        enabled = true
+    )
+}
+
+@Preview(name = "Disabled")
+@Composable
+fun PlayButtonPreviewDisabled() {
+    PlayButton(
+        onClick = {},
+        enabled = false
+    )
+}

--- a/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/PlayButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/PlayButton.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediaui.components.controls
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.wear.compose.material.ButtonColors
+import androidx.wear.compose.material.ButtonDefaults
+import com.google.android.horologist.media.ui.R
+import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
+
+@ExperimentalMediaUiApi
+@Composable
+public fun PlayButton(
+    onClick: () -> Unit,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+    colors: ButtonColors = ButtonDefaults.iconButtonColors(),
+) {
+    MediaButton(
+        onClick = onClick,
+        enabled = enabled,
+        icon = Icons.Default.PlayArrow,
+        contentDescription = stringResource(id = R.string.play_button_content_description),
+        modifier = modifier,
+        colors = colors,
+    )
+}

--- a/media-ui/src/main/res/values/strings.xml
+++ b/media-ui/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="pause_button_content_description">Pause</string>
+    <string name="play_button_content_description">Play</string>
 </resources>


### PR DESCRIPTION
#### WHAT
Add `PlayButton`.

<img width="125" alt="Screen Shot 2022-04-12 at 17 57 05" src="https://user-images.githubusercontent.com/878134/163016203-75057502-47f5-42ef-a5da-8aaf367e247b.png">

#### WHY
In order to provide common media controls.

#### HOW
- Add `PlayButton` implementation;
- Add preview in `debug` build source folder;

#### Checklist :clipboard:
- [x] Added explicit visibility modifier and explicit return types for public declarations
- [x] Updated metalava's signature text files
