### PR TITLE
Explicitly archive affectedModuleDetector report folder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,7 @@ jobs:
             **/build/test-results/*
             **/build/reports/*
             **/build/reports/paparazzi/*
+            **/build/reports/affectedModuleDetector/*
 
       - name: Upload snapshot test failures
         if: failure()

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ affectedModuleDetector {
     ]
 
     logFilename = "output.log"
-    logFolder = "${rootProject.buildDir}/affectedModuleDetector"
+    logFolder = "${rootProject.buildDir}/reports/affectedModuleDetector"
 
     String baseRef = findProperty("affected_base_ref")
     // If we have a base ref to diff against, extract the branch name and use it


### PR DESCRIPTION
#### WHAT

Explicitly archive affectedModuleDetector report folder.

#### WHY

So the logs are archived in the CI artifact.

#### HOW

- Change `logFolder` of `affectedModuleDetector` plugin to be inside `reports` folder;
- Add `*/build/reports/affectedModuleDetector/*` to `build.yml` as previous attempt with just changing `logFolder` did not result in having them archived in the generated artifact, even though I see the configuration to archive `**/build/reports/*`

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
