### PR TITLE
Add missing ExperimentalMediaUiApi annotation

### DIFF
--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -42,7 +42,7 @@ package com.google.android.horologist.media.ui.components.controls {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalMediaUiApi public static void SeekBackButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement seekButtonIncrement, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional androidx.wear.compose.material.ButtonColors colors);
   }
 
-  public abstract sealed class SeekButtonIncrement {
+  @com.google.android.horologist.media.ui.ExperimentalMediaUiApi public abstract sealed class SeekButtonIncrement {
     method public int getSeconds();
     property public int seconds;
   }
@@ -104,14 +104,14 @@ package com.google.android.horologist.media.ui.components.semantics {
 package com.google.android.horologist.media.ui.screens {
 
   public final class PlayScreenKt {
-    method @androidx.compose.runtime.Composable public static void PlayScreen(kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.ColumnScope,kotlin.Unit> mediaDisplay, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.RowScope,kotlin.Unit> controlButtons, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.RowScope,kotlin.Unit> buttons, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.BoxScope,kotlin.Unit> background);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalMediaUiApi public static void PlayScreen(kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.ColumnScope,kotlin.Unit> mediaDisplay, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.RowScope,kotlin.Unit> controlButtons, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.RowScope,kotlin.Unit> buttons, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.BoxScope,kotlin.Unit> background);
   }
 
 }
 
 package com.google.android.horologist.media.ui.state {
 
-  public final class PlayerUiState {
+  @com.google.android.horologist.media.ui.ExperimentalMediaUiApi public final class PlayerUiState {
     ctor public PlayerUiState(boolean playEnabled, boolean pauseEnabled, boolean seekBackEnabled, boolean seekForwardEnabled, boolean seekToPreviousEnabled, boolean seekToNextEnabled, boolean shuffleEnabled, boolean shuffleOn, boolean playPauseEnabled, boolean playing, com.google.android.horologist.media.ui.state.model.MediaItemUiModel? mediaItem, com.google.android.horologist.media.ui.state.model.TrackPositionUiModel? trackPosition);
     method public boolean component1();
     method public boolean component10();
@@ -156,17 +156,17 @@ package com.google.android.horologist.media.ui.state {
 
 package com.google.android.horologist.media.ui.state.mapper {
 
-  public final class MediaItemUiModelMapper {
+  @com.google.android.horologist.media.ui.ExperimentalMediaUiApi public final class MediaItemUiModelMapper {
     method public com.google.android.horologist.media.ui.state.model.MediaItemUiModel map(androidx.media3.common.MediaItem mediaItem);
     field public static final com.google.android.horologist.media.ui.state.mapper.MediaItemUiModelMapper INSTANCE;
   }
 
-  public final class PlayerUiStateMapper {
+  @com.google.android.horologist.media.ui.ExperimentalMediaUiApi public final class PlayerUiStateMapper {
     method public com.google.android.horologist.media.ui.state.PlayerUiState map(androidx.media3.common.Player.Commands playerCommands, boolean shuffleEnabled, boolean isPlaying, androidx.media3.common.MediaItem? mediaItem, com.google.android.horologist.media.data.model.TrackPosition? trackPosition);
     field public static final com.google.android.horologist.media.ui.state.mapper.PlayerUiStateMapper INSTANCE;
   }
 
-  public final class TrackPositionUiModelMapper {
+  @com.google.android.horologist.media.ui.ExperimentalMediaUiApi public final class TrackPositionUiModelMapper {
     method public com.google.android.horologist.media.ui.state.model.TrackPositionUiModel map(com.google.android.horologist.media.data.model.TrackPosition trackPosition);
     field public static final com.google.android.horologist.media.ui.state.mapper.TrackPositionUiModelMapper INSTANCE;
   }
@@ -175,7 +175,7 @@ package com.google.android.horologist.media.ui.state.mapper {
 
 package com.google.android.horologist.media.ui.state.model {
 
-  public final class MediaItemUiModel {
+  @com.google.android.horologist.media.ui.ExperimentalMediaUiApi public final class MediaItemUiModel {
     ctor public MediaItemUiModel(optional String? title, optional String? artist);
     method public String? component1();
     method public String? component2();
@@ -186,7 +186,7 @@ package com.google.android.horologist.media.ui.state.model {
     property public final String? title;
   }
 
-  public final class TrackPositionUiModel {
+  @com.google.android.horologist.media.ui.ExperimentalMediaUiApi public final class TrackPositionUiModel {
     ctor public TrackPositionUiModel(long current, long duration, float percent);
     method public long component1();
     method public long component2();

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/SeekButtonIncrement.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/SeekButtonIncrement.kt
@@ -16,6 +16,9 @@
 
 package com.google.android.horologist.media.ui.components.controls
 
+import com.google.android.horologist.media.ui.ExperimentalMediaUiApi
+
+@ExperimentalMediaUiApi
 public sealed class SeekButtonIncrement(
     public open val seconds: Int
 ) {

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/PlayScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/PlayScreen.kt
@@ -31,7 +31,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.google.android.horologist.media.ui.ExperimentalMediaUiApi
 
+@ExperimentalMediaUiApi
 @Composable
 public fun PlayScreen(
     mediaDisplay: @Composable ColumnScope.() -> Unit,

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/PlayerUiState.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/PlayerUiState.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.horologist.media.ui.state
 
+import com.google.android.horologist.media.ui.ExperimentalMediaUiApi
 import com.google.android.horologist.media.ui.components.PlayPauseButton
 import com.google.android.horologist.media.ui.components.controls.PauseButton
 import com.google.android.horologist.media.ui.components.controls.PlayButton
@@ -43,6 +44,7 @@ import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
  * @param mediaItem current [MediaItemUiModel]
  * @param trackPosition current [TrackPositionUiModel]
  */
+@ExperimentalMediaUiApi
 public data class PlayerUiState(
     val playEnabled: Boolean,
     val pauseEnabled: Boolean,

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/MediaItemUiModelMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/MediaItemUiModelMapper.kt
@@ -17,11 +17,13 @@
 package com.google.android.horologist.media.ui.state.mapper
 
 import androidx.media3.common.MediaItem
+import com.google.android.horologist.media.ui.ExperimentalMediaUiApi
 import com.google.android.horologist.media.ui.state.model.MediaItemUiModel
 
 /**
  * Map a [MediaItem] into a [MediaItemUiModel]
  */
+@ExperimentalMediaUiApi
 public object MediaItemUiModelMapper {
 
     public fun map(mediaItem: MediaItem): MediaItemUiModel = MediaItemUiModel(

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/PlayerUiStateMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/PlayerUiStateMapper.kt
@@ -19,11 +19,13 @@ package com.google.android.horologist.media.ui.state.mapper
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import com.google.android.horologist.media.data.model.TrackPosition
+import com.google.android.horologist.media.ui.ExperimentalMediaUiApi
 import com.google.android.horologist.media.ui.state.PlayerUiState
 
 /**
  * Map [Player.Commands] plus other set of properties into a [PlayerUiState]
  */
+@ExperimentalMediaUiApi
 public object PlayerUiStateMapper {
 
     public fun map(

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
@@ -17,11 +17,13 @@
 package com.google.android.horologist.media.ui.state.mapper
 
 import com.google.android.horologist.media.data.model.TrackPosition
+import com.google.android.horologist.media.ui.ExperimentalMediaUiApi
 import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
 
 /**
  * Map a [TrackPosition] into a [TrackPositionUiModel]
  */
+@ExperimentalMediaUiApi
 public object TrackPositionUiModelMapper {
 
     public fun map(trackPosition: TrackPosition): TrackPositionUiModel = TrackPositionUiModel(

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/MediaItemUiModel.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/MediaItemUiModel.kt
@@ -16,6 +16,9 @@
 
 package com.google.android.horologist.media.ui.state.model
 
+import com.google.android.horologist.media.ui.ExperimentalMediaUiApi
+
+@ExperimentalMediaUiApi
 public data class MediaItemUiModel(
     val title: String? = null,
     val artist: String? = null

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
@@ -16,6 +16,9 @@
 
 package com.google.android.horologist.media.ui.state.model
 
+import com.google.android.horologist.media.ui.ExperimentalMediaUiApi
+
+@ExperimentalMediaUiApi
 public data class TrackPositionUiModel(
     val current: Long,
     val duration: Long,

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/MediaItemUiModelMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/MediaItemUiModelMapperTest.kt
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalMediaUiApi::class)
+
 package com.google.android.horologist.media.ui.state.mapper
 
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import com.google.android.horologist.media.ui.ExperimentalMediaUiApi
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/PlayerUiStateMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/PlayerUiStateMapperTest.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalMediaUiApi::class)
+
 package com.google.android.horologist.media.ui.state.mapper
 
 import androidx.media3.common.MediaItem
@@ -21,6 +23,7 @@ import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.android.horologist.media.data.model.TrackPosition
+import com.google.android.horologist.media.ui.ExperimentalMediaUiApi
 import com.google.android.horologist.media.ui.state.PlayerUiState
 import com.google.common.truth.Truth.assertThat
 import org.junit.Assert

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapperTest.kt
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalMediaUiApi::class)
+
 package com.google.android.horologist.media.ui.state.mapper
 
 import com.google.android.horologist.media.data.model.TrackPosition
+import com.google.android.horologist.media.ui.ExperimentalMediaUiApi
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 


### PR DESCRIPTION
#### WHAT

Add `ExperimentalMediaUiApi` annotation to classes in `media-ui`.

#### WHY

They were missing from initial implementation.

#### HOW

Add annotation to classes:
- `SeekButtonIncrement`
- `PlayScreen`
- `PlayerUiState`
- `MediaItemUiModelMapper`
- `PlayerUiStateMapper`
- `TrackPositionUiModelMapper`
- `MediaItemUiModel`
- `TrackPositionUiModel`

And opt in in their unit test classes.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
