### PR TITLE
Bump version for next release

### DIFF
--- a/docs/updating.md
+++ b/docs/updating.md
@@ -17,7 +17,7 @@ gradlew clean publish --no-parallel --stacktrace
 release/signing-cleanup.sh
 ```
 
-The deployment then needs to be manually relased via the [Nexus Repository Manager](https://oss.sonatype.org/#stagingRepositories). See [Releasing Deployment from OSSRH](https://central.sonatype.org/publish/release/).
+The deployment then needs to be manually released via the [Nexus Repository Manager](https://oss.sonatype.org/#stagingRepositories). See [Releasing Deployment from OSSRH](https://central.sonatype.org/publish/release/).
 
 ## Snapshot release
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ systemProp.org.gradle.internal.http.socketTimeout=120000
 
 GROUP=com.google.android.horologist
 # !! No longer need to update this manually when using a Compose SNAPSHOT
-VERSION_NAME=0.0.16
+VERSION_NAME=0.0.17
 
 POM_DESCRIPTION=Utilities for Wear OS
 


### PR DESCRIPTION
#### WHAT

Bump version to 0.0.17

#### WHY

In order to be ready for next release.

#### HOW

Change VERSION_NAME is gradle.properties.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [N/A] Run tests
- [N/A] Update metalava's signature text files
