### PR TITLE
Add extras property to MediaItem

### DIFF
--- a/media/api/current.api
+++ b/media/api/current.api
@@ -18,16 +18,18 @@ package com.google.android.horologist.media.model {
   }
 
   @com.google.android.horologist.media.ExperimentalHorologistMediaApi public final class MediaItem {
-    ctor public MediaItem(String id, String uri, optional String? title, String artist, optional String? artworkUri);
+    ctor public MediaItem(String id, String uri, optional String? title, String artist, optional String? artworkUri, optional java.util.Map<java.lang.String,?> extras);
     method public String component1();
     method public String component2();
     method public String? component3();
     method public String component4();
     method public String? component5();
-    method public com.google.android.horologist.media.model.MediaItem copy(String id, String uri, String? title, String artist, String? artworkUri);
+    method public java.util.Map<java.lang.String,java.lang.Object> component6();
+    method public com.google.android.horologist.media.model.MediaItem copy(String id, String uri, String? title, String artist, String? artworkUri, java.util.Map<java.lang.String,?> extras);
     method public boolean equals(Object? other);
     method public String getArtist();
     method public String? getArtworkUri();
+    method public java.util.Map<java.lang.String,java.lang.Object> getExtras();
     method public String getId();
     method public String? getTitle();
     method public String getUri();
@@ -35,6 +37,7 @@ package com.google.android.horologist.media.model {
     method public String toString();
     property public final String artist;
     property public final String? artworkUri;
+    property public final java.util.Map<java.lang.String,java.lang.Object> extras;
     property public final String id;
     property public final String? title;
     property public final String uri;

--- a/media/src/main/java/com/google/android/horologist/media/model/MediaItem.kt
+++ b/media/src/main/java/com/google/android/horologist/media/model/MediaItem.kt
@@ -28,4 +28,5 @@ public data class MediaItem(
     val title: String? = null,
     val artist: String,
     val artworkUri: String? = null,
+    val extras: Map<String, Any> = emptyMap()
 )


### PR DESCRIPTION
#### WHAT

Add `extras` property to `MediaItem`.

#### WHY

In order to provide flexibility for users of the API to pass extra attributes between data and ui layer or use these attributes to implement specific use cases.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
