### PR TITLE
Add SettingsButtons to audio-ui module

### DIFF
--- a/audio-ui/api/current.api
+++ b/audio-ui/api/current.api
@@ -46,6 +46,14 @@ package com.google.android.horologist.audio.ui {
 
 }
 
+package com.google.android.horologist.audio.ui.components {
+
+  public final class SettingsButtonsKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi public static void SettingsButtons(com.google.android.horologist.audio.VolumeState volumeState, kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, kotlin.jvm.functions.Function0<kotlin.Unit> onOutputClick, optional androidx.compose.ui.Modifier modifier);
+  }
+
+}
+
 package com.google.android.horologist.audio.ui.components.actions {
 
   public final class AudioOutputButtonKt {

--- a/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/actions/SettingsButtonsPreview.kt
+++ b/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/actions/SettingsButtonsPreview.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistAudioUiApi::class)
+
+package com.google.android.horologist.audio.ui.components.actions
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.google.android.horologist.audio.VolumeState
+import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
+import com.google.android.horologist.audio.ui.components.SettingsButtons
+
+@Preview
+@Composable
+fun SettingsButtonsPreview() {
+    SettingsButtons(
+        volumeState = VolumeState(4, 10),
+        onVolumeClick = {},
+        onOutputClick = {},
+    )
+}

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/SettingsButtons.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/SettingsButtons.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.sample.media
+package com.google.android.horologist.audio.ui.components
 
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -23,6 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.google.android.horologist.audio.VolumeState
+import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
 import com.google.android.horologist.audio.ui.components.actions.AudioOutputButton
 import com.google.android.horologist.audio.ui.components.actions.SetVolumeButton
 
@@ -30,8 +31,9 @@ import com.google.android.horologist.audio.ui.components.actions.SetVolumeButton
  * Settings buttons for a typical media app.
  * Set Volume and Select Audio Output.
  */
+@ExperimentalHorologistAudioUiApi
 @Composable
-fun SettingsButtons(
+public fun SettingsButtons(
     volumeState: VolumeState,
     onVolumeClick: () -> Unit,
     onOutputClick: () -> Unit,

--- a/sample/src/main/java/com/google/android/horologist/sample/media/MediaPlayerScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/MediaPlayerScreen.kt
@@ -26,6 +26,7 @@ import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.TimeText
 import com.google.android.horologist.audio.ui.VolumePositionIndicator
 import com.google.android.horologist.audio.ui.VolumeViewModel
+import com.google.android.horologist.audio.ui.components.SettingsButtons
 import com.google.android.horologist.compose.navscaffold.scrollableColumn
 import com.google.android.horologist.compose.pager.FocusOnResume
 import com.google.android.horologist.media.ui.screens.PlayerScreen


### PR DESCRIPTION
#### WHAT

Add `SettingsButtons` to `audio-ui` module.

![Screen Shot 2022-05-12 at 15 09 19](https://user-images.githubusercontent.com/878134/168094745-7402ed73-dc26-4c77-9333-1b612cb28482.png)

#### WHY

In order to provide common audio components.

This component contextually belongs to media and not audio.  We can revisit this if we decide to make `media-ui` depend on `audio-ui`, or if we decide to create a separated module that depends on both media and audio modules.

#### HOW

- Add `SettingsButtons` implementation;
- Add preview in debug build source folder;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
