### PR TITLE
Ignore paparazzi failures output folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ checksum.txt
 
 /localbin/
 /.java-version
+
+# Paparazzi failures output folder
+out/


### PR DESCRIPTION
#### WHAT

Ignore paparazzi failures output folder.

#### WHY

So failures output images are not added to source code.

#### HOW

Add `out/` folder to `.gitignore` file. Paparazzi does not seem to allow us to configure this folder, seems to be [hard coded](https://github.com/cashapp/paparazzi/blob/ead091e220b95fda8d4e75a67916e29bc29dcbd7/paparazzi/src/main/java/app/cash/paparazzi/internal/ImageUtils.kt#L56).


#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [N/A] Run tests
- [N/A] Update metalava's signature text files
