### PR TITLE
Change tint color of icons used in previews

### DIFF
--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/MediaChipPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/MediaChipPreview.kt
@@ -21,10 +21,11 @@ package com.google.android.horologist.media.ui.components
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Album
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.state.model.MediaItemUiModel
+import com.google.android.horologist.media.ui.utils.rememberVectorPainter
 
 @Preview(
     backgroundColor = 0xff000000,
@@ -39,7 +40,10 @@ fun MediaChipPreview() {
             artworkUri = "artworkUri"
         ),
         onClick = {},
-        placeholder = rememberVectorPainter(image = Icons.Default.Album)
+        placeholder = rememberVectorPainter(
+            image = Icons.Default.Album,
+            tintColor = Color.Blue,
+        )
     )
 }
 
@@ -53,7 +57,10 @@ fun MediaChipPreviewNoArtwork() {
     MediaChip(
         mediaItem = MediaItemUiModel(id = "id", title = "Red Hot Chilli Peppers"),
         onClick = {},
-        placeholder = rememberVectorPainter(image = Icons.Default.Album)
+        placeholder = rememberVectorPainter(
+            image = Icons.Default.Album,
+            tintColor = Color.Blue,
+        )
     )
 }
 
@@ -68,7 +75,10 @@ fun MediaChipPreviewNoTitle() {
         mediaItem = MediaItemUiModel(id = "id", artworkUri = "artworkUri"),
         onClick = {},
         defaultTitle = "No title",
-        placeholder = rememberVectorPainter(image = Icons.Default.Album)
+        placeholder = rememberVectorPainter(
+            image = Icons.Default.Album,
+            tintColor = Color.Blue,
+        )
     )
 }
 
@@ -86,6 +96,9 @@ fun MediaChipPreviewVeryLongTitle() {
             artworkUri = "artworkUri"
         ),
         onClick = {},
-        placeholder = rememberVectorPainter(image = Icons.Default.Album)
+        placeholder = rememberVectorPainter(
+            image = Icons.Default.Album,
+            tintColor = Color.Blue,
+        )
     )
 }

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChipPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChipPreview.kt
@@ -21,9 +21,10 @@ package com.google.android.horologist.media.ui.components.actions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FeaturedPlayList
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
+import com.google.android.horologist.media.ui.utils.rememberVectorPainter
 
 @Preview(
     backgroundColor = 0xff000000,
@@ -35,7 +36,10 @@ fun ShowPlaylistChipPreview() {
         artworkUri = "artworkUri",
         name = "Playlists",
         onClick = {},
-        placeholder = rememberVectorPainter(image = Icons.Default.FeaturedPlayList)
+        placeholder = rememberVectorPainter(
+            image = Icons.Default.FeaturedPlayList,
+            tintColor = Color.Green,
+        )
     )
 }
 
@@ -64,7 +68,10 @@ fun ShowPlaylistChipPreviewNoName() {
         artworkUri = "artworkUri",
         name = null,
         onClick = {},
-        placeholder = rememberVectorPainter(image = Icons.Default.FeaturedPlayList)
+        placeholder = rememberVectorPainter(
+            image = Icons.Default.FeaturedPlayList,
+            tintColor = Color.Green,
+        )
     )
 }
 
@@ -79,6 +86,9 @@ fun ShowPlaylistChipPreviewVeryLongName() {
         artworkUri = "artworkUri",
         name = "Very very very very very very very very very very very very very very very very very very very long title",
         onClick = {},
-        placeholder = rememberVectorPainter(image = Icons.Default.FeaturedPlayList)
+        placeholder = rememberVectorPainter(
+            image = Icons.Default.FeaturedPlayList,
+            tintColor = Color.Green,
+        )
     )
 }

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/utils/PainterUtils.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/utils/PainterUtils.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.RenderVectorGroup
+import androidx.compose.ui.graphics.vector.VectorPainter
+
+/**
+ * Create a [VectorPainter] with the Vector defined by the provided sub-composition and use a
+ * different tint color than what is defined in [image].
+ *
+ * @param [image] ImageVector used to create a vector graphic sub-composition.
+ * @param [tintColor] color used to tint the root group of this vector graphic.
+ * @param [tintBlendMode] optional BlendMode used in combination with [tintColor], defaults to
+ * value defined in [image].
+ */
+@Composable
+internal fun rememberVectorPainter(
+    image: ImageVector,
+    tintColor: Color,
+    tintBlendMode: BlendMode = image.tintBlendMode,
+) =
+    androidx.compose.ui.graphics.vector.rememberVectorPainter(
+        defaultWidth = image.defaultWidth,
+        defaultHeight = image.defaultHeight,
+        viewportWidth = image.viewportWidth,
+        viewportHeight = image.viewportHeight,
+        name = image.name,
+        tintColor = tintColor,
+        tintBlendMode = tintBlendMode,
+        autoMirror = image.autoMirror,
+        content = { _, _ -> RenderVectorGroup(group = image.root) }
+    )


### PR DESCRIPTION
#### WHAT

Change tint color of icons used in previews.

![Screen Shot 2022-06-30 at 19 20 01](https://user-images.githubusercontent.com/878134/176751784-2c17a1eb-3880-4046-844d-98825827b5c9.png)

![Screen Shot 2022-06-30 at 19 21 10](https://user-images.githubusercontent.com/878134/176751805-ad218bea-96ca-47ad-b005-65528e76fc08.png)


#### WHY

As requested in:
- https://github.com/google/horologist/pull/291#issuecomment-1169954567
- https://github.com/google/horologist/pull/299#discussion_r911275207


#### HOW

- Add helper function `rememberVectorPainter`  which calls the one defined in `androidx.compose.ui.graphics.vector` but allowing to pass a different tint color as parameter;
- Change preview code to use this helper function;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
