### PR TITLE
Typealias for display components.

### DIFF
--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/PlayerScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/PlayerScreen.kt
@@ -41,6 +41,18 @@ import com.google.android.horologist.media.ui.state.PlayerUiState
 import com.google.android.horologist.media.ui.state.PlayerViewModel
 import com.google.android.horologist.media.ui.utils.StateUtils.rememberStateWithLifecycle
 
+@OptIn(ExperimentalHorologistMediaUiApi::class)
+typealias MediaDisplay = @Composable ColumnScope.(playerUiState: PlayerUiState) -> Unit
+
+@OptIn(ExperimentalHorologistMediaUiApi::class)
+typealias ControlButtons = @Composable RowScope.(playerUiState: PlayerUiState) -> Unit
+
+@OptIn(ExperimentalHorologistMediaUiApi::class)
+typealias SettingsButtons = @Composable RowScope.(playerUiState: PlayerUiState) -> Unit
+
+@OptIn(ExperimentalHorologistMediaUiApi::class)
+typealias PlayerBackground = @Composable BoxScope.(playerUiState: PlayerUiState) -> Unit
+
 /**
  * Stateful version of [PlayerScreen] that provides default implementation for media display and
  * control buttons.
@@ -51,14 +63,14 @@ import com.google.android.horologist.media.ui.utils.StateUtils.rememberStateWith
 public fun PlayerScreen(
     playerViewModel: PlayerViewModel,
     modifier: Modifier = Modifier,
-    mediaDisplay: @Composable ColumnScope.(playerUiState: PlayerUiState) -> Unit = { playerUiState ->
+    mediaDisplay: MediaDisplay = { playerUiState ->
         DefaultPlayerScreenMediaDisplay(playerUiState)
     },
-    controlButtons: @Composable RowScope.(playerUiState: PlayerUiState) -> Unit = { playerUiState ->
+    controlButtons: ControlButtons = { playerUiState ->
         DefaultPlayerScreenControlButtons(playerViewModel, playerUiState)
     },
-    buttons: @Composable RowScope.(PlayerUiState) -> Unit = {},
-    background: @Composable BoxScope.(PlayerUiState) -> Unit = {}
+    buttons: SettingsButtons = {},
+    background: PlayerBackground = {}
 ) {
     val playerUiState by rememberStateWithLifecycle(flow = playerViewModel.playerUiState)
 

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/PlayerScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/PlayerScreen.kt
@@ -42,16 +42,16 @@ import com.google.android.horologist.media.ui.state.PlayerViewModel
 import com.google.android.horologist.media.ui.utils.StateUtils.rememberStateWithLifecycle
 
 @OptIn(ExperimentalHorologistMediaUiApi::class)
-typealias MediaDisplay = @Composable ColumnScope.(playerUiState: PlayerUiState) -> Unit
+public typealias MediaDisplay = @Composable ColumnScope.(playerUiState: PlayerUiState) -> Unit
 
 @OptIn(ExperimentalHorologistMediaUiApi::class)
-typealias ControlButtons = @Composable RowScope.(playerUiState: PlayerUiState) -> Unit
+public typealias ControlButtons = @Composable RowScope.(playerUiState: PlayerUiState) -> Unit
 
 @OptIn(ExperimentalHorologistMediaUiApi::class)
-typealias SettingsButtons = @Composable RowScope.(playerUiState: PlayerUiState) -> Unit
+public typealias SettingsButtons = @Composable RowScope.(playerUiState: PlayerUiState) -> Unit
 
 @OptIn(ExperimentalHorologistMediaUiApi::class)
-typealias PlayerBackground = @Composable BoxScope.(playerUiState: PlayerUiState) -> Unit
+public typealias PlayerBackground = @Composable BoxScope.(playerUiState: PlayerUiState) -> Unit
 
 /**
  * Stateful version of [PlayerScreen] that provides default implementation for media display and


### PR DESCRIPTION
#### WHAT

Avoid horribly long param types

#### WHY

They are awkward to refer to with ColumnScope and RowScope.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
