### PR TITLE
Don't use run-affected for unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,6 @@ jobs:
         run: |
           ./scripts/run-tests.sh \
               --unit-tests \
-              --run-affected \
               --affected-base-ref=$BASE_REF
 
       - name: Snapshot tests


### PR DESCRIPTION
#### WHAT

Don't use run-affected param for unit tests.

#### WHY

In order to not use this [plugin](https://github.com/google/horologist/blob/2c1e329c50a6cfa5d85eaa553ab1131a8fe0608a/gradle/libs.versions.toml#L38) which might be causing https://github.com/google/horologist/issues/340

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
