### PR TITLE
Fix volume scrolling.

### DIFF
--- a/audio/src/main/java/com/google/android/horologist/audio/SystemAudioRepository.kt
+++ b/audio/src/main/java/com/google/android/horologist/audio/SystemAudioRepository.kt
@@ -120,7 +120,7 @@ private fun MediaRouter.fixInconsistency() {
 @ExperimentalHorologistAudioApi
 private inline val MediaRouter.volume: VolumeState
     get() {
-        return defaultRoute.volumeState
+        return selectedRoute.volumeState
     }
 
 @ExperimentalHorologistAudioApi


### PR DESCRIPTION
#### WHAT

Volume scrolling wasn't working reliably.

#### WHY

Was looking at multiple routes, phone in this example.

```
17:13:21.582  I  onRouteVolumeChanged VolumeState(current=6, max=15) VolumeState(current=6, max=15) Yuri's Pixel Buds A-Series Phone
17:13:22.246  I  onRouteVolumeChanged VolumeState(current=6, max=15) VolumeState(current=6, max=15) Yuri's Pixel Buds A-Series Phone
```

#### HOW

```
17:14:52.584  I  onRouteVolumeChanged VolumeState(current=15, max=15) VolumeState(current=15, max=15) Yuri's Pixel Buds A-Series Phone
17:14:54.417  I  onRouteVolumeChanged VolumeState(current=13, max=15) VolumeState(current=13, max=15) Yuri's Pixel Buds A-Series Phone
```

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
