### PR TITLE
Add maven publish plugin to media-ui module

### DIFF
--- a/media-ui/build.gradle
+++ b/media-ui/build.gradle
@@ -17,6 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
+    id 'org.jetbrains.dokka'
 }
 
 android {
@@ -94,3 +95,5 @@ dependencies {
 
     androidTestImplementation libs.compose.ui.test.junit4
 }
+
+apply plugin: "com.vanniktech.maven.publish"


### PR DESCRIPTION
#### WHAT
Add maven publish plugin to `media-ui` module

#### WHY
So this module can be published to maven when the release scripts run.

#### HOW
- Add maven publish and dokka plugin to `build.gradle` of `media-ui` module;

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [N/A] Run tests
- [N/A] Update metalava's signature text files
