### PR TITLE
Add artworkUri to MediaItem

### DIFF
--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -214,15 +214,18 @@ package com.google.android.horologist.media.ui.state.mapper {
 package com.google.android.horologist.media.ui.state.model {
 
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public final class MediaItemUiModel {
-    ctor public MediaItemUiModel(String id, optional String? title, optional String? artist);
+    ctor public MediaItemUiModel(String id, optional String? title, optional String? artist, optional String? artworkUri);
     method public String component1();
     method public String? component2();
     method public String? component3();
-    method public com.google.android.horologist.media.ui.state.model.MediaItemUiModel copy(String id, String? title, String? artist);
+    method public String? component4();
+    method public com.google.android.horologist.media.ui.state.model.MediaItemUiModel copy(String id, String? title, String? artist, String? artworkUri);
     method public String? getArtist();
+    method public String? getArtworkUri();
     method public String getId();
     method public String? getTitle();
     property public final String? artist;
+    property public final String? artworkUri;
     property public final String id;
     property public final String? title;
   }

--- a/media-ui/build.gradle
+++ b/media-ui/build.gradle
@@ -43,6 +43,7 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
         freeCompilerArgs += "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
+        freeCompilerArgs += "-opt-in=com.google.android.horologist.media.ExperimentalHorologistMediaApi"
     }
 
     composeOptions {

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/PlayerViewModel.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/PlayerViewModel.kt
@@ -18,7 +18,6 @@ package com.google.android.horologist.media.ui.state
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.android.horologist.media.ExperimentalHorologistMediaApi
 import com.google.android.horologist.media.repository.PlayerRepository
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.state.mapper.PlayerUiStateMapper
@@ -29,7 +28,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 
-@OptIn(ExperimentalHorologistMediaApi::class)
 @ExperimentalHorologistMediaUiApi
 public open class PlayerViewModel(
     private val playerRepository: PlayerRepository

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/MediaItemUiModelMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/MediaItemUiModelMapper.kt
@@ -29,6 +29,7 @@ public object MediaItemUiModelMapper {
     public fun map(mediaItem: MediaItem): MediaItemUiModel = MediaItemUiModel(
         id = mediaItem.id,
         title = mediaItem.title,
-        artist = mediaItem.artist
+        artist = mediaItem.artist,
+        artworkUri = mediaItem.artworkUri
     )
 }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/MediaItemUiModel.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/MediaItemUiModel.kt
@@ -22,5 +22,6 @@ import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 public data class MediaItemUiModel(
     val id: String,
     val title: String? = null,
-    val artist: String? = null
+    val artist: String? = null,
+    val artworkUri: String? = null,
 )

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/MediaItemUiModelMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/MediaItemUiModelMapperTest.kt
@@ -31,11 +31,13 @@ class MediaItemUiModelMapperTest {
         val id = "id"
         val title = "title"
         val artist = "artist"
+        val artworkUri = "artworkUri"
         val mediaItem = MediaItem(
             id = id,
             uri = "http://www.example.com",
             title = title,
-            artist = artist
+            artist = artist,
+            artworkUri = artworkUri
         )
 
         // when
@@ -45,5 +47,6 @@ class MediaItemUiModelMapperTest {
         assertThat(result.id).isEqualTo(id)
         assertThat(result.title).isEqualTo(title)
         assertThat(result.artist).isEqualTo(artist)
+        assertThat(result.artworkUri).isEqualTo(artworkUri)
     }
 }

--- a/media/api/current.api
+++ b/media/api/current.api
@@ -8,7 +8,7 @@ package com.google.android.horologist.media {
 
 package com.google.android.horologist.media.model {
 
-  public enum Command {
+  @com.google.android.horologist.media.ExperimentalHorologistMediaApi public enum Command {
     enum_constant public static final com.google.android.horologist.media.model.Command PlayPause;
     enum_constant public static final com.google.android.horologist.media.model.Command SeekBack;
     enum_constant public static final com.google.android.horologist.media.model.Command SeekForward;
@@ -17,27 +17,30 @@ package com.google.android.horologist.media.model {
     enum_constant public static final com.google.android.horologist.media.model.Command SkipToPreviousMediaItem;
   }
 
-  public final class MediaItem {
-    ctor public MediaItem(String id, String uri, optional String? title, String artist);
+  @com.google.android.horologist.media.ExperimentalHorologistMediaApi public final class MediaItem {
+    ctor public MediaItem(String id, String uri, optional String? title, String artist, optional String? artworkUri);
     method public String component1();
     method public String component2();
     method public String? component3();
     method public String component4();
-    method public com.google.android.horologist.media.model.MediaItem copy(String id, String uri, String? title, String artist);
+    method public String? component5();
+    method public com.google.android.horologist.media.model.MediaItem copy(String id, String uri, String? title, String artist, String? artworkUri);
     method public boolean equals(Object? other);
     method public String getArtist();
+    method public String? getArtworkUri();
     method public String getId();
     method public String? getTitle();
     method public String getUri();
     method public int hashCode();
     method public String toString();
     property public final String artist;
+    property public final String? artworkUri;
     property public final String id;
     property public final String? title;
     property public final String uri;
   }
 
-  public abstract sealed class MediaItemPosition {
+  @com.google.android.horologist.media.ExperimentalHorologistMediaApi public abstract sealed class MediaItemPosition {
     method public long getCurrent();
     property public long current;
     field public static final com.google.android.horologist.media.model.MediaItemPosition.Companion Companion;
@@ -65,7 +68,7 @@ package com.google.android.horologist.media.model {
     property public long current;
   }
 
-  public enum PlayerState {
+  @com.google.android.horologist.media.ExperimentalHorologistMediaApi public enum PlayerState {
     enum_constant public static final com.google.android.horologist.media.model.PlayerState Ended;
     enum_constant public static final com.google.android.horologist.media.model.PlayerState Idle;
     enum_constant public static final com.google.android.horologist.media.model.PlayerState Loading;

--- a/media/src/main/java/com/google/android/horologist/media/model/Command.kt
+++ b/media/src/main/java/com/google/android/horologist/media/model/Command.kt
@@ -16,9 +16,12 @@
 
 package com.google.android.horologist.media.model
 
+import com.google.android.horologist.media.ExperimentalHorologistMediaApi
+
 /**
  * Commands that can be executed on a player.
  */
+@ExperimentalHorologistMediaApi
 public enum class Command {
     PlayPause,
     SeekBack,

--- a/media/src/main/java/com/google/android/horologist/media/model/MediaItem.kt
+++ b/media/src/main/java/com/google/android/horologist/media/model/MediaItem.kt
@@ -16,12 +16,16 @@
 
 package com.google.android.horologist.media.model
 
+import com.google.android.horologist.media.ExperimentalHorologistMediaApi
+
 /**
  * Representation of a media item.
  */
+@ExperimentalHorologistMediaApi
 public data class MediaItem(
     val id: String,
     val uri: String,
     val title: String? = null,
-    val artist: String
+    val artist: String,
+    val artworkUri: String? = null,
 )

--- a/media/src/main/java/com/google/android/horologist/media/model/MediaItemPosition.kt
+++ b/media/src/main/java/com/google/android/horologist/media/model/MediaItemPosition.kt
@@ -16,12 +16,14 @@
 
 package com.google.android.horologist.media.model
 
+import com.google.android.horologist.media.ExperimentalHorologistMediaApi
 import kotlin.time.Duration
 
 /**
  * Represents the current [media item][MediaItem] position, duration and percent progress.
  * Current position and duration are measured in milliseconds.
  */
+@ExperimentalHorologistMediaApi
 public sealed class MediaItemPosition(
     public open val current: Duration,
 ) {

--- a/media/src/main/java/com/google/android/horologist/media/model/PlayerState.kt
+++ b/media/src/main/java/com/google/android/horologist/media/model/PlayerState.kt
@@ -16,9 +16,12 @@
 
 package com.google.android.horologist.media.model
 
+import com.google.android.horologist.media.ExperimentalHorologistMediaApi
+
 /**
  * Represents the state of the player.
  */
+@ExperimentalHorologistMediaApi
 public enum class PlayerState {
 
     /**

--- a/media/src/test/java/com/google/android/horologist/media/model/MediaItemPositionTest.kt
+++ b/media/src/test/java/com/google/android/horologist/media/model/MediaItemPositionTest.kt
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalHorologistMediaApi::class)
+
 package com.google.android.horologist.media.model
 
+import com.google.android.horologist.media.ExperimentalHorologistMediaApi
 import com.google.common.truth.Truth.assertThat
 import org.junit.Assert.assertThrows
 import org.junit.Test


### PR DESCRIPTION
#### WHAT

- Add `artworkUri` property to `MediaItem`;
- Add missing `ExperimentalHorologistMediaApi` annotation to classes of media module;

#### WHY

Second follow-up from review in https://github.com/google/horologist/pull/173#discussion_r873600662

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
