### PR TITLE
Add DefaultMediaDisplay

### DIFF
--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -8,6 +8,10 @@ package com.google.android.horologist.media.ui {
 
 package com.google.android.horologist.media.ui.components {
 
+  public final class DefaultMediaDisplayKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void DefaultMediaDisplay(com.google.android.horologist.media.ui.state.model.MediaItemUiModel? mediaItem, optional androidx.compose.ui.Modifier modifier);
+  }
+
   public final class MediaControlButtonsKt {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void MediaControlButtons(kotlin.jvm.functions.Function0<kotlin.Unit> onPlayButtonClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPauseButtonClick, boolean playPauseButtonEnabled, boolean playing, float percent, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekToPreviousButtonClick, boolean seekToPreviousButtonEnabled, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekToNextButtonClick, boolean seekToNextButtonEnabled, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors, optional long progressColour);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void MediaControlButtons(kotlin.jvm.functions.Function0<kotlin.Unit> onPlayButtonClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPauseButtonClick, boolean playPauseButtonEnabled, boolean playing, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekToPreviousButtonClick, boolean seekToPreviousButtonEnabled, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekToNextButtonClick, boolean seekToNextButtonEnabled, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/DefaultMediaDisplayPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/DefaultMediaDisplayPreview.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistMediaUiApi::class)
+
+package com.google.android.horologist.media.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
+import com.google.android.horologist.media.ui.state.model.MediaItemUiModel
+
+@Preview(
+    backgroundColor = 0xff000000,
+    showBackground = true,
+)
+@Composable
+fun DefaultMediaDisplayPreview() {
+    DefaultMediaDisplay(
+        mediaItem = MediaItemUiModel(
+            id = "id",
+            title = "Song title",
+            artist = "Artist name"
+        )
+    )
+}
+
+@Preview(
+    "With long text",
+    backgroundColor = 0xff000000,
+    showBackground = true,
+)
+@Composable
+fun DefaultMediaDisplayPreviewLongText() {
+    DefaultMediaDisplay(
+        mediaItem = MediaItemUiModel(
+            id = "id",
+            title = "I Predict That You Look Good In A Riot",
+            artist = "Arctic Monkeys feat Kaiser Chiefs"
+        )
+    )
+}

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/DefaultMediaDisplay.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/DefaultMediaDisplay.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
+import com.google.android.horologist.media.ui.state.model.MediaItemUiModel
+
+/**
+ * A simple text only display of [MediaItemUiModel] showing artist and title in two separated rows.
+ */
+@ExperimentalHorologistMediaUiApi
+@Composable
+public fun DefaultMediaDisplay(
+    mediaItem: MediaItemUiModel?,
+    modifier: Modifier = Modifier,
+) {
+    TextMediaDisplay(
+        modifier = modifier,
+        title = mediaItem?.title,
+        artist = mediaItem?.artist
+    )
+}


### PR DESCRIPTION
#### WHAT

Add `DefaultMediaDisplay`.

![Screen Shot 2022-06-27 at 17 31 20](https://user-images.githubusercontent.com/878134/175990605-16275444-cfdc-4b10-a092-1eb8eca897b2.png)

#### WHY

In order to provide common components.


#### HOW

- Add code from media toolkit project;
- Add preview in debug folder;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
