### PR TITLE
Speed up locally run ci checks

### DIFF
--- a/.idea/runConfigurations/horologist_CI_checks.xml
+++ b/.idea/runConfigurations/horologist_CI_checks.xml
@@ -17,7 +17,8 @@
         <list>
           <option value="spotlessApply" />
           <option value="spotlessCheck" />
-          <option value="assemble" />
+          <option value="compileDebugSources" />
+          <option value="compileReleaseSources" />
           <option value="metalavaGenerateSignature" />
           <option value="lintDebug" />
         </list>


### PR DESCRIPTION
Avoiding building the release app.