### PR TITLE
Add media player screen to sample app

### DIFF
--- a/media-data/src/main/java/com/google/android/horologist/media/data/model/TrackPosition.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/model/TrackPosition.kt
@@ -18,9 +18,10 @@ package com.google.android.horologist.media.data.model
 
 /**
  * Data class for representing the current track position, track length and
- * percent progress.  Track position and duration are measure in milliseconds.
+ * percent progress. Track position and duration are measure in milliseconds.
  */
 public data class TrackPosition(val current: Long, val duration: Long) {
+
     val percent: Float
         get() = current.toFloat() / duration.toFloat()
 

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/screens/PlayScreenTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/screens/PlayScreenTest.kt
@@ -33,7 +33,7 @@ import androidx.media3.common.Player
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.state.PlayerViewModel
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import com.google.test.toolbox.hasProgressBar
 import com.google.test.toolbox.testdoubles.FakePlayerRepository
 import org.junit.Rule
@@ -88,7 +88,7 @@ class PlayScreenTest {
 
         val playerViewModel = PlayerViewModel(playerRepository)
 
-        Truth.assertThat(playerRepository.isPlaying.value).isFalse()
+        assertThat(playerRepository.isPlaying.value).isFalse()
 
         composeTestRule.setContent { PlayScreen(playerViewModel = playerViewModel) }
 
@@ -109,7 +109,7 @@ class PlayScreenTest {
 
         val playerViewModel = PlayerViewModel(playerRepository)
 
-        Truth.assertThat(playerRepository.isPlaying.value).isTrue()
+        assertThat(playerRepository.isPlaying.value).isTrue()
 
         composeTestRule.setContent { PlayScreen(playerViewModel = playerViewModel) }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -65,6 +65,8 @@ android {
         freeCompilerArgs += "-opt-in=com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.audio.ExperimentalHorologistAudioApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.audioui.ExperimentalHorologistAudioUiApi"
+        freeCompilerArgs += "-opt-in=com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi"
+        freeCompilerArgs += "-opt-in=com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi"
         freeCompilerArgs += "-opt-in=androidx.compose.ui.ExperimentalComposeUiApi"
         freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
         freeCompilerArgs += "-opt-in=com.google.accompanist.pager.ExperimentalPagerApi"
@@ -82,6 +84,8 @@ dependencies {
     implementation projects.audioUi
     implementation projects.tiles
     implementation projects.composables
+    implementation projects.mediaUi
+    implementation projects.mediaData
 
     implementation libs.compose.ui.tooling
     implementation libs.compose.ui.util
@@ -101,6 +105,8 @@ dependencies {
     implementation libs.androidx.wear.tiles
 
     implementation libs.kotlin.stdlib
+
+    implementation libs.androidx.media3.common
 
     androidTestImplementation libs.compose.ui.test.junit4
     androidTestImplementation libs.espresso.core

--- a/sample/src/main/java/com/google/android/horologist/sample/MainActivity.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/MainActivity.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.navigation.SwipeDismissableNavHost
@@ -40,19 +41,29 @@ import com.google.android.horologist.audioui.VolumeScreen
 import com.google.android.horologist.composables.DatePicker
 import com.google.android.horologist.composables.TimePicker
 import com.google.android.horologist.composables.TimePickerWith12HourClock
+import com.google.android.horologist.sample.di.SampleAppDI
+import com.google.android.horologist.sample.media.MediaPlayerScreen
+import com.google.android.horologist.sample.media.MediaPlayerScreenViewModel
 
 class MainActivity : ComponentActivity() {
+
+    lateinit var mediaPlayerScreenViewModelFactory: MediaPlayerScreenViewModel.Factory
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        SampleAppDI.inject(this)
+
         setContent {
-            WearApp()
+            WearApp(mediaPlayerScreenViewModelFactory)
         }
     }
 }
 
 @Composable
-fun WearApp() {
+fun WearApp(
+    mediaPlayerScreenViewModelFactory: MediaPlayerScreenViewModel.Factory
+) {
     val navController = rememberSwipeDismissableNavController()
 
     Scaffold(
@@ -139,6 +150,9 @@ fun WearApp() {
                         navController.popBackStack()
                     }
                 )
+            }
+            composable(Screen.MediaPlayer.route) {
+                MediaPlayerScreen(mediaPlayerScreenViewModel = viewModel(factory = mediaPlayerScreenViewModelFactory))
             }
         }
     }

--- a/sample/src/main/java/com/google/android/horologist/sample/MainActivity.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/MainActivity.kt
@@ -38,6 +38,7 @@ import androidx.wear.compose.navigation.SwipeDismissableNavHost
 import androidx.wear.compose.navigation.composable
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import com.google.android.horologist.audioui.VolumeScreen
+import com.google.android.horologist.audioui.VolumeViewModel
 import com.google.android.horologist.composables.DatePicker
 import com.google.android.horologist.composables.TimePicker
 import com.google.android.horologist.composables.TimePickerWith12HourClock
@@ -152,7 +153,10 @@ fun WearApp(
                 )
             }
             composable(Screen.MediaPlayer.route) {
-                MediaPlayerScreen(mediaPlayerScreenViewModel = viewModel(factory = mediaPlayerScreenViewModelFactory))
+                MediaPlayerScreen(
+                    mediaPlayerScreenViewModel = viewModel(factory = mediaPlayerScreenViewModelFactory),
+                    volumeViewModel = viewModel(factory = VolumeViewModel.Factory)
+                )
             }
         }
     }

--- a/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
@@ -78,6 +78,9 @@ fun MenuScreen(
         item {
             TimeWithSecondsPickerChip { navigateToRoute(Screen.TimeWithSecondsPicker.route) }
         }
+        item {
+            MediaPlayerChip { navigateToRoute(Screen.MediaPlayer.route) }
+        }
     }
 
     LaunchedEffect(Unit) {

--- a/sample/src/main/java/com/google/android/horologist/sample/di/SampleAppDI.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/di/SampleAppDI.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.sample.di
+
+import com.google.android.horologist.sample.MainActivity
+import com.google.android.horologist.sample.media.MediaDataSource
+import com.google.android.horologist.sample.media.MediaPlayerScreenViewModel
+import com.google.android.horologist.sample.media.PlayerRepositoryImpl
+
+/**
+ * Simple DI implementation - to be replaced by hilt.
+ */
+object SampleAppDI {
+
+    fun inject(mainActivity: MainActivity) {
+        mainActivity.mediaPlayerScreenViewModelFactory =
+            getMediaPlayerScreenViewModelFactory(getPlayerRepositoryImpl(getMediaDataSource()))
+    }
+
+    private fun getMediaPlayerScreenViewModelFactory(playerRepositoryImpl: PlayerRepositoryImpl): MediaPlayerScreenViewModel.Factory =
+        MediaPlayerScreenViewModel.Factory(playerRepositoryImpl)
+
+    private fun getPlayerRepositoryImpl(mediaDataSource: MediaDataSource): PlayerRepositoryImpl =
+        PlayerRepositoryImpl(mediaDataSource)
+
+    private fun getMediaDataSource(): MediaDataSource = MediaDataSource()
+}

--- a/sample/src/main/java/com/google/android/horologist/sample/di/SampleAppDI.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/di/SampleAppDI.kt
@@ -28,14 +28,18 @@ object SampleAppDI {
 
     fun inject(mainActivity: MainActivity) {
         mainActivity.mediaPlayerScreenViewModelFactory =
-            getMediaPlayerScreenViewModelFactory(getPlayerRepositoryImpl(getMediaDataSource()))
+            getMediaPlayerScreenViewModelFactory(getPlayerRepositoryImplFactory(getMediaDataSource()))
     }
 
-    private fun getMediaPlayerScreenViewModelFactory(playerRepositoryImpl: PlayerRepositoryImpl): MediaPlayerScreenViewModel.Factory =
-        MediaPlayerScreenViewModel.Factory(playerRepositoryImpl)
+    private fun getMediaPlayerScreenViewModelFactory(
+        playerRepositoryImplFactory: PlayerRepositoryImpl.Factory
+    ): MediaPlayerScreenViewModel.Factory =
+        MediaPlayerScreenViewModel.Factory(playerRepositoryImplFactory)
 
-    private fun getPlayerRepositoryImpl(mediaDataSource: MediaDataSource): PlayerRepositoryImpl =
-        PlayerRepositoryImpl(mediaDataSource)
+    private fun getPlayerRepositoryImplFactory(
+        mediaDataSource: MediaDataSource
+    ): PlayerRepositoryImpl.Factory =
+        PlayerRepositoryImpl.Factory(mediaDataSource)
 
     private fun getMediaDataSource(): MediaDataSource = MediaDataSource()
 }

--- a/sample/src/main/java/com/google/android/horologist/sample/media/MediaDataSource.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/MediaDataSource.kt
@@ -20,7 +20,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 
 /**
- * Simple data source or a list of fake [MediaItem]s
+ * Simple data source for a list of fake [MediaItem]s
  */
 class MediaDataSource {
 

--- a/sample/src/main/java/com/google/android/horologist/sample/media/MediaDataSource.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/MediaDataSource.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.sample.media
+
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+
+/**
+ * Simple data source or a list of fake [MediaItem]s
+ */
+class MediaDataSource {
+
+    private val songs = listOf(
+        Pair("Highway Star", "Deep Purple"),
+        Pair("Paranoid", "Black Sabbath"),
+        Pair("Peter Gunn", "Henry Mancini"),
+        Pair("Bad to the Bone", "George Thorogood and the Destroyers"),
+        Pair("Born to Be Wild", "Steppenwolf"),
+    )
+
+    fun fetchData(): List<MediaItem> {
+        return mutableListOf<MediaItem>().also {
+            for (song in songs) {
+                it.add(
+                    MediaItem.Builder()
+                        .setMediaMetadata(
+                            MediaMetadata.Builder()
+                                .setDisplayTitle(song.first)
+                                .setArtist(song.second)
+                                .build()
+                        )
+                        .build()
+                )
+            }
+        }
+    }
+}

--- a/sample/src/main/java/com/google/android/horologist/sample/media/MediaPlayerScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/MediaPlayerScreen.kt
@@ -18,19 +18,41 @@ package com.google.android.horologist.sample.media
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
 import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.TimeText
+import com.google.android.horologist.audioui.VolumePositionIndicator
+import com.google.android.horologist.audioui.VolumeViewModel
+import com.google.android.horologist.compose.navscaffold.scrollableColumn
+import com.google.android.horologist.compose.pager.FocusOnResume
 import com.google.android.horologist.media.ui.screens.PlayScreen
+import com.google.android.horologist.utils.rememberStateWithLifecycle
 
 @Composable
 fun MediaPlayerScreen(
-    mediaPlayerScreenViewModel: MediaPlayerScreenViewModel
+    mediaPlayerScreenViewModel: MediaPlayerScreenViewModel,
+    volumeViewModel: VolumeViewModel,
 ) {
+    val playerFocusRequester = remember { FocusRequester() }
+
     Scaffold(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .scrollableColumn(
+                focusRequester = playerFocusRequester,
+                volumeViewModel.volumeScrollableState
+            ),
+        positionIndicator = {
+            val volumeState by rememberStateWithLifecycle(flow = volumeViewModel.volumeState)
+            VolumePositionIndicator(volumeState = { volumeState })
+        },
         timeText = { TimeText() }
     ) {
         PlayScreen(playerViewModel = mediaPlayerScreenViewModel)
     }
+
+    FocusOnResume(playerFocusRequester)
 }

--- a/sample/src/main/java/com/google/android/horologist/sample/media/MediaPlayerScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/MediaPlayerScreen.kt
@@ -14,19 +14,23 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.sample
+package com.google.android.horologist.sample.media
 
-sealed class Screen(
-    val route: String
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.wear.compose.material.Scaffold
+import androidx.wear.compose.material.TimeText
+import com.google.android.horologist.media.ui.screens.PlayScreen
+
+@Composable
+fun MediaPlayerScreen(
+    mediaPlayerScreenViewModel: MediaPlayerScreenViewModel
 ) {
-    object Menu : Screen("menu")
-    object FillMaxRectangle : Screen("fmr")
-    object FadeAway : Screen("fadeAway")
-    object FadeAwaySLC : Screen("fadeAwaySLC")
-    object FadeAwayColumn : Screen("fadeAwayColumn")
-    object Volume : Screen("volume")
-    object DatePicker : Screen("datePicker")
-    object TimePicker : Screen("timePicker")
-    object TimeWithSecondsPicker : Screen("timeWithSecondsPicker")
-    object MediaPlayer : Screen("mediaPlayer")
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        timeText = { TimeText() }
+    ) {
+        PlayScreen(playerViewModel = mediaPlayerScreenViewModel)
+    }
 }

--- a/sample/src/main/java/com/google/android/horologist/sample/media/MediaPlayerScreenViewModel.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/MediaPlayerScreenViewModel.kt
@@ -32,13 +32,13 @@ class MediaPlayerScreenViewModel(
     }
 
     class Factory(
-        private val playerRepository: PlayerRepositoryImpl
+        private val playerRepositoryFactory: PlayerRepositoryImpl.Factory
     ) : ViewModelProvider.Factory {
 
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
             if (modelClass.isAssignableFrom(MediaPlayerScreenViewModel::class.java)) {
-                return MediaPlayerScreenViewModel(playerRepository) as T
+                return MediaPlayerScreenViewModel(playerRepositoryFactory.create()) as T
             }
             throw IllegalArgumentException("Unknown ViewModel class")
         }

--- a/sample/src/main/java/com/google/android/horologist/sample/media/MediaPlayerScreenViewModel.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/MediaPlayerScreenViewModel.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.sample.media
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
+import com.google.android.horologist.media.ui.state.PlayerViewModel
+
+class MediaPlayerScreenViewModel(
+    playerRepository: PlayerRepositoryImpl
+) : PlayerViewModel(playerRepository) {
+
+    init {
+        playerRepository.setCoroutineScope(viewModelScope)
+        playerRepository.fetchData()
+    }
+
+    class Factory(
+        private val playerRepository: PlayerRepositoryImpl
+    ) : ViewModelProvider.Factory {
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+            if (modelClass.isAssignableFrom(MediaPlayerScreenViewModel::class.java)) {
+                return MediaPlayerScreenViewModel(playerRepository) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel class")
+        }
+    }
+}

--- a/sample/src/main/java/com/google/android/horologist/sample/media/PlayerRepositoryImpl.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/PlayerRepositoryImpl.kt
@@ -19,6 +19,7 @@ package com.google.android.horologist.sample.media
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.Player.Command
+import androidx.media3.common.util.UnstableApi
 import com.google.android.horologist.media.data.model.TrackPosition
 import com.google.android.horologist.media.data.repository.PlayerRepository
 import kotlinx.coroutines.CoroutineScope
@@ -184,6 +185,7 @@ class PlayerRepositoryImpl(
     }
 
     private fun addCommand(@Command command: Int) {
+        @androidx.annotation.OptIn(UnstableApi::class)
         _availableCommandsList.value = Player.Commands.Builder()
             .addAll(_availableCommandsList.value)
             .add(command)
@@ -191,6 +193,7 @@ class PlayerRepositoryImpl(
     }
 
     private fun removeCommand(@Command command: Int) {
+        @androidx.annotation.OptIn(UnstableApi::class)
         _availableCommandsList.value = Player.Commands.Builder()
             .addAll(_availableCommandsList.value)
             .remove(command)

--- a/sample/src/main/java/com/google/android/horologist/sample/media/PlayerRepositoryImpl.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/PlayerRepositoryImpl.kt
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.sample.media
+
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.Player.Command
+import com.google.android.horologist.media.data.model.TrackPosition
+import com.google.android.horologist.media.data.repository.PlayerRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * A fake implementation of [PlayerRepository].
+ *
+ * It does NOT output any audio, it just manipulates the state to pretend it's playing.
+ */
+class PlayerRepositoryImpl(
+    private val mediaDataSource: MediaDataSource
+) : PlayerRepository {
+
+    private var _availableCommandsList = MutableStateFlow(Player.Commands.EMPTY)
+    override val availableCommands: StateFlow<Player.Commands> = _availableCommandsList
+
+    private var _playing = MutableStateFlow(false)
+    override val isPlaying: StateFlow<Boolean> = _playing
+
+    private var _currentMediaItem: MutableStateFlow<MediaItem?> = MutableStateFlow(null)
+    override val currentMediaItem: StateFlow<MediaItem?> = _currentMediaItem
+
+    private var _trackPosition: MutableStateFlow<TrackPosition?> = MutableStateFlow(null)
+    override val trackPosition: StateFlow<TrackPosition?> = _trackPosition
+
+    private var _shuffleModeEnabled = MutableStateFlow(false)
+    override val shuffleModeEnabled: StateFlow<Boolean> = _shuffleModeEnabled
+
+    private var mediaItems: List<MediaItem>? = null
+    private var currentItemIndex = -1
+
+    private lateinit var coroutineScope: CoroutineScope
+    private var playingJob: Job? = null
+
+    fun setCoroutineScope(coroutineScope: CoroutineScope) {
+        this.coroutineScope = coroutineScope
+    }
+
+    fun fetchData() {
+        mediaDataSource.fetchData().also {
+            mediaItems = it
+            currentItemIndex++
+            _currentMediaItem.value = it[currentItemIndex]
+            updateCommands()
+        }
+    }
+
+    private fun updateCommands() {
+        mediaItems?.let {
+            addCommand(Player.COMMAND_PLAY_PAUSE)
+
+            if (currentItemIndex < it.size - 1) {
+                addCommand(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
+            } else {
+                removeCommand(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
+            }
+        } ?: run {
+            removeCommand(Player.COMMAND_PLAY_PAUSE)
+        }
+
+        if (currentItemIndex > 0) {
+            addCommand(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
+        } else {
+            removeCommand(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
+        }
+    }
+
+    override fun prepareAndPlay(mediaItem: MediaItem, play: Boolean) {
+        _currentMediaItem.value = mediaItem
+
+        if (play) {
+            pretendIsPlaying()
+        }
+    }
+
+    override fun prepareAndPlay(mediaItems: List<MediaItem>?, startIndex: Int, play: Boolean) {
+        mediaItems?.let {
+            this.mediaItems = it
+            currentItemIndex = startIndex
+            _currentMediaItem.value = it[startIndex]
+        }
+
+        if (play) {
+            pretendIsPlaying()
+        }
+    }
+
+    private fun pretendIsPlaying() {
+        _playing.value = true
+
+        playingJob = coroutineScope.launch {
+            repeat(DURATION.toInt()) {
+                updatePosition()
+                delay(1_000L)
+            }
+        }
+    }
+
+    override fun seekToPreviousMediaItem() {
+        val wasPlaying = _playing.value
+        if (wasPlaying) {
+            playingJob?.cancel()
+            _playing.value = false
+        }
+
+        currentItemIndex--
+        _currentMediaItem.value = mediaItems!![currentItemIndex]
+        _trackPosition.value = INITIAL_TRACK_POSITION
+        updateCommands()
+
+        if (wasPlaying) {
+            prepareAndPlay()
+        }
+    }
+
+    override fun seekToNextMediaItem() {
+        val wasPlaying = _playing.value
+        if (wasPlaying) {
+            playingJob?.cancel()
+            _playing.value = false
+        }
+
+        currentItemIndex++
+        _currentMediaItem.value = mediaItems!![currentItemIndex]
+        _trackPosition.value = INITIAL_TRACK_POSITION
+        updateCommands()
+
+        if (wasPlaying) {
+            prepareAndPlay()
+        }
+    }
+
+    override fun getSeekBackIncrement(): Long = 0
+
+    override fun seekBack() {
+        // do nothing
+    }
+
+    override fun getSeekForwardIncrement(): Long = 0
+
+    override fun seekForward() {
+        // do nothing
+    }
+
+    override fun pause() {
+        _playing.value = false
+        playingJob?.cancel()
+    }
+
+    override fun toggleShuffle() {
+        // do nothing
+    }
+
+    override fun updatePosition() {
+        _trackPosition.value = _trackPosition.value?.let {
+            it.copy(current = it.current + 1)
+        } ?: INITIAL_TRACK_POSITION
+    }
+
+    private fun addCommand(@Command command: Int) {
+        _availableCommandsList.value = Player.Commands.Builder()
+            .addAll(_availableCommandsList.value)
+            .add(command)
+            .build()
+    }
+
+    private fun removeCommand(@Command command: Int) {
+        _availableCommandsList.value = Player.Commands.Builder()
+            .addAll(_availableCommandsList.value)
+            .remove(command)
+            .build()
+    }
+
+    companion object {
+        private const val DURATION = 180L
+
+        private val INITIAL_TRACK_POSITION = TrackPosition(0, DURATION)
+    }
+}

--- a/sample/src/main/java/com/google/android/horologist/sample/media/PlayerRepositoryImpl.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/PlayerRepositoryImpl.kt
@@ -115,10 +115,24 @@ class PlayerRepositoryImpl(
     private fun pretendIsPlaying() {
         _playing.value = true
 
+        if (trackPosition.value?.current == DURATION) {
+            _trackPosition.value = INITIAL_TRACK_POSITION
+        }
+
         playingJob = coroutineScope.launch {
             repeat(DURATION.toInt()) {
-                updatePosition()
                 delay(1_000L)
+                updatePosition()
+            }
+            mediaItems?.let {
+                if (currentItemIndex < it.size - 1) {
+                    delay(1_000L)
+                    seekToNextMediaItem()
+                } else {
+                    pause()
+                }
+            } ?: run {
+                pause()
             }
         }
     }
@@ -181,7 +195,7 @@ class PlayerRepositoryImpl(
     override fun updatePosition() {
         _trackPosition.value = _trackPosition.value?.let {
             it.copy(current = it.current + 1)
-        } ?: INITIAL_TRACK_POSITION
+        } ?: INITIAL_TRACK_POSITION.copy(current = INITIAL_TRACK_POSITION.current + 1)
     }
 
     private fun addCommand(@Command command: Int) {

--- a/sample/src/main/java/com/google/android/horologist/sample/media/PlayerRepositoryImpl.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/PlayerRepositoryImpl.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.horologist.sample.media
 
+import androidx.annotation.OptIn
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.Player.Command
@@ -199,7 +200,7 @@ class PlayerRepositoryImpl(
     }
 
     private fun addCommand(@Command command: Int) {
-        @androidx.annotation.OptIn(UnstableApi::class)
+        @OptIn(UnstableApi::class)
         _availableCommandsList.value = Player.Commands.Builder()
             .addAll(_availableCommandsList.value)
             .add(command)
@@ -207,7 +208,7 @@ class PlayerRepositoryImpl(
     }
 
     private fun removeCommand(@Command command: Int) {
-        @androidx.annotation.OptIn(UnstableApi::class)
+        @OptIn(UnstableApi::class)
         _availableCommandsList.value = Player.Commands.Builder()
             .addAll(_availableCommandsList.value)
             .remove(command)
@@ -218,5 +219,12 @@ class PlayerRepositoryImpl(
         private const val DURATION = 180L
 
         private val INITIAL_TRACK_POSITION = TrackPosition(0, DURATION)
+    }
+
+    class Factory(
+        private val mediaDataSource: MediaDataSource
+    ) {
+
+        fun create(): PlayerRepositoryImpl = PlayerRepositoryImpl(mediaDataSource)
     }
 }

--- a/sample/src/main/java/com/google/android/horologist/sample/menuChips.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/menuChips.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -153,5 +154,13 @@ fun FadeAwayChip(
         content = {
             Text(text = "10:10 AM", fontSize = 6f.sp)
         }
+    )
+}
+
+@Composable
+fun MediaPlayerChip(navigateToRoute: () -> Unit) {
+    SampleChip(
+        onClick = { navigateToRoute() },
+        label = stringResource(id = R.string.chip_media_player_sample)
     )
 }

--- a/sample/src/main/java/com/google/android/horologist/utils/StateUtils.kt
+++ b/sample/src/main/java/com/google/android/horologist/utils/StateUtils.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.flowWithLifecycle
+import kotlinx.coroutines.flow.StateFlow
+
+@Composable
+fun <T> rememberStateWithLifecycle(
+    flow: StateFlow<T>,
+    lifecycle: Lifecycle = LocalLifecycleOwner.current.lifecycle,
+    minActiveState: Lifecycle.State = Lifecycle.State.STARTED
+): State<T> {
+    val initialValue = remember(flow) { flow.value }
+    return remember(flow, lifecycle) {
+        flow.flowWithLifecycle(
+            lifecycle = lifecycle,
+            minActiveState = minActiveState
+        )
+    }.collectAsState(initial = initialValue)
+}

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -21,4 +21,5 @@
     <string name="tile_basic_title">Basic tile</string>
     <string name="tile_description">Basic tile description</string>
     <string name="tile_text">Hello world</string>
+    <string name="chip_media_player_sample">Media Player Sample</string>
 </resources>


### PR DESCRIPTION
#### WHAT

Add media player screen to sample app.

|Menu|Screen|
|---|---|
| ![Screenshot_20220509_102605](https://user-images.githubusercontent.com/878134/167381304-ef5979d5-a9a0-4165-a49a-47d4a3270f0a.png) | ![Screenshot_20220509_112644](https://user-images.githubusercontent.com/878134/167394815-fb0fc1b6-9228-4705-b9b2-20dd1de35c37.png) |

#### WHY

In order to have an example on how to build a screen with `PlayScreen` component.

#### HOW
- Add `MediaPlayerScreen` implementation using `PlayScreen`;
- Add `MediaPlayerChip` and add as an item in `MenuScreen` to navigate to `MediaPlayerScreen`;
- Add `MediaPlayerScreenViewModel` as a ViewModel for `MediaPlayerScreen`;
- Add `PlayerRepositoryImpl` as a fake implementation of `PlayerRepository`. It pretends that a list of `MediaItem`s are fetched and it pretends that they are playing when the play command is issued;
- Add `MediaDataSource` to provide hardcoded list of `MediaItem`s;
- Add `SampleAppDI`, a simple DI implementation until hilt is introduced to the project;
- Add `rememberStateWithLifecycle` utils function to sample app;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
