### PR TITLE
Add PlayerViewModel

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-kt
 androidx-lifecycle-service = { module = "androidx.lifecycle:lifecycle-service", version.ref = "androidxLifecycle" }
 androidx-lifecycle-testing = { module = "androidx.lifecycle:lifecycle-runtime-testing", version.ref = "androidxLifecycle" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
+androidx-lifecycle-viewmodelktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidxLifecycle" }
 androidx-mediarouter = "androidx.mediarouter:mediarouter:1.3.0"
 androidx-media3-common = { module = "androidx.media3:media3-common", version.ref = "androidx-media3" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidxNavigation" }

--- a/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepository.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepository.kt
@@ -47,11 +47,11 @@ public interface PlayerRepository {
     public val currentMediaItem: StateFlow<MediaItem?>
 
     /**
-     * The current track position of the player.  This is not updated automatically
+     * The current track position of the player. This is not updated automatically
      * so [updatePosition] should be called within a ViewModel coroutineScope regularly
      * to update the UI while the activity is in the foreground.
      */
-    public val trackPosition: StateFlow<TrackPosition>
+    public val trackPosition: StateFlow<TrackPosition?>
 
     /**
      * The current value for shuffling of media items mode.

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -152,6 +152,23 @@ package com.google.android.horologist.media.ui.state {
     property public final com.google.android.horologist.media.ui.state.model.TrackPositionUiModel? trackPosition;
   }
 
+  @com.google.android.horologist.media.ui.ExperimentalMediaUiApi public class PlayerViewModel extends androidx.lifecycle.ViewModel {
+    ctor public PlayerViewModel(com.google.android.horologist.media.data.repository.PlayerRepository playerRepository);
+    method public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.media.ui.state.PlayerUiState> getPlayerUiState();
+    method public final void pause();
+    method public final void prepareAndPlay();
+    method public final void seekBack();
+    method public final void seekForward();
+    method public final void seekToNextMediaItem();
+    method public final void seekToPreviousMediaItem();
+    method public final void toggleShuffle();
+    property public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.media.ui.state.PlayerUiState> playerUiState;
+    field public static final com.google.android.horologist.media.ui.state.PlayerViewModel.Companion Companion;
+  }
+
+  public static final class PlayerViewModel.Companion {
+  }
+
 }
 
 package com.google.android.horologist.media.ui.state.mapper {

--- a/media-ui/build.gradle
+++ b/media-ui/build.gradle
@@ -42,6 +42,7 @@ android {
 
     kotlinOptions {
         jvmTarget = '1.8'
+        freeCompilerArgs += "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
     }
 
     composeOptions {
@@ -81,6 +82,7 @@ dependencies {
     implementation projects.mediaData
     implementation libs.kotlin.stdlib
     implementation libs.androidx.wear
+    implementation libs.androidx.lifecycle.viewmodelktx
     implementation libs.wearcompose.material
     implementation libs.wearcompose.foundation
     implementation libs.compose.ui.tooling
@@ -95,6 +97,7 @@ dependencies {
 
     testImplementation libs.junit
     testImplementation libs.androidx.test.ext.ktx
+    testImplementation libs.kotlinx.coroutines.test
     testImplementation libs.truth
     testImplementation libs.robolectric
 

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/PlayerViewModel.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/PlayerViewModel.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.state
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.android.horologist.media.data.ExperimentalMediaDataApi
+import com.google.android.horologist.media.data.repository.PlayerRepository
+import com.google.android.horologist.media.ui.ExperimentalMediaUiApi
+import com.google.android.horologist.media.ui.state.mapper.PlayerUiStateMapper
+import com.google.android.horologist.media.ui.state.model.MediaItemUiModel
+import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+
+@OptIn(ExperimentalMediaDataApi::class)
+@ExperimentalMediaUiApi
+public open class PlayerViewModel(
+    private val playerRepository: PlayerRepository
+) : ViewModel() {
+
+    public val playerUiState: StateFlow<PlayerUiState> = combine(
+        playerRepository.availableCommands,
+        playerRepository.shuffleModeEnabled,
+        playerRepository.isPlaying,
+        playerRepository.currentMediaItem,
+        playerRepository.trackPosition,
+        PlayerUiStateMapper::map
+    ).stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
+        initialValue = INITIAL_PLAYER_UI_STATE
+    )
+
+    public fun prepareAndPlay() {
+        playerRepository.prepareAndPlay()
+    }
+
+    public fun pause() {
+        playerRepository.pause()
+    }
+
+    public fun seekToPreviousMediaItem() {
+        playerRepository.seekToPreviousMediaItem()
+    }
+
+    public fun seekToNextMediaItem() {
+        playerRepository.seekToNextMediaItem()
+    }
+
+    public fun seekBack() {
+        playerRepository.seekBack()
+    }
+
+    public fun seekForward() {
+        playerRepository.seekForward()
+    }
+
+    public fun toggleShuffle() {
+        playerRepository.toggleShuffle()
+    }
+
+    public companion object {
+        private val INITIAL_MEDIA_ITEM = MediaItemUiModel(null, null)
+
+        private val INITIAL_TRACK_POSITION = TrackPositionUiModel(0, 0, 0f)
+
+        private val INITIAL_PLAYER_UI_STATE = PlayerUiState(
+            playEnabled = false,
+            pauseEnabled = false,
+            seekBackEnabled = false,
+            seekForwardEnabled = false,
+            seekToPreviousEnabled = false,
+            seekToNextEnabled = false,
+            shuffleEnabled = false,
+            shuffleOn = false,
+            playPauseEnabled = false,
+            playing = false,
+            mediaItem = INITIAL_MEDIA_ITEM,
+            trackPosition = INITIAL_TRACK_POSITION,
+        )
+    }
+}

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/PlayerViewModelTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/PlayerViewModelTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalMediaUiApi::class)
+
+package com.google.android.horologist.media.ui.state
+
+import com.google.android.horologist.media.ui.ExperimentalMediaUiApi
+import com.google.android.horologist.media.ui.state.model.MediaItemUiModel
+import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
+import com.google.common.truth.Truth.assertThat
+import com.google.test.toolbox.testdoubles.StubPlayerRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class PlayerViewModelTest {
+
+    private lateinit var sut: PlayerViewModel
+
+    @Before
+    fun setUp() {
+        sut = PlayerViewModel(StubPlayerRepository())
+    }
+
+    @Test
+    fun givenAConnectedPlayerRepository_thenPlayerUiStateHasPlayAndPauseEnabled() = runTest {
+        // when
+        val result = sut.playerUiState.first()
+
+        // then
+        assertThat(result).isEqualTo(
+            PlayerUiState(
+                playEnabled = false,
+                pauseEnabled = false,
+                seekBackEnabled = false,
+                seekForwardEnabled = false,
+                seekToPreviousEnabled = false,
+                seekToNextEnabled = false,
+                shuffleEnabled = false,
+                shuffleOn = false,
+                playPauseEnabled = false,
+                playing = false,
+                mediaItem = MediaItemUiModel(title = null, artist = null),
+                trackPosition = TrackPositionUiModel(current = 0, duration = 0, percent = 0f),
+            )
+        )
+    }
+}

--- a/media-ui/src/test/java/com/google/test/toolbox/testdoubles/StubPlayerRepository.kt
+++ b/media-ui/src/test/java/com/google/test/toolbox/testdoubles/StubPlayerRepository.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.test.toolbox.testdoubles
+
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import com.google.android.horologist.media.data.ExperimentalMediaDataApi
+import com.google.android.horologist.media.data.model.TrackPosition
+import com.google.android.horologist.media.data.repository.PlayerRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+@OptIn(ExperimentalMediaDataApi::class)
+class StubPlayerRepository : PlayerRepository {
+
+    override val availableCommands: StateFlow<Player.Commands>
+        get() = MutableStateFlow(Player.Commands.EMPTY)
+
+    override val isPlaying: StateFlow<Boolean>
+        get() = MutableStateFlow(false)
+
+    override val currentMediaItem: StateFlow<MediaItem?>
+        get() = MutableStateFlow(null)
+
+    override val trackPosition: StateFlow<TrackPosition?>
+        get() = MutableStateFlow(null)
+
+    override val shuffleModeEnabled: StateFlow<Boolean>
+        get() = MutableStateFlow(false)
+
+    override fun prepareAndPlay(mediaItem: MediaItem, play: Boolean) {
+        // do nothing
+    }
+
+    override fun prepareAndPlay(
+        mediaItems: List<MediaItem>?,
+        startIndex: Int,
+        play: Boolean
+    ) {
+        // do nothing
+    }
+
+    override fun seekToPreviousMediaItem() {
+        // do nothing
+    }
+
+    override fun seekToNextMediaItem() {
+        // do nothing
+    }
+
+    override fun getSeekBackIncrement(): Long = SEEK_INCREMENT
+
+    override fun seekBack() {
+        // do nothing
+    }
+
+    override fun getSeekForwardIncrement(): Long = SEEK_INCREMENT
+
+    override fun seekForward() {
+        // do nothing
+    }
+
+    override fun pause() {
+        // do nothing
+    }
+
+    override fun toggleShuffle() {
+        // do nothing
+    }
+
+    override fun updatePosition() {
+        // do nothing
+    }
+
+    companion object {
+        const val SEEK_INCREMENT = 15000L
+    }
+}


### PR DESCRIPTION
#### WHAT

Add `PlayerViewModel`

#### WHY

In order to provide a [view model as source of truth](https://developer.android.com/jetpack/compose/state#viewmodels-source-of-truth) to this module's composables.

#### HOW

- Add `PlayerViewModel`;
- Add `StubPlayerRepository` test double;
- Add unit tests;
- Add dependency on `lifecycle-viewmodel-ktx` to `media-ui`;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
