### PR TITLE
Change media sample to use BrowseScreen

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
@@ -26,14 +26,17 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import com.google.android.horologist.audio.ui.VolumeViewModel
 import com.google.android.horologist.compose.layout.StateUtils.rememberStateWithLifecycle
+import com.google.android.horologist.media.ui.navigation.MediaNavController.navigateToCollections
 import com.google.android.horologist.media.ui.navigation.MediaNavController.navigateToLibrary
 import com.google.android.horologist.media.ui.navigation.MediaNavController.navigateToPlayer
 import com.google.android.horologist.media.ui.navigation.MediaNavController.navigateToSettings
 import com.google.android.horologist.media.ui.navigation.MediaNavController.navigateToVolume
 import com.google.android.horologist.media.ui.navigation.MediaPlayerScaffold
+import com.google.android.horologist.media.ui.screens.browse.BrowseScreen
+import com.google.android.horologist.media.ui.screens.browse.BrowseScreenState
 import com.google.android.horologist.mediasample.ui.debug.MediaInfoTimeText
-import com.google.android.horologist.mediasample.ui.library.LibraryScreenViewModel
-import com.google.android.horologist.mediasample.ui.library.UampLibraryScreen
+import com.google.android.horologist.mediasample.ui.library.UampPlaylistsScreen
+import com.google.android.horologist.mediasample.ui.library.UampPlaylistsScreenViewModel
 import com.google.android.horologist.mediasample.ui.player.MediaPlayerScreenViewModel
 import com.google.android.horologist.mediasample.ui.player.UampMediaPlayerScreen
 import com.google.android.horologist.mediasample.ui.settings.SettingsScreenViewModel
@@ -83,21 +86,14 @@ fun UampWearApp(
                     settingsState = settingsState
                 )
             },
-            libraryScreen = { focusRequester, state ->
-                val libraryScreenViewModel: LibraryScreenViewModel =
-                    viewModel(factory = LibraryScreenViewModel.Factory, extras = creationExtras())
-
-                UampLibraryScreen(
+            libraryScreen = { focusRequester, scalingLazyListState ->
+                BrowseScreen(
+                    browseScreenState = BrowseScreenState.Loaded(emptyList()),
+                    onDownloadItemClick = { },
+                    onPlaylistsClick = { navController.navigateToCollections() },
+                    onSettingsClick = { navController.navigateToSettings() },
                     focusRequester = focusRequester,
-                    state = state,
-                    onSettingsClick = {
-                        navController.navigateToSettings()
-                    },
-                    libraryScreenViewModel = libraryScreenViewModel,
-                    onPlayClick = {
-                        navController.navigateToPlayer()
-                    },
-                    settingsState = settingsState
+                    scalingLazyListState = scalingLazyListState,
                 )
             },
             categoryEntityScreen = { _, _ ->
@@ -106,8 +102,22 @@ fun UampWearApp(
             mediaEntityScreen = { _, _ ->
                 TODO()
             },
-            playlistsScreen = { _, _ ->
-                TODO()
+            playlistsScreen = { focusRequester, scalingLazyListState ->
+                val uampPlaylistsScreenViewModel: UampPlaylistsScreenViewModel =
+                    viewModel(
+                        factory = UampPlaylistsScreenViewModel.Factory,
+                        extras = creationExtras()
+                    )
+
+                UampPlaylistsScreen(
+                    focusRequester = focusRequester,
+                    state = scalingLazyListState,
+                    uampPlaylistsScreenViewModel = uampPlaylistsScreenViewModel,
+                    onPlayClick = {
+                        navController.navigateToPlayer()
+                    },
+                    settingsState = settingsState
+                )
             },
             settingsScreen = { focusRequester, state ->
                 UampSettingsScreen(

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/library/UampPlaylistsScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/library/UampPlaylistsScreen.kt
@@ -17,15 +17,11 @@
 package com.google.android.horologist.mediasample.ui.library
 
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.res.stringResource
-import androidx.wear.compose.material.Button
-import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.ScalingLazyColumn
 import androidx.wear.compose.material.ScalingLazyListState
@@ -38,16 +34,15 @@ import com.google.android.horologist.mediasample.R
 import com.google.android.horologist.mediasample.domain.Settings
 
 @Composable
-fun UampLibraryScreen(
+fun UampPlaylistsScreen(
     focusRequester: FocusRequester,
-    libraryScreenViewModel: LibraryScreenViewModel,
+    uampPlaylistsScreenViewModel: UampPlaylistsScreenViewModel,
     state: ScalingLazyListState,
-    onSettingsClick: () -> Unit,
     onPlayClick: () -> Unit,
     modifier: Modifier = Modifier,
     settingsState: Settings?,
 ) {
-    val uiState by rememberStateWithLifecycle(libraryScreenViewModel.uiState)
+    val uiState by rememberStateWithLifecycle(uampPlaylistsScreenViewModel.uiState)
 
     ScalingLazyColumn(
         modifier = modifier
@@ -69,7 +64,7 @@ fun UampLibraryScreen(
                 MediaChip(
                     mediaItem = mediaItem,
                     onClick = {
-                        libraryScreenViewModel.play(it)
+                        uampPlaylistsScreenViewModel.play(it)
                         onPlayClick()
                     },
                     defaultTitle = stringResource(id = R.string.horologist_no_title),
@@ -78,11 +73,6 @@ fun UampLibraryScreen(
         } else {
             item {
                 Text("Loading...", style = MaterialTheme.typography.caption3)
-            }
-        }
-        item {
-            Button(onClick = onSettingsClick) {
-                Icon(Icons.Default.Settings, contentDescription = "Settings")
             }
         }
     }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/library/UampPlaylistsScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/library/UampPlaylistsScreenViewModel.kt
@@ -36,7 +36,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import java.io.IOException
 
-class LibraryScreenViewModel(
+class UampPlaylistsScreenViewModel(
     uampService: UampService,
     private val playerRepository: PlayerRepository,
     private val snackbarManager: SnackbarManager
@@ -81,7 +81,7 @@ class LibraryScreenViewModel(
     companion object {
         val Factory = viewModelFactory {
             initializer {
-                LibraryScreenViewModel(
+                UampPlaylistsScreenViewModel(
                     uampService = this[MediaApplicationContainer.UampServiceKey]!!,
                     playerRepository = this[MediaApplicationContainer.PlayerRepositoryImplKey]!!,
                     snackbarManager = this[SnackbarViewModel.SnackbarManagerKey]!!,


### PR DESCRIPTION
#### WHAT

Change media sample app to use `BrowseScreen`.

#### WHY

As per specs in Figma.

#### HOW

- Pass `BrowseScreen` to `libraryScreen` slot in `MediaPlayerScaffold`;
- Move `UampLibraryScreen` to `playlistsScreen` slot;
- Remove settings button from `UampLibraryScreen`;

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
