### PR TITLE
Add ShuffleButton

### DIFF
--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -28,6 +28,10 @@ package com.google.android.horologist.mediaui.components.controls {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void SeekToPreviousButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, boolean enabled, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);
   }
 
+  public final class ShuffleButtonKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void ShuffleButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, boolean enabled, boolean shuffleOn, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);
+  }
+
 }
 
 package com.google.android.horologist.mediaui.components.semantics {

--- a/media-ui/src/androidTest/java/com/google/android/horologist/mediaui/components/controls/ShuffleButtonTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/mediaui/components/controls/ShuffleButtonTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalMediaUiApi::class)
+
+package com.google.android.horologist.mediaui.components.controls
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Shuffle
+import androidx.compose.material.icons.filled.ShuffleOn
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
+import org.junit.Rule
+import org.junit.Test
+import toolbox.hasIconImageVector
+
+class ShuffleButtonTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun givenShuffleIsOn_thenIconIsShuffleOn() {
+        // given
+        composeTestRule.setContent {
+            ShuffleButton(
+                onClick = {},
+                enabled = true,
+                shuffleOn = true,
+            )
+        }
+
+        // then
+        composeTestRule.onNode(hasIconImageVector(Icons.Default.ShuffleOn)).assertExists()
+    }
+
+    @Test
+    fun givenShuffleIsOff_thenIconIsShuffle() {
+        // given
+        composeTestRule.setContent {
+            ShuffleButton(
+                onClick = {},
+                enabled = true,
+                shuffleOn = false,
+            )
+        }
+
+        // then
+        composeTestRule.onNode(hasIconImageVector(Icons.Default.Shuffle)).assertExists()
+    }
+}

--- a/media-ui/src/androidTest/java/com/google/android/horologist/mediaui/components/controls/ShuffleButtonTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/mediaui/components/controls/ShuffleButtonTest.kt
@@ -23,9 +23,9 @@ import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material.icons.filled.ShuffleOn
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
+import com.google.test.toolbox.hasIconImageVector
 import org.junit.Rule
 import org.junit.Test
-import toolbox.hasIconImageVector
 
 class ShuffleButtonTest {
 

--- a/media-ui/src/androidTest/java/com/google/test/toolbox/SemanticsMatchers.kt
+++ b/media-ui/src/androidTest/java/com/google/test/toolbox/SemanticsMatchers.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.test.toolbox
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.test.SemanticsMatcher
+import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
+import com.google.android.horologist.mediaui.components.semantics.CustomSemanticsProperties.IconImageVectorKey
+
+@OptIn(ExperimentalMediaUiApi::class)
+fun hasIconImageVector(imageVector: ImageVector): SemanticsMatcher =
+    SemanticsMatcher.expectValue(IconImageVectorKey, imageVector)

--- a/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/ShuffleButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/ShuffleButtonPreview.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalMediaUiApi::class)
+
+package com.google.android.horologist.mediaui.components.controls
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
+
+@Preview("Disabled - Off")
+@Composable
+fun ShuffleButtonPreviewDisabledOff() {
+    ShuffleButton(
+        onClick = {},
+        enabled = false,
+        shuffleOn = false
+    )
+}
+
+@Preview("Enabled - Off")
+@Composable
+fun ShuffleButtonPreviewEnabledOff() {
+    ShuffleButton(
+        onClick = {},
+        enabled = true,
+        shuffleOn = false
+    )
+}
+
+@Preview("Disabled - On")
+@Composable
+fun ShuffleButtonPreviewDisabledOn() {
+    ShuffleButton(
+        onClick = {},
+        enabled = false,
+        shuffleOn = true
+    )
+}
+
+@Preview("Enabled - On")
+@Composable
+fun ShuffleButtonPreviewEnabledOn() {
+    ShuffleButton(
+        onClick = {},
+        enabled = true,
+        shuffleOn = true
+    )
+}

--- a/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/ShuffleButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/ShuffleButton.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediaui.components.controls
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Shuffle
+import androidx.compose.material.icons.filled.ShuffleOn
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.wear.compose.material.Button
+import androidx.wear.compose.material.ButtonColors
+import androidx.wear.compose.material.ButtonDefaults
+import androidx.wear.compose.material.Icon
+import com.google.android.horologist.media.ui.R
+import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
+import com.google.android.horologist.mediaui.components.semantics.CustomSemanticsProperties.iconImageVector
+
+@ExperimentalMediaUiApi
+@Composable
+public fun ShuffleButton(
+    onClick: () -> Unit,
+    enabled: Boolean,
+    shuffleOn: Boolean,
+    modifier: Modifier = Modifier,
+    colors: ButtonColors = ButtonDefaults.iconButtonColors(),
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        colors = colors,
+    ) {
+        val icon = if (shuffleOn) Icons.Default.ShuffleOn else Icons.Default.Shuffle
+        Icon(
+            imageVector = icon,
+            contentDescription = stringResource(id = R.string.shuffle_button_content_description),
+            modifier = Modifier.semantics { iconImageVector = icon },
+        )
+    }
+}

--- a/media-ui/src/main/res/values/strings.xml
+++ b/media-ui/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="play_button_content_description">Play</string>
     <string name="seek_to_next_button_content_description">Next</string>
     <string name="seek_to_previous_button_content_description">Previous</string>
+    <string name="shuffle_button_content_description">Toggle Shuffle</string>
 </resources>


### PR DESCRIPTION
#### WHAT
Add `ShuffleButton`.

![Screen Shot 2022-04-13 at 15 11 27](https://user-images.githubusercontent.com/878134/163199943-e7341aa0-1ab6-4141-aef2-c83313f8706e.png)

#### WHY
In order to provide common media controls.

#### HOW
- Add `ShuffleButton` implementation;
- Add preview in `debug` build source folder;
- Add UI test;

#### Checklist :clipboard:
- [x] Added explicit visibility modifier and explicit return types for public declarations
- [x] Updated metalava's signature text files
