### PR TITLE
Add Preferences DataStore to allow configuring sample ui for testing.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,6 +44,7 @@ androidx-concurrent-future = { module = "androidx.concurrent:concurrent-futures"
 androidx-concurrent-future-ktx = { module = "androidx.concurrent:concurrent-futures-ktx", version.ref = "androidx-concurrent" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
 androidx-corektx = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
+androidx-datastore-preferences = "androidx.datastore:datastore-preferences:1.0.0"
 androidx-fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "androidxFragment" }
 androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidxLifecycle" }
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }

--- a/media-sample/build.gradle
+++ b/media-sample/build.gradle
@@ -141,6 +141,8 @@ dependencies {
 
     debugImplementation projects.composeTools
 
+    implementation libs.androidx.datastore.preferences
+
     androidTestImplementation libs.compose.ui.test.junit4
     androidTestImplementation libs.espresso.core
     androidTestImplementation libs.junit

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/AppConfig.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/AppConfig.kt
@@ -25,7 +25,6 @@ data class AppConfig(
     val strictNetworking: NetworkingRules? = NetworkingRules.Conservative,
     val deeplinkUriPrefix: String = "uamp${if (BuildConfig.DEBUG) "-debug" else ""}://uamp",
     val showTimeTextInfo: Boolean = false,
-    val loadItemsOnStartup: Boolean = false,
     val cacheItems: Boolean = true,
     val cacheWriteBack: Boolean = true,
     val offloadMode: Int = DefaultAudioSink.OFFLOAD_MODE_ENABLED_GAPLESS_REQUIRED,

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/MediaApplicationContainer.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/MediaApplicationContainer.kt
@@ -19,9 +19,7 @@ package com.google.android.horologist.mediasample.di
 import android.os.Build
 import android.os.StrictMode
 import android.os.Vibrator
-import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
-import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStoreFile
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -41,6 +39,7 @@ import com.google.android.horologist.mediasample.catalog.UampService
 import com.google.android.horologist.mediasample.components.MediaActivity
 import com.google.android.horologist.mediasample.components.MediaApplication
 import com.google.android.horologist.mediasample.components.PlaybackService
+import com.google.android.horologist.mediasample.domain.SettingsRepository
 import com.google.android.horologist.mediasample.system.Logging
 import com.google.android.horologist.networks.data.DataRequestRepository
 import com.google.android.horologist.networks.status.NetworkRepository
@@ -76,6 +75,10 @@ class MediaApplicationContainer(
         ) {
             application.preferencesDataStoreFile("prefs")
         }
+    }
+
+    val settingsRepository by lazy {
+        SettingsRepository(prefsDataStore)
     }
 
     val coroutineScope: CoroutineScope by lazy {
@@ -181,6 +184,6 @@ class MediaApplicationContainer(
         val UampServiceKey = object : CreationExtras.Key<UampService> {}
         val SystemAudioRepositoryKey = object : CreationExtras.Key<SystemAudioRepository> {}
         val VibratorKey = object : CreationExtras.Key<Vibrator> {}
-        val DataStoreKey = object : CreationExtras.Key<DataStore<Preferences>> {}
+        val SettingsRepositoryKey = object : CreationExtras.Key<SettingsRepository> {}
     }
 }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/MediaApplicationContainer.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/MediaApplicationContainer.kt
@@ -19,6 +19,10 @@ package com.google.android.horologist.mediasample.di
 import android.os.Build
 import android.os.StrictMode
 import android.os.Vibrator
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.viewmodel.CreationExtras
@@ -61,6 +65,16 @@ class MediaApplicationContainer(
             PlaybackRules.SpeakerAllowed
         } else {
             PlaybackRules.Normal
+        }
+    }
+
+    val prefsDataStore by lazy {
+        PreferenceDataStoreFactory.create(
+            corruptionHandler = null,
+            migrations = listOf(),
+            scope = coroutineScope
+        ) {
+            application.preferencesDataStoreFile("prefs")
         }
     }
 
@@ -167,5 +181,6 @@ class MediaApplicationContainer(
         val UampServiceKey = object : CreationExtras.Key<UampService> {}
         val SystemAudioRepositoryKey = object : CreationExtras.Key<SystemAudioRepository> {}
         val VibratorKey = object : CreationExtras.Key<Vibrator> {}
+        val DataStoreKey = object : CreationExtras.Key<DataStore<Preferences>> {}
     }
 }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/ViewModelModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/ViewModelModule.kt
@@ -87,8 +87,8 @@ class ViewModelModule(
             mediaApplicationContainer.audioContainer.systemAudioRepository
         creationExtras[MediaApplicationContainer.VibratorKey] =
             mediaApplicationContainer.vibrator
-        creationExtras[MediaApplicationContainer.DataStoreKey] =
-            mediaApplicationContainer.prefsDataStore
+        creationExtras[MediaApplicationContainer.SettingsRepositoryKey] =
+            mediaApplicationContainer.settingsRepository
     }
 
     override fun close() {

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/ViewModelModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/ViewModelModule.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
 /**
@@ -88,6 +87,8 @@ class ViewModelModule(
             mediaApplicationContainer.audioContainer.systemAudioRepository
         creationExtras[MediaApplicationContainer.VibratorKey] =
             mediaApplicationContainer.vibrator
+        creationExtras[MediaApplicationContainer.DataStoreKey] =
+            mediaApplicationContainer.prefsDataStore
     }
 
     override fun close() {

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/Settings.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/Settings.kt
@@ -14,22 +14,9 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.mediasample.ui.settings
-
-import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.booleanPreferencesKey
+package com.google.android.horologist.mediasample.domain
 
 data class Settings(
     val podcastControls: Boolean = false,
     val loadItemsAtStartup: Boolean = true
-) {
-    constructor(preferences: Preferences) : this(
-        preferences[PodcastControls] ?: false,
-        preferences[LoadItemsAtStartup] ?: true
-    )
-
-    companion object {
-        val PodcastControls = booleanPreferencesKey("podcast_controls")
-        val LoadItemsAtStartup = booleanPreferencesKey("load_items_at_startup")
-    }
-}
+)

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/SettingsRepository.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/SettingsRepository.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.domain
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class SettingsRepository(
+    private val dataStore: DataStore<Preferences>,
+) {
+    suspend fun edit(transform: suspend (MutablePreferences) -> Unit) {
+        dataStore.edit {
+            transform(it)
+        }
+    }
+
+    suspend fun writePodcastControls(enabled: Boolean) {
+        edit {
+            it[PodcastControls] = enabled
+        }
+    }
+
+    suspend fun writeLoadItemsAtStartup(enabled: Boolean) {
+        edit {
+            it[LoadItemsAtStartup] = enabled
+        }
+    }
+
+    val settingsFlow: Flow<Settings> = dataStore.data.map {
+        it.toSettings()
+    }
+
+    companion object {
+        val PodcastControls = booleanPreferencesKey("podcast_controls")
+        val LoadItemsAtStartup = booleanPreferencesKey("load_items_at_startup")
+
+        fun Preferences.toSettings() = Settings(
+            this[PodcastControls] ?: false,
+            this[LoadItemsAtStartup] ?: true
+        )
+    }
+}

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/MediaPlayerAppViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/MediaPlayerAppViewModel.kt
@@ -16,8 +16,6 @@
 
 package com.google.android.horologist.mediasample.ui.app
 
-import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.Preferences
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
@@ -27,8 +25,8 @@ import com.google.android.horologist.media3.offload.AudioOffloadManager
 import com.google.android.horologist.mediasample.AppConfig
 import com.google.android.horologist.mediasample.catalog.UampService
 import com.google.android.horologist.mediasample.di.MediaApplicationContainer
+import com.google.android.horologist.mediasample.domain.SettingsRepository
 import com.google.android.horologist.mediasample.ui.debug.OffloadState
-import com.google.android.horologist.mediasample.ui.settings.Settings
 import com.google.android.horologist.networks.data.DataRequestRepository
 import com.google.android.horologist.networks.data.DataUsageReport
 import com.google.android.horologist.networks.data.Networks
@@ -40,7 +38,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import java.io.IOException
 import kotlin.time.Duration.Companion.seconds
@@ -49,7 +46,7 @@ class MediaPlayerAppViewModel(
     networkRepository: NetworkRepository,
     dataRequestRepository: DataRequestRepository,
     audioOffloadManager: AudioOffloadManager,
-    private val prefsDataStore: DataStore<Preferences>,
+    private val settings: SettingsRepository,
     private val playerRepository: PlayerRepository,
     private val uampService: UampService,
     private val appConfig: AppConfig
@@ -115,7 +112,7 @@ class MediaPlayerAppViewModel(
 
     suspend fun startupSetup(navigateToLibrary: () -> Unit) {
         val loadAtStartup =
-            prefsDataStore.data.map { Settings(it) }.first().loadItemsAtStartup
+            settings.settingsFlow.first().loadItemsAtStartup
 
         // setMediaItems is a noop before this point
         playerRepository.connected.filter { it }.first()
@@ -134,7 +131,7 @@ class MediaPlayerAppViewModel(
                     this[MediaApplicationContainer.NetworkRepositoryKey]!!,
                     this[MediaApplicationContainer.DataRequestRepositoryKey]!!,
                     this[MediaApplicationContainer.AudioOffloadManagerKey]!!,
-                    this[MediaApplicationContainer.DataStoreKey]!!,
+                    this[MediaApplicationContainer.SettingsRepositoryKey]!!,
                     this[MediaApplicationContainer.PlayerRepositoryImplKey]!!,
                     this[MediaApplicationContainer.UampServiceKey]!!,
                     this[MediaApplicationContainer.AppConfigKey]!!,

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/WearApp.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/WearApp.kt
@@ -154,7 +154,10 @@ fun WearApp(
                 UampSettingsScreen(
                     focusRequester = it.viewModel.focusRequester,
                     state = it.scrollableState,
-                    settingsScreenViewModel = viewModel(factory = SettingsScreenViewModel.Factory)
+                    settingsScreenViewModel = viewModel(
+                        factory = SettingsScreenViewModel.Factory,
+                        extras = creationExtras()
+                    )
                 )
             }
         }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/player/MediaPlayerScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/player/MediaPlayerScreenViewModel.kt
@@ -16,8 +16,6 @@
 
 package com.google.android.horologist.mediasample.ui.player
 
-import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.Preferences
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
@@ -25,23 +23,21 @@ import com.google.android.horologist.media.data.PlayerRepositoryImpl
 import com.google.android.horologist.media.ui.state.PlayerViewModel
 import com.google.android.horologist.media3.audio.AudioOutputSelector
 import com.google.android.horologist.mediasample.di.MediaApplicationContainer
-import com.google.android.horologist.mediasample.ui.settings.Settings
+import com.google.android.horologist.mediasample.domain.Settings
+import com.google.android.horologist.mediasample.domain.SettingsRepository
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 class MediaPlayerScreenViewModel(
     playerRepository: PlayerRepositoryImpl,
-    private val dataStore: DataStore<Preferences>,
+    private val settingsRepository: SettingsRepository,
     private val audioOutputSelector: AudioOutputSelector
 ) : PlayerViewModel(playerRepository) {
-    val settingsState: StateFlow<Settings?> = dataStore.data.map {
-        Settings(it)
-    }.stateIn(
+    val settingsState: StateFlow<Settings?> = settingsRepository.settingsFlow.stateIn(
         viewModelScope,
         SharingStarted.WhileSubscribed(5000),
         null
@@ -66,7 +62,7 @@ class MediaPlayerScreenViewModel(
             initializer {
                 MediaPlayerScreenViewModel(
                     playerRepository = this[MediaApplicationContainer.PlayerRepositoryImplKey]!!,
-                    dataStore = this[MediaApplicationContainer.DataStoreKey]!!,
+                    settingsRepository = this[MediaApplicationContainer.SettingsRepositoryKey]!!,
                     audioOutputSelector = this[MediaApplicationContainer.AudioOutputSelectorKey]!!
                 )
             }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/player/UampMediaPlayerScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/player/UampMediaPlayerScreen.kt
@@ -28,8 +28,12 @@ import com.google.android.horologist.audio.ui.components.SettingsButtons
 import com.google.android.horologist.audio.ui.components.SettingsButtonsDefaults
 import com.google.android.horologist.compose.layout.StateUtils.rememberStateWithLifecycle
 import com.google.android.horologist.compose.navscaffold.scrollableColumn
+import com.google.android.horologist.media.ui.components.PodcastControlButtons
 import com.google.android.horologist.media.ui.components.background.ArtworkColorBackground
+import com.google.android.horologist.media.ui.screens.DefaultPlayerScreenControlButtons
 import com.google.android.horologist.media.ui.screens.PlayerScreen
+import com.google.android.horologist.media.ui.state.PlayerUiState
+import com.google.android.horologist.media.ui.state.PlayerViewModel
 import com.google.android.horologist.mediasample.R
 
 @Composable
@@ -42,6 +46,7 @@ fun UampMediaPlayerScreen(
     modifier: Modifier = Modifier,
 ) {
     val volumeState by rememberStateWithLifecycle(flow = volumeViewModel.volumeState)
+    val settingsState by rememberStateWithLifecycle(flow = mediaPlayerScreenViewModel.settingsState)
 
     Scaffold(
         modifier = modifier
@@ -64,9 +69,36 @@ fun UampMediaPlayerScreen(
                     }
                 )
             },
+            controlButtons = {
+                if (settingsState != null) {
+                    if (settingsState?.podcastControls == true) {
+                        PlayerScreenPodcastControlButtons(mediaPlayerScreenViewModel, it)
+                    } else {
+                        DefaultPlayerScreenControlButtons(mediaPlayerScreenViewModel, it)
+                    }
+                }
+            },
             background = {
                 ArtworkColorBackground(artworkUri = it.mediaItem?.artworkUri)
             }
         )
     }
+}
+
+@Composable
+public fun PlayerScreenPodcastControlButtons(
+    playerViewModel: PlayerViewModel,
+    playerUiState: PlayerUiState,
+) {
+    PodcastControlButtons(
+        onPlayButtonClick = { playerViewModel.play() },
+        onPauseButtonClick = { playerViewModel.pause() },
+        playPauseButtonEnabled = playerUiState.playPauseEnabled,
+        playing = playerUiState.playing,
+        percent = playerUiState.trackPosition?.percent ?: 0f,
+        onSeekBackButtonClick = { playerViewModel.seekBack() },
+        seekBackButtonEnabled = playerUiState.seekBackEnabled,
+        onSeekForwardButtonClick = { playerViewModel.seekForward() },
+        seekForwardButtonEnabled = playerUiState.seekForwardEnabled,
+    )
 }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/settings/Settings.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/settings/Settings.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.ui.settings
+
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+
+data class Settings(
+    val podcastControls: Boolean = false,
+    val loadItemsAtStartup: Boolean = true
+) {
+    constructor(preferences: Preferences) : this(
+        preferences[PodcastControls] ?: false,
+        preferences[LoadItemsAtStartup] ?: true
+    )
+
+    companion object {
+        val PodcastControls = booleanPreferencesKey("podcast_controls")
+        val LoadItemsAtStartup = booleanPreferencesKey("load_items_at_startup")
+    }
+}

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/settings/UampSettingsScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/settings/UampSettingsScreen.kt
@@ -51,14 +51,18 @@ fun UampSettingsScreen(
     ) {
         item {
             CheckedSetting(
-                uiState.podcastControls, stringResource(id = R.string.horologist_podcast_controls)
+                uiState.settings?.podcastControls ?: false,
+                stringResource(id = R.string.horologist_podcast_controls),
+                enabled = uiState.settings != null
             ) {
                 settingsScreenViewModel.setPodcastControls(it)
             }
         }
         item {
             CheckedSetting(
-                uiState.loadItemsAtStartup, stringResource(id = R.string.horologist_load_items)
+                uiState.settings?.loadItemsAtStartup ?: false,
+                stringResource(id = R.string.horologist_load_items),
+                enabled = uiState.settings != null
             ) {
                 settingsScreenViewModel.setLoadItemsAtStartup(it)
             }
@@ -87,19 +91,24 @@ private fun ActionSetting(
     private fun ToggleSetting(
         value: Boolean,
         text: String,
+        enabled: Boolean = true,
         onCheckedChange: (Boolean) -> Unit,
     ) {
         ToggleChip(
-            checked = value, toggleControl = {
+            checked = value,
+            toggleControl = {
                 Icon(
                     imageVector = ToggleChipDefaults.radioIcon(checked = value),
                     contentDescription = if (value) stringResource(id = R.string.horologist_on) else stringResource(
                         id = R.string.horologist_off
                     ),
                 )
-            }, onCheckedChange = onCheckedChange, label = {
-            Text(text)
-        }, modifier = Modifier.fillMaxWidth()
+            },
+            enabled = enabled,
+            onCheckedChange = onCheckedChange,
+            label = {
+                Text(text)
+            }, modifier = Modifier.fillMaxWidth()
             )
         }
 
@@ -107,19 +116,24 @@ private fun ActionSetting(
         private fun CheckedSetting(
             value: Boolean,
             text: String,
+            enabled: Boolean = true,
             onCheckedChange: (Boolean) -> Unit,
         ) {
             ToggleChip(
-                checked = value, toggleControl = {
+                checked = value,
+                toggleControl = {
                     Icon(
                         imageVector = ToggleChipDefaults.checkboxIcon(checked = value),
                         contentDescription = if (value) stringResource(id = R.string.horologist_on) else stringResource(
                             id = R.string.horologist_off
                         ),
                     )
-                }, onCheckedChange = onCheckedChange, label = {
-                Text(text)
-            }, modifier = Modifier.fillMaxWidth()
+                },
+                enabled = enabled,
+                onCheckedChange = onCheckedChange,
+                label = {
+                    Text(text)
+                }, modifier = Modifier.fillMaxWidth()
                 )
             }
             

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/settings/UampSettingsScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/settings/UampSettingsScreen.kt
@@ -51,18 +51,18 @@ fun UampSettingsScreen(
     ) {
         item {
             CheckedSetting(
-                uiState.settings?.podcastControls ?: false,
+                uiState.podcastControls,
                 stringResource(id = R.string.horologist_podcast_controls),
-                enabled = uiState.settings != null
+                enabled = uiState.writable
             ) {
                 settingsScreenViewModel.setPodcastControls(it)
             }
         }
         item {
             CheckedSetting(
-                uiState.settings?.loadItemsAtStartup ?: false,
+                uiState.loadItemsAtStartup,
                 stringResource(id = R.string.horologist_load_items),
-                enabled = uiState.settings != null
+                enabled = uiState.writable
             ) {
                 settingsScreenViewModel.setLoadItemsAtStartup(it)
             }
@@ -81,14 +81,41 @@ private fun ActionSetting(
     onClick: () -> Unit,
 ) {
     Chip(
-        onClick = onClick, label = {
+        onClick = onClick,
+        label = {
+            Text(text)
+        },
+        modifier = Modifier.fillMaxWidth()
+    )
+}
+
+@Composable
+private fun ToggleSetting(
+    value: Boolean,
+    text: String,
+    enabled: Boolean = true,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    ToggleChip(
+        checked = value,
+        toggleControl = {
+            Icon(
+                imageVector = ToggleChipDefaults.radioIcon(checked = value),
+                contentDescription = if (value) stringResource(id = R.string.horologist_on) else stringResource(
+                    id = R.string.horologist_off
+                ),
+            )
+        },
+        enabled = enabled,
+        onCheckedChange = onCheckedChange,
+        label = {
             Text(text)
         }, modifier = Modifier.fillMaxWidth()
         )
     }
 
     @Composable
-    private fun ToggleSetting(
+    private fun CheckedSetting(
         value: Boolean,
         text: String,
         enabled: Boolean = true,
@@ -98,7 +125,7 @@ private fun ActionSetting(
             checked = value,
             toggleControl = {
                 Icon(
-                    imageVector = ToggleChipDefaults.radioIcon(checked = value),
+                    imageVector = ToggleChipDefaults.checkboxIcon(checked = value),
                     contentDescription = if (value) stringResource(id = R.string.horologist_on) else stringResource(
                         id = R.string.horologist_off
                     ),
@@ -111,29 +138,4 @@ private fun ActionSetting(
             }, modifier = Modifier.fillMaxWidth()
             )
         }
-
-        @Composable
-        private fun CheckedSetting(
-            value: Boolean,
-            text: String,
-            enabled: Boolean = true,
-            onCheckedChange: (Boolean) -> Unit,
-        ) {
-            ToggleChip(
-                checked = value,
-                toggleControl = {
-                    Icon(
-                        imageVector = ToggleChipDefaults.checkboxIcon(checked = value),
-                        contentDescription = if (value) stringResource(id = R.string.horologist_on) else stringResource(
-                            id = R.string.horologist_off
-                        ),
-                    )
-                },
-                enabled = enabled,
-                onCheckedChange = onCheckedChange,
-                label = {
-                    Text(text)
-                }, modifier = Modifier.fillMaxWidth()
-                )
-            }
-            
+        


### PR DESCRIPTION
#### WHAT

![image](https://user-images.githubusercontent.com/231923/176161565-13bac6dc-f31f-4a27-b476-ab459d6b8e5f.png)

![image](https://user-images.githubusercontent.com/231923/176161596-62971bbd-e9cb-4700-aed2-0d5751e10082.png)


#### WHY

Need to test other UI designs.

#### HOW

Use Preferences DataStore to control UI layout. 

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
