### PR TITLE
Add Media module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,10 +39,12 @@ buildscript {
 }
 
 plugins {
+
     id "com.diffplug.spotless" version "5.9.0"
     id 'org.jetbrains.kotlin.android' version '1.6.20' apply false
     id "com.github.ben-manes.versions" version "0.41.0"
     id "nl.littlerobots.version-catalog-update" version "0.3.0" apply false
+    id 'org.jetbrains.kotlin.jvm' version '1.6.21' apply false
     id "org.jetbrains.kotlin.kapt" version '1.6.20' apply false
 }
 

--- a/media/api/current.api
+++ b/media/api/current.api
@@ -1,0 +1,8 @@
+// Signature format: 4.0
+package com.google.android.horologist.media {
+
+  @kotlin.RequiresOptIn(message="Horologist Media is experimental. The API may be changed in the future.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention) public @interface ExperimentalHorologistMediaApi {
+  }
+
+}
+

--- a/media/build.gradle
+++ b/media/build.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+
+    id 'java-library'
+    id 'org.jetbrains.kotlin.jvm'
+    id 'org.jetbrains.dokka'
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_7
+    targetCompatibility = JavaVersion.VERSION_1_7
+}
+
+apply plugin: "com.vanniktech.maven.publish"

--- a/media/gradle.properties
+++ b/media/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=horologist-media
+POM_NAME=Horologist Media library
+POM_PACKAGING=jar

--- a/media/src/main/java/com/google/android/horologist/media/ExperimentalHorologistMediaApi.kt
+++ b/media/src/main/java/com/google/android/horologist/media/ExperimentalHorologistMediaApi.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media
+
+@RequiresOptIn(
+    message = "Horologist Media is experimental. The API may be changed in the future."
+)
+@Retention(AnnotationRetention.BINARY)
+public annotation class ExperimentalHorologistMediaApi

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,9 +31,10 @@ include ':composables'
 include ':audio'
 include ':audio-ui'
 include ':tiles'
+include ':media'
 include ':media-ui'
-include ':paparazzi'
 include ':media-data'
+include ':paparazzi'
 include ':compose-testing'
 
 // Enable Gradle's version catalog support


### PR DESCRIPTION
#### WHAT

Add module for Media domain library.

#### WHY

In order to include domain code related to media and publish them as an individual library.

#### HOW
- Add a new java/kotlin module;
- Add maven publish plugin configuration to the module;
- Add annotation `ExperimentalHorologistMediaApi`;
- Add metalava generated API file;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
