### PR TITLE
Remove ViewModel from SettingsButton

### DIFF
--- a/sample/src/main/java/com/google/android/horologist/sample/media/AudioOutputButton.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/AudioOutputButton.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.wear.media3.ui.components.actions
+package com.google.android.horologist.sample.media
 
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons

--- a/sample/src/main/java/com/google/android/horologist/sample/media/MediaPlayerScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/MediaPlayerScreen.kt
@@ -40,6 +40,7 @@ fun MediaPlayerScreen(
     modifier: Modifier = Modifier,
 ) {
     val playerFocusRequester = remember { FocusRequester() }
+    val volumeState by rememberStateWithLifecycle(flow = volumeViewModel.volumeState)
 
     Scaffold(
         modifier = modifier
@@ -48,17 +49,14 @@ fun MediaPlayerScreen(
                 focusRequester = playerFocusRequester,
                 volumeViewModel.volumeScrollableState
             ),
-        positionIndicator = {
-            val volumeState by rememberStateWithLifecycle(flow = volumeViewModel.volumeState)
-            VolumePositionIndicator(volumeState = { volumeState })
-        },
+        positionIndicator = { VolumePositionIndicator(volumeState = { volumeState }) },
         timeText = { TimeText() }
     ) {
         PlayerScreen(
             playerViewModel = mediaPlayerScreenViewModel,
             buttons = {
                 SettingsButtons(
-                    volumeViewModel = volumeViewModel,
+                    volumeState = volumeState,
                     onVolumeClick = onVolumeClick,
                     onOutputClick = onOutputClick
                 )

--- a/sample/src/main/java/com/google/android/horologist/sample/media/SettingsButtons.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/SettingsButtons.kt
@@ -20,11 +20,9 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.google.android.horologist.audioui.VolumeViewModel
-import com.google.wear.media3.ui.components.actions.AudioOutputButton
+import com.google.android.horologist.audio.VolumeState
 
 /**
  * Settings buttons for a typical media app.
@@ -32,13 +30,11 @@ import com.google.wear.media3.ui.components.actions.AudioOutputButton
  */
 @Composable
 fun SettingsButtons(
-    volumeViewModel: VolumeViewModel,
+    volumeState: VolumeState,
     onVolumeClick: () -> Unit,
     onOutputClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val volumeState = volumeViewModel.volumeState.collectAsState().value
-
     Row(modifier = modifier) {
         SetVolumeButton(
             onVolumeClick = onVolumeClick,


### PR DESCRIPTION
#### WHAT

Remove ViewModel from `SettingsButton`.

#### WHY

In order to align with [official guidelines](https://developer.android.com/jetpack/compose/state#viewmodels-source-of-truth) that only screen-level composables should use ViewModel for providing access to business logic and being the source of truth for their UI state.

#### HOW

- Pass `VolumeState` instead of `VolumeViewModel` to `SettingsButton`;
- Let `MediaPlayerScreen` deal with ViewModel;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
