### PR TITLE
Add UI mappers

### DIFF
--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -154,6 +154,25 @@ package com.google.android.horologist.media.ui.state {
 
 }
 
+package com.google.android.horologist.media.ui.state.mapper {
+
+  public final class MediaItemUiModelMapper {
+    method public com.google.android.horologist.media.ui.state.model.MediaItemUiModel map(androidx.media3.common.MediaItem mediaItem);
+    field public static final com.google.android.horologist.media.ui.state.mapper.MediaItemUiModelMapper INSTANCE;
+  }
+
+  public final class PlayerUiStateMapper {
+    method public com.google.android.horologist.media.ui.state.PlayerUiState map(androidx.media3.common.Player.Commands playerCommands, boolean shuffleEnabled, boolean isPlaying, androidx.media3.common.MediaItem? mediaItem, com.google.android.horologist.media.data.model.TrackPosition? trackPosition);
+    field public static final com.google.android.horologist.media.ui.state.mapper.PlayerUiStateMapper INSTANCE;
+  }
+
+  public final class TrackPositionUiModelMapper {
+    method public com.google.android.horologist.media.ui.state.model.TrackPositionUiModel map(com.google.android.horologist.media.data.model.TrackPosition trackPosition);
+    field public static final com.google.android.horologist.media.ui.state.mapper.TrackPositionUiModelMapper INSTANCE;
+  }
+
+}
+
 package com.google.android.horologist.media.ui.state.model {
 
   public final class MediaItemUiModel {

--- a/media-ui/build.gradle
+++ b/media-ui/build.gradle
@@ -78,6 +78,7 @@ project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile.class).co
 }
 
 dependencies {
+    implementation projects.mediaData
     implementation libs.kotlin.stdlib
     implementation libs.androidx.wear
     implementation libs.wearcompose.material
@@ -85,6 +86,7 @@ dependencies {
     implementation libs.compose.ui.tooling
     implementation libs.compose.material.iconscore
     implementation libs.compose.material.iconsext
+    implementation libs.androidx.media3.common
 
     debugImplementation libs.androidx.customview
     debugImplementation libs.androidx.customview.pooling
@@ -92,6 +94,9 @@ dependencies {
     debugImplementation libs.compose.ui.toolingpreview
 
     testImplementation libs.junit
+    testImplementation libs.androidx.test.ext.ktx
+    testImplementation libs.truth
+    testImplementation libs.robolectric
 
     androidTestImplementation libs.compose.ui.test.junit4
     androidTestImplementation libs.truth

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/MediaItemUiModelMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/MediaItemUiModelMapper.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.state.mapper
+
+import androidx.media3.common.MediaItem
+import com.google.android.horologist.media.ui.state.model.MediaItemUiModel
+
+/**
+ * Map a [MediaItem] into a [MediaItemUiModel]
+ */
+public object MediaItemUiModelMapper {
+
+    public fun map(mediaItem: MediaItem): MediaItemUiModel = MediaItemUiModel(
+        title = mediaItem.mediaMetadata.displayTitle?.toString(),
+        artist = mediaItem.mediaMetadata.artist?.toString()
+    )
+}

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/PlayerUiStateMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/PlayerUiStateMapper.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.state.mapper
+
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import com.google.android.horologist.media.data.model.TrackPosition
+import com.google.android.horologist.media.ui.state.PlayerUiState
+
+/**
+ * Map [Player.Commands] plus other set of properties into a [PlayerUiState]
+ */
+public object PlayerUiStateMapper {
+
+    public fun map(
+        playerCommands: Player.Commands,
+        shuffleEnabled: Boolean,
+        isPlaying: Boolean,
+        mediaItem: MediaItem?,
+        trackPosition: TrackPosition?,
+    ): PlayerUiState {
+        val playPauseCommandAvailable = playerCommands.contains(Player.COMMAND_PLAY_PAUSE)
+
+        return PlayerUiState(
+            playEnabled = playPauseCommandAvailable,
+            pauseEnabled = playPauseCommandAvailable,
+            seekBackEnabled = playerCommands.contains(Player.COMMAND_SEEK_BACK),
+            seekForwardEnabled = playerCommands.contains(Player.COMMAND_SEEK_FORWARD),
+            seekToPreviousEnabled = playerCommands.contains(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM),
+            seekToNextEnabled = playerCommands.contains(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM),
+            shuffleEnabled = playerCommands.contains(Player.COMMAND_SET_SHUFFLE_MODE),
+            shuffleOn = shuffleEnabled,
+            playPauseEnabled = playPauseCommandAvailable,
+            playing = isPlaying,
+            mediaItem = mediaItem?.let(MediaItemUiModelMapper::map),
+            trackPosition = trackPosition?.let(TrackPositionUiModelMapper::map)
+        )
+    }
+}

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.state.mapper
+
+import com.google.android.horologist.media.data.model.TrackPosition
+import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
+
+/**
+ * Map a [TrackPosition] into a [TrackPositionUiModel]
+ */
+public object TrackPositionUiModelMapper {
+
+    public fun map(trackPosition: TrackPosition): TrackPositionUiModel = TrackPositionUiModel(
+        current = trackPosition.current,
+        duration = trackPosition.duration,
+        percent = trackPosition.percent
+    )
+}

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/MediaItemUiModelMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/MediaItemUiModelMapperTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.state.mapper
+
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class MediaItemUiModelMapperTest {
+
+    @Test
+    fun givenMediaItem_thenMapsCorrectly() {
+        // given
+        val title = "title"
+        val artist = "artist"
+        val metadataBuilder = MediaMetadata.Builder()
+            .setDisplayTitle(title)
+            .setArtist(artist)
+
+        val mediaItem = MediaItem.Builder()
+            .setMediaMetadata(metadataBuilder.build())
+            .build()
+
+        // when
+        val result = MediaItemUiModelMapper.map(mediaItem)
+
+        // then
+        assertThat(result.title).isEqualTo(title)
+        assertThat(result.artist).isEqualTo(artist)
+    }
+}

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/PlayerUiStateMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/PlayerUiStateMapperTest.kt
@@ -1,0 +1,338 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.state.mapper
+
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.Player
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.horologist.media.data.model.TrackPosition
+import com.google.android.horologist.media.ui.state.PlayerUiState
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class PlayerUiStateMapperTest {
+
+    @Test
+    fun givenNoCommandsAreAvailable_thenAllIsDisabled() {
+        // given
+        val commands = Player.Commands.EMPTY
+
+        // when
+        val result = PlayerUiStateMapper.map(
+            commands,
+            shuffleEnabled = false,
+            isPlaying = false,
+            mediaItem = null,
+            trackPosition = null
+        )
+
+        // then
+        assertThat(result).isEqualTo(
+            PlayerUiState(
+                playEnabled = false,
+                pauseEnabled = false,
+                seekBackEnabled = false,
+                seekForwardEnabled = false,
+                seekToPreviousEnabled = false,
+                seekToNextEnabled = false,
+                shuffleEnabled = false,
+                shuffleOn = false,
+                playPauseEnabled = false,
+                playing = false,
+                mediaItem = null,
+                trackPosition = null
+            )
+        )
+    }
+
+    @Test
+    fun givenPlayPauseCommandIsAvailable_thenPlayIsEnabled() {
+        // given
+        val commands = Player.Commands.Builder().add(Player.COMMAND_PLAY_PAUSE).build()
+
+        // when
+        val result = PlayerUiStateMapper.map(
+            commands,
+            shuffleEnabled = false,
+            isPlaying = false,
+            mediaItem = null,
+            trackPosition = null
+        )
+
+        // then
+        assertThat(result.playEnabled).isTrue()
+    }
+
+    @Test
+    fun givenPlayPauseCommandIsAvailable_thenPauseIsEnabled() {
+        // given
+        val commands = Player.Commands.Builder().add(Player.COMMAND_PLAY_PAUSE).build()
+
+        // when
+        val result = PlayerUiStateMapper.map(
+            commands,
+            shuffleEnabled = false,
+            isPlaying = false,
+            mediaItem = null,
+            trackPosition = null
+        )
+
+        // then
+        assertThat(result.pauseEnabled).isTrue()
+    }
+
+    @Test
+    fun givenSeekBackCommandIsAvailable_thenSeekBackIsEnabled() {
+        // given
+        val commands = Player.Commands.Builder().add(Player.COMMAND_SEEK_BACK).build()
+
+        // when
+        val result = PlayerUiStateMapper.map(
+            commands,
+            shuffleEnabled = false,
+            isPlaying = false,
+            mediaItem = null,
+            trackPosition = null
+        )
+
+        // then
+        assertThat(result.seekBackEnabled).isTrue()
+    }
+
+    @Test
+    fun givenSeekForwardCommandIsAvailable_thenSeekForwardIsEnabled() {
+        // given
+        val commands = Player.Commands.Builder().add(Player.COMMAND_SEEK_FORWARD).build()
+
+        // when
+        val result = PlayerUiStateMapper.map(
+            commands,
+            shuffleEnabled = false,
+            isPlaying = false,
+            mediaItem = null,
+            trackPosition = null
+        )
+
+        // then
+        assertThat(result.seekForwardEnabled).isTrue()
+    }
+
+    @Test
+    fun givenSeekToPreviousMediaItemCommandIsAvailable_thenSeekToPreviousIsEnabled() {
+        // given
+        val commands =
+            Player.Commands.Builder().add(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM).build()
+
+        // when
+        val result = PlayerUiStateMapper.map(
+            commands,
+            shuffleEnabled = false,
+            isPlaying = false,
+            mediaItem = null,
+            trackPosition = null
+        )
+
+        // then
+        assertThat(result.seekToPreviousEnabled).isTrue()
+    }
+
+    @Test
+    fun givenSeekToNextMediaItemCommandIsAvailable_thenSeekToNextIsEnabled() {
+        // given
+        val commands =
+            Player.Commands.Builder().add(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM).build()
+
+        // when
+        val result = PlayerUiStateMapper.map(
+            commands,
+            shuffleEnabled = false,
+            isPlaying = false,
+            mediaItem = null,
+            trackPosition = null
+        )
+
+        // then
+        assertThat(result.seekToNextEnabled).isTrue()
+    }
+
+    @Test
+    fun givenSetShuffleModeCommandIsAvailable_thenShuffleIsEnabled() {
+        // given
+        val commands =
+            Player.Commands.Builder().add(Player.COMMAND_SET_SHUFFLE_MODE).build()
+
+        // when
+        val result = PlayerUiStateMapper.map(
+            commands,
+            shuffleEnabled = false,
+            isPlaying = false,
+            mediaItem = null,
+            trackPosition = null
+        )
+
+        // then
+        assertThat(result.shuffleEnabled).isTrue()
+    }
+
+    @Test
+    fun givenShuffleDisabled_thenShuffleOnIsFalse() {
+        // given
+        val shuffleEnabled = false
+
+        // when
+        val result = PlayerUiStateMapper.map(
+            Player.Commands.EMPTY,
+            shuffleEnabled = shuffleEnabled,
+            isPlaying = false,
+            mediaItem = null,
+            trackPosition = null
+        )
+
+        // then
+        assertThat(result.shuffleOn).isEqualTo(shuffleEnabled)
+    }
+
+    @Test
+    fun givenShuffleEnabled_thenShuffleOnIsTrue() {
+        // given
+        val shuffleEnabled = true
+
+        // when
+        val result = PlayerUiStateMapper.map(
+            Player.Commands.EMPTY,
+            shuffleEnabled = shuffleEnabled,
+            isPlaying = false,
+            mediaItem = null,
+            trackPosition = null
+        )
+
+        // then
+        assertThat(result.shuffleOn).isEqualTo(shuffleEnabled)
+    }
+
+    @Test
+    fun givenPlayPauseCommandIsAvailable_thenPlayPauseIsEnabled() {
+        // given
+        val commands = Player.Commands.Builder().add(Player.COMMAND_PLAY_PAUSE).build()
+
+        // when
+        val result = PlayerUiStateMapper.map(
+            commands,
+            shuffleEnabled = false,
+            isPlaying = false,
+            mediaItem = null,
+            trackPosition = null
+        )
+
+        // then
+        assertThat(result.playPauseEnabled).isTrue()
+    }
+
+    @Test
+    fun givenIsNOTPlaying_thenPlayingIsFalse() {
+        // given
+        val isPlaying = false
+
+        // when
+        val result = PlayerUiStateMapper.map(
+            Player.Commands.EMPTY,
+            shuffleEnabled = false,
+            isPlaying = isPlaying,
+            mediaItem = null,
+            trackPosition = null
+        )
+
+        // then
+        assertThat(result.playing).isEqualTo(isPlaying)
+    }
+
+    @Test
+    fun givenIsPlaying_thenPlayingIsTrue() {
+        // given
+        val isPlaying = true
+
+        // when
+        val result = PlayerUiStateMapper.map(
+            Player.Commands.EMPTY,
+            shuffleEnabled = false,
+            isPlaying = isPlaying,
+            mediaItem = null,
+            trackPosition = null
+        )
+
+        // then
+        assertThat(result.playing).isEqualTo(isPlaying)
+    }
+
+    @Test
+    fun givenMediaItem_thenMediaItemIsMappedCorrectly() {
+        // given
+        val title = "title"
+        val artist = "artist"
+        val metadataBuilder = MediaMetadata.Builder()
+            .setDisplayTitle(title)
+            .setArtist(artist)
+
+        val mediaItem = MediaItem.Builder()
+            .setMediaMetadata(metadataBuilder.build())
+            .build()
+
+        // when
+        val result = PlayerUiStateMapper.map(
+            Player.Commands.EMPTY,
+            shuffleEnabled = false,
+            isPlaying = false,
+            mediaItem = mediaItem,
+            trackPosition = null
+        )
+
+        // then
+        Assert.assertNotNull(result.mediaItem)
+        val expectedMediaItem = result.mediaItem!!
+        assertThat(expectedMediaItem.title).isEqualTo(title)
+        assertThat(expectedMediaItem.artist).isEqualTo(artist)
+    }
+
+    @Test
+    fun givenTrackPosition_thenTrackPositionIsMappedCorrectly() {
+        // given
+        val current = 1L
+        val duration = 2L
+        val trackPosition = TrackPosition(current, duration)
+
+        // when
+        val result = PlayerUiStateMapper.map(
+            Player.Commands.EMPTY,
+            shuffleEnabled = false,
+            isPlaying = false,
+            mediaItem = null,
+            trackPosition = trackPosition
+        )
+
+        // then
+        Assert.assertNotNull(result.trackPosition)
+        val expectedTrackPosition = result.trackPosition!!
+        assertThat(expectedTrackPosition.current).isEqualTo(current)
+        assertThat(expectedTrackPosition.percent).isEqualTo(0.5f)
+    }
+}

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapperTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.state.mapper
+
+import com.google.android.horologist.media.data.model.TrackPosition
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class TrackPositionUiModelMapperTest {
+
+    @Test
+    fun givenTrackPosition_thenMapsCorrectly() {
+        // given
+        val current = 1L
+        val duration = 2L
+        val trackPosition = TrackPosition(current, duration)
+
+        // when
+        val result = TrackPositionUiModelMapper.map(trackPosition)
+
+        // then
+        assertThat(result.current).isEqualTo(current)
+        assertThat(result.duration).isEqualTo(duration)
+        assertThat(result.percent).isEqualTo(0.5f)
+    }
+}


### PR DESCRIPTION
#### WHAT

Add mappers to map models from the data layer into models from the UI layer.

#### WHY

Reduce amount of code in the view model that would have to map those models across layers.
Make it easier to unit test.

#### HOW

- Add dependency on `media-data` and `media3-common` to `media-ui`;
- Add `PlayerUiStateMapper`;
- Add `MediaItemUiModelMapper`;
- Add `TrackPositionUiModelMapper`;
- Add unit tests;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
