### PR TITLE
Add TextMediaDisplay

### DIFF
--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -18,6 +18,10 @@ package com.google.android.horologist.mediaui.components {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void PlayPauseProgressButton(kotlin.jvm.functions.Function0<kotlin.Unit> onPlayClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPauseClick, boolean playing, float percent, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional androidx.wear.compose.material.ButtonColors colors, optional long progressColour);
   }
 
+  public final class TextMediaDisplayKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public static void TextMediaDisplay(optional androidx.compose.ui.Modifier modifier, optional String? title, optional String? artist);
+  }
+
 }
 
 package com.google.android.horologist.mediaui.components.controls {

--- a/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/TextMediaDisplayPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/TextMediaDisplayPreview.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalMediaUiApi::class)
+
+package com.google.android.horologist.mediaui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
+
+@Preview()
+@Composable
+fun TextMediaDisplayPreview() {
+    TextMediaDisplay(
+        title = "Song title",
+        artist = "Artist name"
+    )
+}
+
+@Preview("With long text")
+@Composable
+fun TextMediaDisplayPreviewLongText() {
+    TextMediaDisplay(
+        title = "I Predict That You Look Good In A Riot",
+        artist = "Arctic Monkeys feat Kaiser Chiefs"
+    )
+}

--- a/media-ui/src/main/java/com/google/android/horologist/mediaui/components/TextMediaDisplay.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/mediaui/components/TextMediaDisplay.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediaui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
+import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
+
+/**
+ * A simple text only display showing artist and title in two separated rows.
+ */
+@ExperimentalMediaUiApi
+@Composable
+public fun TextMediaDisplay(
+    modifier: Modifier = Modifier,
+    title: String? = null,
+    artist: String? = null
+) {
+    Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = title.orEmpty(),
+            modifier = Modifier.fillMaxWidth(0.7f),
+            color = MaterialTheme.colors.onBackground,
+            textAlign = TextAlign.Center,
+            overflow = TextOverflow.Ellipsis,
+            maxLines = 1,
+            style = MaterialTheme.typography.body1,
+        )
+        Spacer(modifier = Modifier.size(2.dp))
+        Text(
+            text = artist.orEmpty(),
+            modifier = Modifier.fillMaxWidth(0.8f),
+            color = MaterialTheme.colors.primary,
+            textAlign = TextAlign.Center,
+            overflow = TextOverflow.Ellipsis,
+            maxLines = 1,
+            style = MaterialTheme.typography.body2,
+        )
+    }
+}


### PR DESCRIPTION
#### WHAT

Add `TextMediaDisplay`

![Screen Shot 2022-04-22 at 12 17 57](https://user-images.githubusercontent.com/878134/164705433-dd99999b-27ab-44ad-b8a1-8233ba1e1203.png)


#### WHY

In order to provide common media components.

#### HOW
- Add `TextMediaDisplay` implementation;
- Add preview in `debug` build source folder;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
