### PR TITLE
Add stateful PlayButton

### DIFF
--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -36,6 +36,7 @@ package com.google.android.horologist.media.ui.components.controls {
   }
 
   public final class PlayButtonKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalMediaUiApi public static void PlayButton(com.google.android.horologist.media.ui.state.PlayerViewModel playerViewModel, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalMediaUiApi public static void PlayButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional androidx.wear.compose.material.ButtonColors colors);
   }
 
@@ -216,13 +217,6 @@ package com.google.android.horologist.media.ui.state.model {
     property public final long current;
     property public final long duration;
     property public final float percent;
-  }
-
-}
-
-package com.google.android.horologist.media.ui.utils {
-
-  public final class StateWithLifecycleKt {
   }
 
 }

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/controls/PlayButtonTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/controls/PlayButtonTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalMediaUiApi::class)
+
+package com.google.android.horologist.media.ui.components.controls
+
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.media3.common.Player
+import com.google.android.horologist.media.ui.ExperimentalMediaUiApi
+import com.google.android.horologist.media.ui.state.PlayerViewModel
+import com.google.common.truth.Truth.assertThat
+import com.google.test.toolbox.testdoubles.FakePlayerRepository
+import org.junit.Rule
+import org.junit.Test
+
+class PlayButtonTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun whenPlayPauseCommandBecomesAvailable_thenPlayButtonGetsEnabled() {
+        // given
+        val playerRepository = FakePlayerRepository()
+
+        val playerViewModel = PlayerViewModel(playerRepository)
+
+        composeTestRule.setContent { PlayButton(playerViewModel = playerViewModel) }
+
+        val playButton = composeTestRule.onNodeWithContentDescription("Play")
+
+        // then
+        playButton.assertIsNotEnabled()
+
+        // when
+        playerRepository.addCommand(Player.COMMAND_PLAY_PAUSE)
+
+        // then
+        playButton.assertIsEnabled()
+    }
+
+    @Test
+    fun givenPlayerRepoIsNOTPlaying_whenPlayIsClicked_thenPlayerRepoIsPlaying() {
+        // given
+        val playerRepository = FakePlayerRepository()
+        playerRepository.addCommand(Player.COMMAND_PLAY_PAUSE)
+        assertThat(playerRepository.isPlaying.value).isFalse()
+
+        val playerViewModel = PlayerViewModel(playerRepository)
+
+        composeTestRule.setContent { PlayButton(playerViewModel = playerViewModel) }
+
+        // when
+        composeTestRule.onNodeWithContentDescription("Play").performClick()
+
+        // then
+        composeTestRule.waitUntil(timeoutMillis = 1_000) { playerRepository.isPlaying.value }
+    }
+}

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/PauseButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/PauseButton.kt
@@ -27,7 +27,7 @@ import androidx.wear.compose.material.ButtonDefaults
 import com.google.android.horologist.media.ui.ExperimentalMediaUiApi
 import com.google.android.horologist.media.ui.R
 import com.google.android.horologist.media.ui.state.PlayerViewModel
-import com.google.android.horologist.media.ui.utils.rememberStateWithLifecycle
+import com.google.android.horologist.media.ui.utils.StateUtils.rememberStateWithLifecycle
 
 @ExperimentalMediaUiApi
 @Composable

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/PlayButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/PlayButton.kt
@@ -19,12 +19,32 @@ package com.google.android.horologist.media.ui.components.controls
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.wear.compose.material.ButtonColors
 import androidx.wear.compose.material.ButtonDefaults
 import com.google.android.horologist.media.ui.ExperimentalMediaUiApi
 import com.google.android.horologist.media.ui.R
+import com.google.android.horologist.media.ui.state.PlayerViewModel
+import com.google.android.horologist.media.ui.utils.StateUtils.rememberStateWithLifecycle
+
+@ExperimentalMediaUiApi
+@Composable
+public fun PlayButton(
+    playerViewModel: PlayerViewModel,
+    modifier: Modifier = Modifier,
+    colors: ButtonColors = ButtonDefaults.iconButtonColors(),
+) {
+    val playerUiState by rememberStateWithLifecycle(flow = playerViewModel.playerUiState)
+
+    PlayButton(
+        onClick = { playerViewModel.prepareAndPlay() },
+        modifier = modifier,
+        enabled = playerUiState.playEnabled,
+        colors = colors
+    )
+}
 
 @ExperimentalMediaUiApi
 @Composable

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/utils/StateUtils.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/utils/StateUtils.kt
@@ -25,17 +25,20 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import kotlinx.coroutines.flow.StateFlow
 
-@Composable
-internal fun <T> rememberStateWithLifecycle(
-    flow: StateFlow<T>,
-    lifecycle: Lifecycle = LocalLifecycleOwner.current.lifecycle,
-    minActiveState: Lifecycle.State = Lifecycle.State.STARTED
-): State<T> {
-    val initialValue = remember(flow) { flow.value }
-    return remember(flow, lifecycle) {
-        flow.flowWithLifecycle(
-            lifecycle = lifecycle,
-            minActiveState = minActiveState
-        )
-    }.collectAsState(initial = initialValue)
+internal object StateUtils {
+
+    @Composable
+    internal fun <T> rememberStateWithLifecycle(
+        flow: StateFlow<T>,
+        lifecycle: Lifecycle = LocalLifecycleOwner.current.lifecycle,
+        minActiveState: Lifecycle.State = Lifecycle.State.STARTED
+    ): State<T> {
+        val initialValue = remember(flow) { flow.value }
+        return remember(flow, lifecycle) {
+            flow.flowWithLifecycle(
+                lifecycle = lifecycle,
+                minActiveState = minActiveState
+            )
+        }.collectAsState(initial = initialValue)
+    }
 }


### PR DESCRIPTION
#### WHAT

Add stateful `PlayButton`

#### WHY

In order to provide a version of the UI components with default behaviour, using `PlayerViewModel` and `PlayerUiState`.

#### HOW

- Add stateful implementation of `PlayButton`;
- Add tests;
- Move `rememberStateWithLifecycle` function into an internal class in order to address https://github.com/google/horologist/pull/104#discussion_r863648026;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
