### PR TITLE
Bump version for next release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ systemProp.org.gradle.internal.http.socketTimeout=120000
 
 GROUP=com.google.android.horologist
 # !! No longer need to update this manually when using a Compose SNAPSHOT
-VERSION_NAME=0.0.20
+VERSION_NAME=0.0.21
 
 POM_DESCRIPTION=Utilities for Wear OS
 


### PR DESCRIPTION
#### WHAT

Bump version to 0.0.21

#### WHY

In order to be ready for next release.

#### HOW

Change VERSION_NAME is gradle.properties.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [N/A] Run tests
- [N/A] Update metalava's signature text files
