### PR TITLE
Add stateful PauseButton

### DIFF
--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -31,6 +31,7 @@ package com.google.android.horologist.media.ui.components.controls {
   }
 
   public final class PauseButtonKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalMediaUiApi public static void PauseButton(com.google.android.horologist.media.ui.state.PlayerViewModel playerViewModel, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalMediaUiApi public static void PauseButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional androidx.wear.compose.material.ButtonColors colors);
   }
 
@@ -215,6 +216,13 @@ package com.google.android.horologist.media.ui.state.model {
     property public final long current;
     property public final long duration;
     property public final float percent;
+  }
+
+}
+
+package com.google.android.horologist.media.ui.utils {
+
+  public final class StateWithLifecycleKt {
   }
 
 }

--- a/media-ui/build.gradle
+++ b/media-ui/build.gradle
@@ -82,6 +82,7 @@ dependencies {
     implementation projects.mediaData
     implementation libs.kotlin.stdlib
     implementation libs.androidx.wear
+    implementation libs.androidx.lifecycle.runtime
     implementation libs.androidx.lifecycle.viewmodelktx
     implementation libs.wearcompose.material
     implementation libs.wearcompose.foundation

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/controls/PauseButtonTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/controls/PauseButtonTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalMediaUiApi::class)
+
+package com.google.android.horologist.media.ui.components.controls
+
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.media3.common.Player.COMMAND_PLAY_PAUSE
+import com.google.android.horologist.media.ui.ExperimentalMediaUiApi
+import com.google.android.horologist.media.ui.state.PlayerViewModel
+import com.google.common.truth.Truth.assertThat
+import com.google.test.toolbox.testdoubles.FakePlayerRepository
+import org.junit.Rule
+import org.junit.Test
+
+class PauseButtonTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun whenPlayPauseCommandBecomesAvailable_thenPauseButtonGetsEnabled() {
+        // given
+        val playerRepository = FakePlayerRepository()
+
+        val playerViewModel = PlayerViewModel(playerRepository)
+
+        composeTestRule.setContent { PauseButton(playerViewModel = playerViewModel) }
+
+        val pauseButton = composeTestRule.onNodeWithContentDescription("Pause")
+
+        // then
+        pauseButton.assertIsNotEnabled()
+
+        // when
+        playerRepository.addCommand(COMMAND_PLAY_PAUSE)
+
+        // then
+        pauseButton.assertIsEnabled()
+    }
+
+    @Test
+    fun givenPlayerRepoIsPlaying_whenPauseIsClicked_thenPlayerRepoIsNOTPlaying() {
+        // given
+        val playerRepository = FakePlayerRepository()
+        playerRepository.addCommand(COMMAND_PLAY_PAUSE)
+        playerRepository.prepareAndPlay()
+        assertThat(playerRepository.isPlaying.value).isTrue()
+
+        val playerViewModel = PlayerViewModel(playerRepository)
+
+        composeTestRule.setContent { PauseButton(playerViewModel = playerViewModel) }
+
+        // when
+        composeTestRule.onNodeWithContentDescription("Pause").performClick()
+
+        // then
+        composeTestRule.waitUntil(timeoutMillis = 1_000) { !playerRepository.isPlaying.value }
+    }
+}

--- a/media-ui/src/androidTest/java/com/google/test/toolbox/testdoubles/FakePlayerRepository.kt
+++ b/media-ui/src/androidTest/java/com/google/test/toolbox/testdoubles/FakePlayerRepository.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalMediaDataApi::class)
+
+package com.google.test.toolbox.testdoubles
+
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.Player.Command
+import com.google.android.horologist.media.data.ExperimentalMediaDataApi
+import com.google.android.horologist.media.data.model.TrackPosition
+import com.google.android.horologist.media.data.repository.PlayerRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class FakePlayerRepository : PlayerRepository {
+
+    private var _availableCommandsList = MutableStateFlow(Player.Commands.EMPTY)
+    override val availableCommands: StateFlow<Player.Commands> = _availableCommandsList
+
+    private var _playing = MutableStateFlow(false)
+    override val isPlaying: StateFlow<Boolean> = _playing
+
+    private var _currentMediaItem: MutableStateFlow<MediaItem?> = MutableStateFlow(null)
+    override val currentMediaItem: StateFlow<MediaItem?> = _currentMediaItem
+
+    private var _trackPosition: MutableStateFlow<TrackPosition?> = MutableStateFlow(null)
+    override val trackPosition: StateFlow<TrackPosition?> = _trackPosition
+
+    private var _shuffleModeEnabled = MutableStateFlow(false)
+    override val shuffleModeEnabled: StateFlow<Boolean> = _shuffleModeEnabled
+
+    override fun prepareAndPlay(mediaItem: MediaItem, play: Boolean) {
+        _currentMediaItem.value = mediaItem
+        if (play) {
+            _playing.value = true
+        }
+    }
+
+    override fun prepareAndPlay(mediaItems: List<MediaItem>?, startIndex: Int, play: Boolean) {
+        mediaItems?.let { _currentMediaItem.value = it[startIndex] }
+
+        if (play) {
+            _playing.value = true
+        }
+    }
+
+    override fun seekToPreviousMediaItem() {
+        TODO("Not yet implemented")
+    }
+
+    override fun seekToNextMediaItem() {
+        TODO("Not yet implemented")
+    }
+
+    override fun getSeekBackIncrement(): Long? {
+        TODO("Not yet implemented")
+    }
+
+    override fun seekBack() {
+        TODO("Not yet implemented")
+    }
+
+    override fun getSeekForwardIncrement(): Long? {
+        TODO("Not yet implemented")
+    }
+
+    override fun seekForward() {
+        TODO("Not yet implemented")
+    }
+
+    override fun pause() {
+        _playing.value = false
+    }
+
+    override fun toggleShuffle() {
+        TODO("Not yet implemented")
+    }
+
+    override fun updatePosition() {
+        TODO("Not yet implemented")
+    }
+
+    fun addCommand(@Command command: Int) {
+        _availableCommandsList.value = Player.Commands.Builder()
+            .addAll(_availableCommandsList.value)
+            .add(command)
+            .build()
+    }
+}

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/PauseButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/PauseButton.kt
@@ -19,12 +19,32 @@ package com.google.android.horologist.media.ui.components.controls
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.wear.compose.material.ButtonColors
 import androidx.wear.compose.material.ButtonDefaults
 import com.google.android.horologist.media.ui.ExperimentalMediaUiApi
 import com.google.android.horologist.media.ui.R
+import com.google.android.horologist.media.ui.state.PlayerViewModel
+import com.google.android.horologist.media.ui.utils.rememberStateWithLifecycle
+
+@ExperimentalMediaUiApi
+@Composable
+public fun PauseButton(
+    playerViewModel: PlayerViewModel,
+    modifier: Modifier = Modifier,
+    colors: ButtonColors = ButtonDefaults.iconButtonColors(),
+) {
+    val playerUiState by rememberStateWithLifecycle(flow = playerViewModel.playerUiState)
+
+    PauseButton(
+        onClick = { playerViewModel.pause() },
+        modifier = modifier,
+        enabled = playerUiState.pauseEnabled,
+        colors = colors
+    )
+}
 
 @ExperimentalMediaUiApi
 @Composable

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/utils/StateWithLifecycle.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/utils/StateWithLifecycle.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.flowWithLifecycle
+import kotlinx.coroutines.flow.StateFlow
+
+@Composable
+internal fun <T> rememberStateWithLifecycle(
+    flow: StateFlow<T>,
+    lifecycle: Lifecycle = LocalLifecycleOwner.current.lifecycle,
+    minActiveState: Lifecycle.State = Lifecycle.State.STARTED
+): State<T> {
+    val initialValue = remember(flow) { flow.value }
+    return remember(flow, lifecycle) {
+        flow.flowWithLifecycle(
+            lifecycle = lifecycle,
+            minActiveState = minActiveState
+        )
+    }.collectAsState(initial = initialValue)
+}


### PR DESCRIPTION
#### WHAT

Add stateful `PauseButton`

#### WHY

In order to provide a version of the UI components with default behaviour, using `PlayerViewModel` and `PlayerUiState`.

#### HOW

- Add stateful implementation of `PauseButton`;
- Add tests;
- Add util function `rememberStateWithLifecycle`;
- Add test double `FakePlayerRepository` - it should be moved in another iteration to a separate test fixtures module;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
