### PR TITLE
[Tiles] Split LayoutPreview api into element/root variants.

### DIFF
--- a/compose-tools/api/current.api
+++ b/compose-tools/api/current.api
@@ -37,7 +37,8 @@ package com.google.android.horologist.compose.tools {
   }
 
   public final class TilePreviewKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi public static void LayoutPreview(androidx.wear.tiles.LayoutElementBuilders.LayoutElement layout, optional kotlin.jvm.functions.Function1<? super androidx.wear.tiles.ResourceBuilders.Resources.Builder,kotlin.Unit> tileResourcesFn);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi public static void LayoutElementPreview(androidx.wear.tiles.LayoutElementBuilders.LayoutElement element, optional @ColorInt int windowBackgroundColor, optional kotlin.jvm.functions.Function1<? super androidx.wear.tiles.ResourceBuilders.Resources.Builder,kotlin.Unit> tileResourcesFn);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi public static void LayoutRootPreview(androidx.wear.tiles.LayoutElementBuilders.LayoutElement root, optional kotlin.jvm.functions.Function1<? super androidx.wear.tiles.ResourceBuilders.Resources.Builder,kotlin.Unit> tileResourcesFn);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi public static <T, R> void TileLayoutPreview(T? state, R? resourceState, com.google.android.horologist.tiles.render.TileLayoutRenderer<T,R> renderer);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi public static void TilePreview(androidx.wear.tiles.TileBuilders.Tile tile, androidx.wear.tiles.ResourceBuilders.Resources tileResources);
     method public static androidx.wear.tiles.DeviceParametersBuilders.DeviceParameters buildDeviceParameters(android.content.res.Resources resources);

--- a/compose-tools/src/main/java/com/google/android/horologist/compose/tools/TilePreview.kt
+++ b/compose-tools/src/main/java/com/google/android/horologist/compose/tools/TilePreview.kt
@@ -22,6 +22,7 @@ import android.content.res.Resources
 import android.graphics.Color
 import android.util.DisplayMetrics
 import android.widget.FrameLayout
+import androidx.annotation.ColorInt
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -107,44 +108,49 @@ public fun TilePreview(
  */
 @ExperimentalHorologistComposeToolsApi
 @Composable
-public fun LayoutPreview(
-    layout: LayoutElement,
+public fun LayoutElementPreview(
+    element: LayoutElement,
+    @ColorInt windowBackgroundColor: Int = Color.DKGRAY,
+    tileResourcesFn: ResourceBuilders.Resources.Builder.() -> Unit = {}
+) {
+    val root = Box.Builder()
+        .setModifiers(
+            Modifiers.Builder().setBackground(
+                Background.Builder()
+                    .setColor(argb(windowBackgroundColor))
+                    .build()
+            ).build()
+        )
+        .setHorizontalAlignment(HORIZONTAL_ALIGN_CENTER)
+        .setVerticalAlignment(VERTICAL_ALIGN_CENTER)
+        .setHeight(ExpandedDimensionProp.Builder().build())
+        .setWidth(ExpandedDimensionProp.Builder().build())
+        .addContent(element)
+        .build()
+
+    LayoutRootPreview(root, tileResourcesFn)
+}
+
+/**
+ * Preview a root layout component such as a PrimaryLayout, that is full screen.
+ */
+@ExperimentalHorologistComposeToolsApi
+@Composable
+public fun LayoutRootPreview(
+    root: LayoutElement,
     tileResourcesFn: ResourceBuilders.Resources.Builder.() -> Unit = {}
 ) {
     val tile = remember {
         TileBuilders.Tile.Builder()
             .setResourcesVersion(PERMANENT_RESOURCES_VERSION)
-            // Creates a timeline to hold one or more tile entries for a specific time periods.
             .setTimeline(
                 TimelineBuilders.Timeline.Builder().addTimelineEntry(
-                    TimelineBuilders.TimelineEntry.Builder().setLayout(
-                        LayoutElementBuilders.Layout.Builder().setRoot(
-                            Box.Builder()
-                                .setHorizontalAlignment(HORIZONTAL_ALIGN_CENTER)
-                                .setVerticalAlignment(VERTICAL_ALIGN_CENTER)
-                                .setHeight(ExpandedDimensionProp.Builder().build())
-                                .setWidth(ExpandedDimensionProp.Builder().build())
-                                .setModifiers(
-                                    Modifiers.Builder().setBackground(
-                                        Background.Builder()
-                                            .setColor(argb(Color.DKGRAY))
-                                            .build()
-                                    ).build()
-                                ).addContent(
-                                    Box.Builder()
-                                        .setHorizontalAlignment(HORIZONTAL_ALIGN_CENTER)
-                                        .setVerticalAlignment(VERTICAL_ALIGN_CENTER)
-                                        .setModifiers(
-                                            Modifiers.Builder().setBackground(
-                                                Background.Builder().setColor(
-                                                    argb(Color.BLACK)
-                                                ).build()
-                                            ).build()
-                                        )
-                                        .addContent(layout).build()
-                                ).build()
+                    TimelineBuilders.TimelineEntry.Builder()
+                        .setLayout(
+                            LayoutElementBuilders.Layout.Builder()
+                                .setRoot(root)
+                                .build()
                         ).build()
-                    ).build()
                 ).build()
             ).build()
     }

--- a/sample/src/main/java/com/google/android/horologist/tile/SampleTileRenderer.kt
+++ b/sample/src/main/java/com/google/android/horologist/tile/SampleTileRenderer.kt
@@ -39,7 +39,7 @@ import androidx.wear.tiles.material.Typography
 import androidx.wear.tiles.material.layouts.MultiButtonLayout
 import androidx.wear.tiles.material.layouts.PrimaryLayout
 import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
-import com.google.android.horologist.compose.tools.LayoutPreview
+import com.google.android.horologist.compose.tools.LayoutRootPreview
 import com.google.android.horologist.compose.tools.TileLayoutPreview
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 import com.google.android.horologist.compose.tools.WearPreviewFontSizes
@@ -163,7 +163,7 @@ fun SampleButtonImagePreview() {
         .setId("click")
         .build()
 
-    LayoutPreview(
+    LayoutRootPreview(
         renderer.imageButton(clickable)
     ) {
         addIdToImageMapping(
@@ -186,7 +186,7 @@ fun SampleButtonIconPreview() {
         .setId("click")
         .build()
 
-    LayoutPreview(
+    LayoutRootPreview(
         renderer.iconButton(clickable)
     ) {
         addIdToImageMapping(

--- a/sample/src/main/java/com/google/android/horologist/tile/SampleTileRenderer.kt
+++ b/sample/src/main/java/com/google/android/horologist/tile/SampleTileRenderer.kt
@@ -39,7 +39,7 @@ import androidx.wear.tiles.material.Typography
 import androidx.wear.tiles.material.layouts.MultiButtonLayout
 import androidx.wear.tiles.material.layouts.PrimaryLayout
 import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
-import com.google.android.horologist.compose.tools.LayoutRootPreview
+import com.google.android.horologist.compose.tools.LayoutElementPreview
 import com.google.android.horologist.compose.tools.TileLayoutPreview
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 import com.google.android.horologist.compose.tools.WearPreviewFontSizes
@@ -163,7 +163,7 @@ fun SampleButtonImagePreview() {
         .setId("click")
         .build()
 
-    LayoutRootPreview(
+    LayoutElementPreview(
         renderer.imageButton(clickable)
     ) {
         addIdToImageMapping(
@@ -186,7 +186,7 @@ fun SampleButtonIconPreview() {
         .setId("click")
         .build()
 
-    LayoutRootPreview(
+    LayoutElementPreview(
         renderer.iconButton(clickable)
     ) {
         addIdToImageMapping(


### PR DESCRIPTION
#### WHAT
Splits the `LayoutPreview` preview API for tiles into `LayoutElementPreview` and `LayoutRootPreview`.

#### WHY
The previous LayoutPreview API only worked for non-root elements, like Button. This is because the passed LayoutElement was also wrapped in a BoxLayout so that the passed element could be rendered in the center of the screen. Passing a root element (like PrimaryLayout) to this API which assumes that it has full width and height didn't work.

#### HOW
This PR adds two APIs, one intended for elements and one for root layouts. They're chained together, such that the element one will wrap the element in a BoxLayout (a root layout), and pass that to the root layout API.

<img width="429" alt="image" src="https://user-images.githubusercontent.com/2678555/174091232-0adb87e9-4e38-41fb-ad26-ee89e248fd5c.png">

#### Checklist :clipboard:
[-] Add explicit visibility modifier and explicit return types for public declarations
[-] Run spotless check
[] Run tests
[-] Update metalava's signature text files
