### PR TITLE
Add PlayerRepository to media module

### DIFF
--- a/media/api/current.api
+++ b/media/api/current.api
@@ -31,20 +31,32 @@ package com.google.android.horologist.media.model {
     property public final String? title;
   }
 
-  public final class MediaItemPosition {
-    ctor public MediaItemPosition(long current, long duration);
-    method public long component1();
-    method public long component2();
-    method public com.google.android.horologist.media.model.MediaItemPosition copy(long current, long duration);
-    method public boolean equals(Object? other);
+  public abstract sealed class MediaItemPosition {
     method public long getCurrent();
+    property public long current;
+    field public static final com.google.android.horologist.media.model.MediaItemPosition.Companion Companion;
+  }
+
+  public static final class MediaItemPosition.Companion {
+    method public com.google.android.horologist.media.model.MediaItemPosition.KnownDuration create(long current, long duration);
+  }
+
+  public static final class MediaItemPosition.KnownDuration extends com.google.android.horologist.media.model.MediaItemPosition {
     method public long getDuration();
     method public float getPercent();
-    method public int hashCode();
-    method public String toString();
-    property public final long current;
+    property public long current;
     property public final long duration;
     property public final float percent;
+  }
+
+  public static final class MediaItemPosition.UnknownDuration extends com.google.android.horologist.media.model.MediaItemPosition {
+    ctor public MediaItemPosition.UnknownDuration(long current);
+    method public long component1();
+    method public com.google.android.horologist.media.model.MediaItemPosition.UnknownDuration copy(long current);
+    method public boolean equals(Object? other);
+    method public int hashCode();
+    method public String toString();
+    property public long current;
   }
 
   public enum PlayerState {
@@ -73,7 +85,6 @@ package com.google.android.horologist.media.repository {
     method public long getSeekBackIncrement();
     method public long getSeekForwardIncrement();
     method public kotlinx.coroutines.flow.StateFlow<java.lang.Boolean> getShuffleModeEnabled();
-    method public boolean getShuffleModeEnabled();
     method public boolean hasNextMediaItem();
     method public boolean hasPreviousMediaItem();
     method public void pause();

--- a/media/api/current.api
+++ b/media/api/current.api
@@ -12,22 +12,22 @@ package com.google.android.horologist.media.model {
     enum_constant public static final com.google.android.horologist.media.model.Command PlayPause;
     enum_constant public static final com.google.android.horologist.media.model.Command SeekBack;
     enum_constant public static final com.google.android.horologist.media.model.Command SeekForward;
-    enum_constant public static final com.google.android.horologist.media.model.Command SeekToNextMediaItem;
-    enum_constant public static final com.google.android.horologist.media.model.Command SeekToPreviousMediaItem;
     enum_constant public static final com.google.android.horologist.media.model.Command SetShuffle;
+    enum_constant public static final com.google.android.horologist.media.model.Command SkipToNextMediaItem;
+    enum_constant public static final com.google.android.horologist.media.model.Command SkipToPreviousMediaItem;
   }
 
   public final class MediaItem {
-    ctor public MediaItem(optional String? title, optional String? artist);
+    ctor public MediaItem(optional String? title, String artist);
     method public String? component1();
-    method public String? component2();
-    method public com.google.android.horologist.media.model.MediaItem copy(String? title, String? artist);
+    method public String component2();
+    method public com.google.android.horologist.media.model.MediaItem copy(String? title, String artist);
     method public boolean equals(Object? other);
-    method public String? getArtist();
+    method public String getArtist();
     method public String? getTitle();
     method public int hashCode();
     method public String toString();
-    property public final String? artist;
+    property public final String artist;
     property public final String? title;
   }
 
@@ -51,8 +51,8 @@ package com.google.android.horologist.media.model {
 
   public static final class MediaItemPosition.UnknownDuration extends com.google.android.horologist.media.model.MediaItemPosition {
     ctor public MediaItemPosition.UnknownDuration(long current);
-    method public long component1();
-    method public com.google.android.horologist.media.model.MediaItemPosition.UnknownDuration copy(long current);
+    method public long component1-UwyO8pc();
+    method public com.google.android.horologist.media.model.MediaItemPosition.UnknownDuration copy-LRDsOJo(long current);
     method public boolean equals(Object? other);
     method public int hashCode();
     method public String toString();
@@ -94,11 +94,11 @@ package com.google.android.horologist.media.repository {
     method public void removeMediaItem(int index);
     method public void seekBack();
     method public void seekForward();
-    method public void seekToNextMediaItem();
-    method public void seekToPreviousMediaItem();
     method public void setMediaItem(com.google.android.horologist.media.model.MediaItem mediaItem);
     method public void setMediaItems(java.util.List<com.google.android.horologist.media.model.MediaItem> mediaItems);
     method public void setShuffleModeEnabled(boolean shuffleModeEnabled);
+    method public void skipToNextMediaItem();
+    method public void skipToPreviousMediaItem();
     property public abstract kotlinx.coroutines.flow.StateFlow<java.util.Set<com.google.android.horologist.media.model.Command>> availableCommands;
     property public abstract kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.media.model.MediaItem> currentMediaItem;
     property public abstract kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.media.model.PlayerState> currentState;

--- a/media/api/current.api
+++ b/media/api/current.api
@@ -6,3 +6,94 @@ package com.google.android.horologist.media {
 
 }
 
+package com.google.android.horologist.media.model {
+
+  public enum Command {
+    enum_constant public static final com.google.android.horologist.media.model.Command PlayPause;
+    enum_constant public static final com.google.android.horologist.media.model.Command SeekBack;
+    enum_constant public static final com.google.android.horologist.media.model.Command SeekForward;
+    enum_constant public static final com.google.android.horologist.media.model.Command SeekToNextMediaItem;
+    enum_constant public static final com.google.android.horologist.media.model.Command SeekToPreviousMediaItem;
+    enum_constant public static final com.google.android.horologist.media.model.Command SetShuffle;
+  }
+
+  public final class MediaItem {
+    ctor public MediaItem(optional String? title, optional String? artist);
+    method public String? component1();
+    method public String? component2();
+    method public com.google.android.horologist.media.model.MediaItem copy(String? title, String? artist);
+    method public boolean equals(Object? other);
+    method public String? getArtist();
+    method public String? getTitle();
+    method public int hashCode();
+    method public String toString();
+    property public final String? artist;
+    property public final String? title;
+  }
+
+  public final class MediaItemPosition {
+    ctor public MediaItemPosition(long current, long duration);
+    method public long component1();
+    method public long component2();
+    method public com.google.android.horologist.media.model.MediaItemPosition copy(long current, long duration);
+    method public boolean equals(Object? other);
+    method public long getCurrent();
+    method public long getDuration();
+    method public float getPercent();
+    method public int hashCode();
+    method public String toString();
+    property public final long current;
+    property public final long duration;
+    property public final float percent;
+  }
+
+  public enum PlayerState {
+    enum_constant public static final com.google.android.horologist.media.model.PlayerState Ended;
+    enum_constant public static final com.google.android.horologist.media.model.PlayerState Idle;
+    enum_constant public static final com.google.android.horologist.media.model.PlayerState Loading;
+    enum_constant public static final com.google.android.horologist.media.model.PlayerState Playing;
+    enum_constant public static final com.google.android.horologist.media.model.PlayerState Ready;
+  }
+
+}
+
+package com.google.android.horologist.media.repository {
+
+  @com.google.android.horologist.media.ExperimentalHorologistMediaApi public interface PlayerRepository {
+    method public void addMediaItem(com.google.android.horologist.media.model.MediaItem mediaItem);
+    method public void addMediaItem(int index, com.google.android.horologist.media.model.MediaItem mediaItem);
+    method public void clearMediaItems();
+    method public kotlinx.coroutines.flow.StateFlow<java.util.Set<com.google.android.horologist.media.model.Command>> getAvailableCommands();
+    method public kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.media.model.MediaItem> getCurrentMediaItem();
+    method public int getCurrentMediaItemIndex();
+    method public kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.media.model.PlayerState> getCurrentState();
+    method public com.google.android.horologist.media.model.MediaItem? getMediaItemAt(int index);
+    method public int getMediaItemCount();
+    method public kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.media.model.MediaItemPosition> getMediaItemPosition();
+    method public long getSeekBackIncrement();
+    method public long getSeekForwardIncrement();
+    method public kotlinx.coroutines.flow.StateFlow<java.lang.Boolean> getShuffleModeEnabled();
+    method public boolean getShuffleModeEnabled();
+    method public boolean hasNextMediaItem();
+    method public boolean hasPreviousMediaItem();
+    method public void pause();
+    method public void play();
+    method public void prepare();
+    method public void release();
+    method public void removeMediaItem(int index);
+    method public void seekBack();
+    method public void seekForward();
+    method public void seekToNextMediaItem();
+    method public void seekToPreviousMediaItem();
+    method public void setMediaItem(com.google.android.horologist.media.model.MediaItem mediaItem);
+    method public void setMediaItems(java.util.List<com.google.android.horologist.media.model.MediaItem> mediaItems);
+    method public void setShuffleModeEnabled(boolean shuffleModeEnabled);
+    property public abstract kotlinx.coroutines.flow.StateFlow<java.util.Set<com.google.android.horologist.media.model.Command>> availableCommands;
+    property public abstract kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.media.model.MediaItem> currentMediaItem;
+    property public abstract kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.media.model.PlayerState> currentState;
+    property public abstract kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.media.model.MediaItemPosition> mediaItemPosition;
+    property public abstract kotlinx.coroutines.flow.StateFlow<java.lang.Boolean> shuffleModeEnabled;
+  }
+
+}
+

--- a/media/build.gradle
+++ b/media/build.gradle
@@ -29,6 +29,8 @@ java {
 dependencies {
 
     implementation libs.kotlinx.coroutines.core
+
+    testImplementation libs.junit
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/media/src/main/java/com/google/android/horologist/media/model/Command.kt
+++ b/media/src/main/java/com/google/android/horologist/media/model/Command.kt
@@ -23,7 +23,7 @@ public enum class Command {
     PlayPause,
     SeekBack,
     SeekForward,
-    SeekToPreviousMediaItem,
-    SeekToNextMediaItem,
+    SkipToPreviousMediaItem,
+    SkipToNextMediaItem,
     SetShuffle
 }

--- a/media/src/main/java/com/google/android/horologist/media/model/Command.kt
+++ b/media/src/main/java/com/google/android/horologist/media/model/Command.kt
@@ -14,21 +14,16 @@
  * limitations under the License.
  */
 
-plugins {
+package com.google.android.horologist.media.model
 
-    id 'java-library'
-    id 'org.jetbrains.kotlin.jvm'
-    id 'org.jetbrains.dokka'
+/**
+ * Commands that can be executed on a player.
+ */
+public enum class Command {
+    PlayPause,
+    SeekBack,
+    SeekForward,
+    SeekToPreviousMediaItem,
+    SeekToNextMediaItem,
+    SetShuffle
 }
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_7
-    targetCompatibility = JavaVersion.VERSION_1_7
-}
-
-dependencies {
-
-    implementation libs.kotlinx.coroutines.core
-}
-
-apply plugin: "com.vanniktech.maven.publish"

--- a/media/src/main/java/com/google/android/horologist/media/model/MediaItem.kt
+++ b/media/src/main/java/com/google/android/horologist/media/model/MediaItem.kt
@@ -21,5 +21,5 @@ package com.google.android.horologist.media.model
  */
 public data class MediaItem(
     val title: String? = null,
-    val artist: String? = null
+    val artist: String
 )

--- a/media/src/main/java/com/google/android/horologist/media/model/MediaItem.kt
+++ b/media/src/main/java/com/google/android/horologist/media/model/MediaItem.kt
@@ -14,21 +14,12 @@
  * limitations under the License.
  */
 
-plugins {
+package com.google.android.horologist.media.model
 
-    id 'java-library'
-    id 'org.jetbrains.kotlin.jvm'
-    id 'org.jetbrains.dokka'
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_7
-    targetCompatibility = JavaVersion.VERSION_1_7
-}
-
-dependencies {
-
-    implementation libs.kotlinx.coroutines.core
-}
-
-apply plugin: "com.vanniktech.maven.publish"
+/**
+ * Representation of a media item.
+ */
+public data class MediaItem(
+    val title: String? = null,
+    val artist: String? = null
+)

--- a/media/src/main/java/com/google/android/horologist/media/model/MediaItemPosition.kt
+++ b/media/src/main/java/com/google/android/horologist/media/model/MediaItemPosition.kt
@@ -20,9 +20,36 @@ package com.google.android.horologist.media.model
  * Represents the current [media item][MediaItem] position, duration and percent progress.
  * Current position and duration are measured in milliseconds.
  */
-public data class MediaItemPosition(
-    val current: Long,
-    val duration: Long,
+public sealed class MediaItemPosition(
+    public open val current: Long,
 ) {
-    val percent: Float = current.toFloat() / duration.toFloat()
+    public class KnownDuration internal constructor(
+        override val current: Long,
+        public val duration: Long,
+        public val percent: Float,
+    ) : MediaItemPosition(current)
+
+    public data class UnknownDuration(override val current: Long) : MediaItemPosition(current)
+
+    public companion object {
+
+        public fun create(
+            current: Long,
+            duration: Long
+        ): KnownDuration {
+            check(current >= 0) {
+                "Current position can't be a negative value [current: $current] [duration: $duration]."
+            }
+            check(duration > 0) {
+                "Duration has to be greater than zero [current: $current] [duration: $duration]."
+            }
+            check(current <= duration) {
+                "Current position has to be greater than duration [current: $current] [duration: $duration]."
+            }
+
+            val percent = current.toFloat() / duration.toFloat()
+
+            return KnownDuration(current, duration, percent)
+        }
+    }
 }

--- a/media/src/main/java/com/google/android/horologist/media/model/MediaItemPosition.kt
+++ b/media/src/main/java/com/google/android/horologist/media/model/MediaItemPosition.kt
@@ -14,21 +14,15 @@
  * limitations under the License.
  */
 
-plugins {
+package com.google.android.horologist.media.model
 
-    id 'java-library'
-    id 'org.jetbrains.kotlin.jvm'
-    id 'org.jetbrains.dokka'
+/**
+ * Represents the current [media item][MediaItem] position, duration and percent progress.
+ * Current position and duration are measured in milliseconds.
+ */
+public data class MediaItemPosition(
+    val current: Long,
+    val duration: Long,
+) {
+    val percent: Float = current.toFloat() / duration.toFloat()
 }
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_7
-    targetCompatibility = JavaVersion.VERSION_1_7
-}
-
-dependencies {
-
-    implementation libs.kotlinx.coroutines.core
-}
-
-apply plugin: "com.vanniktech.maven.publish"

--- a/media/src/main/java/com/google/android/horologist/media/model/MediaItemPosition.kt
+++ b/media/src/main/java/com/google/android/horologist/media/model/MediaItemPosition.kt
@@ -16,38 +16,41 @@
 
 package com.google.android.horologist.media.model
 
+import kotlin.time.Duration
+
 /**
  * Represents the current [media item][MediaItem] position, duration and percent progress.
  * Current position and duration are measured in milliseconds.
  */
 public sealed class MediaItemPosition(
-    public open val current: Long,
+    public open val current: Duration,
 ) {
     public class KnownDuration internal constructor(
-        override val current: Long,
-        public val duration: Long,
+        override val current: Duration,
+        public val duration: Duration,
         public val percent: Float,
     ) : MediaItemPosition(current)
 
-    public data class UnknownDuration(override val current: Long) : MediaItemPosition(current)
+    public data class UnknownDuration(override val current: Duration) : MediaItemPosition(current)
 
     public companion object {
 
         public fun create(
-            current: Long,
-            duration: Long
+            current: Duration,
+            duration: Duration
         ): KnownDuration {
-            check(current >= 0) {
+            check(current.isNegative()) {
                 "Current position can't be a negative value [current: $current] [duration: $duration]."
             }
-            check(duration > 0) {
+            check(!duration.isPositive()) {
                 "Duration has to be greater than zero [current: $current] [duration: $duration]."
             }
             check(current <= duration) {
                 "Current position has to be greater than duration [current: $current] [duration: $duration]."
             }
 
-            val percent = current.toFloat() / duration.toFloat()
+            val percent =
+                current.inWholeMilliseconds.toFloat() / duration.inWholeMilliseconds.toFloat()
 
             return KnownDuration(current, duration, percent)
         }

--- a/media/src/main/java/com/google/android/horologist/media/model/PlayerState.kt
+++ b/media/src/main/java/com/google/android/horologist/media/model/PlayerState.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.model
+
+/**
+ * Represents the state of the player.
+ */
+public enum class PlayerState {
+
+    /**
+     * The player is idle, meaning it holds only limited resources. The player must be prepared
+     * before it will play the media.
+     */
+    Idle,
+
+    /**
+     * The player is not able to immediately play the media, but is doing work toward being able to
+     * do so. This state typically occurs when the player needs to buffer more data before playback
+     * can start.
+     */
+    Loading,
+
+    /**
+     * The player is able to immediately play from its current position.
+     */
+    Ready,
+
+    /**
+     * The player is playing.
+     */
+    Playing,
+
+    /**
+     * The player has finished playing the media.
+     */
+    Ended
+}

--- a/media/src/main/java/com/google/android/horologist/media/repository/PlayerRepository.kt
+++ b/media/src/main/java/com/google/android/horologist/media/repository/PlayerRepository.kt
@@ -116,11 +116,6 @@ public interface PlayerRepository {
     public fun setShuffleModeEnabled(shuffleModeEnabled: Boolean)
 
     /**
-     * Returns whether shuffling of [media items][MediaItem] is enabled.
-     */
-    public fun getShuffleModeEnabled(): Boolean
-
-    /**
      * Clears the playlist, adds the specified [media item][MediaItem] and resets the position to
      * the default position.
      */

--- a/media/src/main/java/com/google/android/horologist/media/repository/PlayerRepository.kt
+++ b/media/src/main/java/com/google/android/horologist/media/repository/PlayerRepository.kt
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.repository
+
+import com.google.android.horologist.media.ExperimentalHorologistMediaApi
+import com.google.android.horologist.media.model.Command
+import com.google.android.horologist.media.model.MediaItem
+import com.google.android.horologist.media.model.MediaItemPosition
+import com.google.android.horologist.media.model.PlayerState
+import kotlinx.coroutines.flow.StateFlow
+
+@ExperimentalHorologistMediaApi
+public interface PlayerRepository {
+
+    /**
+     * Returns the player's currently available [commands][Command].
+     */
+    public val availableCommands: StateFlow<Set<Command>>
+
+    /**
+     * Returns the player's current [state][PlayerState].
+     */
+    public val currentState: StateFlow<PlayerState>
+
+    /**
+     * Returns the current [media item][MediaItem] playing, or that would play when player starts playing.
+     */
+    public val currentMediaItem: StateFlow<MediaItem?>
+
+    /**
+     * Returns the current [media item position][MediaItemPosition] of the player.
+     */
+    public val mediaItemPosition: StateFlow<MediaItemPosition?>
+
+    /**
+     * Returns the current value for shuffling of [media items][MediaItem] mode.
+     */
+    public val shuffleModeEnabled: StateFlow<Boolean>
+
+    /**
+     * Prepares the player. E.g. player will start acquiring all the required resources to play.
+     */
+    public fun prepare()
+
+    /**
+     * Resumes playback as soon as player is ready.
+     */
+    public fun play()
+
+    /**
+     * Pauses playback.
+     */
+    public fun pause()
+
+    /**
+     * Returns whether a previous [media item][MediaItem] exists.
+     */
+    public fun hasPreviousMediaItem(): Boolean
+
+    /**
+     * Seeks to the default position of previous [media item][MediaItem].
+     */
+    public fun seekToPreviousMediaItem()
+
+    /**
+     * Returns whether a next [media item][MediaItem] exists.
+     */
+    public fun hasNextMediaItem(): Boolean
+
+    /**
+     * Seeks to the default position of next [media item][MediaItem].
+     */
+    public fun seekToNextMediaItem()
+
+    /**
+     * Returns the [seekBack] increment.
+     *
+     * @return The seek back increment, in milliseconds.
+     */
+    public fun getSeekBackIncrement(): Long
+
+    /**
+     * Seeks back in the [current media item][currentMediaItem] by [seek back increment][getSeekBackIncrement].
+     */
+    public fun seekBack()
+
+    /**
+     * Returns the [seekForward] increment.
+     *
+     * @return The seek forward increment, in milliseconds.
+     */
+    public fun getSeekForwardIncrement(): Long
+
+    /**
+     * Seek forward in the [current media item][currentMediaItem] by [seek forward increment][getSeekForwardIncrement].
+     */
+    public fun seekForward()
+
+    /**
+     * Sets whether shuffling of [media items][MediaItem] is enabled.
+     */
+    public fun setShuffleModeEnabled(shuffleModeEnabled: Boolean)
+
+    /**
+     * Returns whether shuffling of [media items][MediaItem] is enabled.
+     */
+    public fun getShuffleModeEnabled(): Boolean
+
+    /**
+     * Clears the playlist, adds the specified [media item][MediaItem] and resets the position to
+     * the default position.
+     */
+    public fun setMediaItem(mediaItem: MediaItem)
+
+    /**
+     * Clears the playlist, adds the specified [media items][MediaItem] and resets the position to
+     * the default position.
+     *
+     * @param mediaItems The new [media item][MediaItem].
+     */
+    public fun setMediaItems(mediaItems: List<MediaItem>)
+
+    /**
+     * Adds a [media item][MediaItem] to the end of the playlist.
+     */
+    public fun addMediaItem(mediaItem: MediaItem)
+
+    /**
+     * Adds a [media item][MediaItem] at the given index of the playlist.
+     *
+     * @param index The index at which to add the [media item][MediaItem]. If the index is larger than the size
+     * of the playlist, the media item is added to the end of the playlist.
+     * @param mediaItem The [media item][MediaItem] to add.
+     */
+    public fun addMediaItem(index: Int, mediaItem: MediaItem)
+
+    /**
+     * Removes the [media item][MediaItem] at the given index of the playlist.
+     *
+     * @param index The index at which to remove the [media item][MediaItem].
+     */
+    public fun removeMediaItem(index: Int)
+
+    /**
+     * Clears the playlist.
+     */
+    public fun clearMediaItems()
+
+    /**
+     * Returns the number of [media items][MediaItem] in the playlist.
+     * */
+    public fun getMediaItemCount(): Int
+
+    /**
+     * Returns the [media item][MediaItem] at the given index.
+     */
+    public fun getMediaItemAt(index: Int): MediaItem?
+
+    /**
+     * Returns the index of the current [media item][MediaItem].
+     */
+    public fun getCurrentMediaItemIndex(): Int
+
+    /**
+     * Releases the player. This method must be called when the player is no longer required. The
+     * player must not be used after calling this method.
+     */
+    public fun release()
+}

--- a/media/src/main/java/com/google/android/horologist/media/repository/PlayerRepository.kt
+++ b/media/src/main/java/com/google/android/horologist/media/repository/PlayerRepository.kt
@@ -72,9 +72,9 @@ public interface PlayerRepository {
     public fun hasPreviousMediaItem(): Boolean
 
     /**
-     * Seeks to the default position of previous [media item][MediaItem].
+     * Skips to the default position of previous [media item][MediaItem].
      */
-    public fun seekToPreviousMediaItem()
+    public fun skipToPreviousMediaItem()
 
     /**
      * Returns whether a next [media item][MediaItem] exists.
@@ -82,9 +82,9 @@ public interface PlayerRepository {
     public fun hasNextMediaItem(): Boolean
 
     /**
-     * Seeks to the default position of next [media item][MediaItem].
+     * Skips to the default position of next [media item][MediaItem].
      */
-    public fun seekToNextMediaItem()
+    public fun skipToNextMediaItem()
 
     /**
      * Returns the [seekBack] increment.

--- a/media/src/test/java/com/google/android/horologist/media/model/MediaItemPositionTest.kt
+++ b/media/src/test/java/com/google/android/horologist/media/model/MediaItemPositionTest.kt
@@ -18,16 +18,18 @@ package com.google.android.horologist.media.model
 
 import org.junit.Assert.assertThrows
 import org.junit.Test
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 class MediaItemPositionTest {
 
     @Test
     fun givenCurrentPositionIsNegative_whenCreateKnownPosition_thenExceptionIsThrown() {
         // given
-        val current = -1L
+        val current = (-1).seconds
 
         // when
-        val whenBlock = { MediaItemPosition.create(current = current, duration = 10L) }
+        val whenBlock = { MediaItemPosition.create(current = current, duration = 10.seconds) }
 
         // then
         assertThrows(IllegalStateException::class.java) { whenBlock() }
@@ -36,10 +38,10 @@ class MediaItemPositionTest {
     @Test
     fun givenDurationIsZero_whenCreateKnownPosition_thenExceptionIsThrown() {
         // given
-        val duration = 0L
+        val duration = Duration.ZERO
 
         // when
-        val whenBlock = { MediaItemPosition.create(current = 0L, duration = duration) }
+        val whenBlock = { MediaItemPosition.create(current = Duration.ZERO, duration = duration) }
 
         // then
         assertThrows(IllegalStateException::class.java) { whenBlock() }
@@ -48,8 +50,8 @@ class MediaItemPositionTest {
     @Test
     fun givenCurrentPositionIsGreaterThanDuration_whenCreateKnownPosition_thenExceptionIsThrown() {
         // given
-        val current = 2L
-        val duration = 1L
+        val current = 2.seconds
+        val duration = 1.seconds
 
         // when
         val whenBlock = { MediaItemPosition.create(current = current, duration = duration) }

--- a/media/src/test/java/com/google/android/horologist/media/model/MediaItemPositionTest.kt
+++ b/media/src/test/java/com/google/android/horologist/media/model/MediaItemPositionTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.model
+
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class MediaItemPositionTest {
+
+    @Test
+    fun givenCurrentPositionIsNegative_whenCreateKnownPosition_thenExceptionIsThrown() {
+        // given
+        val current = -1L
+
+        // when
+        val whenBlock = { MediaItemPosition.create(current = current, duration = 10L) }
+
+        // then
+        assertThrows(IllegalStateException::class.java) { whenBlock() }
+    }
+
+    @Test
+    fun givenDurationIsZero_whenCreateKnownPosition_thenExceptionIsThrown() {
+        // given
+        val duration = 0L
+
+        // when
+        val whenBlock = { MediaItemPosition.create(current = 0L, duration = duration) }
+
+        // then
+        assertThrows(IllegalStateException::class.java) { whenBlock() }
+    }
+
+    @Test
+    fun givenCurrentPositionIsGreaterThanDuration_whenCreateKnownPosition_thenExceptionIsThrown() {
+        // given
+        val current = 2L
+        val duration = 1L
+
+        // when
+        val whenBlock = { MediaItemPosition.create(current = current, duration = duration) }
+
+        // then
+        assertThrows(IllegalStateException::class.java) { whenBlock() }
+    }
+}


### PR DESCRIPTION
#### WHAT

Add `PlayerRepository` and domain models to `media` module.

#### WHY

In order to have a `PlayerRepository` that is independent of [Media3](https://developer.android.com/jetpack/androidx/releases/media3) dependencies.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
