### PR TITLE
Add SetVolumeButton to audio-ui module

### DIFF
--- a/audio-ui/api/current.api
+++ b/audio-ui/api/current.api
@@ -46,3 +46,24 @@ package com.google.android.horologist.audio.ui {
 
 }
 
+package com.google.android.horologist.audio.ui.components.actions {
+
+  public final class SetVolumeButtonKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi public static void SetVolumeButton(kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, com.google.android.horologist.audio.VolumeState volumeState, optional androidx.compose.ui.Modifier modifier);
+  }
+
+}
+
+package com.google.android.horologist.audio.ui.semantics {
+
+  @com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi public final class CustomSemanticsProperties {
+    method public androidx.compose.ui.graphics.vector.ImageVector getIconImageVector(androidx.compose.ui.semantics.SemanticsPropertyReceiver);
+    method public androidx.compose.ui.semantics.SemanticsPropertyKey<androidx.compose.ui.graphics.vector.ImageVector> getIconImageVectorKey();
+    method public void setIconImageVector(androidx.compose.ui.semantics.SemanticsPropertyReceiver, androidx.compose.ui.graphics.vector.ImageVector iconImageVector);
+    property public final androidx.compose.ui.semantics.SemanticsPropertyKey<androidx.compose.ui.graphics.vector.ImageVector> IconImageVectorKey;
+    property public final androidx.compose.ui.graphics.vector.ImageVector iconImageVector;
+    field public static final com.google.android.horologist.audio.ui.semantics.CustomSemanticsProperties INSTANCE;
+  }
+
+}
+

--- a/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonTest.kt
+++ b/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistAudioUiApi::class)
+
+package com.google.android.horologist.audio.ui.components.actions
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.VolumeDown
+import androidx.compose.material.icons.filled.VolumeMute
+import androidx.compose.material.icons.filled.VolumeUp
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import com.google.android.horologist.audio.VolumeState
+import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
+import com.google.test.toolbox.matchers.hasIconImageVector
+import org.junit.Rule
+import org.junit.Test
+
+class SetVolumeButtonTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun givenCurrentVolumeIsNotMaxAndNotMin_thenIconIsVolumeDown() {
+        // given
+        val currentVolume = 5
+        composeTestRule.setContent {
+            SetVolumeButton(
+                onVolumeClick = {},
+                volumeState = VolumeState(current = currentVolume, max = 10)
+            )
+        }
+
+        // then
+        composeTestRule.onNodeWithContentDescription("Set Volume")
+            .assert(hasIconImageVector(Icons.Default.VolumeDown))
+    }
+
+    @Test
+    fun givenCurrentVolumeIsMinimum_thenIconIsVolumeMute() {
+        // given
+        val currentVolume = 0
+        composeTestRule.setContent {
+            SetVolumeButton(
+                onVolumeClick = {},
+                volumeState = VolumeState(current = currentVolume, max = 10)
+            )
+        }
+
+        // then
+        composeTestRule.onNodeWithContentDescription("Set Volume")
+            .assert(hasIconImageVector(Icons.Default.VolumeMute))
+    }
+
+    @Test
+    fun givenCurrentVolumeIsMaximum_thenIconIsVolumeUp() {
+        // given
+        val currentVolume = 10
+        composeTestRule.setContent {
+            SetVolumeButton(
+                onVolumeClick = {},
+                volumeState = VolumeState(current = currentVolume, max = currentVolume)
+            )
+        }
+
+        // then
+        composeTestRule.onNodeWithContentDescription("Set Volume")
+            .assert(hasIconImageVector(Icons.Default.VolumeUp))
+    }
+}

--- a/audio-ui/src/androidTest/java/com/google/test/toolbox/matchers/SemanticsMatchers.kt
+++ b/audio-ui/src/androidTest/java/com/google/test/toolbox/matchers/SemanticsMatchers.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.test.toolbox.matchers
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsMatcher.Companion.expectValue
+import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
+import com.google.android.horologist.audio.ui.semantics.CustomSemanticsProperties.IconImageVectorKey
+
+@OptIn(ExperimentalHorologistAudioUiApi::class)
+fun hasIconImageVector(imageVector: ImageVector): SemanticsMatcher =
+    expectValue(IconImageVectorKey, imageVector)

--- a/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonPreview.kt
+++ b/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonPreview.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistAudioUiApi::class)
+
+package com.google.android.horologist.audio.ui.components.actions
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.google.android.horologist.audio.VolumeState
+import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
+
+@Preview(name = "Other volume")
+@Composable
+fun SetVolumeButtonPreview() {
+    SetVolumeButton(
+        onVolumeClick = {},
+        volumeState = VolumeState(current = 4, max = 10)
+    )
+}
+
+@Preview(name = "Min volume")
+@Composable
+fun SetVolumeButtonPreviewMinVolume() {
+    SetVolumeButton(
+        onVolumeClick = {},
+        volumeState = VolumeState(current = 0, max = 10)
+    )
+}
+
+@Preview(name = "Max volume")
+@Composable
+fun SetVolumeButtonPreviewMaxVolume() {
+    SetVolumeButton(
+        onVolumeClick = {},
+        volumeState = VolumeState(current = 10, max = 10)
+    )
+}

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.sample.media
+package com.google.android.horologist.audio.ui.components.actions
 
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
@@ -24,19 +24,23 @@ import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
 import androidx.wear.compose.material.Button
 import androidx.wear.compose.material.ButtonDefaults
 import androidx.wear.compose.material.Icon
 import com.google.android.horologist.audio.VolumeState
-import com.google.android.horologist.sample.R
+import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
+import com.google.android.horologist.audio.ui.R
+import com.google.android.horologist.audio.ui.semantics.CustomSemanticsProperties.iconImageVector
 
 /**
  * Button to launch a screen to control the system volume.
  *
  * See [VolumeState]
  */
+@ExperimentalHorologistAudioUiApi
 @Composable
-fun SetVolumeButton(
+public fun SetVolumeButton(
     onVolumeClick: () -> Unit,
     volumeState: VolumeState,
     modifier: Modifier = Modifier,
@@ -54,7 +58,8 @@ fun SetVolumeButton(
 
         Icon(
             imageVector = imageVector,
-            contentDescription = stringResource(R.string.set_volume_content_description)
+            contentDescription = stringResource(R.string.set_volume_content_description),
+            modifier = Modifier.semantics { iconImageVector = imageVector }
         )
     }
 }

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/semantics/CustomSemanticsProperties.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/semantics/CustomSemanticsProperties.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.audio.ui.semantics
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
+
+/**
+ * Custom semantic properties, mainly used for accessibility and testing.
+ */
+@ExperimentalHorologistAudioUiApi
+public object CustomSemanticsProperties {
+
+    public val IconImageVectorKey: SemanticsPropertyKey<ImageVector> =
+        SemanticsPropertyKey("IconImageVector")
+    public var SemanticsPropertyReceiver.iconImageVector: ImageVector by IconImageVectorKey
+}

--- a/audio-ui/src/main/res/values/strings.xml
+++ b/audio-ui/src/main/res/values/strings.xml
@@ -17,4 +17,5 @@
 <resources>
     <string name="volume_screen_volume_up">Volume Up</string>
     <string name="volume_screen_volume_down">Volume Down</string>
+    <string name="set_volume_content_description">Set Volume</string>
 </resources>

--- a/sample/src/main/java/com/google/android/horologist/sample/media/SettingsButtons.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/SettingsButtons.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.google.android.horologist.audio.VolumeState
+import com.google.android.horologist.audio.ui.components.actions.SetVolumeButton
 
 /**
  * Settings buttons for a typical media app.

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -23,5 +23,4 @@
     <string name="tile_text">Hello world</string>
     <string name="chip_media_player_sample">Media Player Sample</string>
     <string name="audio_output_content_description">Audio Output</string>
-    <string name="set_volume_content_description">Set Volume</string>
 </resources>


### PR DESCRIPTION
#### WHAT

Add `SetVolumeButton` to `audio-ui` module.

![Screen Shot 2022-05-11 at 15 24 11](https://user-images.githubusercontent.com/878134/167881767-387827e2-d370-4c78-b4f3-1e1388a79b2c.png)

#### WHY

In order to provide common audio actions.

#### HOW

- Add `SetVolumeButton` implementation;
- Add preview in debug build source folder;
- Add tests;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
