### PR TITLE
Document version strategy

### DIFF
--- a/tiles/build.gradle
+++ b/tiles/build.gradle
@@ -25,9 +25,9 @@ android {
     compileSdkVersion 32
 
     defaultConfig {
-//        Tiles is API 26, but if we don't stop this here, then we can't run the sample app
-//        on older devices (25).  We also don't want this to bleed into other modules via
-//        compose-tools which is used just for testing.
+        //        Tiles is API 26, but if we don't stop this here, then we can't run the sample app
+        //        on older devices (25).  We also don't want this to bleed into other modules via
+        //        compose-tools which is used just for testing.
         minSdk 25
         targetSdk 30
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/tiles/build.gradle
+++ b/tiles/build.gradle
@@ -25,6 +25,9 @@ android {
     compileSdkVersion 32
 
     defaultConfig {
+//        Tiles is API 26, but if we don't stop this here, then we can't run the sample app
+//        on older devices (25).  We also don't want this to bleed into other modules via
+//        compose-tools which is used just for testing.
         minSdk 25
         targetSdk 30
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/tiles/src/main/AndroidManifest.xml
+++ b/tiles/src/main/AndroidManifest.xml
@@ -20,5 +20,9 @@
 
     <uses-feature android:name="android.hardware.type.watch" />
 
+    <!-- Tiles is API 26, but if we don't stop this here, then we can't run the sample app
+    on older devices (25).  We also don't want this to bleed into other modules via
+    compose-tools which is used just for testing.
+     -->
     <uses-sdk tools:overrideLibrary="androidx.wear.tiles.material, androidx.wear.tiles.renderer, androidx.wear.tiles.testing" />
 </manifest>


### PR DESCRIPTION
This versioning is confusing, but comes about because.

sample -> compose-tools -> tiles -> androidx.tiles (26)

We are stopping the version bump to 26 before we get to compose-tools so those libraries can be used in external apps.