### PR TITLE
Minor fix on README

### DIFF
--- a/audio-ui/README.md
+++ b/audio-ui/README.md
@@ -3,7 +3,6 @@
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.android.horologist/horologist-audio-ui)](https://search.maven.org/search?q=g:com.google.android.horologist)
 
 For more information, visit the documentation: https://google.github.io/horologist/audio-ui
-```
 
 ## Download
 

--- a/composables/README.md
+++ b/composables/README.md
@@ -3,7 +3,6 @@
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.android.horologist/horologist-composables)](https://search.maven.org/search?q=g:com.google.android.horologist)
 
 For more information, visit the documentation: https://google.github.io/horologist/composables
-```
 
 ## Download
 


### PR DESCRIPTION
#### WHAT

Fix README for `audio-ui` and `composables` module.

#### WHY

Markdown is broken, displaying "```groovy" in the preview.

#### HOW

Remove extra "```".

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [N/A] Run tests
- [N/A] Update metalava's signature text files
