### PR TITLE
Avoid setting background for screens.

### DIFF
--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/PlayerScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/PlayerScreen.kt
@@ -16,7 +16,6 @@
 
 package com.google.android.horologist.media.ui.screens
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -33,7 +32,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.wear.compose.material.MaterialTheme
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.components.MediaControlButtons
 import com.google.android.horologist.media.ui.components.TextMediaDisplay
@@ -132,7 +130,7 @@ public fun PlayerScreen(
     background: @Composable BoxScope.() -> Unit = {}
 ) {
     Box(
-        modifier = modifier.fillMaxSize().background(MaterialTheme.colors.background),
+        modifier = modifier.fillMaxSize(),
     ) {
         background()
 

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerScreenTest.kt
@@ -18,6 +18,10 @@
 
 package com.google.android.horologist.media.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import app.cash.paparazzi.Paparazzi
 import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.ThemeValues
@@ -67,7 +71,9 @@ class MediaPlayerScreenTest(
         )
 
         paparazzi.snapshot(name = themeValue.safeName) {
-            MediaPlayerTestCase(colors = themeValue.colors, playerUiState = playerUiState)
+            Box(modifier = Modifier.background(Color.Black)) {
+                MediaPlayerTestCase(colors = themeValue.colors, playerUiState = playerUiState)
+            }
         }
     }
 

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/PodcastPlayerScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/PodcastPlayerScreenTest.kt
@@ -18,6 +18,10 @@
 
 package com.google.android.horologist.media.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import app.cash.paparazzi.Paparazzi
 import com.google.android.horologist.media.ui.components.PodcastControlButtons
 import com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement
@@ -70,21 +74,23 @@ class PodcastPlayerScreenTest(
         )
 
         paparazzi.snapshot(options.toString()) {
-            MediaPlayerTestCase(playerUiState = playerUiState, controlButtons = {
-                PodcastControlButtons(
-                    onPlayButtonClick = { },
-                    onPauseButtonClick = { },
-                    playPauseButtonEnabled = playerUiState.playPauseEnabled,
-                    playing = playerUiState.playing,
-                    percent = playerUiState.trackPosition?.percent ?: 0f,
-                    onSeekBackButtonClick = { },
-                    seekBackButtonEnabled = playerUiState.seekBackEnabled,
-                    onSeekForwardButtonClick = { },
-                    seekForwardButtonEnabled = playerUiState.seekForwardEnabled,
-                    seekBackButtonIncrement = options.seekBackButtonIncrement,
-                    seekForwardButtonIncrement = options.seekForwardButtonIncrement,
-                )
-            })
+            Box(modifier = Modifier.background(Color.Black)) {
+                MediaPlayerTestCase(playerUiState = playerUiState, controlButtons = {
+                    PodcastControlButtons(
+                        onPlayButtonClick = { },
+                        onPauseButtonClick = { },
+                        playPauseButtonEnabled = playerUiState.playPauseEnabled,
+                        playing = playerUiState.playing,
+                        percent = playerUiState.trackPosition?.percent ?: 0f,
+                        onSeekBackButtonClick = { },
+                        seekBackButtonEnabled = playerUiState.seekBackEnabled,
+                        onSeekForwardButtonClick = { },
+                        seekForwardButtonEnabled = playerUiState.seekForwardEnabled,
+                        seekBackButtonIncrement = options.seekBackButtonIncrement,
+                        seekForwardButtonIncrement = options.seekForwardButtonIncrement,
+                    )
+                })
+            }
         }
     }
 


### PR DESCRIPTION
#### WHAT

![image](https://user-images.githubusercontent.com/231923/174341096-96706e20-bed6-448b-840e-afb4c1624aa0.png)

#### WHY

Screens should sit naturally on any background behind them, setting a constant background makes this impossible without overiding MaterialTheme just for this component.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
