### PR TITLE
Add module for Media Data library

### DIFF
--- a/media-data/README.md
+++ b/media-data/README.md
@@ -1,0 +1,1 @@
+# Media Data library

--- a/media-data/api/current.api
+++ b/media-data/api/current.api
@@ -1,0 +1,8 @@
+// Signature format: 4.0
+package com.google.android.horologist.media.data {
+
+  @kotlin.RequiresOptIn(message="Horologist Media is experimental. The API may be changed in the future.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention) public @interface ExperimentalMediaDataApi {
+  }
+
+}
+

--- a/media-data/build.gradle
+++ b/media-data/build.gradle
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'org.jetbrains.dokka'
+}
+
+android {
+    compileSdkVersion 31
+
+    defaultConfig {
+        minSdk 26
+        targetSdk 30
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    buildFeatures {
+        buildConfig false
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
+    lintOptions {
+        textReport true
+        textOutput 'stdout'
+        // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
+        checkReleaseBuilds false
+    }
+
+    packagingOptions {
+        // Some of the META-INF files conflict with coroutines-test. Exclude them to enable
+        // our test APK to build (has no effect on our AARs)
+        excludes += "/META-INF/AL2.0"
+        excludes += "/META-INF/LGPL2.1"
+    }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+        animationsDisabled true
+    }
+}
+
+dependencies {
+
+    implementation libs.kotlin.stdlib
+    implementation libs.androidx.wear
+
+    testImplementation libs.junit
+}
+
+apply plugin: "com.vanniktech.maven.publish"

--- a/media-data/gradle.properties
+++ b/media-data/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=horologist-media-data
+POM_NAME=Horologist Media Data library
+POM_PACKAGING=aar

--- a/media-data/src/main/AndroidManifest.xml
+++ b/media-data/src/main/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2022 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.google.android.horologist.media.data">
+
+    <uses-feature android:name="android.hardware.type.watch" />
+</manifest>

--- a/media-data/src/main/java/com/google/android/horologist/media/data/ExperimentalMediaDataApi.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/ExperimentalMediaDataApi.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.data
+
+@RequiresOptIn(
+    message = "Horologist Media is experimental. The API may be changed in the future."
+)
+@Retention(AnnotationRetention.BINARY)
+public annotation class ExperimentalMediaDataApi

--- a/settings.gradle
+++ b/settings.gradle
@@ -32,6 +32,7 @@ include ':audio'
 include ':audio-ui'
 include ':tiles'
 include ':media-ui'
+include ':media-data'
 
 // Enable Gradle's version catalog support
 // https://docs.gradle.org/current/userguide/platforms.html


### PR DESCRIPTION
#### WHAT

Add module for Media Data library

#### WHY

In order to include data components related to media and publish them as an individual library.

#### HOW

- Add a new android ui module with same setup as other modules from the project;
- Add maven publish plugin configuration to the module;
- Add annotation `ExperimentalMediaDataApi`;
- Add metalava generated API file;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
