### PR TITLE
Add AudioOutputButton to audio-ui module

### DIFF
--- a/audio-ui/api/current.api
+++ b/audio-ui/api/current.api
@@ -48,6 +48,10 @@ package com.google.android.horologist.audio.ui {
 
 package com.google.android.horologist.audio.ui.components.actions {
 
+  public final class AudioOutputButtonKt {
+    method @androidx.compose.runtime.Composable public static void AudioOutputButton(kotlin.jvm.functions.Function0<kotlin.Unit> onOutputClick, optional androidx.compose.ui.Modifier modifier, optional boolean enabled);
+  }
+
   public final class SetVolumeButtonKt {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi public static void SetVolumeButton(kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, com.google.android.horologist.audio.VolumeState volumeState, optional androidx.compose.ui.Modifier modifier);
   }

--- a/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/actions/AudioOutputButtonPreview.kt
+++ b/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/actions/AudioOutputButtonPreview.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.audio.ui.components.actions
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview
+@Composable
+fun AudioOutputButtonPreview() {
+    AudioOutputButton(onOutputClick = {})
+}

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/AudioOutputButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/AudioOutputButton.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.sample.media
+package com.google.android.horologist.audio.ui.components.actions
 
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
@@ -25,19 +25,21 @@ import androidx.compose.ui.res.stringResource
 import androidx.wear.compose.material.Button
 import androidx.wear.compose.material.ButtonDefaults
 import androidx.wear.compose.material.Icon
-import com.google.android.horologist.sample.R
+import com.google.android.horologist.audio.ui.R
 
 /**
  * A button to launch the system bluetooth settings to connect to a headset.
  */
 @Composable
-fun AudioOutputButton(
+public fun AudioOutputButton(
     onOutputClick: () -> Unit,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
 ) {
     Button(
-        modifier = modifier.size(ButtonDefaults.SmallButtonSize),
         onClick = onOutputClick,
+        modifier = modifier.size(ButtonDefaults.SmallButtonSize),
+        enabled = enabled,
         colors = ButtonDefaults.iconButtonColors(),
     ) {
         Icon(

--- a/audio-ui/src/main/res/values/strings.xml
+++ b/audio-ui/src/main/res/values/strings.xml
@@ -21,4 +21,5 @@
     <string name="volume_screen_not_connected">Not Connected</string>
     <string name="volume_screen_change_audio_output">Change Audio Output</string>
     <string name="set_volume_content_description">Set Volume</string>
+    <string name="audio_output_content_description">Audio Output</string>
 </resources>

--- a/sample/src/main/java/com/google/android/horologist/sample/media/SettingsButtons.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/SettingsButtons.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.google.android.horologist.audio.VolumeState
+import com.google.android.horologist.audio.ui.components.actions.AudioOutputButton
 import com.google.android.horologist.audio.ui.components.actions.SetVolumeButton
 
 /**

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -22,5 +22,4 @@
     <string name="tile_description">Basic tile description</string>
     <string name="tile_text">Hello world</string>
     <string name="chip_media_player_sample">Media Player Sample</string>
-    <string name="audio_output_content_description">Audio Output</string>
 </resources>


### PR DESCRIPTION
#### WHAT

Add `AudioOutputButton` to `audio-ui` module.

![Screen Shot 2022-05-12 at 13 20 53](https://user-images.githubusercontent.com/878134/168078137-1c7deb89-1034-4305-9b6a-57b1ed96df62.png)

#### WHY

In order to provide common audio actions.

#### HOW

- Add `AudioOutputButton` implementation;
- Add preview in debug build source folder;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
