### PR TITLE
Add SecondaryPlaceholderChip

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,6 +85,7 @@ com-squareup-okhttp3-logging-interceptor = { module = "com.squareup.okhttp3:logg
 compose-foundation-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
 compose-material-iconscore = { module = "androidx.compose.material:material-icons-core", version.ref = "compose" }
 compose-material-iconsext = { module = "androidx.compose.material:material-icons-extended", version.ref = "compose" }
+compose-material-ripple = { module = "androidx.compose.material:material-ripple", version.ref = "compose" }
 compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
 compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -101,6 +101,9 @@ package com.google.android.horologist.media.ui.components.base {
   public final class SecondaryChipKt {
   }
 
+  public final class SecondaryPlaceholderChipKt {
+  }
+
 }
 
 package com.google.android.horologist.media.ui.components.controls {

--- a/media-ui/build.gradle
+++ b/media-ui/build.gradle
@@ -104,6 +104,7 @@ dependencies {
     implementation libs.compose.ui.tooling
     implementation libs.compose.material.iconscore
     implementation libs.compose.material.iconsext
+    implementation libs.compose.material.ripple
     implementation libs.androidx.lifecycle.viewmodel.compose
 
     implementation libs.coil

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/base/SecondaryPlaceholderChipPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/base/SecondaryPlaceholderChipPreview.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistMediaUiApi::class)
+
+package com.google.android.horologist.media.ui.components.base
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
+
+@Preview(
+    backgroundColor = 0xff000000,
+    showBackground = true,
+)
+@Composable
+fun SecondaryPlaceholderChipPreview() {
+    SecondaryPlaceholderChip()
+}

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/base/SecondaryChip.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/base/SecondaryChip.kt
@@ -38,7 +38,7 @@ import coil.compose.rememberAsyncImagePainter
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 
 /**
- * This composable fulfil the redlines of the following components:
+ * This composable fulfils the redlines of the following components:
  * - Secondary standard chip - when [largeIcon] value is `false`;
  * - Chip with small or large avatar - according to [largeIcon] value;
  */

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/base/SecondaryPlaceholderChip.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/base/SecondaryPlaceholderChip.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.components.base
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.paint
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.ChipDefaults
+import androidx.wear.compose.material.MaterialTheme
+import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
+
+/**
+ * Secondary placeholder chip.
+ */
+@ExperimentalHorologistMediaUiApi
+@Composable
+internal fun SecondaryPlaceholderChip(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
+    enabled: Boolean = true,
+) {
+    val backgroundColor = Color(
+        red = MaterialTheme.colors.onSurfaceVariant.red,
+        green = MaterialTheme.colors.onSurfaceVariant.green,
+        blue = MaterialTheme.colors.onSurfaceVariant.blue,
+        alpha = 0.38f
+    )
+    Row(
+        modifier = modifier
+            .height(52.dp) // ChipDefaults.Height
+            .fillMaxWidth()
+            .clip(shape = MaterialTheme.shapes.small)
+            .paint(
+                painter = ChipDefaults
+                    .secondaryChipColors()
+                    .background(enabled = enabled).value,
+                contentScale = ContentScale.Crop
+            )
+            .clickable(
+                enabled = enabled,
+                onClick = onClick,
+                role = Role.Button,
+                indication = rememberRipple(),
+                interactionSource = remember { MutableInteractionSource() },
+            )
+            .padding(ChipDefaults.ContentPadding),
+    ) {
+        Box(
+            modifier = Modifier
+                .align(Alignment.CenterVertically)
+                .clip(CircleShape)
+                .background(backgroundColor)
+                .size(ChipDefaults.LargeIconSize)
+        )
+
+        Spacer(modifier = Modifier.width(6.dp))
+
+        Column(
+            modifier = Modifier
+                .fillMaxHeight()
+                .weight(1.0f),
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(backgroundColor)
+                    .fillMaxWidth()
+                    .height(12.dp)
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(modifier = Modifier.fillMaxWidth()) {
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(backgroundColor)
+                        .weight(1.0f)
+                        .height(12.dp)
+                )
+
+                Spacer(modifier = Modifier.width(20.dp))
+            }
+        }
+
+        Spacer(modifier = Modifier.width(10.dp))
+    }
+}

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/base/SecondaryPlaceholderChipTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/base/SecondaryPlaceholderChipTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistMediaUiApi::class)
+
+package com.google.android.horologist.media.ui.components.base
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import app.cash.paparazzi.Paparazzi
+import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
+import com.google.android.horologist.paparazzi.GALAXY_WATCH4_CLASSIC_LARGE
+import com.google.android.horologist.paparazzi.WearSnapshotHandler
+import com.google.android.horologist.paparazzi.determineHandler
+import org.junit.Rule
+import org.junit.Test
+
+class SecondaryPlaceholderChipTest {
+
+    @get:Rule
+    val paparazzi = Paparazzi(
+        deviceConfig = GALAXY_WATCH4_CLASSIC_LARGE,
+        theme = "android:ThemeOverlay.Material.Dark",
+        maxPercentDifference = 0.0,
+        snapshotHandler = WearSnapshotHandler(determineHandler(0.1))
+    )
+
+    @Test
+    fun default() {
+        paparazzi.snapshot {
+            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
+                SecondaryPlaceholderChip()
+            }
+        }
+    }
+}

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_SecondaryPlaceholderChipTest_default.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_SecondaryPlaceholderChipTest_default.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88de358235d5bab6bffd309dc775d3193457262a072852a74835e1c84ed67df9
+size 28192


### PR DESCRIPTION
#### WHAT

Add `SecondaryPlaceholderChip`.

![Screen Shot 2022-07-05 at 18 24 54](https://user-images.githubusercontent.com/878134/177383151-6686e0c4-19b9-4f30-823a-aeaae6054679.png)

#### WHY

In order to have our base building blocks aligned with specs in Figma.

#### HOW

- Add `material-ripple` as dependency to `media-ui`;
- Add implementation based on [Chip](https://github.com/androidx/androidx/blob/5775cb72bdc32a90328bf39e212fab31c5960316/wear/compose/compose-material/src/commonMain/kotlin/androidx/wear/compose/material/Chip.kt#L294);
- Add preview in the debug folder;
- Add snapshot test;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
