### PR TITLE
Add SeekToPreviousButton

### DIFF
--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -24,6 +24,10 @@ package com.google.android.horologist.mediaui.components.controls {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void SeekToNextButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, boolean enabled, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);
   }
 
+  public final class SeekToPreviousButtonKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void SeekToPreviousButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, boolean enabled, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);
+  }
+
 }
 
 package com.google.android.horologist.mediaui.components.semantics {

--- a/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/SeekToPreviousButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/SeekToPreviousButtonPreview.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalMediaUiApi::class)
+
+package com.google.android.horologist.mediaui.components.controls
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
+
+@Preview(name = "Enabled")
+@Composable
+fun SeekToPreviousButtonPreviewEnabled() {
+    SeekToPreviousButton(onClick = {}, enabled = true)
+}
+
+@Preview(name = "Disabled")
+@Composable
+fun SeekToPreviousButtonPreviewDisabled() {
+    SeekToPreviousButton(onClick = {}, enabled = false)
+}

--- a/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/SeekToPreviousButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/SeekToPreviousButton.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediaui.components.controls
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.wear.compose.material.ButtonColors
+import androidx.wear.compose.material.ButtonDefaults
+import com.google.android.horologist.media.ui.R
+import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
+
+@ExperimentalMediaUiApi
+@Composable
+public fun SeekToPreviousButton(
+    onClick: () -> Unit,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+    colors: ButtonColors = ButtonDefaults.iconButtonColors(),
+) {
+    MediaButton(
+        onClick = onClick,
+        enabled = enabled,
+        icon = Icons.Default.SkipPrevious,
+        contentDescription = stringResource(id = R.string.seek_to_previous_button_content_description),
+        modifier = modifier,
+        colors = colors,
+    )
+}

--- a/media-ui/src/main/res/values/strings.xml
+++ b/media-ui/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
     <string name="pause_button_content_description">Pause</string>
     <string name="play_button_content_description">Play</string>
     <string name="seek_to_next_button_content_description">Next</string>
+    <string name="seek_to_previous_button_content_description">Previous</string>
 </resources>


### PR DESCRIPTION
#### WHAT
Add `SeekToPreviousButton`.

![Screen Shot 2022-04-13 at 10 57 34](https://user-images.githubusercontent.com/878134/163169243-bc62b264-1122-4e8b-8d11-990e91e424e4.png)

#### WHY
In order to provide common media controls.

#### HOW
- Add `SeekToPreviousButton` implementation;
- Add preview in `debug` build source folder;

#### Checklist :clipboard:
- [x] Added explicit visibility modifier and explicit return types for public declarations
- [x] Updated metalava's signature text files
