### PR TITLE
Add PlayerRepository

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 affectedmoduledetector = "0.1.5"
 androidx-concurrent = "1.1.0"
+androidx-media3 = "1.0.0-alpha03"
 androidx-test-ext = "1.1.3"
 androidxActivity = "1.4.0"
 androidxCore = "1.7.0"
@@ -39,6 +40,7 @@ androidx-lifecycle-service = { module = "androidx.lifecycle:lifecycle-service", 
 androidx-lifecycle-testing = { module = "androidx.lifecycle:lifecycle-runtime-testing", version.ref = "androidxLifecycle" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
 androidx-mediarouter = "androidx.mediarouter:mediarouter:1.3.0"
+androidx-media3-common = { module = "androidx.media3:media3-common", version.ref = "androidx-media3" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidxNavigation" }
 androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidxNavigation" }
 androidx-test-ext = { module = "androidx.test.ext:junit", version.ref = "androidx-test-ext" }
@@ -61,6 +63,7 @@ gradleMavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.19.0"
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutine" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutine" }
 metalavaGradle = { module = "me.tylerbwong.gradle:metalava-gradle", version.ref = "metalava" }
 robolectric = "org.robolectric:robolectric:4.7.3"

--- a/media-data/api/current.api
+++ b/media-data/api/current.api
@@ -6,3 +6,54 @@ package com.google.android.horologist.media.data {
 
 }
 
+package com.google.android.horologist.media.data.model {
+
+  public final class TrackPosition {
+    ctor public TrackPosition(long current, long duration);
+    method public long component1();
+    method public long component2();
+    method public com.google.android.horologist.media.data.model.TrackPosition copy(long current, long duration);
+    method public long getCurrent();
+    method public long getDuration();
+    method public float getPercent();
+    property public final long current;
+    property public final long duration;
+    property public final float percent;
+    field public static final com.google.android.horologist.media.data.model.TrackPosition.Companion Companion;
+  }
+
+  public static final class TrackPosition.Companion {
+    method public com.google.android.horologist.media.data.model.TrackPosition getUnknown();
+    property public final com.google.android.horologist.media.data.model.TrackPosition Unknown;
+  }
+
+}
+
+package com.google.android.horologist.media.data.repository {
+
+  @com.google.android.horologist.media.data.ExperimentalMediaDataApi public interface PlayerRepository {
+    method public kotlinx.coroutines.flow.StateFlow<androidx.media3.common.Player.Commands> getAvailableCommands();
+    method public kotlinx.coroutines.flow.StateFlow<androidx.media3.common.MediaItem> getCurrentMediaItem();
+    method public Long? getSeekBackIncrement();
+    method public Long? getSeekForwardIncrement();
+    method public kotlinx.coroutines.flow.StateFlow<java.lang.Boolean> getShuffleEnabled();
+    method public kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.media.data.model.TrackPosition> getTrackPosition();
+    method public kotlinx.coroutines.flow.StateFlow<java.lang.Boolean> isPlaying();
+    method public void pause();
+    method public void prepareAndPlay(androidx.media3.common.MediaItem mediaItem, optional boolean play);
+    method public void prepareAndPlay(optional java.util.List<androidx.media3.common.MediaItem>? mediaItems, optional int startIndex, optional boolean play);
+    method public void seekBack();
+    method public void seekForward();
+    method public void seekToNextMediaItem();
+    method public void seekToPreviousMediaItem();
+    method public void toggleShuffle();
+    method public void updatePosition();
+    property public abstract kotlinx.coroutines.flow.StateFlow<androidx.media3.common.Player.Commands> availableCommands;
+    property public abstract kotlinx.coroutines.flow.StateFlow<androidx.media3.common.MediaItem> currentMediaItem;
+    property public abstract kotlinx.coroutines.flow.StateFlow<java.lang.Boolean> isPlaying;
+    property public abstract kotlinx.coroutines.flow.StateFlow<java.lang.Boolean> shuffleEnabled;
+    property public abstract kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.media.data.model.TrackPosition> trackPosition;
+  }
+
+}
+

--- a/media-data/build.gradle
+++ b/media-data/build.gradle
@@ -68,7 +68,9 @@ android {
 dependencies {
 
     implementation libs.kotlin.stdlib
+    implementation libs.kotlinx.coroutines.core
     implementation libs.androidx.wear
+    implementation libs.androidx.media3.common
 
     testImplementation libs.junit
 }

--- a/media-data/src/main/java/com/google/android/horologist/media/data/model/TrackPosition.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/model/TrackPosition.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.data.model
+
+/**
+ * Data class for representing the current track position, track length and
+ * percent progress.  Track position and duration are measure in milliseconds.
+ */
+public data class TrackPosition(val current: Long, val duration: Long) {
+    val percent: Float
+        get() = current.toFloat() / duration.toFloat()
+
+    public companion object {
+        public val Unknown: TrackPosition = TrackPosition(0, 0)
+    }
+}

--- a/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepository.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepository.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.data.repository
+
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import com.google.android.horologist.media.data.ExperimentalMediaDataApi
+import com.google.android.horologist.media.data.model.TrackPosition
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Repository for the current [Player].
+ */
+@ExperimentalMediaDataApi
+public interface PlayerRepository {
+
+    /**
+     * The list of available commands at this moment in time. All UI
+     * controls that affect the Player should be enabled/disabled based on
+     * the available commands.
+     */
+    public val availableCommands: StateFlow<Player.Commands>
+
+    /**
+     * Is the player already playing or set to start playing as soon
+     * as the media has buffered?
+     */
+    public val isPlaying: StateFlow<Boolean>
+
+    /**
+     * The current media item playing, or that would play when user hit play.
+     */
+    public val currentMediaItem: StateFlow<MediaItem?>
+
+    /**
+     * The current track position of the player.  This is not updated automatically
+     * so [updatePosition] should be called within a ViewModel coroutineScope regularly
+     * to update the UI while the activity is in the foreground.
+     */
+    public val trackPosition: StateFlow<TrackPosition>
+
+    /**
+     * The current value for shuffling of media items mode.
+     */
+    public val shuffleEnabled: StateFlow<Boolean>
+
+    /**
+     * Plays the mediaItem after preparing (buffering).
+     */
+    public fun prepareAndPlay(
+        mediaItem: MediaItem,
+        play: Boolean = true,
+    )
+
+    /**
+     * Plays the mediaItems after preparing (buffering).
+     * If mediaItems is null, the existing mediaItems and position
+     * will be kept.
+     */
+    public fun prepareAndPlay(
+        mediaItems: List<MediaItem>? = null,
+        startIndex: Int = 0,
+        play: Boolean = true,
+    )
+
+    /**
+     * Go to the previous track, see [Player.seekToPreviousMediaItem].
+     */
+    public fun seekToPreviousMediaItem()
+
+    /**
+     * Next track, see [Player.seekToNextMediaItem]
+     */
+    public fun seekToNextMediaItem()
+
+    /**
+     * Returns the [seekBack] increment.
+     *
+     * @return The seek back increment, in milliseconds, or null if this info is not available.
+     */
+    public fun getSeekBackIncrement(): Long?
+
+    /**
+     * Seek back by the default amount, see [Player.seekForward]
+     */
+    public fun seekBack()
+
+    /**
+     * Returns the [seekForward] increment.
+     *
+     * @return The seek forward increment, in milliseconds, or null if this info is not available.
+     */
+    public fun getSeekForwardIncrement(): Long?
+
+    /**
+     * Seek forward by the default amount, see [Player.seekForward]
+     */
+    public fun seekForward()
+
+    /**
+     * Pause the player, see [Player.pause]
+     */
+    public fun pause()
+
+    /**
+     * Sets whether shuffling of media items is enabled, see [Player.setShuffleModeEnabled]
+     */
+    public fun toggleShuffle()
+
+    /**
+     * Update the position to show track progress correctly on screen.
+     * Updating roughly once a second while activity is foregrounded is appropriate.
+     */
+    public fun updatePosition()
+}


### PR DESCRIPTION
#### WHAT

Add `PlayerRepository` to `media-data` with specific implementation for `media3.Player`.

This should be temporary and in a future iteration it should be moved to a `domain` layer with its own models and be agnostic to which player would be used to implement it.

#### WHY

As per reasons detailed in the [data layer](https://developer.android.com/topic/architecture/data-layer) topic from the android guide to app architecture.

#### HOW

- Add `PlayerRepository` interface;
- Add `TrackPosition` model;
- Add dependency to `kotlinx-coroutines-core` and `androidx.media3` to `media-data` module;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
