### PR TITLE
Add PlayScreen

### DIFF
--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -88,6 +88,14 @@ package com.google.android.horologist.mediaui.components.controls {
 
 }
 
+package com.google.android.horologist.mediaui.components.screens {
+
+  public final class PlayScreenKt {
+    method @androidx.compose.runtime.Composable public static void PlayScreen(kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.ColumnScope,kotlin.Unit> mediaDisplay, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.RowScope,kotlin.Unit> controlButtons, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.RowScope,kotlin.Unit> buttons, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.BoxScope,kotlin.Unit> background);
+  }
+
+}
+
 package com.google.android.horologist.mediaui.components.semantics {
 
   @com.google.android.horologist.mediaui.ExperimentalMediaUiApi public final class CustomSemanticsProperties {

--- a/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/screens/PlayScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/mediaui/components/screens/PlayScreenPreview.kt
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalMediaUiApi::class)
+
+package com.google.android.horologist.mediaui.components.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.VolumeUp
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.Button
+import androidx.wear.compose.material.ButtonDefaults
+import androidx.wear.compose.material.CircularProgressIndicator
+import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Scaffold
+import androidx.wear.compose.material.Text
+import androidx.wear.compose.material.TimeText
+import com.google.android.horologist.mediaui.ExperimentalMediaUiApi
+import com.google.android.horologist.mediaui.components.MediaControlButtons
+import com.google.android.horologist.mediaui.components.TextMediaDisplay
+
+@Preview(
+    group = "Large Round",
+    device = Devices.WEAR_OS_LARGE_ROUND,
+    showSystemUi = true,
+    backgroundColor = BACKGROUND_COLOR,
+    showBackground = true
+)
+@Preview(
+    group = "Small Round",
+    device = Devices.WEAR_OS_SMALL_ROUND,
+    showSystemUi = true,
+    backgroundColor = BACKGROUND_COLOR,
+    showBackground = true
+)
+@Preview(
+    group = "Square",
+    device = Devices.WEAR_OS_SQUARE,
+    showSystemUi = true,
+    backgroundColor = BACKGROUND_COLOR,
+    showBackground = true
+)
+@Composable
+fun PlayScreenPreview() {
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        timeText = { TimeText() }
+    ) {
+        PlayScreen(
+            mediaDisplay = {
+                TextMediaDisplay(
+                    artist = "Journey",
+                    title = "Don't Stop Believin'"
+                )
+            },
+            controlButtons = {
+                MediaControlButtons(
+                    onPlayClick = {},
+                    onPauseClick = {},
+                    playPauseEnabled = true,
+                    playing = true,
+                    percent = 0.25F,
+                    onSeekToNextButtonClick = {},
+                    seekToNextButtonEnabled = true,
+                    onSeekToPreviousButtonClick = {},
+                    seekToPreviousButtonEnabled = true,
+                )
+            },
+            buttons = {},
+        )
+    }
+}
+
+@Preview(
+    name = "With custom media display",
+    group = "Large Round",
+    device = Devices.WEAR_OS_LARGE_ROUND,
+    showSystemUi = true,
+    backgroundColor = BACKGROUND_COLOR,
+    showBackground = true
+)
+@Preview(
+    name = "With custom media display",
+    group = "Small Round",
+    device = Devices.WEAR_OS_SMALL_ROUND,
+    showSystemUi = true,
+    backgroundColor = BACKGROUND_COLOR,
+    showBackground = true
+)
+@Preview(
+    name = "With custom media display",
+    group = "Square",
+    device = Devices.WEAR_OS_SQUARE,
+    showSystemUi = true,
+    backgroundColor = BACKGROUND_COLOR,
+    showBackground = true
+)
+@Composable
+fun PlayScreenPreviewCustomMediaDisplay() {
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        timeText = { TimeText() }
+    ) {
+        PlayScreen(
+            mediaDisplay = {
+                Text(
+                    "RTÉ Lyric FM\nRTÉ",
+                    style = MaterialTheme.typography.title2.copy(color = Color.Red),
+                    textAlign = TextAlign.Center
+                )
+            },
+            controlButtons = {
+                MediaControlButtons(
+                    onPlayClick = {},
+                    onPauseClick = {},
+                    playPauseEnabled = true,
+                    playing = true,
+                    percent = 0.75F,
+                    onSeekToNextButtonClick = {},
+                    seekToNextButtonEnabled = true,
+                    onSeekToPreviousButtonClick = {},
+                    seekToPreviousButtonEnabled = true,
+                )
+            },
+            buttons = {
+                Button(
+                    onClick = { },
+                    colors = ButtonDefaults.iconButtonColors(),
+                    modifier = Modifier.size(ButtonDefaults.SmallButtonSize),
+                ) {
+                    Icon(imageVector = Icons.Default.VolumeUp, contentDescription = "Set Volume")
+                }
+            },
+        )
+    }
+}
+
+@Preview(
+    name = "With custom background",
+    group = "Large Round",
+    device = Devices.WEAR_OS_LARGE_ROUND,
+    showSystemUi = true,
+    backgroundColor = BACKGROUND_COLOR,
+    showBackground = true
+)
+@Preview(
+    name = "With custom background",
+    group = "Small Round",
+    device = Devices.WEAR_OS_SMALL_ROUND,
+    showSystemUi = true,
+    backgroundColor = BACKGROUND_COLOR,
+    showBackground = true
+)
+@Preview(
+    name = "With custom background",
+    group = "Square",
+    device = Devices.WEAR_OS_SQUARE,
+    showSystemUi = true,
+    backgroundColor = BACKGROUND_COLOR,
+    showBackground = true
+)
+@Composable
+fun PlayScreenPreviewCustomBackground() {
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        timeText = { TimeText() }
+    ) {
+        PlayScreen(
+            mediaDisplay = {
+                TextMediaDisplay(
+                    artist = "Casaca",
+                    title = "Da Da Da"
+                )
+            },
+            controlButtons = {
+                MediaControlButtons(
+                    onPlayClick = {},
+                    onPauseClick = {},
+                    playPauseEnabled = true,
+                    playing = true,
+                    onSeekToNextButtonClick = {},
+                    seekToNextButtonEnabled = true,
+                    onSeekToPreviousButtonClick = {},
+                    seekToPreviousButtonEnabled = true,
+                )
+            },
+            buttons = {},
+            background = {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .size(124.dp),
+                        progress = 0.75f,
+                        indicatorColor = Color.Magenta,
+                    )
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .size(132.dp),
+                        progress = 0.75f,
+                        indicatorColor = Color.White,
+                    )
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .size(140.dp),
+                        progress = 0.75f,
+                        indicatorColor = Color.Blue,
+                    )
+                }
+            }
+        )
+    }
+}
+
+private const val BACKGROUND_COLOR = 0xFF313234

--- a/media-ui/src/main/java/com/google/android/horologist/mediaui/components/screens/PlayScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/mediaui/components/screens/PlayScreen.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediaui.components.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+public fun PlayScreen(
+    mediaDisplay: @Composable ColumnScope.() -> Unit,
+    controlButtons: @Composable RowScope.() -> Unit,
+    buttons: @Composable RowScope.() -> Unit,
+    modifier: Modifier = Modifier,
+    background: @Composable BoxScope.() -> Unit = {}
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        background()
+
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Spacer(modifier = Modifier.size(26.dp))
+
+                mediaDisplay()
+            }
+            Spacer(modifier = Modifier.size(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceAround
+            ) {
+                controlButtons()
+            }
+            Spacer(modifier = Modifier.size(8.dp))
+            Row(
+                modifier = Modifier.weight(1f),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.Top
+            ) {
+                buttons()
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### WHAT

Add `PlayScreen`

![Screen Shot 2022-04-26 at 09 50 12](https://user-images.githubusercontent.com/878134/165262058-d20b45d1-d2f4-4339-a7d5-667a005a2272.png)

- The layout doesn't display correctly on Small Round or Square devices at the moment, it will be iterated over in the future.
- The artist name is being displayed under the control buttons on row 1 column 3 due to this [issue](https://b.corp.google.com/issues/228463206)

#### WHY

In order to provide common media screens.

#### HOW
- Add `PlayScreen` implementation;
- Add preview in `debug` build source folder;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
