### PR TITLE
Add id and uri to MediaItem

### DIFF
--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -214,13 +214,16 @@ package com.google.android.horologist.media.ui.state.mapper {
 package com.google.android.horologist.media.ui.state.model {
 
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public final class MediaItemUiModel {
-    ctor public MediaItemUiModel(optional String? title, optional String? artist);
-    method public String? component1();
+    ctor public MediaItemUiModel(String id, optional String? title, optional String? artist);
+    method public String component1();
     method public String? component2();
-    method public com.google.android.horologist.media.ui.state.model.MediaItemUiModel copy(String? title, String? artist);
+    method public String? component3();
+    method public com.google.android.horologist.media.ui.state.model.MediaItemUiModel copy(String id, String? title, String? artist);
     method public String? getArtist();
+    method public String getId();
     method public String? getTitle();
     property public final String? artist;
+    property public final String id;
     property public final String? title;
   }
 

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/screens/PlayerScreenTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/screens/PlayerScreenTest.kt
@@ -130,8 +130,8 @@ class PlayerScreenTest {
         // given
         val playerRepository = FakePlayerRepository()
 
-        val mediaItem1 = MediaItem("", "")
-        val mediaItem2 = MediaItem("", "")
+        val mediaItem1 = MediaItem(id = "", uri = "", title = "", artist = "")
+        val mediaItem2 = MediaItem(id = "", uri = "", title = "", artist = "")
         playerRepository.setMediaItems(listOf(mediaItem1, mediaItem2))
         playerRepository.play(1)
 
@@ -156,8 +156,8 @@ class PlayerScreenTest {
         // given
         val playerRepository = FakePlayerRepository()
 
-        val mediaItem1 = MediaItem("", "")
-        val mediaItem2 = MediaItem("", "")
+        val mediaItem1 = MediaItem(id = "", uri = "", title = "", artist = "")
+        val mediaItem2 = MediaItem(id = "", uri = "", title = "", artist = "")
         playerRepository.setMediaItems(listOf(mediaItem1, mediaItem2))
         playerRepository.play(0)
 
@@ -268,7 +268,7 @@ class PlayerScreenTest {
         val playerRepository = FakePlayerRepository()
         val artist = "artist"
         val title = "title"
-        val mediaItem = MediaItem(title = title, artist = artist)
+        val mediaItem = MediaItem(id = "", uri = "", title = title, artist = artist)
         playerRepository.setMediaItem(mediaItem)
         playerRepository.play()
 
@@ -287,7 +287,7 @@ class PlayerScreenTest {
         val playerRepository = FakePlayerRepository()
         val artist = "artist"
         val title = "title"
-        val mediaItem = MediaItem(title = title, artist = artist)
+        val mediaItem = MediaItem(id = "", uri = "", title = title, artist = artist)
         playerRepository.setMediaItem(mediaItem)
         playerRepository.play()
 

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/PlayerViewModel.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/PlayerViewModel.kt
@@ -73,9 +73,13 @@ public open class PlayerViewModel(
     }
 
     public companion object {
-        private val INITIAL_MEDIA_ITEM = MediaItemUiModel(null, null)
+        private val INITIAL_MEDIA_ITEM = MediaItemUiModel(id = "", title = null, artist = null)
 
-        private val INITIAL_TRACK_POSITION = TrackPositionUiModel(0, 0, 0f)
+        private val INITIAL_TRACK_POSITION = TrackPositionUiModel(
+            current = 0,
+            duration = 0,
+            percent = 0f
+        )
 
         private val INITIAL_PLAYER_UI_STATE = PlayerUiState(
             playEnabled = false,

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/MediaItemUiModelMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/MediaItemUiModelMapper.kt
@@ -27,6 +27,7 @@ import com.google.android.horologist.media.ui.state.model.MediaItemUiModel
 public object MediaItemUiModelMapper {
 
     public fun map(mediaItem: MediaItem): MediaItemUiModel = MediaItemUiModel(
+        id = mediaItem.id,
         title = mediaItem.title,
         artist = mediaItem.artist
     )

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/MediaItemUiModel.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/MediaItemUiModel.kt
@@ -20,6 +20,7 @@ import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 
 @ExperimentalHorologistMediaUiApi
 public data class MediaItemUiModel(
+    val id: String,
     val title: String? = null,
     val artist: String? = null
 )

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/PlayerViewModelTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/PlayerViewModelTest.kt
@@ -55,7 +55,7 @@ class PlayerViewModelTest {
                 shuffleOn = false,
                 playPauseEnabled = false,
                 playing = false,
-                mediaItem = MediaItemUiModel(title = null, artist = null),
+                mediaItem = MediaItemUiModel(id = "", title = null, artist = null),
                 trackPosition = TrackPositionUiModel(current = 0, duration = 0, percent = 0f),
             )
         )

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/MediaItemUiModelMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/MediaItemUiModelMapperTest.kt
@@ -28,14 +28,21 @@ class MediaItemUiModelMapperTest {
     @Test
     fun givenMediaItem_thenMapsCorrectly() {
         // given
+        val id = "id"
         val title = "title"
         val artist = "artist"
-        val mediaItem = MediaItem(title = title, artist = artist)
+        val mediaItem = MediaItem(
+            id = id,
+            uri = "http://www.example.com",
+            title = title,
+            artist = artist
+        )
 
         // when
         val result = MediaItemUiModelMapper.map(mediaItem)
 
         // then
+        assertThat(result.id).isEqualTo(id)
         assertThat(result.title).isEqualTo(title)
         assertThat(result.artist).isEqualTo(artist)
     }

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/PlayerUiStateMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/PlayerUiStateMapperTest.kt
@@ -288,9 +288,15 @@ class PlayerUiStateMapperTest {
     @Test
     fun givenMediaItem_thenMediaItemIsMappedCorrectly() {
         // given
+        val id = "id"
         val title = "title"
         val artist = "artist"
-        val mediaItem = MediaItem(title = title, artist = artist)
+        val mediaItem = MediaItem(
+            id = id,
+            uri = "http://www.example.com",
+            title = title,
+            artist = artist
+        )
 
         // when
         val result = PlayerUiStateMapper.map(
@@ -304,6 +310,7 @@ class PlayerUiStateMapperTest {
         // then
         assertNotNull(result.mediaItem)
         val expectedMediaItem = result.mediaItem!!
+        assertThat(expectedMediaItem.id).isEqualTo(id)
         assertThat(expectedMediaItem.title).isEqualTo(title)
         assertThat(expectedMediaItem.artist).isEqualTo(artist)
     }

--- a/media/api/current.api
+++ b/media/api/current.api
@@ -18,17 +18,23 @@ package com.google.android.horologist.media.model {
   }
 
   public final class MediaItem {
-    ctor public MediaItem(optional String? title, String artist);
-    method public String? component1();
+    ctor public MediaItem(String id, String uri, optional String? title, String artist);
+    method public String component1();
     method public String component2();
-    method public com.google.android.horologist.media.model.MediaItem copy(String? title, String artist);
+    method public String? component3();
+    method public String component4();
+    method public com.google.android.horologist.media.model.MediaItem copy(String id, String uri, String? title, String artist);
     method public boolean equals(Object? other);
     method public String getArtist();
+    method public String getId();
     method public String? getTitle();
+    method public String getUri();
     method public int hashCode();
     method public String toString();
     property public final String artist;
+    property public final String id;
     property public final String? title;
+    property public final String uri;
   }
 
   public abstract sealed class MediaItemPosition {

--- a/media/src/main/java/com/google/android/horologist/media/model/MediaItem.kt
+++ b/media/src/main/java/com/google/android/horologist/media/model/MediaItem.kt
@@ -20,6 +20,8 @@ package com.google.android.horologist.media.model
  * Representation of a media item.
  */
 public data class MediaItem(
+    val id: String,
+    val uri: String,
     val title: String? = null,
     val artist: String
 )

--- a/sample/src/main/java/com/google/android/horologist/sample/media/MediaDataSource.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/MediaDataSource.kt
@@ -32,11 +32,16 @@ class MediaDataSource {
         "Born to Be Wild" to "Steppenwolf",
     )
 
-    fun fetchData(): List<MediaItem> {
-        return mutableListOf<MediaItem>().also {
-            for ((title, artist) in songs) {
-                it.add(MediaItem(title = title, artist = artist))
-            }
+    fun fetchData(): List<MediaItem> = mutableListOf<MediaItem>().also {
+        songs.forEachIndexed { i, (title, artist) ->
+            it.add(
+                MediaItem(
+                    id = i.toString(),
+                    uri = "http://www.example.com/song/$i",
+                    title = title,
+                    artist = artist
+                )
+            )
         }
     }
 }


### PR DESCRIPTION
#### WHAT

Add `id` and `uri` properties to `MediaItem`.

#### WHY

First follow-up from review in https://github.com/google/horologist/pull/173#discussion_r873600662

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
