### PR TITLE
Fix flaky UI tests

### DIFF
--- a/media-ui/src/androidTest/java/com/google/android/horologist/mediaui/components/PlayPauseButtonTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/mediaui/components/PlayPauseButtonTest.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.performClick
 import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
-import com.google.common.truth.Truth.assertThat
 import com.google.test.toolbox.hasProgressBar
 import org.junit.Rule
 import org.junit.Test
@@ -52,7 +51,8 @@ class PlayPauseButtonTest {
             .assertIsDisplayed()
             .performClick()
 
-        assertThat(clicked).isTrue()
+        // assert that the click event was assigned to the correct button
+        composeTestRule.waitUntil(timeoutMillis = 1_000) { clicked }
 
         composeTestRule.onNode(hasAnyChild(hasContentDescription("Play")))
             .assertDoesNotExist()
@@ -79,7 +79,8 @@ class PlayPauseButtonTest {
             .assertIsDisplayed()
             .performClick()
 
-        assertThat(clicked).isTrue()
+        // assert that the click event was assigned to the correct button
+        composeTestRule.waitUntil(timeoutMillis = 1_000) { clicked }
 
         composeTestRule.onNode(hasAnyChild(hasContentDescription("Pause")))
             .assertDoesNotExist()

--- a/media-ui/src/androidTest/java/com/google/android/horologist/mediaui/components/PlayPauseProgressButtonTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/mediaui/components/PlayPauseProgressButtonTest.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.test.hasProgressBarRangeInfo
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.performClick
 import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
-import com.google.common.truth.Truth.assertThat
 import com.google.test.toolbox.hasProgressBar
 import org.junit.Rule
 import org.junit.Test
@@ -58,7 +57,8 @@ class PlayPauseProgressButtonTest {
             .assertIsDisplayed()
             .performClick()
 
-        assertThat(clicked).isTrue()
+        // assert that the click event was assigned to the correct button
+        composeTestRule.waitUntil(timeoutMillis = 1_000) { clicked }
 
         composeTestRule.onNode(hasAnyChild(hasContentDescription("Play")))
             .assertDoesNotExist()
@@ -86,7 +86,8 @@ class PlayPauseProgressButtonTest {
             .assertIsDisplayed()
             .performClick()
 
-        assertThat(clicked).isTrue()
+        // assert that the click event was assigned to the correct button
+        composeTestRule.waitUntil(timeoutMillis = 1_000) { clicked }
 
         composeTestRule.onNode(hasAnyChild(hasContentDescription("Pause")))
             .assertDoesNotExist()


### PR DESCRIPTION
#### WHAT

Fix flaky UI tests in `PlayPauseButtonTest`  and `PlayPauseProgressButtonTest` introduced in https://github.com/google/horologist/pull/87.

#### WHY

These tests are often failing in CI.

#### HOW

Use `composeTestRule.waitUntil` to wait for the `clicked` value to be changed to `true` within a one second timeout.


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
