### PR TITLE
Add PlayerUiState

### DIFF
--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -109,3 +109,77 @@ package com.google.android.horologist.media.ui.screens {
 
 }
 
+package com.google.android.horologist.media.ui.state {
+
+  public final class PlayerUiState {
+    ctor public PlayerUiState(boolean playEnabled, boolean pauseEnabled, boolean seekBackEnabled, boolean seekForwardEnabled, boolean seekToPreviousEnabled, boolean seekToNextEnabled, boolean shuffleEnabled, boolean shuffleOn, boolean playPauseEnabled, boolean playing, com.google.android.horologist.media.ui.state.model.MediaItemUiModel? mediaItem, com.google.android.horologist.media.ui.state.model.TrackPositionUiModel? trackPosition);
+    method public boolean component1();
+    method public boolean component10();
+    method public com.google.android.horologist.media.ui.state.model.MediaItemUiModel? component11();
+    method public com.google.android.horologist.media.ui.state.model.TrackPositionUiModel? component12();
+    method public boolean component2();
+    method public boolean component3();
+    method public boolean component4();
+    method public boolean component5();
+    method public boolean component6();
+    method public boolean component7();
+    method public boolean component8();
+    method public boolean component9();
+    method public com.google.android.horologist.media.ui.state.PlayerUiState copy(boolean playEnabled, boolean pauseEnabled, boolean seekBackEnabled, boolean seekForwardEnabled, boolean seekToPreviousEnabled, boolean seekToNextEnabled, boolean shuffleEnabled, boolean shuffleOn, boolean playPauseEnabled, boolean playing, com.google.android.horologist.media.ui.state.model.MediaItemUiModel? mediaItem, com.google.android.horologist.media.ui.state.model.TrackPositionUiModel? trackPosition);
+    method public com.google.android.horologist.media.ui.state.model.MediaItemUiModel? getMediaItem();
+    method public boolean getPauseEnabled();
+    method public boolean getPlayEnabled();
+    method public boolean getPlayPauseEnabled();
+    method public boolean getPlaying();
+    method public boolean getSeekBackEnabled();
+    method public boolean getSeekForwardEnabled();
+    method public boolean getSeekToNextEnabled();
+    method public boolean getSeekToPreviousEnabled();
+    method public boolean getShuffleEnabled();
+    method public boolean getShuffleOn();
+    method public com.google.android.horologist.media.ui.state.model.TrackPositionUiModel? getTrackPosition();
+    property public final com.google.android.horologist.media.ui.state.model.MediaItemUiModel? mediaItem;
+    property public final boolean pauseEnabled;
+    property public final boolean playEnabled;
+    property public final boolean playPauseEnabled;
+    property public final boolean playing;
+    property public final boolean seekBackEnabled;
+    property public final boolean seekForwardEnabled;
+    property public final boolean seekToNextEnabled;
+    property public final boolean seekToPreviousEnabled;
+    property public final boolean shuffleEnabled;
+    property public final boolean shuffleOn;
+    property public final com.google.android.horologist.media.ui.state.model.TrackPositionUiModel? trackPosition;
+  }
+
+}
+
+package com.google.android.horologist.media.ui.state.model {
+
+  public final class MediaItemUiModel {
+    ctor public MediaItemUiModel(optional String? title, optional String? artist);
+    method public String? component1();
+    method public String? component2();
+    method public com.google.android.horologist.media.ui.state.model.MediaItemUiModel copy(String? title, String? artist);
+    method public String? getArtist();
+    method public String? getTitle();
+    property public final String? artist;
+    property public final String? title;
+  }
+
+  public final class TrackPositionUiModel {
+    ctor public TrackPositionUiModel(long current, long duration, float percent);
+    method public long component1();
+    method public long component2();
+    method public float component3();
+    method public com.google.android.horologist.media.ui.state.model.TrackPositionUiModel copy(long current, long duration, float percent);
+    method public long getCurrent();
+    method public long getDuration();
+    method public float getPercent();
+    property public final long current;
+    property public final long duration;
+    property public final float percent;
+  }
+
+}
+

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/PlayerUiState.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/PlayerUiState.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.state
+
+import com.google.android.horologist.media.ui.components.PlayPauseButton
+import com.google.android.horologist.media.ui.components.controls.PauseButton
+import com.google.android.horologist.media.ui.components.controls.PlayButton
+import com.google.android.horologist.media.ui.components.controls.SeekBackButton
+import com.google.android.horologist.media.ui.components.controls.SeekForwardButton
+import com.google.android.horologist.media.ui.components.controls.SeekToNextButton
+import com.google.android.horologist.media.ui.components.controls.SeekToPreviousButton
+import com.google.android.horologist.media.ui.components.controls.ShuffleButton
+import com.google.android.horologist.media.ui.state.model.MediaItemUiModel
+import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
+
+/**
+ * Represent the state of the Media UI components.
+ *
+ * @param playEnabled whether [PlayButton] is enabled
+ * @param pauseEnabled whether [PauseButton] is enabled
+ * @param seekBackEnabled whether [SeekBackButton] button is enabled
+ * @param seekForwardEnabled whether [SeekForwardButton] button is enabled
+ * @param seekToPreviousEnabled whether [SeekToPreviousButton] is enabled
+ * @param seekToNextEnabled whether [SeekToNextButton] is enabled
+ * @param shuffleEnabled whether [ShuffleButton] is enabled
+ * @param shuffleOn whether [ShuffleButton] should display a shuffle on icon
+ * @param playPauseEnabled whether [PlayPauseButton] is enabled
+ * @param playing whether [PlayPauseButton] should display the play or pause button
+ * @param mediaItem current [MediaItemUiModel]
+ * @param trackPosition current [TrackPositionUiModel]
+ */
+public data class PlayerUiState(
+    val playEnabled: Boolean,
+    val pauseEnabled: Boolean,
+    val seekBackEnabled: Boolean,
+    val seekForwardEnabled: Boolean,
+    val seekToPreviousEnabled: Boolean,
+    val seekToNextEnabled: Boolean,
+    val shuffleEnabled: Boolean,
+    val shuffleOn: Boolean,
+    val playPauseEnabled: Boolean,
+    val playing: Boolean,
+    val mediaItem: MediaItemUiModel?,
+    val trackPosition: TrackPositionUiModel?,
+)

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/MediaItemUiModel.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/MediaItemUiModel.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.state.model
+
+public data class MediaItemUiModel(
+    val title: String? = null,
+    val artist: String? = null
+)

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.state.model
+
+public data class TrackPositionUiModel(
+    val current: Long,
+    val duration: Long,
+    val percent: Float
+)


### PR DESCRIPTION
#### WHAT

Add `PlayerUiState`.

#### WHY

In order to have a class to represent the state of the Media UI components.

#### HOW
- Add `PlayerUiState`;
- Add `MediaItemUiModel`;
- Add `TrackPositionUiModel`;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
