### PR TITLE
Picker API review

### DIFF
--- a/composables/api/current.api
+++ b/composables/api/current.api
@@ -2,15 +2,15 @@
 package com.google.android.horologist.composables {
 
   public final class DatePickerKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public static void DatePicker(kotlin.jvm.functions.Function1<? super java.time.LocalDate,kotlin.Unit> onValueConfirm, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalDate value);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public static void DatePicker(kotlin.jvm.functions.Function1<? super java.time.LocalDate,kotlin.Unit> onDateConfirm, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalDate date);
   }
 
   @kotlin.RequiresOptIn(message="Composables is experimental. The API may be changed in the future.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention) public @interface ExperimentalHorologistComposablesApi {
   }
 
   public final class TimePickerKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public static void TimePicker(kotlin.jvm.functions.Function1<? super java.time.LocalTime,kotlin.Unit> onValueConfirm, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalTime value);
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public static void TimePickerWith12HourClock(kotlin.jvm.functions.Function1<? super java.time.LocalTime,kotlin.Unit> onValueConfirm, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalTime value);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public static void TimePicker(kotlin.jvm.functions.Function1<? super java.time.LocalTime,kotlin.Unit> onTimeConfirm, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalTime time);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public static void TimePickerWith12HourClock(kotlin.jvm.functions.Function1<? super java.time.LocalTime,kotlin.Unit> onTimeConfirm, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalTime time);
   }
 
 }

--- a/composables/api/current.api
+++ b/composables/api/current.api
@@ -2,15 +2,15 @@
 package com.google.android.horologist.composables {
 
   public final class DatePickerKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public static void DatePicker(kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.BoxScope,kotlin.Unit> buttonIcon, kotlin.jvm.functions.Function1<? super java.time.LocalDate,kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalDate initial);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public static void DatePicker(kotlin.jvm.functions.Function1<? super java.time.LocalDate,kotlin.Unit> onValueConfirm, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalDate value);
   }
 
   @kotlin.RequiresOptIn(message="Composables is experimental. The API may be changed in the future.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention) public @interface ExperimentalHorologistComposablesApi {
   }
 
   public final class TimePickerKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public static void TimePicker(kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.BoxScope,kotlin.Unit> buttonIcon, kotlin.jvm.functions.Function1<? super java.time.LocalTime,kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalTime initial);
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public static void TimePickerWith12HourClock(kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.BoxScope,kotlin.Unit> buttonIcon, kotlin.jvm.functions.Function1<? super java.time.LocalTime,kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalTime initial);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public static void TimePicker(kotlin.jvm.functions.Function1<? super java.time.LocalTime,kotlin.Unit> onValueConfirm, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalTime value);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public static void TimePickerWith12HourClock(kotlin.jvm.functions.Function1<? super java.time.LocalTime,kotlin.Unit> onValueConfirm, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalTime value);
   }
 
 }

--- a/composables/src/androidTest/java/com/google/android/horologist/DatePickerTest.kt
+++ b/composables/src/androidTest/java/com/google/android/horologist/DatePickerTest.kt
@@ -18,14 +18,9 @@
 
 package com.google.android.horologist
 
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertTextEquals
@@ -33,8 +28,6 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.unit.dp
-import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.composables.DatePicker
 import com.google.android.horologist.composables.ExperimentalHorologistComposablesApi
@@ -52,19 +45,10 @@ class DatePickerTest {
         composeTestRule.setContent {
             if (date == null) {
                 DatePicker(
-                    buttonIcon = {
-                        Icon(
-                            imageVector = Icons.Filled.Check,
-                            contentDescription = "check",
-                            modifier = Modifier
-                                .size(24.dp)
-                                .wrapContentSize(align = Alignment.Center),
-                        )
-                    },
-                    onClick = {
+                    onDateConfirm = {
                         date = it
                     },
-                    initial = LocalDate.of(2022, 4, 25)
+                    date = LocalDate.of(2022, 4, 25)
                 )
             } else {
                 Text(modifier = Modifier.testTag("date"), text = "$date")

--- a/composables/src/androidTest/java/com/google/android/horologist/DatePickerTest.kt
+++ b/composables/src/androidTest/java/com/google/android/horologist/DatePickerTest.kt
@@ -55,7 +55,7 @@ class DatePickerTest {
             }
         }
 
-        composeTestRule.onNodeWithContentDescription("check").performClick()
+        composeTestRule.onNodeWithContentDescription("Confirm").performClick()
 
         composeTestRule.onNodeWithTag("date").assertTextEquals("2022-04-25")
     }

--- a/composables/src/androidTest/java/com/google/android/horologist/TimePickerTest.kt
+++ b/composables/src/androidTest/java/com/google/android/horologist/TimePickerTest.kt
@@ -18,14 +18,9 @@
 
 package com.google.android.horologist
 
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertTextEquals
@@ -33,8 +28,6 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.unit.dp
-import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.composables.ExperimentalHorologistComposablesApi
 import com.google.android.horologist.composables.TimePicker
@@ -53,19 +46,10 @@ class TimePickerTest {
         composeTestRule.setContent {
             if (time == null) {
                 TimePicker(
-                    buttonIcon = {
-                        Icon(
-                            imageVector = Icons.Filled.Check,
-                            contentDescription = "check",
-                            modifier = Modifier
-                                .size(24.dp)
-                                .wrapContentSize(align = Alignment.Center),
-                        )
-                    },
-                    onClick = {
+                    onValueConfirm = {
                         time = it
                     },
-                    initial = LocalTime.of(11, 59, 31)
+                    value = LocalTime.of(11, 59, 31)
                 )
             } else {
                 Text(modifier = Modifier.testTag("time"), text = "$time")
@@ -83,19 +67,10 @@ class TimePickerTest {
         composeTestRule.setContent {
             if (time == null) {
                 TimePickerWith12HourClock(
-                    buttonIcon = {
-                        Icon(
-                            imageVector = Icons.Filled.Check,
-                            contentDescription = "check",
-                            modifier = Modifier
-                                .size(24.dp)
-                                .wrapContentSize(align = Alignment.Center),
-                        )
-                    },
-                    onClick = {
+                    onValueConfirm = {
                         time = it
                     },
-                    initial = LocalTime.of(11, 59)
+                    value = LocalTime.of(11, 59)
                 )
             } else {
                 Text(modifier = Modifier.testTag("time"), text = "$time")

--- a/composables/src/androidTest/java/com/google/android/horologist/TimePickerTest.kt
+++ b/composables/src/androidTest/java/com/google/android/horologist/TimePickerTest.kt
@@ -56,7 +56,7 @@ class TimePickerTest {
             }
         }
 
-        composeTestRule.onNodeWithContentDescription("check").performClick()
+        composeTestRule.onNodeWithContentDescription("Confirm").performClick()
 
         composeTestRule.onNodeWithTag("time").assertTextEquals("11:59:31")
     }
@@ -77,7 +77,7 @@ class TimePickerTest {
             }
         }
 
-        composeTestRule.onNodeWithContentDescription("check").performClick()
+        composeTestRule.onNodeWithContentDescription("Confirm").performClick()
 
         composeTestRule.onNodeWithTag("time").assertTextEquals("11:59")
     }

--- a/composables/src/androidTest/java/com/google/android/horologist/TimePickerTest.kt
+++ b/composables/src/androidTest/java/com/google/android/horologist/TimePickerTest.kt
@@ -46,10 +46,10 @@ class TimePickerTest {
         composeTestRule.setContent {
             if (time == null) {
                 TimePicker(
-                    onValueConfirm = {
+                    onTimeConfirm = {
                         time = it
                     },
-                    value = LocalTime.of(11, 59, 31)
+                    time = LocalTime.of(11, 59, 31)
                 )
             } else {
                 Text(modifier = Modifier.testTag("time"), text = "$time")
@@ -67,10 +67,10 @@ class TimePickerTest {
         composeTestRule.setContent {
             if (time == null) {
                 TimePickerWith12HourClock(
-                    onValueConfirm = {
+                    onTimeConfirm = {
                         time = it
                     },
-                    value = LocalTime.of(11, 59)
+                    time = LocalTime.of(11, 59)
                 )
             } else {
                 Text(modifier = Modifier.testTag("time"), text = "$time")

--- a/composables/src/debug/java/com/google/android/horologist/composables/DatePickerPreview.kt
+++ b/composables/src/debug/java/com/google/android/horologist/composables/DatePickerPreview.kt
@@ -32,7 +32,7 @@ fun DatePickerPreview() {
     // Due to a limitation with ScalingLazyColumn,
     // previews only work in interactive mode.
     DatePicker(
-        onValueConfirm = {},
-        value = LocalDate.of(2022, 4, 25)
+        onDateConfirm = {},
+        date = LocalDate.of(2022, 4, 25)
     )
 }

--- a/composables/src/debug/java/com/google/android/horologist/composables/DatePickerPreview.kt
+++ b/composables/src/debug/java/com/google/android/horologist/composables/DatePickerPreview.kt
@@ -18,15 +18,7 @@
 
 package com.google.android.horologist.composables
 
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import androidx.wear.compose.material.Icon
 import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 import com.google.android.horologist.compose.tools.WearPreviewFontSizes
@@ -40,16 +32,7 @@ fun DatePickerPreview() {
     // Due to a limitation with ScalingLazyColumn,
     // previews only work in interactive mode.
     DatePicker(
-        buttonIcon = {
-            Icon(
-                imageVector = Icons.Filled.Check,
-                contentDescription = "check",
-                modifier = Modifier
-                    .size(24.dp)
-                    .wrapContentSize(align = Alignment.Center),
-            )
-        },
-        onClick = {},
-        initial = LocalDate.of(2022, 4, 25)
+        onValueConfirm = {},
+        value = LocalDate.of(2022, 4, 25)
     )
 }

--- a/composables/src/debug/java/com/google/android/horologist/composables/TimePicker12hPreview.kt
+++ b/composables/src/debug/java/com/google/android/horologist/composables/TimePicker12hPreview.kt
@@ -18,15 +18,7 @@
 
 package com.google.android.horologist.composables
 
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import androidx.wear.compose.material.Icon
 import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 import com.google.android.horologist.compose.tools.WearPreviewFontSizes
@@ -40,16 +32,7 @@ fun TimePicker12hPreview() {
     // Due to a limitation with ScalingLazyColumn,
     // previews only work in interactive mode.
     TimePickerWith12HourClock(
-        buttonIcon = {
-            Icon(
-                imageVector = Icons.Filled.Check,
-                contentDescription = "check",
-                modifier = Modifier
-                    .size(24.dp)
-                    .wrapContentSize(align = Alignment.Center),
-            )
-        },
-        initial = LocalTime.of(10, 10, 0),
-        onClick = {}
+        value = LocalTime.of(10, 10, 0),
+        onValueConfirm = {}
     )
 }

--- a/composables/src/debug/java/com/google/android/horologist/composables/TimePicker12hPreview.kt
+++ b/composables/src/debug/java/com/google/android/horologist/composables/TimePicker12hPreview.kt
@@ -32,7 +32,7 @@ fun TimePicker12hPreview() {
     // Due to a limitation with ScalingLazyColumn,
     // previews only work in interactive mode.
     TimePickerWith12HourClock(
-        value = LocalTime.of(10, 10, 0),
-        onValueConfirm = {}
+        time = LocalTime.of(10, 10, 0),
+        onTimeConfirm = {}
     )
 }

--- a/composables/src/debug/java/com/google/android/horologist/composables/TimePickerPreview.kt
+++ b/composables/src/debug/java/com/google/android/horologist/composables/TimePickerPreview.kt
@@ -32,7 +32,7 @@ fun TimePickerPreview() {
     // Due to a limitation with ScalingLazyColumn,
     // previews only work in interactive mode.
     TimePicker(
-        value = LocalTime.of(10, 10, 0),
-        onValueConfirm = { }
+        time = LocalTime.of(10, 10, 0),
+        onTimeConfirm = { }
     )
 }

--- a/composables/src/debug/java/com/google/android/horologist/composables/TimePickerPreview.kt
+++ b/composables/src/debug/java/com/google/android/horologist/composables/TimePickerPreview.kt
@@ -18,15 +18,7 @@
 
 package com.google.android.horologist.composables
 
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import androidx.wear.compose.material.Icon
 import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 import com.google.android.horologist.compose.tools.WearPreviewFontSizes
@@ -40,16 +32,7 @@ fun TimePickerPreview() {
     // Due to a limitation with ScalingLazyColumn,
     // previews only work in interactive mode.
     TimePicker(
-        buttonIcon = {
-            Icon(
-                imageVector = Icons.Filled.Check,
-                contentDescription = "check",
-                modifier = Modifier
-                    .size(24.dp)
-                    .wrapContentSize(align = Alignment.Center),
-            )
-        },
-        initial = LocalTime.of(10, 10, 0),
-        onClick = { }
+        value = LocalTime.of(10, 10, 0),
+        onValueConfirm = { }
     )
 }

--- a/composables/src/main/java/com/google/android/horologist/composables/DatePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/DatePicker.kt
@@ -197,12 +197,12 @@ public fun DatePicker(
                 )
                 Button(
                     onClick = {
-                        val date = LocalDate.of(
+                        val confirmedDate = LocalDate.of(
                             yearState.selectedOption + 1,
                             monthState.selectedOption + 1,
                             dayState.selectedOption + 1
                         )
-                        onDateConfirm(date)
+                        onDateConfirm(confirmedDate)
                     },
                 ) {
                     Icon(

--- a/composables/src/main/java/com/google/android/horologist/composables/DatePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/DatePicker.kt
@@ -17,7 +17,6 @@
 package com.google.android.horologist.composables
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -28,6 +27,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -43,6 +45,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Button
+import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.PickerState
 import androidx.wear.compose.material.Text
@@ -60,18 +63,16 @@ import java.time.temporal.TemporalAdjusters
  * overrides for MaterialTheme.typography.display2 which is used to display the main picker
  * value.
  *
- * @param buttonIcon the button content.
- * @param onClick the button event handler.
+ * @param onValueConfirm the button event handler.
  * @param modifier the modifiers for the `Box` containing the UI elements.
- * @param initial the initial value to seed the picker with.
+ * @param value the initial value to seed the picker with.
  */
 @ExperimentalHorologistComposablesApi
 @Composable
 public fun DatePicker(
-    buttonIcon: @Composable BoxScope.() -> Unit,
-    onClick: (LocalDate) -> Unit,
+    onValueConfirm: (LocalDate) -> Unit,
     modifier: Modifier = Modifier,
-    initial: LocalDate = LocalDate.now()
+    value: LocalDate = LocalDate.now()
 ) {
     // Omit scaling according to Settings > Display > Font size for this screen
     val typography = MaterialTheme.typography.copy(
@@ -82,11 +83,11 @@ public fun DatePicker(
     MaterialTheme(typography = typography) {
         val yearState = rememberPickerState(
             initialNumberOfOptions = 3000,
-            initiallySelectedOption = initial.year - 1
+            initiallySelectedOption = value.year - 1
         )
         val monthState = rememberPickerState(
             initialNumberOfOptions = 12,
-            initiallySelectedOption = initial.monthValue - 1
+            initiallySelectedOption = value.monthValue - 1
         )
         val maxDayInMonth by remember {
             derivedStateOf {
@@ -101,7 +102,7 @@ public fun DatePicker(
         }
         val dayState = rememberPickerState(
             initialNumberOfOptions = maxDayInMonth,
-            initiallySelectedOption = initial.dayOfMonth - 1
+            initiallySelectedOption = value.dayOfMonth - 1
         )
         val focusRequester1 = remember { FocusRequester() }
         val focusRequester2 = remember { FocusRequester() }
@@ -201,10 +202,16 @@ public fun DatePicker(
                             monthState.selectedOption + 1,
                             dayState.selectedOption + 1
                         )
-                        onClick(date)
+                        onValueConfirm(date)
                     },
                 ) {
-                    buttonIcon()
+                    Icon(
+                        imageVector = Icons.Filled.Check,
+                        contentDescription = stringResource(id = R.string.picker_check_button),
+                        modifier = Modifier
+                            .size(24.dp)
+                            .wrapContentSize(align = Alignment.Center),
+                    )
                 }
                 Spacer(Modifier.height(12.dp))
             }

--- a/composables/src/main/java/com/google/android/horologist/composables/DatePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/DatePicker.kt
@@ -63,16 +63,16 @@ import java.time.temporal.TemporalAdjusters
  * overrides for MaterialTheme.typography.display2 which is used to display the main picker
  * value.
  *
- * @param onValueConfirm the button event handler.
+ * @param onDateConfirm the button event handler.
  * @param modifier the modifiers for the `Box` containing the UI elements.
- * @param value the initial value to seed the picker with.
+ * @param date the initial value to seed the picker with.
  */
 @ExperimentalHorologistComposablesApi
 @Composable
 public fun DatePicker(
-    onValueConfirm: (LocalDate) -> Unit,
+    onDateConfirm: (LocalDate) -> Unit,
     modifier: Modifier = Modifier,
-    value: LocalDate = LocalDate.now()
+    date: LocalDate = LocalDate.now()
 ) {
     // Omit scaling according to Settings > Display > Font size for this screen
     val typography = MaterialTheme.typography.copy(
@@ -83,11 +83,11 @@ public fun DatePicker(
     MaterialTheme(typography = typography) {
         val yearState = rememberPickerState(
             initialNumberOfOptions = 3000,
-            initiallySelectedOption = value.year - 1
+            initiallySelectedOption = date.year - 1
         )
         val monthState = rememberPickerState(
             initialNumberOfOptions = 12,
-            initiallySelectedOption = value.monthValue - 1
+            initiallySelectedOption = date.monthValue - 1
         )
         val maxDayInMonth by remember {
             derivedStateOf {
@@ -102,7 +102,7 @@ public fun DatePicker(
         }
         val dayState = rememberPickerState(
             initialNumberOfOptions = maxDayInMonth,
-            initiallySelectedOption = value.dayOfMonth - 1
+            initiallySelectedOption = date.dayOfMonth - 1
         )
         val focusRequester1 = remember { FocusRequester() }
         val focusRequester2 = remember { FocusRequester() }
@@ -131,9 +131,9 @@ public fun DatePicker(
                 Spacer(Modifier.height(16.dp))
                 Text(
                     text = when (selectedColumn) {
-                        0 -> stringResource(R.string.picker_day)
-                        1 -> stringResource(R.string.picker_month)
-                        else -> stringResource(R.string.picker_year)
+                        0 -> stringResource(R.string.horologist_picker_day)
+                        1 -> stringResource(R.string.horologist_picker_month)
+                        else -> stringResource(R.string.horologist_picker_year)
                     },
                     color = MaterialTheme.colors.secondary,
                     style = MaterialTheme.typography.button,
@@ -202,12 +202,12 @@ public fun DatePicker(
                             monthState.selectedOption + 1,
                             dayState.selectedOption + 1
                         )
-                        onValueConfirm(date)
+                        onDateConfirm(date)
                     },
                 ) {
                     Icon(
                         imageVector = Icons.Filled.Check,
-                        contentDescription = stringResource(id = R.string.picker_check_button),
+                        contentDescription = stringResource(id = R.string.horologist_picker_confirm_button),
                         modifier = Modifier
                             .size(24.dp)
                             .wrapContentSize(align = Alignment.Center),

--- a/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
@@ -33,6 +33,8 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -53,6 +55,7 @@ import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Button
 import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.CompactChip
+import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Picker
 import androidx.wear.compose.material.PickerDefaults
@@ -73,18 +76,16 @@ import java.time.temporal.ChronoField
  * overrides for MaterialTheme.typography.display3 which is used to display the main picker
  * value.
  *
- * @param buttonIcon the button content.
- * @param onClick the button event handler.
+ * @param onValueConfirm the button event handler.
  * @param modifier the modifiers for the `Box` containing the UI elements.
- * @param initial the initial value to seed the picker with.
+ * @param value the initial value to seed the picker with.
  */
 @ExperimentalHorologistComposablesApi
 @Composable
 public fun TimePicker(
-    buttonIcon: @Composable BoxScope.() -> Unit,
-    onClick: (LocalTime) -> Unit,
+    onValueConfirm: (LocalTime) -> Unit,
     modifier: Modifier = Modifier,
-    initial: LocalTime = LocalTime.now()
+    value: LocalTime = LocalTime.now()
 ) {
     // Omit scaling according to Settings > Display > Font size for this screen
     val typography = MaterialTheme.typography.copy(
@@ -94,15 +95,15 @@ public fun TimePicker(
     )
     val hourState = rememberPickerState(
         initialNumberOfOptions = 24,
-        initiallySelectedOption = initial.hour
+        initiallySelectedOption = value.hour
     )
     val minuteState = rememberPickerState(
         initialNumberOfOptions = 60,
-        initiallySelectedOption = initial.minute
+        initiallySelectedOption = value.minute
     )
     val secondsState = rememberPickerState(
         initialNumberOfOptions = 60,
-        initiallySelectedOption = initial.second
+        initiallySelectedOption = value.second
     )
     MaterialTheme(typography = typography) {
         var selectedColumn by remember { mutableStateOf(0) }
@@ -191,9 +192,15 @@ public fun TimePicker(
                         minuteState.selectedOption,
                         secondsState.selectedOption
                     )
-                    onClick(time)
+                    onValueConfirm(time)
                 }) {
-                    buttonIcon()
+                    Icon(
+                        imageVector = Icons.Filled.Check,
+                        contentDescription = stringResource(id = R.string.picker_check_button),
+                        modifier = Modifier
+                            .size(24.dp)
+                            .wrapContentSize(align = Alignment.Center),
+                    )
                 }
                 Spacer(Modifier.height(12.dp))
             }
@@ -214,18 +221,16 @@ public fun TimePicker(
  * overrides for MaterialTheme.typography.display1 which is used to display the main picker
  * value.
  *
- * @param buttonIcon the button content.
- * @param onClick the button event handler.
+ * @param onValueConfirm the button event handler.
  * @param modifier the modifiers for the `Column` containing the UI elements.
- * @param initial the initial value to seed the picker with.
+ * @param value the initial value to seed the picker with.
  */
 @ExperimentalHorologistComposablesApi
 @Composable
 public fun TimePickerWith12HourClock(
-    buttonIcon: @Composable BoxScope.() -> Unit,
-    onClick: (LocalTime) -> Unit,
+    onValueConfirm: (LocalTime) -> Unit,
     modifier: Modifier = Modifier,
-    initial: LocalTime = LocalTime.now()
+    value: LocalTime = LocalTime.now()
 ) {
     // Omit scaling according to Settings > Display > Font size for this screen,
     val typography = MaterialTheme.typography.copy(
@@ -235,13 +240,15 @@ public fun TimePickerWith12HourClock(
     )
     val hourState = rememberPickerState(
         initialNumberOfOptions = 12,
-        initiallySelectedOption = initial[ChronoField.CLOCK_HOUR_OF_AMPM] - 1
+        initiallySelectedOption = value[ChronoField.CLOCK_HOUR_OF_AMPM] - 1
     )
     val minuteState = rememberPickerState(
         initialNumberOfOptions = 60,
-        initiallySelectedOption = initial.minute
+        initiallySelectedOption = value.minute
     )
-    var amPm by remember { mutableStateOf(initial[ChronoField.AMPM_OF_DAY]) }
+    var amPm by remember { mutableStateOf(value[ChronoField.AMPM_OF_DAY]) }
+    // TODO check the results of talkback with these internally localised values
+    // move to stringResources() otherwise.
     val amString = remember {
         LocalTime.of(6, 0).format(DateTimeFormatter.ofPattern("a"))
     }
@@ -332,9 +339,15 @@ public fun TimePickerWith12HourClock(
                     minuteState.selectedOption,
                     0
                 ).with(ChronoField.AMPM_OF_DAY, amPm.toLong())
-                onClick(time)
+                onValueConfirm(time)
             }) {
-                buttonIcon()
+                Icon(
+                    imageVector = Icons.Filled.Check,
+                    contentDescription = stringResource(id = R.string.picker_check_button),
+                    modifier = Modifier
+                        .size(24.dp)
+                        .wrapContentSize(align = Alignment.Center),
+                )
             }
             Spacer(Modifier.height(8.dp))
             LaunchedEffect(selectedColumn) {

--- a/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
@@ -76,16 +76,16 @@ import java.time.temporal.ChronoField
  * overrides for MaterialTheme.typography.display3 which is used to display the main picker
  * value.
  *
- * @param onValueConfirm the button event handler.
+ * @param onTimeConfirm the button event handler.
  * @param modifier the modifiers for the `Box` containing the UI elements.
- * @param value the initial value to seed the picker with.
+ * @param time the initial value to seed the picker with.
  */
 @ExperimentalHorologistComposablesApi
 @Composable
 public fun TimePicker(
-    onValueConfirm: (LocalTime) -> Unit,
+    onTimeConfirm: (LocalTime) -> Unit,
     modifier: Modifier = Modifier,
-    value: LocalTime = LocalTime.now()
+    time: LocalTime = LocalTime.now()
 ) {
     // Omit scaling according to Settings > Display > Font size for this screen
     val typography = MaterialTheme.typography.copy(
@@ -95,15 +95,15 @@ public fun TimePicker(
     )
     val hourState = rememberPickerState(
         initialNumberOfOptions = 24,
-        initiallySelectedOption = value.hour
+        initiallySelectedOption = time.hour
     )
     val minuteState = rememberPickerState(
         initialNumberOfOptions = 60,
-        initiallySelectedOption = value.minute
+        initiallySelectedOption = time.minute
     )
     val secondsState = rememberPickerState(
         initialNumberOfOptions = 60,
-        initiallySelectedOption = value.second
+        initiallySelectedOption = time.second
     )
     MaterialTheme(typography = typography) {
         var selectedColumn by remember { mutableStateOf(0) }
@@ -120,9 +120,9 @@ public fun TimePicker(
                 Spacer(Modifier.height(12.dp))
                 Text(
                     text = when (selectedColumn) {
-                        0 -> stringResource(R.string.time_picker_hour)
-                        1 -> stringResource(R.string.time_picker_minute)
-                        else -> stringResource(R.string.time_picker_second)
+                        0 -> stringResource(R.string.horologist_time_picker_hour)
+                        1 -> stringResource(R.string.horologist_time_picker_minute)
+                        else -> stringResource(R.string.horologist_time_picker_second)
                     },
                     color = optionColor,
                     style = MaterialTheme.typography.button,
@@ -192,11 +192,11 @@ public fun TimePicker(
                         minuteState.selectedOption,
                         secondsState.selectedOption
                     )
-                    onValueConfirm(time)
+                    onTimeConfirm(time)
                 }) {
                     Icon(
                         imageVector = Icons.Filled.Check,
-                        contentDescription = stringResource(id = R.string.picker_check_button),
+                        contentDescription = stringResource(id = R.string.horologist_picker_confirm_button),
                         modifier = Modifier
                             .size(24.dp)
                             .wrapContentSize(align = Alignment.Center),
@@ -221,16 +221,16 @@ public fun TimePicker(
  * overrides for MaterialTheme.typography.display1 which is used to display the main picker
  * value.
  *
- * @param onValueConfirm the button event handler.
+ * @param onTimeConfirm the button event handler.
  * @param modifier the modifiers for the `Column` containing the UI elements.
- * @param value the initial value to seed the picker with.
+ * @param time the initial value to seed the picker with.
  */
 @ExperimentalHorologistComposablesApi
 @Composable
 public fun TimePickerWith12HourClock(
-    onValueConfirm: (LocalTime) -> Unit,
+    onTimeConfirm: (LocalTime) -> Unit,
     modifier: Modifier = Modifier,
-    value: LocalTime = LocalTime.now()
+    time: LocalTime = LocalTime.now()
 ) {
     // Omit scaling according to Settings > Display > Font size for this screen,
     val typography = MaterialTheme.typography.copy(
@@ -240,13 +240,13 @@ public fun TimePickerWith12HourClock(
     )
     val hourState = rememberPickerState(
         initialNumberOfOptions = 12,
-        initiallySelectedOption = value[ChronoField.CLOCK_HOUR_OF_AMPM] - 1
+        initiallySelectedOption = time[ChronoField.CLOCK_HOUR_OF_AMPM] - 1
     )
     val minuteState = rememberPickerState(
         initialNumberOfOptions = 60,
-        initiallySelectedOption = value.minute
+        initiallySelectedOption = time.minute
     )
-    var amPm by remember { mutableStateOf(value[ChronoField.AMPM_OF_DAY]) }
+    var amPm by remember { mutableStateOf(time[ChronoField.AMPM_OF_DAY]) }
     // TODO check the results of talkback with these internally localised values
     // move to stringResources() otherwise.
     val amString = remember {
@@ -301,7 +301,7 @@ public fun TimePickerWith12HourClock(
                     state = hourState,
                     focusRequester = focusRequester1,
                     modifier = Modifier.size(64.dp, 100.dp),
-                    readOnlyLabel = { LabelText(stringResource(R.string.time_picker_hour)) }
+                    readOnlyLabel = { LabelText(stringResource(R.string.horologist_time_picker_hour)) }
                 ) { hour: Int ->
                     TimePiece(
                         selected = selectedColumn == 0,
@@ -317,7 +317,7 @@ public fun TimePickerWith12HourClock(
                     state = minuteState,
                     focusRequester = focusRequester2,
                     modifier = Modifier.size(64.dp, 100.dp),
-                    readOnlyLabel = { LabelText(stringResource(R.string.time_picker_min)) }
+                    readOnlyLabel = { LabelText(stringResource(R.string.horologist_time_picker_min)) }
                 ) { minute: Int ->
                     TimePiece(
                         selected = selectedColumn == 1,
@@ -339,11 +339,11 @@ public fun TimePickerWith12HourClock(
                     minuteState.selectedOption,
                     0
                 ).with(ChronoField.AMPM_OF_DAY, amPm.toLong())
-                onValueConfirm(time)
+                onTimeConfirm(time)
             }) {
                 Icon(
                     imageVector = Icons.Filled.Check,
-                    contentDescription = stringResource(id = R.string.picker_check_button),
+                    contentDescription = stringResource(id = R.string.horologist_picker_confirm_button),
                     modifier = Modifier
                         .size(24.dp)
                         .wrapContentSize(align = Alignment.Center),

--- a/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
@@ -187,12 +187,12 @@ public fun TimePicker(
                         .weight(weightsToCenterVertically)
                 )
                 Button(onClick = {
-                    val time = LocalTime.of(
+                    val confirmedTime = LocalTime.of(
                         hourState.selectedOption,
                         minuteState.selectedOption,
                         secondsState.selectedOption
                     )
-                    onTimeConfirm(time)
+                    onTimeConfirm(confirmedTime)
                 }) {
                     Icon(
                         imageVector = Icons.Filled.Check,
@@ -334,12 +334,12 @@ public fun TimePickerWith12HourClock(
                     .weight(0.5f)
             )
             Button(onClick = {
-                val time = LocalTime.of(
+                val confirmedTime = LocalTime.of(
                     hourState.selectedOption + 1,
                     minuteState.selectedOption,
                     0
                 ).with(ChronoField.AMPM_OF_DAY, amPm.toLong())
-                onTimeConfirm(time)
+                onTimeConfirm(confirmedTime)
             }) {
                 Icon(
                     imageVector = Icons.Filled.Check,

--- a/composables/src/main/res/values/strings.xml
+++ b/composables/src/main/res/values/strings.xml
@@ -15,12 +15,12 @@
   -->
 
 <resources>
-    <string name="time_picker_hour">Hour</string>
-    <string name="time_picker_min">Min</string>
-    <string name="time_picker_minute">Minute</string>
-    <string name="time_picker_second">Second</string>
-    <string name="picker_day">Day</string>
-    <string name="picker_month">Month</string>
-    <string name="picker_year">Year</string>
-    <string name="picker_check_button">Check</string>
+    <string name="horologist_time_picker_hour">Hour</string>
+    <string name="horologist_time_picker_min">Min</string>
+    <string name="horologist_time_picker_minute">Minute</string>
+    <string name="horologist_time_picker_second">Second</string>
+    <string name="horologist_picker_day">Day</string>
+    <string name="horologist_picker_month">Month</string>
+    <string name="horologist_picker_year">Year</string>
+    <string name="horologist_picker_confirm_button">Confirm</string>
 </resources>

--- a/composables/src/main/res/values/strings.xml
+++ b/composables/src/main/res/values/strings.xml
@@ -22,4 +22,5 @@
     <string name="picker_day">Day</string>
     <string name="picker_month">Month</string>
     <string name="picker_year">Year</string>
+    <string name="picker_check_button">Check</string>
 </resources>

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/DatePickerTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/DatePickerTest.kt
@@ -18,14 +18,6 @@
 
 package com.google.android.horologist.composables
 
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import androidx.wear.compose.material.Icon
 import app.cash.paparazzi.Paparazzi
 import com.google.android.horologist.paparazzi.GALAXY_WATCH4_CLASSIC_LARGE
 import com.google.android.horologist.paparazzi.WearSnapshotHandler
@@ -48,17 +40,8 @@ class DatePickerTest {
     fun datePickerInitial() {
         paparazzi.snapshot {
             DatePicker(
-                buttonIcon = {
-                    Icon(
-                        imageVector = Icons.Filled.Check,
-                        contentDescription = "check",
-                        modifier = Modifier
-                            .size(24.dp)
-                            .wrapContentSize(align = Alignment.Center),
-                    )
-                },
-                onClick = {},
-                initial = LocalDate.of(2022, 4, 25)
+                onValueConfirm = {},
+                value = LocalDate.of(2022, 4, 25)
             )
         }
     }

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/DatePickerTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/DatePickerTest.kt
@@ -40,8 +40,8 @@ class DatePickerTest {
     fun datePickerInitial() {
         paparazzi.snapshot {
             DatePicker(
-                onValueConfirm = {},
-                value = LocalDate.of(2022, 4, 25)
+                onDateConfirm = {},
+                date = LocalDate.of(2022, 4, 25)
             )
         }
     }

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/TimePicker12hTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/TimePicker12hTest.kt
@@ -40,8 +40,8 @@ class TimePicker12hTest {
     fun datePickerInitial() {
         paparazzi.snapshot {
             TimePickerWith12HourClock(
-                value = LocalTime.of(10, 10, 0),
-                onValueConfirm = {},
+                time = LocalTime.of(10, 10, 0),
+                onTimeConfirm = {},
             )
         }
     }

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/TimePicker12hTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/TimePicker12hTest.kt
@@ -18,14 +18,6 @@
 
 package com.google.android.horologist.composables
 
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import androidx.wear.compose.material.Icon
 import app.cash.paparazzi.Paparazzi
 import com.google.android.horologist.paparazzi.GALAXY_WATCH4_CLASSIC_LARGE
 import com.google.android.horologist.paparazzi.WearSnapshotHandler
@@ -48,17 +40,8 @@ class TimePicker12hTest {
     fun datePickerInitial() {
         paparazzi.snapshot {
             TimePickerWith12HourClock(
-                buttonIcon = {
-                    Icon(
-                        imageVector = Icons.Filled.Check,
-                        contentDescription = "check",
-                        modifier = Modifier
-                            .size(24.dp)
-                            .wrapContentSize(align = Alignment.Center),
-                    )
-                },
-                initial = LocalTime.of(10, 10, 0),
-                onClick = {}
+                value = LocalTime.of(10, 10, 0),
+                onValueConfirm = {},
             )
         }
     }

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/TimePickerTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/TimePickerTest.kt
@@ -40,8 +40,8 @@ class TimePickerTest {
     fun datePickerInitial() {
         paparazzi.snapshot {
             TimePicker(
-                value = LocalTime.of(10, 10, 0),
-                onValueConfirm = {},
+                time = LocalTime.of(10, 10, 0),
+                onTimeConfirm = {},
             )
         }
     }

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/TimePickerTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/TimePickerTest.kt
@@ -18,14 +18,6 @@
 
 package com.google.android.horologist.composables
 
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import androidx.wear.compose.material.Icon
 import app.cash.paparazzi.Paparazzi
 import com.google.android.horologist.paparazzi.GALAXY_WATCH4_CLASSIC_LARGE
 import com.google.android.horologist.paparazzi.WearSnapshotHandler
@@ -48,17 +40,8 @@ class TimePickerTest {
     fun datePickerInitial() {
         paparazzi.snapshot {
             TimePicker(
-                buttonIcon = {
-                    Icon(
-                        imageVector = Icons.Filled.Check,
-                        contentDescription = "check",
-                        modifier = Modifier
-                            .size(24.dp)
-                            .wrapContentSize(align = Alignment.Center),
-                    )
-                },
-                initial = LocalTime.of(10, 10, 0),
-                onClick = { }
+                value = LocalTime.of(10, 10, 0),
+                onValueConfirm = {},
             )
         }
     }

--- a/sample/src/main/java/com/google/android/horologist/sample/MainActivity.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/MainActivity.kt
@@ -20,23 +20,16 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.navigation.SwipeDismissableNavHost
 import androidx.wear.compose.navigation.composable
@@ -112,17 +105,8 @@ fun WearApp(
             }
             composable(Screen.DatePicker.route) {
                 DatePicker(
-                    buttonIcon = {
-                        Icon(
-                            imageVector = Icons.Filled.Check,
-                            contentDescription = "check",
-                            modifier = Modifier
-                                .size(24.dp)
-                                .wrapContentSize(align = Alignment.Center),
-                        )
-                    },
-                    initial = time.toLocalDate(),
-                    onClick = {
+                    value = time.toLocalDate(),
+                    onValueConfirm = {
                         time = time.toLocalTime().atDate(it)
                         navController.popBackStack()
                     }
@@ -130,17 +114,8 @@ fun WearApp(
             }
             composable(Screen.TimePicker.route) {
                 TimePickerWith12HourClock(
-                    buttonIcon = {
-                        Icon(
-                            imageVector = Icons.Filled.Check,
-                            contentDescription = "check",
-                            modifier = Modifier
-                                .size(24.dp)
-                                .wrapContentSize(align = Alignment.Center),
-                        )
-                    },
-                    initial = time.toLocalTime(),
-                    onClick = {
+                    value = time.toLocalTime(),
+                    onValueConfirm = {
                         time = time.toLocalDate().atTime(it)
                         navController.popBackStack()
                     }
@@ -148,17 +123,8 @@ fun WearApp(
             }
             composable(Screen.TimeWithSecondsPicker.route) {
                 TimePicker(
-                    buttonIcon = {
-                        Icon(
-                            imageVector = Icons.Filled.Check,
-                            contentDescription = "check",
-                            modifier = Modifier
-                                .size(24.dp)
-                                .wrapContentSize(align = Alignment.Center),
-                        )
-                    },
-                    initial = time.toLocalTime(),
-                    onClick = {
+                    value = time.toLocalTime(),
+                    onValueConfirm = {
                         time = time.toLocalDate().atTime(it)
                         navController.popBackStack()
                     }

--- a/sample/src/main/java/com/google/android/horologist/sample/MainActivity.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/MainActivity.kt
@@ -105,8 +105,8 @@ fun WearApp(
             }
             composable(Screen.DatePicker.route) {
                 DatePicker(
-                    value = time.toLocalDate(),
-                    onValueConfirm = {
+                    date = time.toLocalDate(),
+                    onDateConfirm = {
                         time = time.toLocalTime().atDate(it)
                         navController.popBackStack()
                     }
@@ -114,8 +114,8 @@ fun WearApp(
             }
             composable(Screen.TimePicker.route) {
                 TimePickerWith12HourClock(
-                    value = time.toLocalTime(),
-                    onValueConfirm = {
+                    time = time.toLocalTime(),
+                    onTimeConfirm = {
                         time = time.toLocalDate().atTime(it)
                         navController.popBackStack()
                     }
@@ -123,8 +123,8 @@ fun WearApp(
             }
             composable(Screen.TimeWithSecondsPicker.route) {
                 TimePicker(
-                    value = time.toLocalTime(),
-                    onValueConfirm = {
+                    time = time.toLocalTime(),
+                    onTimeConfirm = {
                         time = time.toLocalDate().atTime(it)
                         navController.popBackStack()
                     }


### PR DESCRIPTION
#### WHAT

Update Pickers API.

#### WHY

Follow idiomatic compose conventions.


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files



#### Later
- [ ] Confirm a11y for AM/PM
- [ ] Add chevron and next for date picker 
- [ ] CompoundPicker and State for a reusable Picker base.
