### PR TITLE
Allow ImageVector to be passed as icon to SecondaryChip

### DIFF
--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/base/SecondaryChipPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/base/SecondaryChipPreview.kt
@@ -71,6 +71,20 @@ fun SecondaryChipPreviewWithIcon() {
 }
 
 @Preview(
+    name = "With ImageVector as icon",
+    backgroundColor = 0xff000000,
+    showBackground = true,
+)
+@Composable
+fun SecondaryChipPreviewWithImageVectorAsIcon() {
+    SecondaryChip(
+        primaryLabel = "Primary label",
+        onClick = { },
+        icon = Icons.Default.Add
+    )
+}
+
+@Preview(
     name = "With large icon",
     backgroundColor = 0xff000000,
     showBackground = true,

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/base/SecondaryChip.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/base/SecondaryChip.kt
@@ -27,12 +27,14 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
+import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.Text
 import coil.compose.rememberAsyncImagePainter
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
@@ -93,15 +95,23 @@ internal fun SecondaryChip(
                         Spacer(modifier = Modifier.width(4.dp))
                     }
 
-                    Image(
-                        painter = rememberAsyncImagePainter(
-                            model = icon,
-                            placeholder = placeholder
-                        ),
-                        contentDescription = null, // hidden from talkback
-                        modifier = Modifier.size(iconSize),
-                        contentScale = ContentScale.Fit
-                    )
+                    if (icon is ImageVector) {
+                        Icon(
+                            imageVector = icon,
+                            contentDescription = null, // hidden from talkback
+                            modifier = Modifier.size(iconSize),
+                        )
+                    } else {
+                        Image(
+                            painter = rememberAsyncImagePainter(
+                                model = icon,
+                                placeholder = placeholder
+                            ),
+                            contentDescription = null, // hidden from talkback
+                            modifier = Modifier.size(iconSize),
+                            contentScale = ContentScale.Fit
+                        )
+                    }
                 }
             }
         }

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/base/SecondaryChipTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/base/SecondaryChipTest.kt
@@ -87,6 +87,19 @@ class SecondaryChipTest {
     }
 
     @Test
+    fun withImageVectorAsIcon() {
+        paparazzi.snapshot {
+            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
+                SecondaryChip(
+                    primaryLabel = "Primary label",
+                    onClick = { },
+                    icon = Icons.Default.Add,
+                )
+            }
+        }
+    }
+
+    @Test
     fun withLargeIcon() {
         paparazzi.snapshot {
             Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_SecondaryChipTest_withImageVectorAsIcon.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_SecondaryChipTest_withImageVectorAsIcon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d031448655889a76acf1cc63e9515ac6d5ac76d81a9484bb585032011fe1cef7
+size 36629


### PR DESCRIPTION
#### WHAT

Allow `ImageVector` to be passed as icon to `SecondaryChip`.

![Screen Shot 2022-07-06 at 12 02 31](https://user-images.githubusercontent.com/878134/177536109-d27cdc97-f1bd-4174-8a02-e5f6411d03ee.png)

<details>
<summary>All previews</summary>

All previews after the changes (in order to check that there were no side effects - which is also checked by snapshot tests).

<img src="https://user-images.githubusercontent.com/878134/177533930-5052aeb1-0516-4aed-b90e-4cc7041ffefe.png" />
</details>

#### WHY

In order to allow usage like the below, which was causing Coil to throw exception otherwise:

```kotlin
    SecondaryChip(
        primaryLabel = "Primary label",
        onClick = { },
        icon = Icons.Default.Add
    )
```

#### HOW

- Verify if `icon` param is of type `ImageVector` and create an `Icon`;
- Add preview;
- Add snapshot test;

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
