### PR TITLE
Add prefix to string resource names

### DIFF
--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeScreen.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeScreen.kt
@@ -170,7 +170,7 @@ public fun VolumeScreen(
         ) {
             val stateDescriptionText = volumeDescription(volumeState, audioOutput)
 
-            val onClickLabel = stringResource(id = R.string.volume_screen_change_audio_output)
+            val onClickLabel = stringResource(id = R.string.horologist_volume_screen_change_audio_output)
 
             Chip(
                 modifier = Modifier
@@ -209,9 +209,9 @@ public fun VolumeScreen(
 @Composable
 private fun volumeDescription(volumeState: VolumeState, audioOutput: AudioOutput): String {
     return if (audioOutput is AudioOutput.BluetoothHeadset)
-        stringResource(id = R.string.volume_screen_connected, volumeState.current)
+        stringResource(id = R.string.horologist_volume_screen_connected, volumeState.current)
     else
-        stringResource(id = R.string.volume_screen_not_connected)
+        stringResource(id = R.string.horologist_volume_screen_not_connected)
 }
 
 public object VolumeScreenDefaults {
@@ -221,7 +221,7 @@ public object VolumeScreenDefaults {
             modifier = Modifier
                 .size(26.dp),
             imageVector = Icons.Default.VolumeUp,
-            contentDescription = stringResource(id = R.string.volume_screen_volume_up),
+            contentDescription = stringResource(id = R.string.horologist_volume_screen_volume_up),
         )
     }
 
@@ -231,7 +231,7 @@ public object VolumeScreenDefaults {
             modifier = Modifier
                 .size(26.dp),
             imageVector = Icons.Default.VolumeDown,
-            contentDescription = stringResource(id = R.string.volume_screen_volume_down),
+            contentDescription = stringResource(id = R.string.horologist_volume_screen_volume_down),
         )
     }
 }

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/AudioOutputButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/AudioOutputButton.kt
@@ -46,7 +46,7 @@ public fun AudioOutputButton(
     ) {
         Icon(
             imageVector = Icons.Default.Radio,
-            contentDescription = stringResource(R.string.audio_output_content_description)
+            contentDescription = stringResource(R.string.horologist_audio_output_content_description)
         )
     }
 }

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
@@ -58,7 +58,7 @@ public fun SetVolumeButton(
 
         Icon(
             imageVector = imageVector,
-            contentDescription = stringResource(R.string.set_volume_content_description),
+            contentDescription = stringResource(R.string.horologist_set_volume_content_description),
             modifier = Modifier.semantics { iconImageVector = imageVector }
         )
     }

--- a/audio-ui/src/main/res/values/strings.xml
+++ b/audio-ui/src/main/res/values/strings.xml
@@ -15,11 +15,11 @@
   -->
 
 <resources>
-    <string name="volume_screen_volume_up">Increase Volume</string>
-    <string name="volume_screen_volume_down">Decrease Volume</string>
-    <string name="volume_screen_connected">Connected, Volume %1$d</string>
-    <string name="volume_screen_not_connected">Not Connected</string>
-    <string name="volume_screen_change_audio_output">Change Audio Output</string>
-    <string name="set_volume_content_description">Set Volume</string>
-    <string name="audio_output_content_description">Audio Output</string>
+    <string name="horologist_volume_screen_volume_up">Increase Volume</string>
+    <string name="horologist_volume_screen_volume_down">Decrease Volume</string>
+    <string name="horologist_volume_screen_connected">Connected, Volume %1$d</string>
+    <string name="horologist_volume_screen_not_connected">Not Connected</string>
+    <string name="horologist_volume_screen_change_audio_output">Change Audio Output</string>
+    <string name="horologist_set_volume_content_description">Set Volume</string>
+    <string name="horologist_audio_output_content_description">Audio Output</string>
 </resources>

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/PauseButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/PauseButton.kt
@@ -37,7 +37,7 @@ public fun PauseButton(
     MediaButton(
         onClick = onClick,
         icon = Icons.Default.Pause,
-        contentDescription = stringResource(id = R.string.pause_button_content_description),
+        contentDescription = stringResource(id = R.string.horologist_pause_button_content_description),
         modifier = modifier,
         enabled = enabled,
         colors = colors,

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/PlayButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/PlayButton.kt
@@ -37,7 +37,7 @@ public fun PlayButton(
     MediaButton(
         onClick = onClick,
         icon = Icons.Default.PlayArrow,
-        contentDescription = stringResource(id = R.string.play_button_content_description),
+        contentDescription = stringResource(id = R.string.horologist_play_button_content_description),
         modifier = modifier,
         enabled = enabled,
         colors = colors,

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/SeekBackButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/SeekBackButton.kt
@@ -46,9 +46,9 @@ public fun SeekBackButton(
     }
 
     val contentDescription = when (seekButtonIncrement) {
-        SeekButtonIncrement.Unknown -> stringResource(id = R.string.seek_back_button_rewind)
+        SeekButtonIncrement.Unknown -> stringResource(id = R.string.horologist_seek_back_button_rewind)
         else -> stringResource(
-            id = R.string.seek_back_button_rewind_seconds,
+            id = R.string.horologist_seek_back_button_rewind_seconds,
             seekButtonIncrement.seconds
         )
     }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/SeekBackButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/SeekBackButton.kt
@@ -46,9 +46,9 @@ public fun SeekBackButton(
     }
 
     val contentDescription = when (seekButtonIncrement) {
-        SeekButtonIncrement.Unknown -> stringResource(id = R.string.horologist_seek_back_button_rewind)
+        SeekButtonIncrement.Unknown -> stringResource(id = R.string.horologist_seek_back_button_content_description)
         else -> stringResource(
-            id = R.string.horologist_seek_back_button_rewind_seconds,
+            id = R.string.horologist_seek_back_button_seconds_content_description,
             seekButtonIncrement.seconds
         )
     }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/SeekForwardButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/SeekForwardButton.kt
@@ -47,9 +47,9 @@ public fun SeekForwardButton(
     }
 
     val contentDescription = when (seekButtonIncrement) {
-        SeekButtonIncrement.Unknown -> stringResource(id = R.string.seek_forward_button_forward)
+        SeekButtonIncrement.Unknown -> stringResource(id = R.string.horologist_seek_forward_button_forward)
         else -> stringResource(
-            id = R.string.seek_forward_button_forward_seconds,
+            id = R.string.horologist_seek_forward_button_forward_seconds,
             seekButtonIncrement.seconds
         )
     }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/SeekForwardButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/SeekForwardButton.kt
@@ -47,9 +47,9 @@ public fun SeekForwardButton(
     }
 
     val contentDescription = when (seekButtonIncrement) {
-        SeekButtonIncrement.Unknown -> stringResource(id = R.string.horologist_seek_forward_button_forward)
+        SeekButtonIncrement.Unknown -> stringResource(id = R.string.horologist_seek_forward_button_content_description)
         else -> stringResource(
-            id = R.string.horologist_seek_forward_button_forward_seconds,
+            id = R.string.horologist_seek_forward_button_seconds_content_description,
             seekButtonIncrement.seconds
         )
     }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/SeekToNextButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/SeekToNextButton.kt
@@ -37,7 +37,7 @@ public fun SeekToNextButton(
     MediaButton(
         onClick = onClick,
         icon = Icons.Default.SkipNext,
-        contentDescription = stringResource(id = R.string.seek_to_next_button_content_description),
+        contentDescription = stringResource(id = R.string.horologist_seek_to_next_button_content_description),
         modifier = modifier,
         enabled = enabled,
         colors = colors,

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/SeekToPreviousButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/SeekToPreviousButton.kt
@@ -37,7 +37,7 @@ public fun SeekToPreviousButton(
     MediaButton(
         onClick = onClick,
         icon = Icons.Default.SkipPrevious,
-        contentDescription = stringResource(id = R.string.seek_to_previous_button_content_description),
+        contentDescription = stringResource(id = R.string.horologist_seek_to_previous_button_content_description),
         modifier = modifier,
         enabled = enabled,
         colors = colors,

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/ShuffleButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/controls/ShuffleButton.kt
@@ -49,7 +49,7 @@ public fun ShuffleButton(
         val icon = if (shuffleOn) Icons.Default.ShuffleOn else Icons.Default.Shuffle
         Icon(
             imageVector = icon,
-            contentDescription = stringResource(id = R.string.shuffle_button_content_description),
+            contentDescription = stringResource(id = R.string.horologist_shuffle_button_content_description),
             modifier = Modifier.semantics { iconImageVector = icon },
         )
     }

--- a/media-ui/src/main/res/values/strings.xml
+++ b/media-ui/src/main/res/values/strings.xml
@@ -15,13 +15,13 @@
   -->
 
 <resources>
-    <string name="pause_button_content_description">Pause</string>
-    <string name="play_button_content_description">Play</string>
-    <string name="seek_to_next_button_content_description">Next</string>
-    <string name="seek_to_previous_button_content_description">Previous</string>
-    <string name="seek_forward_button_forward">Forward</string>
-    <string name="seek_forward_button_forward_seconds">Forward %s seconds</string>
-    <string name="seek_back_button_rewind">Rewind</string>
-    <string name="seek_back_button_rewind_seconds">Rewind %s seconds</string>
-    <string name="shuffle_button_content_description">Toggle Shuffle</string>
+    <string name="horologist_pause_button_content_description">Pause</string>
+    <string name="horologist_play_button_content_description">Play</string>
+    <string name="horologist_seek_to_next_button_content_description">Next</string>
+    <string name="horologist_seek_to_previous_button_content_description">Previous</string>
+    <string name="horologist_seek_forward_button_forward">Forward</string>
+    <string name="horologist_seek_forward_button_forward_seconds">Forward %s seconds</string>
+    <string name="horologist_seek_back_button_rewind">Rewind</string>
+    <string name="horologist_seek_back_button_rewind_seconds">Rewind %s seconds</string>
+    <string name="horologist_shuffle_button_content_description">Toggle Shuffle</string>
 </resources>

--- a/media-ui/src/main/res/values/strings.xml
+++ b/media-ui/src/main/res/values/strings.xml
@@ -19,9 +19,9 @@
     <string name="horologist_play_button_content_description">Play</string>
     <string name="horologist_seek_to_next_button_content_description">Next</string>
     <string name="horologist_seek_to_previous_button_content_description">Previous</string>
-    <string name="horologist_seek_forward_button_forward">Forward</string>
-    <string name="horologist_seek_forward_button_forward_seconds">Forward %s seconds</string>
-    <string name="horologist_seek_back_button_rewind">Rewind</string>
-    <string name="horologist_seek_back_button_rewind_seconds">Rewind %s seconds</string>
+    <string name="horologist_seek_forward_button_content_description">Forward</string>
+    <string name="horologist_seek_forward_button_seconds_content_description">Forward %s seconds</string>
+    <string name="horologist_seek_back_button_content_description">Rewind</string>
+    <string name="horologist_seek_back_button_seconds_content_description">Rewind %s seconds</string>
     <string name="horologist_shuffle_button_content_description">Toggle Shuffle</string>
 </resources>


### PR DESCRIPTION
#### WHAT

add horogolist_ prefix to string resource names.

#### WHY

From the picker PR, @ssancho14 identified we should use a prefix since we merge with app resource names.

#### HOW

AS rename refactor.


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
