### PR TITLE
Only treat warnings as errors in CI.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,8 +133,10 @@ subprojects {
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach { compile ->
         kotlinOptions {
-            // Treat all Kotlin warnings as errors
-            allWarningsAsErrors = true
+            if (System.getenv("CI") == "true") {
+                // Treat all Kotlin warnings as errors
+                allWarningsAsErrors = true
+            }
             // Set JVM target to 1.8
             jvmTarget = "1.8"
             // Allow use of @OptIn


### PR DESCRIPTION
#### WHAT

Only make warnings to errors in CI.

#### WHY

Locally it's annoying as you are moving code around.

#### HOW

Check the CI env variable set in github.
