### PR TITLE
Rename property to shuffleModeEnabled

### DIFF
--- a/media-data/api/current.api
+++ b/media-data/api/current.api
@@ -36,7 +36,7 @@ package com.google.android.horologist.media.data.repository {
     method public kotlinx.coroutines.flow.StateFlow<androidx.media3.common.MediaItem> getCurrentMediaItem();
     method public Long? getSeekBackIncrement();
     method public Long? getSeekForwardIncrement();
-    method public kotlinx.coroutines.flow.StateFlow<java.lang.Boolean> getShuffleEnabled();
+    method public kotlinx.coroutines.flow.StateFlow<java.lang.Boolean> getShuffleModeEnabled();
     method public kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.media.data.model.TrackPosition> getTrackPosition();
     method public kotlinx.coroutines.flow.StateFlow<java.lang.Boolean> isPlaying();
     method public void pause();
@@ -51,7 +51,7 @@ package com.google.android.horologist.media.data.repository {
     property public abstract kotlinx.coroutines.flow.StateFlow<androidx.media3.common.Player.Commands> availableCommands;
     property public abstract kotlinx.coroutines.flow.StateFlow<androidx.media3.common.MediaItem> currentMediaItem;
     property public abstract kotlinx.coroutines.flow.StateFlow<java.lang.Boolean> isPlaying;
-    property public abstract kotlinx.coroutines.flow.StateFlow<java.lang.Boolean> shuffleEnabled;
+    property public abstract kotlinx.coroutines.flow.StateFlow<java.lang.Boolean> shuffleModeEnabled;
     property public abstract kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.media.data.model.TrackPosition> trackPosition;
   }
 

--- a/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepository.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepository.kt
@@ -56,7 +56,7 @@ public interface PlayerRepository {
     /**
      * The current value for shuffling of media items mode.
      */
-    public val shuffleEnabled: StateFlow<Boolean>
+    public val shuffleModeEnabled: StateFlow<Boolean>
 
     /**
      * Plays the mediaItem after preparing (buffering).

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -162,7 +162,7 @@ package com.google.android.horologist.media.ui.state.mapper {
   }
 
   @com.google.android.horologist.media.ui.ExperimentalMediaUiApi public final class PlayerUiStateMapper {
-    method public com.google.android.horologist.media.ui.state.PlayerUiState map(androidx.media3.common.Player.Commands playerCommands, boolean shuffleEnabled, boolean isPlaying, androidx.media3.common.MediaItem? mediaItem, com.google.android.horologist.media.data.model.TrackPosition? trackPosition);
+    method public com.google.android.horologist.media.ui.state.PlayerUiState map(androidx.media3.common.Player.Commands playerCommands, boolean shuffleModeEnabled, boolean isPlaying, androidx.media3.common.MediaItem? mediaItem, com.google.android.horologist.media.data.model.TrackPosition? trackPosition);
     field public static final com.google.android.horologist.media.ui.state.mapper.PlayerUiStateMapper INSTANCE;
   }
 

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/PlayerUiStateMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/PlayerUiStateMapper.kt
@@ -30,7 +30,7 @@ public object PlayerUiStateMapper {
 
     public fun map(
         playerCommands: Player.Commands,
-        shuffleEnabled: Boolean,
+        shuffleModeEnabled: Boolean,
         isPlaying: Boolean,
         mediaItem: MediaItem?,
         trackPosition: TrackPosition?,
@@ -45,7 +45,7 @@ public object PlayerUiStateMapper {
             seekToPreviousEnabled = playerCommands.contains(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM),
             seekToNextEnabled = playerCommands.contains(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM),
             shuffleEnabled = playerCommands.contains(Player.COMMAND_SET_SHUFFLE_MODE),
-            shuffleOn = shuffleEnabled,
+            shuffleOn = shuffleModeEnabled,
             playPauseEnabled = playPauseCommandAvailable,
             playing = isPlaying,
             mediaItem = mediaItem?.let(MediaItemUiModelMapper::map),

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/PlayerUiStateMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/PlayerUiStateMapperTest.kt
@@ -43,7 +43,7 @@ class PlayerUiStateMapperTest {
         // when
         val result = PlayerUiStateMapper.map(
             commands,
-            shuffleEnabled = false,
+            shuffleModeEnabled = false,
             isPlaying = false,
             mediaItem = null,
             trackPosition = null
@@ -76,7 +76,7 @@ class PlayerUiStateMapperTest {
         // when
         val result = PlayerUiStateMapper.map(
             commands,
-            shuffleEnabled = false,
+            shuffleModeEnabled = false,
             isPlaying = false,
             mediaItem = null,
             trackPosition = null
@@ -94,7 +94,7 @@ class PlayerUiStateMapperTest {
         // when
         val result = PlayerUiStateMapper.map(
             commands,
-            shuffleEnabled = false,
+            shuffleModeEnabled = false,
             isPlaying = false,
             mediaItem = null,
             trackPosition = null
@@ -112,7 +112,7 @@ class PlayerUiStateMapperTest {
         // when
         val result = PlayerUiStateMapper.map(
             commands,
-            shuffleEnabled = false,
+            shuffleModeEnabled = false,
             isPlaying = false,
             mediaItem = null,
             trackPosition = null
@@ -130,7 +130,7 @@ class PlayerUiStateMapperTest {
         // when
         val result = PlayerUiStateMapper.map(
             commands,
-            shuffleEnabled = false,
+            shuffleModeEnabled = false,
             isPlaying = false,
             mediaItem = null,
             trackPosition = null
@@ -149,7 +149,7 @@ class PlayerUiStateMapperTest {
         // when
         val result = PlayerUiStateMapper.map(
             commands,
-            shuffleEnabled = false,
+            shuffleModeEnabled = false,
             isPlaying = false,
             mediaItem = null,
             trackPosition = null
@@ -168,7 +168,7 @@ class PlayerUiStateMapperTest {
         // when
         val result = PlayerUiStateMapper.map(
             commands,
-            shuffleEnabled = false,
+            shuffleModeEnabled = false,
             isPlaying = false,
             mediaItem = null,
             trackPosition = null
@@ -187,7 +187,7 @@ class PlayerUiStateMapperTest {
         // when
         val result = PlayerUiStateMapper.map(
             commands,
-            shuffleEnabled = false,
+            shuffleModeEnabled = false,
             isPlaying = false,
             mediaItem = null,
             trackPosition = null
@@ -205,7 +205,7 @@ class PlayerUiStateMapperTest {
         // when
         val result = PlayerUiStateMapper.map(
             Player.Commands.EMPTY,
-            shuffleEnabled = shuffleEnabled,
+            shuffleModeEnabled = shuffleEnabled,
             isPlaying = false,
             mediaItem = null,
             trackPosition = null
@@ -223,7 +223,7 @@ class PlayerUiStateMapperTest {
         // when
         val result = PlayerUiStateMapper.map(
             Player.Commands.EMPTY,
-            shuffleEnabled = shuffleEnabled,
+            shuffleModeEnabled = shuffleEnabled,
             isPlaying = false,
             mediaItem = null,
             trackPosition = null
@@ -241,7 +241,7 @@ class PlayerUiStateMapperTest {
         // when
         val result = PlayerUiStateMapper.map(
             commands,
-            shuffleEnabled = false,
+            shuffleModeEnabled = false,
             isPlaying = false,
             mediaItem = null,
             trackPosition = null
@@ -259,7 +259,7 @@ class PlayerUiStateMapperTest {
         // when
         val result = PlayerUiStateMapper.map(
             Player.Commands.EMPTY,
-            shuffleEnabled = false,
+            shuffleModeEnabled = false,
             isPlaying = isPlaying,
             mediaItem = null,
             trackPosition = null
@@ -277,7 +277,7 @@ class PlayerUiStateMapperTest {
         // when
         val result = PlayerUiStateMapper.map(
             Player.Commands.EMPTY,
-            shuffleEnabled = false,
+            shuffleModeEnabled = false,
             isPlaying = isPlaying,
             mediaItem = null,
             trackPosition = null
@@ -303,7 +303,7 @@ class PlayerUiStateMapperTest {
         // when
         val result = PlayerUiStateMapper.map(
             Player.Commands.EMPTY,
-            shuffleEnabled = false,
+            shuffleModeEnabled = false,
             isPlaying = false,
             mediaItem = mediaItem,
             trackPosition = null
@@ -326,7 +326,7 @@ class PlayerUiStateMapperTest {
         // when
         val result = PlayerUiStateMapper.map(
             Player.Commands.EMPTY,
-            shuffleEnabled = false,
+            shuffleModeEnabled = false,
             isPlaying = false,
             mediaItem = null,
             trackPosition = trackPosition


### PR DESCRIPTION
#### WHAT

Rename property in `PlayerRepository` from `shuffleEnabled` to `shuffleModeEnabled`.

#### WHY

In order to address https://github.com/google/horologist/pull/100#discussion_r861977254

#### HOW

- Renamed property in `PlayerRepository`
- Renamed property in `PlayerUiStateMapper`

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
