### PR TITLE
Tile Canvas Helper

### DIFF
--- a/tiles/api/current.api
+++ b/tiles/api/current.api
@@ -17,6 +17,15 @@ package com.google.android.horologist.tiles {
 
 }
 
+package com.google.android.horologist.tiles.canvas {
+
+  public final class CanvasKt {
+    method @RequiresApi(android.os.Build.VERSION_CODES.O) public static androidx.wear.tiles.ResourceBuilders.ImageResource canvasToImageResource(long size, androidx.compose.ui.unit.Density density, kotlin.jvm.functions.Function1<? super androidx.compose.ui.graphics.drawscope.DrawScope,kotlin.Unit> onDraw);
+    method public static void drawToBitmap(android.graphics.Bitmap bitmap, androidx.compose.ui.unit.Density density, long size, kotlin.jvm.functions.Function1<? super androidx.compose.ui.graphics.drawscope.DrawScope,kotlin.Unit> onDraw);
+  }
+
+}
+
 package com.google.android.horologist.tiles.images {
 
   public final class ImagesKt {

--- a/tiles/src/main/java/com/google/android/horologist/tiles/canvas/canvas.kt
+++ b/tiles/src/main/java/com/google/android/horologist/tiles/canvas/canvas.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.tiles.canvas
+
+import android.graphics.Bitmap
+import android.os.Build.VERSION_CODES
+import androidx.annotation.RequiresApi
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.wear.tiles.ResourceBuilders.ImageResource
+import com.google.android.horologist.tiles.images.toImageResource
+import android.graphics.Canvas as AndroidCanvas
+import androidx.compose.ui.graphics.Canvas as ComposeCanvas
+
+public fun drawToBitmap(
+    bitmap: Bitmap,
+    density: Density,
+    size: Size,
+    onDraw: DrawScope.() -> Unit
+) {
+    val androidCanvas = AndroidCanvas(bitmap)
+    val composeCanvas = ComposeCanvas(androidCanvas)
+    val canvasDrawScope = CanvasDrawScope()
+
+    canvasDrawScope.draw(density, LayoutDirection.Ltr, composeCanvas, size) {
+        onDraw()
+    }
+}
+
+@RequiresApi(VERSION_CODES.O)
+public fun canvasToImageResource(
+    size: Size,
+    density: Density,
+    onDraw: DrawScope.() -> Unit
+): ImageResource {
+    return Bitmap.createBitmap(
+        size.width.toInt(),
+        size.height.toInt(),
+        Bitmap.Config.RGB_565,
+        false
+    ).apply {
+        drawToBitmap(bitmap = this, density = density, size = size, onDraw = onDraw)
+    }.toImageResource()
+}


### PR DESCRIPTION
#### WHAT

Utility to produce ImageResource from a Compose compatible DrawScope function.
The same drawing logic can be used in Compose and Tile.

#### WHY

Reusable graphics components.

#### HOW

Render to a Canvas(bitmap) and then use the existing image path.

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
