### PR TITLE
Explicitly archive paparazzi report folder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,7 @@ jobs:
           path: |
             **/build/test-results/*
             **/build/reports/*
+            **/build/reports/paparazzi/*
 
       - name: Upload snapshot test failures
         if: failure()


### PR DESCRIPTION
#### WHAT

Explicitly archive paparazzi report folder.

#### WHY

Not seeing them in the generated artifact, even though I see the configuration to archive `**/build/reports/*`

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
