### PR TITLE
Change semantics package

### DIFF
--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -88,19 +88,6 @@ package com.google.android.horologist.media.ui.components.controls {
 
 }
 
-package com.google.android.horologist.media.ui.components.semantics {
-
-  @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public final class CustomSemanticsProperties {
-    method public androidx.compose.ui.graphics.vector.ImageVector getIconImageVector(androidx.compose.ui.semantics.SemanticsPropertyReceiver);
-    method public androidx.compose.ui.semantics.SemanticsPropertyKey<androidx.compose.ui.graphics.vector.ImageVector> getIconImageVectorKey();
-    method public void setIconImageVector(androidx.compose.ui.semantics.SemanticsPropertyReceiver, androidx.compose.ui.graphics.vector.ImageVector iconImageVector);
-    property public final androidx.compose.ui.semantics.SemanticsPropertyKey<androidx.compose.ui.graphics.vector.ImageVector> IconImageVectorKey;
-    property public final androidx.compose.ui.graphics.vector.ImageVector iconImageVector;
-    field public static final com.google.android.horologist.media.ui.components.semantics.CustomSemanticsProperties INSTANCE;
-  }
-
-}
-
 package com.google.android.horologist.media.ui.screens {
 
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public interface PlayerScreenControlButtons {
@@ -122,6 +109,19 @@ package com.google.android.horologist.media.ui.screens {
 
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public interface PlayerScreenMediaDisplay {
     method @androidx.compose.runtime.Composable public void Content(androidx.compose.foundation.layout.ColumnScope, com.google.android.horologist.media.ui.state.PlayerUiState playerUiState);
+  }
+
+}
+
+package com.google.android.horologist.media.ui.semantics {
+
+  @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public final class CustomSemanticsProperties {
+    method public androidx.compose.ui.graphics.vector.ImageVector getIconImageVector(androidx.compose.ui.semantics.SemanticsPropertyReceiver);
+    method public androidx.compose.ui.semantics.SemanticsPropertyKey<androidx.compose.ui.graphics.vector.ImageVector> getIconImageVectorKey();
+    method public void setIconImageVector(androidx.compose.ui.semantics.SemanticsPropertyReceiver, androidx.compose.ui.graphics.vector.ImageVector iconImageVector);
+    property public final androidx.compose.ui.semantics.SemanticsPropertyKey<androidx.compose.ui.graphics.vector.ImageVector> IconImageVectorKey;
+    property public final androidx.compose.ui.graphics.vector.ImageVector iconImageVector;
+    field public static final com.google.android.horologist.media.ui.semantics.CustomSemanticsProperties INSTANCE;
   }
 
 }

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/PlayPauseButtonTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/PlayPauseButtonTest.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.performClick
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
-import com.google.test.toolbox.hasProgressBar
+import com.google.test.toolbox.matchers.hasProgressBar
 import org.junit.Rule
 import org.junit.Test
 

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/PlayPauseProgressButtonTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/PlayPauseProgressButtonTest.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.test.hasProgressBarRangeInfo
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.performClick
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
-import com.google.test.toolbox.hasProgressBar
+import com.google.test.toolbox.matchers.hasProgressBar
 import org.junit.Rule
 import org.junit.Test
 

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/controls/SeekBackButtonTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/controls/SeekBackButtonTest.kt
@@ -26,7 +26,7 @@ import androidx.compose.material.icons.filled.Replay5
 import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
-import com.google.test.toolbox.hasIconImageVector
+import com.google.test.toolbox.matchers.hasIconImageVector
 import org.junit.Rule
 import org.junit.Test
 

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/controls/SeekForwardButtonTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/controls/SeekForwardButtonTest.kt
@@ -26,7 +26,7 @@ import androidx.compose.material.icons.filled.Redo
 import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
-import com.google.test.toolbox.hasIconImageVector
+import com.google.test.toolbox.matchers.hasIconImageVector
 import org.junit.Rule
 import org.junit.Test
 

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/controls/ShuffleButtonTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/controls/ShuffleButtonTest.kt
@@ -23,7 +23,7 @@ import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material.icons.filled.ShuffleOn
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
-import com.google.test.toolbox.hasIconImageVector
+import com.google.test.toolbox.matchers.hasIconImageVector
 import org.junit.Rule
 import org.junit.Test
 

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/screens/PlayerScreenTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/screens/PlayerScreenTest.kt
@@ -34,7 +34,7 @@ import androidx.wear.compose.material.Text
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.state.PlayerViewModel
 import com.google.common.truth.Truth.assertThat
-import com.google.test.toolbox.hasProgressBar
+import com.google.test.toolbox.matchers.hasProgressBar
 import com.google.test.toolbox.testdoubles.FakePlayerRepository
 import org.junit.Rule
 import org.junit.Test

--- a/media-ui/src/androidTest/java/com/google/test/toolbox/matchers/SemanticsMatchers.kt
+++ b/media-ui/src/androidTest/java/com/google/test/toolbox/matchers/SemanticsMatchers.kt
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package com.google.test.toolbox
+package com.google.test.toolbox.matchers
 
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
-import com.google.android.horologist.media.ui.components.semantics.CustomSemanticsProperties.IconImageVectorKey
+import com.google.android.horologist.media.ui.semantics.CustomSemanticsProperties.IconImageVectorKey
 
 @OptIn(ExperimentalHorologistMediaUiApi::class)
 fun hasIconImageVector(imageVector: ImageVector): SemanticsMatcher =

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/MediaButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/MediaButton.kt
@@ -26,7 +26,7 @@ import androidx.wear.compose.material.ButtonColors
 import androidx.wear.compose.material.ButtonDefaults
 import androidx.wear.compose.material.Icon
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
-import com.google.android.horologist.media.ui.components.semantics.CustomSemanticsProperties.iconImageVector
+import com.google.android.horologist.media.ui.semantics.CustomSemanticsProperties.iconImageVector
 
 /**
  * A base button for media controls.

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/ShuffleButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/ShuffleButton.kt
@@ -29,7 +29,7 @@ import androidx.wear.compose.material.ButtonDefaults
 import androidx.wear.compose.material.Icon
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.R
-import com.google.android.horologist.media.ui.components.semantics.CustomSemanticsProperties.iconImageVector
+import com.google.android.horologist.media.ui.semantics.CustomSemanticsProperties.iconImageVector
 
 @ExperimentalHorologistMediaUiApi
 @Composable

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/semantics/CustomSemanticsProperties.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/semantics/CustomSemanticsProperties.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.media.ui.components.semantics
+package com.google.android.horologist.media.ui.semantics
 
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.SemanticsPropertyKey


### PR DESCRIPTION
#### WHAT

Move `semantics` package to one level up. 

#### WHY

So it can be seen as related to the `media-ui` module in general and not just specific to the `components` package.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
