### PR TITLE
Add connected StateFlow to PlayerRepository.

### DIFF
--- a/media-ui/src/androidTest/java/com/google/android/horologist/test/toolbox/testdoubles/FakePlayerRepository.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/test/toolbox/testdoubles/FakePlayerRepository.kt
@@ -31,6 +31,9 @@ import kotlin.time.Duration.Companion.seconds
 
 class FakePlayerRepository : PlayerRepository {
 
+    private val _connected = MutableStateFlow(true)
+    override val connected: StateFlow<Boolean> = _connected
+
     private var _availableCommandsList = MutableStateFlow(emptySet<Command>())
     override val availableCommands: StateFlow<Set<Command>> = _availableCommandsList
 
@@ -133,7 +136,7 @@ class FakePlayerRepository : PlayerRepository {
     override fun getCurrentMediaItemIndex(): Int = 0 // not implemented
 
     override fun release() {
-        // do nothing
+        _connected.value = false
     }
 
     fun updatePosition() {

--- a/media-ui/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/StubPlayerRepository.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/StubPlayerRepository.kt
@@ -29,6 +29,8 @@ import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalHorologistMediaApi::class)
 class StubPlayerRepository : PlayerRepository {
+    override val connected: StateFlow<Boolean>
+        get() = MutableStateFlow(false)
 
     override val availableCommands: StateFlow<Set<Command>>
         get() = MutableStateFlow(emptySet())

--- a/media/src/main/java/com/google/android/horologist/media/repository/PlayerRepository.kt
+++ b/media/src/main/java/com/google/android/horologist/media/repository/PlayerRepository.kt
@@ -28,6 +28,11 @@ import kotlin.time.Duration
 public interface PlayerRepository {
 
     /**
+     * Returns whether the repository is currently connected to a working Player.
+     */
+    public val connected: StateFlow<Boolean>
+
+    /**
      * Returns the player's currently available [commands][Command].
      */
     public val availableCommands: StateFlow<Set<Command>>

--- a/sample/src/main/java/com/google/android/horologist/sample/media/PlayerRepositoryImpl.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/media/PlayerRepositoryImpl.kt
@@ -39,6 +39,9 @@ class PlayerRepositoryImpl(
     private val mediaDataSource: MediaDataSource
 ) : PlayerRepository {
 
+    private val _connected = MutableStateFlow(true)
+    override val connected: StateFlow<Boolean> = _connected
+
     private val _availableCommands = MutableStateFlow<Set<Command>>(emptySet())
     override val availableCommands: StateFlow<Set<Command>> = _availableCommands
 


### PR DESCRIPTION
#### WHAT

Add connected state to the Repository, before which playback and commands are not possible.

#### WHY

In some cases it may be critical to know if the player is connected.

#### HOW

Add StateFlow<Boolean> to the Repository.


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
