### PR TITLE
Add settings buttons into the media sample

### DIFF
--- a/sample/src/main/java/com/google/android/horologist/sample/MainActivity.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/MainActivity.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.wear.compose.material.Icon
@@ -37,6 +38,7 @@ import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.navigation.SwipeDismissableNavHost
 import androidx.wear.compose.navigation.composable
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
+import com.google.android.horologist.audio.BluetoothSettings.launchBluetoothSettings
 import com.google.android.horologist.audioui.VolumeScreen
 import com.google.android.horologist.audioui.VolumeViewModel
 import com.google.android.horologist.composables.DatePicker
@@ -153,11 +155,16 @@ fun WearApp(
                 )
             }
             composable(Screen.MediaPlayer.route) {
+                val context = LocalContext.current
+
                 MediaPlayerScreen(
                     mediaPlayerScreenViewModel = viewModel(factory = mediaPlayerScreenViewModelFactory),
                     volumeViewModel = viewModel(factory = VolumeViewModel.Factory),
                     onVolumeClick = {
                         navController.navigate(Screen.Volume.route)
+                    },
+                    onOutputClick = {
+                        context.launchBluetoothSettings()
                     }
                 )
             }

--- a/sample/src/main/java/com/google/android/horologist/sample/MainActivity.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/MainActivity.kt
@@ -155,7 +155,10 @@ fun WearApp(
             composable(Screen.MediaPlayer.route) {
                 MediaPlayerScreen(
                     mediaPlayerScreenViewModel = viewModel(factory = mediaPlayerScreenViewModelFactory),
-                    volumeViewModel = viewModel(factory = VolumeViewModel.Factory)
+                    volumeViewModel = viewModel(factory = VolumeViewModel.Factory),
+                    onVolumeClick = {
+                        navController.navigate(Screen.Volume.route)
+                    }
                 )
             }
         }

--- a/sample/src/main/java/com/google/android/horologist/sample/media/AudioOutputButton.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/AudioOutputButton.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.wear.media3.ui.components.actions
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Radio
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.wear.compose.material.Button
+import androidx.wear.compose.material.ButtonDefaults
+import androidx.wear.compose.material.Icon
+
+/**
+ * A button to launch the system bluetooth settings to connect to a headset.
+ */
+@Composable
+fun AudioOutputButton(
+    modifier: Modifier = Modifier,
+    onOutputClick: () -> Unit
+) {
+    Button(
+        modifier = modifier.size(ButtonDefaults.SmallButtonSize),
+        onClick = onOutputClick,
+        colors = ButtonDefaults.iconButtonColors(),
+    ) {
+        Icon(imageVector = Icons.Default.Radio, contentDescription = "Radio")
+    }
+}

--- a/sample/src/main/java/com/google/android/horologist/sample/media/AudioOutputButton.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/AudioOutputButton.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,23 +21,28 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Radio
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.wear.compose.material.Button
 import androidx.wear.compose.material.ButtonDefaults
 import androidx.wear.compose.material.Icon
+import com.google.android.horologist.sample.R
 
 /**
  * A button to launch the system bluetooth settings to connect to a headset.
  */
 @Composable
 fun AudioOutputButton(
+    onOutputClick: () -> Unit,
     modifier: Modifier = Modifier,
-    onOutputClick: () -> Unit
 ) {
     Button(
         modifier = modifier.size(ButtonDefaults.SmallButtonSize),
         onClick = onOutputClick,
         colors = ButtonDefaults.iconButtonColors(),
     ) {
-        Icon(imageVector = Icons.Default.Radio, contentDescription = "Radio")
+        Icon(
+            imageVector = Icons.Default.Radio,
+            contentDescription = stringResource(R.string.audio_output_content_description)
+        )
     }
 }

--- a/sample/src/main/java/com/google/android/horologist/sample/media/MediaPlayerScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/MediaPlayerScreen.kt
@@ -35,6 +35,7 @@ import com.google.android.horologist.utils.rememberStateWithLifecycle
 fun MediaPlayerScreen(
     mediaPlayerScreenViewModel: MediaPlayerScreenViewModel,
     volumeViewModel: VolumeViewModel,
+    onVolumeClick: () -> Unit,
 ) {
     val playerFocusRequester = remember { FocusRequester() }
 
@@ -51,7 +52,12 @@ fun MediaPlayerScreen(
         },
         timeText = { TimeText() }
     ) {
-        PlayerScreen(playerViewModel = mediaPlayerScreenViewModel)
+        PlayerScreen(
+            playerViewModel = mediaPlayerScreenViewModel,
+            buttons = {
+                SettingsButtons(volumeViewModel = volumeViewModel, onVolumeClick = onVolumeClick)
+            }
+        )
     }
 
     FocusOnResume(playerFocusRequester)

--- a/sample/src/main/java/com/google/android/horologist/sample/media/MediaPlayerScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/MediaPlayerScreen.kt
@@ -36,11 +36,13 @@ fun MediaPlayerScreen(
     mediaPlayerScreenViewModel: MediaPlayerScreenViewModel,
     volumeViewModel: VolumeViewModel,
     onVolumeClick: () -> Unit,
+    onOutputClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val playerFocusRequester = remember { FocusRequester() }
 
     Scaffold(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .scrollableColumn(
                 focusRequester = playerFocusRequester,
@@ -55,7 +57,11 @@ fun MediaPlayerScreen(
         PlayerScreen(
             playerViewModel = mediaPlayerScreenViewModel,
             buttons = {
-                SettingsButtons(volumeViewModel = volumeViewModel, onVolumeClick = onVolumeClick)
+                SettingsButtons(
+                    volumeViewModel = volumeViewModel,
+                    onVolumeClick = onVolumeClick,
+                    onOutputClick = onOutputClick
+                )
             }
         )
     }

--- a/sample/src/main/java/com/google/android/horologist/sample/media/SetVolumeButton.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/SetVolumeButton.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.sample.media
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.VolumeDown
+import androidx.compose.material.icons.filled.VolumeMute
+import androidx.compose.material.icons.filled.VolumeUp
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.wear.compose.material.Button
+import androidx.wear.compose.material.ButtonDefaults
+import androidx.wear.compose.material.Icon
+import com.google.android.horologist.audio.VolumeState
+
+/**
+ * Button to launch a screen to control the system volume.
+ *
+ * See [VolumeState]
+ */
+@Composable
+fun SetVolumeButton(
+    modifier: Modifier = Modifier,
+    onVolumeClick: () -> Unit,
+    volumeState: VolumeState
+) {
+    Button(
+        modifier = modifier.size(ButtonDefaults.SmallButtonSize),
+        onClick = onVolumeClick,
+        colors = ButtonDefaults.iconButtonColors(),
+    ) {
+        val imageVector = when {
+            volumeState.current == 0 -> Icons.Default.VolumeMute
+            volumeState.isMax -> Icons.Default.VolumeUp
+            else -> Icons.Default.VolumeDown
+        }
+
+        Icon(imageVector = imageVector, contentDescription = "Set Volume")
+    }
+}

--- a/sample/src/main/java/com/google/android/horologist/sample/media/SetVolumeButton.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/SetVolumeButton.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,12 @@ import androidx.compose.material.icons.filled.VolumeMute
 import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.wear.compose.material.Button
 import androidx.wear.compose.material.ButtonDefaults
 import androidx.wear.compose.material.Icon
 import com.google.android.horologist.audio.VolumeState
+import com.google.android.horologist.sample.R
 
 /**
  * Button to launch a screen to control the system volume.
@@ -35,9 +37,9 @@ import com.google.android.horologist.audio.VolumeState
  */
 @Composable
 fun SetVolumeButton(
-    modifier: Modifier = Modifier,
     onVolumeClick: () -> Unit,
-    volumeState: VolumeState
+    volumeState: VolumeState,
+    modifier: Modifier = Modifier,
 ) {
     Button(
         modifier = modifier.size(ButtonDefaults.SmallButtonSize),
@@ -50,6 +52,9 @@ fun SetVolumeButton(
             else -> Icons.Default.VolumeDown
         }
 
-        Icon(imageVector = imageVector, contentDescription = "Set Volume")
+        Icon(
+            imageVector = imageVector,
+            contentDescription = stringResource(R.string.set_volume_content_description)
+        )
     }
 }

--- a/sample/src/main/java/com/google/android/horologist/sample/media/SettingsButtons.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/SettingsButtons.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.sample.media
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.google.android.horologist.audio.BluetoothSettings.launchBluetoothSettings
+import com.google.android.horologist.audioui.VolumeViewModel
+import com.google.wear.media3.ui.components.actions.AudioOutputButton
+
+/**
+ * Settings buttons for a typical media app.
+ * Set Volume and Select Audio Output.
+ */
+@Composable
+fun SettingsButtons(
+    modifier: Modifier = Modifier,
+    volumeViewModel: VolumeViewModel,
+    onVolumeClick: () -> Unit
+) {
+    val context = LocalContext.current
+    val volumeState = volumeViewModel.volumeState.collectAsState().value
+
+    Row(modifier = modifier) {
+        SetVolumeButton(
+            onVolumeClick = onVolumeClick,
+            volumeState = volumeState
+        )
+        Spacer(modifier = Modifier.size(16.dp))
+        AudioOutputButton(
+            onOutputClick = { context.launchBluetoothSettings() }
+        )
+    }
+}

--- a/sample/src/main/java/com/google/android/horologist/sample/media/SettingsButtons.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/SettingsButtons.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import com.google.android.horologist.audio.BluetoothSettings.launchBluetoothSettings
 import com.google.android.horologist.audioui.VolumeViewModel
 import com.google.wear.media3.ui.components.actions.AudioOutputButton
 
@@ -34,11 +32,11 @@ import com.google.wear.media3.ui.components.actions.AudioOutputButton
  */
 @Composable
 fun SettingsButtons(
-    modifier: Modifier = Modifier,
     volumeViewModel: VolumeViewModel,
-    onVolumeClick: () -> Unit
+    onVolumeClick: () -> Unit,
+    onOutputClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    val context = LocalContext.current
     val volumeState = volumeViewModel.volumeState.collectAsState().value
 
     Row(modifier = modifier) {
@@ -48,7 +46,7 @@ fun SettingsButtons(
         )
         Spacer(modifier = Modifier.size(16.dp))
         AudioOutputButton(
-            onOutputClick = { context.launchBluetoothSettings() }
+            onOutputClick = onOutputClick
         )
     }
 }

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -22,4 +22,6 @@
     <string name="tile_description">Basic tile description</string>
     <string name="tile_text">Hello world</string>
     <string name="chip_media_player_sample">Media Player Sample</string>
+    <string name="audio_output_content_description">Audio Output</string>
+    <string name="set_volume_content_description">Set Volume</string>
 </resources>


### PR DESCRIPTION
#### WHAT

Add settings buttons in.  Just as sample, can delete later once we have more properly supported functionality.

#### WHY

Removes the gap in the PlayerScreen sample.


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
