### PR TITLE
Fix AM/PM label related to CompactChip chnages in 1.0.0-rc01

### DIFF
--- a/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
@@ -280,7 +281,7 @@ public fun TimePickerWith12HourClock(
             Spacer(Modifier.height(8.dp))
             CompactChip(
                 onClick = { amPm = 1 - amPm },
-                modifier = Modifier.size(width = 50.dp, height = 24.dp),
+                modifier = Modifier.size(width = 50.dp, height = 40.dp),
                 label = {
                     Row(
                         modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
#### WHAT
TimePicker's AM/PM label looks broken on the recent Compose for Wear OS version

#### WHY
TimePicker's AM/PM label is shrunk after updating to wear-compose 1.0.0-rc01 (https://github.com/google/horologist/issues/237)

#### HOW
Since we've added default vertical padding (8.dp) for enlarging tappable area of CompatChip, increasing height from 24dp to 40dp (24+8+8) fixes the issue.
There is a small visual change in layout due to increased area, but it still looks good:

_Before:_
![sdk_gwear_x86RWD4 211013 001kshum06152022225606](https://user-images.githubusercontent.com/1803903/174056982-2ec14171-9274-4102-a22c-d23f8d919cf1.png)

_After:_
![sdk_gwear_x86RWD4 211013 001kshum06152022224923](https://user-images.githubusercontent.com/1803903/174057010-f3f88087-24de-44d7-af44-fb53446bdb9c.png)

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files