### PR TITLE
Add default value for enabled param

### DIFF
--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -9,19 +9,19 @@ package com.google.android.horologist.mediaui {
 package com.google.android.horologist.mediaui.components.controls {
 
   public final class MediaButtonKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void MediaButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, boolean enabled, androidx.compose.ui.graphics.vector.ImageVector icon, String contentDescription, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void MediaButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, androidx.compose.ui.graphics.vector.ImageVector icon, String contentDescription, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional androidx.wear.compose.material.ButtonColors colors);
   }
 
   public final class PauseButtonKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void PauseButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, boolean enabled, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void PauseButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional androidx.wear.compose.material.ButtonColors colors);
   }
 
   public final class PlayButtonKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void PlayButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, boolean enabled, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void PlayButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional androidx.wear.compose.material.ButtonColors colors);
   }
 
   public final class SeekBackButtonKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void SeekBackButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, boolean enabled, com.google.android.horologist.mediaui.components.controls.SeekButtonIncrement seekButtonIncrement, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void SeekBackButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, com.google.android.horologist.mediaui.components.controls.SeekButtonIncrement seekButtonIncrement, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional androidx.wear.compose.material.ButtonColors colors);
   }
 
   public abstract sealed class SeekButtonIncrement {
@@ -53,19 +53,19 @@ package com.google.android.horologist.mediaui.components.controls {
   }
 
   public final class SeekForwardButtonKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void SeekForwardButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, boolean enabled, com.google.android.horologist.mediaui.components.controls.SeekButtonIncrement seekButtonIncrement, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void SeekForwardButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, com.google.android.horologist.mediaui.components.controls.SeekButtonIncrement seekButtonIncrement, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional androidx.wear.compose.material.ButtonColors colors);
   }
 
   public final class SeekToNextButtonKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void SeekToNextButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, boolean enabled, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void SeekToNextButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional androidx.wear.compose.material.ButtonColors colors);
   }
 
   public final class SeekToPreviousButtonKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void SeekToPreviousButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, boolean enabled, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void SeekToPreviousButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional androidx.wear.compose.material.ButtonColors colors);
   }
 
   public final class ShuffleButtonKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void ShuffleButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, boolean enabled, boolean shuffleOn, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void ShuffleButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, boolean shuffleOn, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional androidx.wear.compose.material.ButtonColors colors);
   }
 
 }

--- a/media-ui/src/androidTest/java/com/google/android/horologist/mediaui/components/controls/SeekBackButtonTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/mediaui/components/controls/SeekBackButtonTest.kt
@@ -41,7 +41,6 @@ class SeekBackButtonTest {
         composeTestRule.setContent {
             SeekBackButton(
                 onClick = {},
-                true,
                 seekButtonIncrement = SeekButtonIncrement.Five,
             )
         }
@@ -58,7 +57,6 @@ class SeekBackButtonTest {
         composeTestRule.setContent {
             SeekBackButton(
                 onClick = {},
-                true,
                 seekButtonIncrement = SeekButtonIncrement.Ten,
             )
         }
@@ -75,7 +73,6 @@ class SeekBackButtonTest {
         composeTestRule.setContent {
             SeekBackButton(
                 onClick = {},
-                true,
                 seekButtonIncrement = SeekButtonIncrement.Thirty,
             )
         }
@@ -92,7 +89,6 @@ class SeekBackButtonTest {
         composeTestRule.setContent {
             SeekBackButton(
                 onClick = {},
-                true,
                 seekButtonIncrement = SeekButtonIncrement.Other(15),
             )
         }
@@ -109,7 +105,6 @@ class SeekBackButtonTest {
         composeTestRule.setContent {
             SeekBackButton(
                 onClick = {},
-                true,
                 seekButtonIncrement = SeekButtonIncrement.Unknown,
             )
         }

--- a/media-ui/src/androidTest/java/com/google/android/horologist/mediaui/components/controls/SeekForwardButtonTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/mediaui/components/controls/SeekForwardButtonTest.kt
@@ -41,7 +41,6 @@ class SeekForwardButtonTest {
         composeTestRule.setContent {
             SeekForwardButton(
                 onClick = {},
-                true,
                 seekButtonIncrement = SeekButtonIncrement.Five,
             )
         }
@@ -58,7 +57,6 @@ class SeekForwardButtonTest {
         composeTestRule.setContent {
             SeekForwardButton(
                 onClick = {},
-                true,
                 seekButtonIncrement = SeekButtonIncrement.Ten,
             )
         }
@@ -75,7 +73,6 @@ class SeekForwardButtonTest {
         composeTestRule.setContent {
             SeekForwardButton(
                 onClick = {},
-                true,
                 seekButtonIncrement = SeekButtonIncrement.Thirty,
             )
         }
@@ -92,7 +89,6 @@ class SeekForwardButtonTest {
         composeTestRule.setContent {
             SeekForwardButton(
                 onClick = {},
-                true,
                 seekButtonIncrement = SeekButtonIncrement.Other(15),
             )
         }
@@ -109,7 +105,6 @@ class SeekForwardButtonTest {
         composeTestRule.setContent {
             SeekForwardButton(
                 onClick = {},
-                true,
                 seekButtonIncrement = SeekButtonIncrement.Unknown,
             )
         }

--- a/media-ui/src/androidTest/java/com/google/android/horologist/mediaui/components/controls/ShuffleButtonTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/mediaui/components/controls/ShuffleButtonTest.kt
@@ -38,7 +38,6 @@ class ShuffleButtonTest {
         composeTestRule.setContent {
             ShuffleButton(
                 onClick = {},
-                enabled = true,
                 shuffleOn = true,
             )
         }
@@ -53,7 +52,6 @@ class ShuffleButtonTest {
         composeTestRule.setContent {
             ShuffleButton(
                 onClick = {},
-                enabled = true,
                 shuffleOn = false,
             )
         }

--- a/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/MediaButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/MediaButtonPreview.kt
@@ -30,9 +30,8 @@ import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
 fun MediaButtonPreviewPlayEnabled() {
     MediaButton(
         onClick = {},
-        enabled = true,
         icon = Icons.Default.PlayArrow,
-        "Play"
+        "Play",
     )
 }
 
@@ -41,8 +40,8 @@ fun MediaButtonPreviewPlayEnabled() {
 fun MediaButtonPreviewPauseDisabled() {
     MediaButton(
         onClick = {},
-        enabled = false,
         icon = Icons.Default.Pause,
-        "Pause"
+        "Pause",
+        enabled = false,
     )
 }

--- a/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/PauseButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/PauseButtonPreview.kt
@@ -27,7 +27,6 @@ import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
 fun PauseButtonPreviewEnabled() {
     PauseButton(
         onClick = {},
-        enabled = true
     )
 }
 

--- a/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/PlayButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/PlayButtonPreview.kt
@@ -27,7 +27,6 @@ import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
 fun PlayButtonPreviewEnabled() {
     PlayButton(
         onClick = {},
-        enabled = true
     )
 }
 

--- a/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/SeekBackButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/SeekBackButtonPreview.kt
@@ -27,8 +27,7 @@ import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
 fun SeekBackButtonPreview5() {
     SeekBackButton(
         onClick = {},
-        enabled = true,
-        seekButtonIncrement = SeekButtonIncrement.Five
+        seekButtonIncrement = SeekButtonIncrement.Five,
     )
 }
 
@@ -37,8 +36,8 @@ fun SeekBackButtonPreview5() {
 fun SeekBackButtonPreview10() {
     SeekBackButton(
         onClick = {},
-        enabled = false,
-        seekButtonIncrement = SeekButtonIncrement.Ten
+        seekButtonIncrement = SeekButtonIncrement.Ten,
+        enabled = false
     )
 }
 
@@ -47,8 +46,7 @@ fun SeekBackButtonPreview10() {
 fun SeekBackButtonPreview30() {
     SeekBackButton(
         onClick = {},
-        enabled = true,
-        seekButtonIncrement = SeekButtonIncrement.Thirty
+        seekButtonIncrement = SeekButtonIncrement.Thirty,
     )
 }
 
@@ -57,8 +55,8 @@ fun SeekBackButtonPreview30() {
 fun SeekBackButtonPreviewOther() {
     SeekBackButton(
         onClick = {},
-        enabled = false,
-        seekButtonIncrement = SeekButtonIncrement.Other(15)
+        seekButtonIncrement = SeekButtonIncrement.Other(15),
+        enabled = false
     )
 }
 
@@ -67,7 +65,6 @@ fun SeekBackButtonPreviewOther() {
 fun SeekBackButtonPreviewUnknown() {
     SeekBackButton(
         onClick = {},
-        enabled = true,
-        seekButtonIncrement = SeekButtonIncrement.Unknown
+        seekButtonIncrement = SeekButtonIncrement.Unknown,
     )
 }

--- a/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/SeekForwardButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/SeekForwardButtonPreview.kt
@@ -27,8 +27,7 @@ import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
 fun SeekForwardButtonPreview5() {
     SeekForwardButton(
         onClick = {},
-        enabled = true,
-        seekButtonIncrement = SeekButtonIncrement.Five
+        seekButtonIncrement = SeekButtonIncrement.Five,
     )
 }
 
@@ -37,8 +36,8 @@ fun SeekForwardButtonPreview5() {
 fun SeekForwardButtonPreview10() {
     SeekForwardButton(
         onClick = {},
-        enabled = false,
-        seekButtonIncrement = SeekButtonIncrement.Ten
+        seekButtonIncrement = SeekButtonIncrement.Ten,
+        enabled = false
     )
 }
 
@@ -47,8 +46,7 @@ fun SeekForwardButtonPreview10() {
 fun SeekForwardButtonPreview30() {
     SeekForwardButton(
         onClick = {},
-        enabled = true,
-        seekButtonIncrement = SeekButtonIncrement.Thirty
+        seekButtonIncrement = SeekButtonIncrement.Thirty,
     )
 }
 
@@ -57,8 +55,8 @@ fun SeekForwardButtonPreview30() {
 fun SeekForwardButtonPreviewOther() {
     SeekForwardButton(
         onClick = {},
-        enabled = false,
-        seekButtonIncrement = SeekButtonIncrement.Other(15)
+        seekButtonIncrement = SeekButtonIncrement.Other(15),
+        enabled = false
     )
 }
 
@@ -67,7 +65,6 @@ fun SeekForwardButtonPreviewOther() {
 fun SeekForwardButtonPreviewUnknown() {
     SeekForwardButton(
         onClick = {},
-        enabled = true,
-        seekButtonIncrement = SeekButtonIncrement.Unknown
+        seekButtonIncrement = SeekButtonIncrement.Unknown,
     )
 }

--- a/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/SeekToNextButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/SeekToNextButtonPreview.kt
@@ -25,7 +25,7 @@ import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
 @Preview(name = "Enabled")
 @Composable
 fun SeekToNextButtonPreviewEnabled() {
-    SeekToNextButton(onClick = {}, enabled = true)
+    SeekToNextButton(onClick = {})
 }
 
 @Preview(name = "Disabled")

--- a/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/SeekToPreviousButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/SeekToPreviousButtonPreview.kt
@@ -25,7 +25,7 @@ import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
 @Preview(name = "Enabled")
 @Composable
 fun SeekToPreviousButtonPreviewEnabled() {
-    SeekToPreviousButton(onClick = {}, enabled = true)
+    SeekToPreviousButton(onClick = {})
 }
 
 @Preview(name = "Disabled")

--- a/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/ShuffleButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/controls/ShuffleButtonPreview.kt
@@ -27,8 +27,8 @@ import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
 fun ShuffleButtonPreviewDisabledOff() {
     ShuffleButton(
         onClick = {},
-        enabled = false,
-        shuffleOn = false
+        shuffleOn = false,
+        enabled = false
     )
 }
 
@@ -37,8 +37,7 @@ fun ShuffleButtonPreviewDisabledOff() {
 fun ShuffleButtonPreviewEnabledOff() {
     ShuffleButton(
         onClick = {},
-        enabled = true,
-        shuffleOn = false
+        shuffleOn = false,
     )
 }
 
@@ -47,8 +46,8 @@ fun ShuffleButtonPreviewEnabledOff() {
 fun ShuffleButtonPreviewDisabledOn() {
     ShuffleButton(
         onClick = {},
-        enabled = false,
-        shuffleOn = true
+        shuffleOn = true,
+        enabled = false
     )
 }
 
@@ -57,7 +56,6 @@ fun ShuffleButtonPreviewDisabledOn() {
 fun ShuffleButtonPreviewEnabledOn() {
     ShuffleButton(
         onClick = {},
-        enabled = true,
-        shuffleOn = true
+        shuffleOn = true,
     )
 }

--- a/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/MediaButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/MediaButton.kt
@@ -35,10 +35,10 @@ import com.google.android.horologist.mediaui.components.semantics.CustomSemantic
 @Composable
 public fun MediaButton(
     onClick: () -> Unit,
-    enabled: Boolean,
     icon: ImageVector,
     contentDescription: String,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
     colors: ButtonColors = ButtonDefaults.iconButtonColors(),
 ) {
     Button(

--- a/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/PauseButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/PauseButton.kt
@@ -30,16 +30,16 @@ import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
 @Composable
 public fun PauseButton(
     onClick: () -> Unit,
-    enabled: Boolean,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
     colors: ButtonColors = ButtonDefaults.iconButtonColors(),
 ) {
     MediaButton(
         onClick = onClick,
-        enabled = enabled,
         icon = Icons.Default.Pause,
         contentDescription = stringResource(id = R.string.pause_button_content_description),
         modifier = modifier,
+        enabled = enabled,
         colors = colors,
     )
 }

--- a/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/PlayButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/PlayButton.kt
@@ -30,16 +30,16 @@ import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
 @Composable
 public fun PlayButton(
     onClick: () -> Unit,
-    enabled: Boolean,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
     colors: ButtonColors = ButtonDefaults.iconButtonColors(),
 ) {
     MediaButton(
         onClick = onClick,
-        enabled = enabled,
         icon = Icons.Default.PlayArrow,
         contentDescription = stringResource(id = R.string.play_button_content_description),
         modifier = modifier,
+        enabled = enabled,
         colors = colors,
     )
 }

--- a/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/SeekBackButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/SeekBackButton.kt
@@ -33,9 +33,9 @@ import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
 @Composable
 public fun SeekBackButton(
     onClick: () -> Unit,
-    enabled: Boolean,
     seekButtonIncrement: SeekButtonIncrement,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
     colors: ButtonColors = ButtonDefaults.iconButtonColors(),
 ) {
     val icon = when (seekButtonIncrement) {
@@ -55,10 +55,10 @@ public fun SeekBackButton(
 
     MediaButton(
         onClick = onClick,
-        enabled = enabled,
         icon = icon,
         contentDescription = contentDescription,
         modifier = modifier,
+        enabled = enabled,
         colors = colors,
     )
 }

--- a/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/SeekForwardButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/SeekForwardButton.kt
@@ -33,9 +33,9 @@ import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
 @Composable
 public fun SeekForwardButton(
     onClick: () -> Unit,
-    enabled: Boolean,
     seekButtonIncrement: SeekButtonIncrement,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
     colors: ButtonColors = ButtonDefaults.iconButtonColors(),
 ) {
     val icon = when (seekButtonIncrement) {
@@ -56,10 +56,10 @@ public fun SeekForwardButton(
 
     MediaButton(
         onClick = onClick,
-        enabled = enabled,
         icon = icon,
         contentDescription = contentDescription,
         modifier = modifier,
+        enabled = enabled,
         colors = colors,
     )
 }

--- a/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/SeekToNextButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/SeekToNextButton.kt
@@ -30,16 +30,16 @@ import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
 @Composable
 public fun SeekToNextButton(
     onClick: () -> Unit,
-    enabled: Boolean,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
     colors: ButtonColors = ButtonDefaults.iconButtonColors(),
 ) {
     MediaButton(
         onClick = onClick,
-        enabled = enabled,
         icon = Icons.Default.SkipNext,
         contentDescription = stringResource(id = R.string.seek_to_next_button_content_description),
         modifier = modifier,
+        enabled = enabled,
         colors = colors,
     )
 }

--- a/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/SeekToPreviousButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/SeekToPreviousButton.kt
@@ -30,16 +30,16 @@ import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
 @Composable
 public fun SeekToPreviousButton(
     onClick: () -> Unit,
-    enabled: Boolean,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
     colors: ButtonColors = ButtonDefaults.iconButtonColors(),
 ) {
     MediaButton(
         onClick = onClick,
-        enabled = enabled,
         icon = Icons.Default.SkipPrevious,
         contentDescription = stringResource(id = R.string.seek_to_previous_button_content_description),
         modifier = modifier,
+        enabled = enabled,
         colors = colors,
     )
 }

--- a/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/ShuffleButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/mediaui/components/controls/ShuffleButton.kt
@@ -35,9 +35,9 @@ import com.google.android.horologist.mediaui.components.semantics.CustomSemantic
 @Composable
 public fun ShuffleButton(
     onClick: () -> Unit,
-    enabled: Boolean,
     shuffleOn: Boolean,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
     colors: ButtonColors = ButtonDefaults.iconButtonColors(),
 ) {
     Button(


### PR DESCRIPTION
#### WHAT
Add `true` as default value for `enabled` param for media ui components.

#### WHY
In order to provide convenience and to be consistent with compose libraries, as per in [Button](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:wear/compose/compose-material/src/commonMain/kotlin/androidx/wear/compose/material/Button.kt;l=82).

#### HOW
- Add `true` as default value for `enabled` param;
- Change order of `enabled` to after `modifier` in the param list as per [guidelines](https://developer.android.com/reference/kotlin/androidx/compose/ui/Modifier);
- Remove redundant values being passed to `enabled` param when matching the default value;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
