### PR TITLE
Rename package from audioui to audio.ui

### DIFF
--- a/audio-ui/api/current.api
+++ b/audio-ui/api/current.api
@@ -1,25 +1,25 @@
 // Signature format: 4.0
-package com.google.android.horologist.audioui {
+package com.google.android.horologist.audio.ui {
 
   @kotlin.RequiresOptIn(message="Horologist Audio is experimental. The API may be changed in the future.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention) public @interface ExperimentalHorologistAudioUiApi {
   }
 
   public final class VolumePositionIndicatorKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.audioui.ExperimentalHorologistAudioUiApi public static void VolumePositionIndicator(kotlin.jvm.functions.Function0<com.google.android.horologist.audio.VolumeState> volumeState, optional androidx.compose.ui.Modifier modifier, optional boolean autoHide);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi public static void VolumePositionIndicator(kotlin.jvm.functions.Function0<com.google.android.horologist.audio.VolumeState> volumeState, optional androidx.compose.ui.Modifier modifier, optional boolean autoHide);
   }
 
   public final class VolumeScreenDefaults {
     method @androidx.compose.runtime.Composable public void DecreaseIcon();
     method @androidx.compose.runtime.Composable public void IncreaseIcon();
-    field public static final com.google.android.horologist.audioui.VolumeScreenDefaults INSTANCE;
+    field public static final com.google.android.horologist.audio.ui.VolumeScreenDefaults INSTANCE;
   }
 
   public final class VolumeScreenKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.audioui.ExperimentalHorologistAudioUiApi public static void VolumeScreen(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.audioui.VolumeViewModel volumeViewModel, optional boolean showVolumeIndicator, optional androidx.compose.ui.focus.FocusRequester focusRequester, optional kotlin.jvm.functions.Function0<kotlin.Unit> increaseIcon, optional kotlin.jvm.functions.Function0<kotlin.Unit> decreaseIcon);
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.audioui.ExperimentalHorologistAudioUiApi public static void VolumeScreen(kotlin.jvm.functions.Function0<com.google.android.horologist.audio.VolumeState> volume, com.google.android.horologist.audio.AudioOutput audioOutput, kotlin.jvm.functions.Function0<kotlin.Unit> increaseVolume, kotlin.jvm.functions.Function0<kotlin.Unit> decreaseVolume, kotlin.jvm.functions.Function0<kotlin.Unit> onAudioOutputClick, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit> increaseIcon, optional kotlin.jvm.functions.Function0<kotlin.Unit> decreaseIcon, optional boolean showVolumeIndicator, optional androidx.compose.ui.focus.FocusRequester focusRequester, optional androidx.compose.foundation.gestures.ScrollableState? scrollableState);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi public static void VolumeScreen(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.audio.ui.VolumeViewModel volumeViewModel, optional boolean showVolumeIndicator, optional androidx.compose.ui.focus.FocusRequester focusRequester, optional kotlin.jvm.functions.Function0<kotlin.Unit> increaseIcon, optional kotlin.jvm.functions.Function0<kotlin.Unit> decreaseIcon);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi public static void VolumeScreen(kotlin.jvm.functions.Function0<com.google.android.horologist.audio.VolumeState> volume, com.google.android.horologist.audio.AudioOutput audioOutput, kotlin.jvm.functions.Function0<kotlin.Unit> increaseVolume, kotlin.jvm.functions.Function0<kotlin.Unit> decreaseVolume, kotlin.jvm.functions.Function0<kotlin.Unit> onAudioOutputClick, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit> increaseIcon, optional kotlin.jvm.functions.Function0<kotlin.Unit> decreaseIcon, optional boolean showVolumeIndicator, optional androidx.compose.ui.focus.FocusRequester focusRequester, optional androidx.compose.foundation.gestures.ScrollableState? scrollableState);
   }
 
-  @com.google.android.horologist.audioui.ExperimentalHorologistAudioUiApi public final class VolumeScrollableState implements androidx.compose.foundation.gestures.ScrollableState {
+  @com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi public final class VolumeScrollableState implements androidx.compose.foundation.gestures.ScrollableState {
     ctor public VolumeScrollableState(com.google.android.horologist.audio.VolumeRepository volumeRepository, android.os.Vibrator vibrator);
     method public float dispatchRawDelta(float delta);
     method public boolean isScrollInProgress();
@@ -27,21 +27,21 @@ package com.google.android.horologist.audioui {
     property public boolean isScrollInProgress;
   }
 
-  @com.google.android.horologist.audioui.ExperimentalHorologistAudioUiApi public class VolumeViewModel extends androidx.lifecycle.ViewModel {
+  @com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi public class VolumeViewModel extends androidx.lifecycle.ViewModel {
     ctor public VolumeViewModel(com.google.android.horologist.audio.VolumeRepository volumeRepository, com.google.android.horologist.audio.AudioOutputRepository audioOutputRepository, optional kotlin.jvm.functions.Function0<kotlin.Unit> onCleared, android.os.Vibrator vibrator);
     method public final void decreaseVolume();
     method public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.AudioOutput> getAudioOutput();
-    method public final com.google.android.horologist.audioui.VolumeScrollableState getVolumeScrollableState();
+    method public final com.google.android.horologist.audio.ui.VolumeScrollableState getVolumeScrollableState();
     method public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.VolumeState> getVolumeState();
     method public final void increaseVolume();
     method public final void launchOutputSelection();
     property public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.AudioOutput> audioOutput;
-    property public final com.google.android.horologist.audioui.VolumeScrollableState volumeScrollableState;
+    property public final com.google.android.horologist.audio.ui.VolumeScrollableState volumeScrollableState;
     property public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.VolumeState> volumeState;
   }
 
-  @com.google.android.horologist.audioui.ExperimentalHorologistAudioUiApi public static final class VolumeViewModel.Factory implements androidx.lifecycle.ViewModelProvider.Factory {
-    field public static final com.google.android.horologist.audioui.VolumeViewModel.Factory INSTANCE;
+  @com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi public static final class VolumeViewModel.Factory implements androidx.lifecycle.ViewModelProvider.Factory {
+    field public static final com.google.android.horologist.audio.ui.VolumeViewModel.Factory INSTANCE;
   }
 
 }

--- a/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/FakeAudioRepository.kt
+++ b/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/FakeAudioRepository.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.audioui
+package com.google.android.horologist.audio.ui
 
 import com.google.android.horologist.audio.AudioOutput
 import com.google.android.horologist.audio.AudioOutputRepository

--- a/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/FakeVolumeRepository.kt
+++ b/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/FakeVolumeRepository.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.audioui
+package com.google.android.horologist.audio.ui
 
 import com.google.android.horologist.audio.ExperimentalHorologistAudioApi
 import com.google.android.horologist.audio.VolumeRepository

--- a/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/VolumePositionIndicatorTest.kt
+++ b/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/VolumePositionIndicatorTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.audioui
+package com.google.android.horologist.audio.ui
 
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf

--- a/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/VolumeScreenTest.kt
+++ b/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/VolumeScreenTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.audioui
+package com.google.android.horologist.audio.ui
 
 import android.os.Vibrator
 import androidx.compose.foundation.layout.fillMaxSize

--- a/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/VolumeScreenPreview.kt
+++ b/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/VolumeScreenPreview.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.audioui
+package com.google.android.horologist.audio.ui
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize

--- a/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/VolumeScreenUxGuide.kt
+++ b/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/VolumeScreenUxGuide.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.audioui
+package com.google.android.horologist.audio.ui
 
 import android.graphics.Color.WHITE
 import android.graphics.Paint

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/ExperimentalHorologistAudioUiApi.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/ExperimentalHorologistAudioUiApi.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.audioui
+package com.google.android.horologist.audio.ui
 
 @RequiresOptIn(
     message = "Horologist Audio is experimental. The API may be changed in the future."

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumePositionIndicator.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumePositionIndicator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.audioui
+package com.google.android.horologist.audio.ui
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeScreen.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeScreen.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 @file:OptIn(ExperimentalComposeUiApi::class)
 
-package com.google.android.horologist.audioui
+package com.google.android.horologist.audio.ui
 
 import android.media.AudioManager
 import androidx.compose.foundation.focusable
@@ -60,9 +60,8 @@ import androidx.wear.compose.material.Text
 import com.google.android.horologist.audio.AudioOutput
 import com.google.android.horologist.audio.ExperimentalHorologistAudioApi
 import com.google.android.horologist.audio.VolumeState
-import com.google.android.horologist.audio.ui.R
-import com.google.android.horologist.audioui.VolumeScreenDefaults.DecreaseIcon
-import com.google.android.horologist.audioui.VolumeScreenDefaults.IncreaseIcon
+import com.google.android.horologist.audio.ui.VolumeScreenDefaults.DecreaseIcon
+import com.google.android.horologist.audio.ui.VolumeScreenDefaults.IncreaseIcon
 import kotlinx.coroutines.launch
 
 /**

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeScrollableState.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeScrollableState.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.audioui
+package com.google.android.horologist.audio.ui
 
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeViewModel.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.audioui
+package com.google.android.horologist.audio.ui
 
 import android.media.AudioManager
 import android.os.Vibrator

--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/RoundPreview.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/RoundPreview.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.audioui
+package com.google.android.horologist.audio.ui
 
 import android.content.res.Configuration
 import androidx.compose.runtime.Composable

--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/ThemeValues.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/ThemeValues.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.audioui
+package com.google.android.horologist.audio.ui
 
 import androidx.compose.ui.graphics.Color
 import androidx.wear.compose.material.Colors

--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreen2Test.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreen2Test.kt
@@ -16,7 +16,7 @@
 
 @file:OptIn(ExperimentalHorologistAudioApi::class)
 
-package com.google.android.horologist.audioui
+package com.google.android.horologist.audio.ui
 
 import androidx.wear.compose.material.MaterialTheme
 import app.cash.paparazzi.Paparazzi

--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenTest.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenTest.kt
@@ -16,7 +16,7 @@
 
 @file:OptIn(ExperimentalHorologistAudioApi::class)
 
-package com.google.android.horologist.audioui
+package com.google.android.horologist.audio.ui
 
 import app.cash.paparazzi.Paparazzi
 import com.google.android.horologist.audio.AudioOutput

--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenTestCase.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenTestCase.kt
@@ -16,7 +16,7 @@
 
 @file:OptIn(ExperimentalHorologistAudioUiApi::class)
 
-package com.google.android.horologist.audioui
+package com.google.android.horologist.audio.ui
 
 import androidx.compose.runtime.Composable
 import androidx.wear.compose.material.Colors

--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/util.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/util.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.audioui
+package com.google.android.horologist.audio.ui
 
 import app.cash.paparazzi.HtmlReportWriter
 import app.cash.paparazzi.SnapshotHandler

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -64,7 +64,7 @@ android {
         freeCompilerArgs += "-opt-in=androidx.wear.compose.material.ExperimentalWearMaterialApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.audio.ExperimentalHorologistAudioApi"
-        freeCompilerArgs += "-opt-in=com.google.android.horologist.audioui.ExperimentalHorologistAudioUiApi"
+        freeCompilerArgs += "-opt-in=com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi"
         freeCompilerArgs += "-opt-in=androidx.compose.ui.ExperimentalComposeUiApi"

--- a/sample/src/main/java/com/google/android/horologist/navsample/NavWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/navsample/NavWearApp.kt
@@ -34,7 +34,7 @@ import androidx.wear.compose.material.edgeSwipeToDismiss
 import androidx.wear.compose.material.rememberSwipeToDismissBoxState
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavHostState
 import com.google.accompanist.pager.rememberPagerState
-import com.google.android.horologist.audioui.VolumeScreen
+import com.google.android.horologist.audio.ui.VolumeScreen
 import com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel
 import com.google.android.horologist.compose.navscaffold.WearNavScaffold
 import com.google.android.horologist.compose.navscaffold.scalingLazyColumnComposable

--- a/sample/src/main/java/com/google/android/horologist/sample/MainActivity.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/MainActivity.kt
@@ -39,8 +39,8 @@ import androidx.wear.compose.navigation.SwipeDismissableNavHost
 import androidx.wear.compose.navigation.composable
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import com.google.android.horologist.audio.BluetoothSettings.launchBluetoothSettings
-import com.google.android.horologist.audioui.VolumeScreen
-import com.google.android.horologist.audioui.VolumeViewModel
+import com.google.android.horologist.audio.ui.VolumeScreen
+import com.google.android.horologist.audio.ui.VolumeViewModel
 import com.google.android.horologist.composables.DatePicker
 import com.google.android.horologist.composables.TimePicker
 import com.google.android.horologist.composables.TimePickerWith12HourClock

--- a/sample/src/main/java/com/google/android/horologist/sample/media/MediaPlayerScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/MediaPlayerScreen.kt
@@ -24,8 +24,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.TimeText
-import com.google.android.horologist.audioui.VolumePositionIndicator
-import com.google.android.horologist.audioui.VolumeViewModel
+import com.google.android.horologist.audio.ui.VolumePositionIndicator
+import com.google.android.horologist.audio.ui.VolumeViewModel
 import com.google.android.horologist.compose.navscaffold.scrollableColumn
 import com.google.android.horologist.compose.pager.FocusOnResume
 import com.google.android.horologist.media.ui.screens.PlayerScreen


### PR DESCRIPTION
#### WHAT

Rename package name from `audioui` to `audio.ui`.

#### WHY

In order to have a common `audio` package for different layers (data, domain and ui).
I also think it was the original idea to have the name like this, based on the package name in [AndroidManifest](https://github.com/google/horologist/blob/ef8582069d3873a05c48377ad526e529999eb968/audio-ui/src/main/AndroidManifest.xml#L18).

#### HOW

- Rename package from files in `main`, `debug`, and `androidTest` folders;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
