### PR TITLE
Add SeekBackButton

### DIFF
--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -20,6 +20,38 @@ package com.google.android.horologist.mediaui.components.controls {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void PlayButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, boolean enabled, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);
   }
 
+  public abstract sealed class SeekBackButtonIncrement {
+    method public int getSeconds();
+    property public int seconds;
+  }
+
+  public static final class SeekBackButtonIncrement.Five extends com.google.android.horologist.mediaui.components.controls.SeekBackButtonIncrement {
+    field public static final com.google.android.horologist.mediaui.components.controls.SeekBackButtonIncrement.Five INSTANCE;
+  }
+
+  public static final class SeekBackButtonIncrement.Other extends com.google.android.horologist.mediaui.components.controls.SeekBackButtonIncrement {
+    ctor public SeekBackButtonIncrement.Other(int seconds);
+    method public int component1();
+    method public com.google.android.horologist.mediaui.components.controls.SeekBackButtonIncrement.Other copy(int seconds);
+    property public int seconds;
+  }
+
+  public static final class SeekBackButtonIncrement.Ten extends com.google.android.horologist.mediaui.components.controls.SeekBackButtonIncrement {
+    field public static final com.google.android.horologist.mediaui.components.controls.SeekBackButtonIncrement.Ten INSTANCE;
+  }
+
+  public static final class SeekBackButtonIncrement.Thirty extends com.google.android.horologist.mediaui.components.controls.SeekBackButtonIncrement {
+    field public static final com.google.android.horologist.mediaui.components.controls.SeekBackButtonIncrement.Thirty INSTANCE;
+  }
+
+  public static final class SeekBackButtonIncrement.Unknown extends com.google.android.horologist.mediaui.components.controls.SeekBackButtonIncrement {
+    field public static final com.google.android.horologist.mediaui.components.controls.SeekBackButtonIncrement.Unknown INSTANCE;
+  }
+
+  public final class SeekBackButtonKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void SeekBackButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, boolean enabled, com.google.android.horologist.mediaui.components.controls.SeekBackButtonIncrement seekBackButtonIncrement, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);
+  }
+
   public final class SeekToNextButtonKt {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void SeekToNextButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, boolean enabled, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);
   }

--- a/media-ui/src/androidTest/java/com/google/android/horologist/mediaui/components/controls/SeekBackButtonTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/mediaui/components/controls/SeekBackButtonTest.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalMediaUiApi::class)
+
+package com.google.android.horologist.mediaui.components.controls
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Replay
+import androidx.compose.material.icons.filled.Replay10
+import androidx.compose.material.icons.filled.Replay30
+import androidx.compose.material.icons.filled.Replay5
+import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
+import com.google.test.toolbox.hasIconImageVector
+import org.junit.Rule
+import org.junit.Test
+
+class SeekBackButtonTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun givenIncrementIsFive_thenIconAndDescriptionAreFive() {
+        // given
+        composeTestRule.setContent {
+            SeekBackButton(
+                onClick = {},
+                true,
+                seekBackButtonIncrement = SeekBackButtonIncrement.Five,
+            )
+        }
+
+        // then
+        composeTestRule
+            .onNode(hasIconImageVector(Icons.Default.Replay5))
+            .assertContentDescriptionEquals("Rewind 5 seconds")
+    }
+
+    @Test
+    fun givenIncrementIsTen_thenIconAndDescriptionAreTen() {
+        // given
+        composeTestRule.setContent {
+            SeekBackButton(
+                onClick = {},
+                true,
+                seekBackButtonIncrement = SeekBackButtonIncrement.Ten,
+            )
+        }
+
+        // then
+        composeTestRule
+            .onNode(hasIconImageVector(Icons.Default.Replay10))
+            .assertContentDescriptionEquals("Rewind 10 seconds")
+    }
+
+    @Test
+    fun givenIncrementIsThirty_thenIconAndDescriptionAreThirty() {
+        // given
+        composeTestRule.setContent {
+            SeekBackButton(
+                onClick = {},
+                true,
+                seekBackButtonIncrement = SeekBackButtonIncrement.Thirty,
+            )
+        }
+
+        // then
+        composeTestRule
+            .onNode(hasIconImageVector(Icons.Default.Replay30))
+            .assertContentDescriptionEquals("Rewind 30 seconds")
+    }
+
+    @Test
+    fun givenIncrementIsOtherValue_thenIconIsDefaultAndDescriptionIsOtherValue() {
+        // given
+        composeTestRule.setContent {
+            SeekBackButton(
+                onClick = {},
+                true,
+                seekBackButtonIncrement = SeekBackButtonIncrement.Other(15),
+            )
+        }
+
+        // then
+        composeTestRule
+            .onNode(hasIconImageVector(Icons.Default.Replay))
+            .assertContentDescriptionEquals("Rewind 15 seconds")
+    }
+
+    @Test
+    fun givenIncrementIsUnknown_thenIconAndDescriptionAreDefault() {
+        // given
+        composeTestRule.setContent {
+            SeekBackButton(
+                onClick = {},
+                true,
+                seekBackButtonIncrement = SeekBackButtonIncrement.Unknown,
+            )
+        }
+
+        // then
+        composeTestRule
+            .onNode(hasIconImageVector(Icons.Default.Replay))
+            .assertContentDescriptionEquals("Rewind")
+    }
+}

--- a/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/SeekBackButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/SeekBackButtonPreview.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalMediaUiApi::class)
+
+package com.google.android.horologist.mediaui.components.controls
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
+
+@Preview(name = "5 seconds increment - Enabled")
+@Composable
+fun SeekBackButtonPreview5() {
+    SeekBackButton(
+        onClick = {},
+        enabled = true,
+        seekBackButtonIncrement = SeekBackButtonIncrement.Five
+    )
+}
+
+@Preview(name = "10 seconds increment - Disabled")
+@Composable
+fun SeekBackButtonPreview10() {
+    SeekBackButton(
+        onClick = {},
+        enabled = false,
+        seekBackButtonIncrement = SeekBackButtonIncrement.Ten
+    )
+}
+
+@Preview(name = "30 seconds increment - Enabled")
+@Composable
+fun SeekBackButtonPreview30() {
+    SeekBackButton(
+        onClick = {},
+        enabled = true,
+        seekBackButtonIncrement = SeekBackButtonIncrement.Thirty
+    )
+}
+
+@Preview(name = "Other amount of seconds increment - Disabled")
+@Composable
+fun SeekBackButtonPreviewOther() {
+    SeekBackButton(
+        onClick = {},
+        enabled = false,
+        seekBackButtonIncrement = SeekBackButtonIncrement.Other(15)
+    )
+}
+
+@Preview(name = "Unknown amount of seconds increment - Enabled")
+@Composable
+fun SeekBackButtonPreviewUnknown() {
+    SeekBackButton(
+        onClick = {},
+        enabled = true,
+        seekBackButtonIncrement = SeekBackButtonIncrement.Unknown
+    )
+}

--- a/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/SeekBackButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/SeekBackButton.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediaui.components.controls
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Replay
+import androidx.compose.material.icons.filled.Replay10
+import androidx.compose.material.icons.filled.Replay30
+import androidx.compose.material.icons.filled.Replay5
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.wear.compose.material.ButtonColors
+import androidx.wear.compose.material.ButtonDefaults
+import com.google.android.horologist.media.ui.R
+import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
+
+@ExperimentalMediaUiApi
+@Composable
+public fun SeekBackButton(
+    onClick: () -> Unit,
+    enabled: Boolean,
+    seekBackButtonIncrement: SeekBackButtonIncrement,
+    modifier: Modifier = Modifier,
+    colors: ButtonColors = ButtonDefaults.iconButtonColors(),
+) {
+    val icon = when (seekBackButtonIncrement) {
+        SeekBackButtonIncrement.Five -> Icons.Default.Replay5
+        SeekBackButtonIncrement.Ten -> Icons.Default.Replay10
+        SeekBackButtonIncrement.Thirty -> Icons.Default.Replay30
+        else -> Icons.Default.Replay
+    }
+
+    val contentDescription = when (seekBackButtonIncrement) {
+        SeekBackButtonIncrement.Unknown -> stringResource(id = R.string.seek_back_button_rewind)
+        else -> stringResource(
+            id = R.string.seek_back_button_rewind_seconds,
+            seekBackButtonIncrement.seconds
+        )
+    }
+
+    MediaButton(
+        onClick = onClick,
+        enabled = enabled,
+        icon = icon,
+        contentDescription = contentDescription,
+        modifier = modifier,
+        colors = colors,
+    )
+}
+
+public sealed class SeekBackButtonIncrement(public open val seconds: Int) {
+
+    public object Unknown : SeekBackButtonIncrement(-1)
+
+    public object Five : SeekBackButtonIncrement(5)
+
+    public object Ten : SeekBackButtonIncrement(10)
+
+    public object Thirty : SeekBackButtonIncrement(30)
+
+    public data class Other(override val seconds: Int) : SeekBackButtonIncrement(seconds)
+}

--- a/media-ui/src/main/res/values/strings.xml
+++ b/media-ui/src/main/res/values/strings.xml
@@ -3,5 +3,7 @@
     <string name="play_button_content_description">Play</string>
     <string name="seek_to_next_button_content_description">Next</string>
     <string name="seek_to_previous_button_content_description">Previous</string>
+    <string name="seek_back_button_rewind">Rewind</string>
+    <string name="seek_back_button_rewind_seconds">Rewind %s seconds</string>
     <string name="shuffle_button_content_description">Toggle Shuffle</string>
 </resources>


### PR DESCRIPTION
#### WHAT
Add `SeekBackButton`.

![Screen Shot 2022-04-13 at 17 02 36](https://user-images.githubusercontent.com/878134/163222454-bde89c3c-f7c0-4a3a-a8df-a773019aa4fb.png)

#### WHY
In order to provide common media controls.

#### HOW
- Add `SeekBackButton` implementation;
- Add preview in `debug` build source folder;
- Add tests;

#### Checklist :clipboard:
- [x] Added explicit visibility modifier and explicit return types for public declarations
- [x] Updated metalava's signature text files
