### PR TITLE
Fix maxPercentDifference discrepancies in tests

### DIFF
--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenIndividualTest.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenIndividualTest.kt
@@ -32,12 +32,14 @@ import org.junit.Test
 
 @Ignore("https://github.com/google/horologist/issues/323")
 class VolumeScreenIndividualTest {
+    private val maxPercentDifference = 0.1
+
     @get:Rule
     val paparazzi = Paparazzi(
         deviceConfig = GALAXY_WATCH4_CLASSIC_LARGE,
         theme = "android:ThemeOverlay.Material.Dark",
-        maxPercentDifference = 0.0,
-        snapshotHandler = WearSnapshotHandler(determineHandler(0.1))
+        maxPercentDifference = maxPercentDifference,
+        snapshotHandler = WearSnapshotHandler(determineHandler(maxPercentDifference))
     )
 
     @Test

--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenThemeTest.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenThemeTest.kt
@@ -39,12 +39,14 @@ import org.junit.runners.Parameterized
 class VolumeScreenThemeTest(
     private val themeValue: ThemeValues
 ) {
+    private val maxPercentDifference = 0.1
+
     @get:Rule
     val paparazzi = Paparazzi(
         deviceConfig = GALAXY_WATCH4_CLASSIC_LARGE,
         theme = "android:ThemeOverlay.Material.Dark",
-        maxPercentDifference = 0.0,
-        snapshotHandler = WearSnapshotHandler(determineHandler(0.1))
+        maxPercentDifference = maxPercentDifference,
+        snapshotHandler = WearSnapshotHandler(determineHandler(maxPercentDifference))
     )
 
     @Test

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/DatePickerTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/DatePickerTest.kt
@@ -28,12 +28,14 @@ import java.time.LocalDate
 
 @Ignore("Waiting for interactive support for paparazzi")
 class DatePickerTest {
+    private val maxPercentDifference = 0.1
+
     @get:Rule
     val paparazzi = Paparazzi(
         deviceConfig = GALAXY_WATCH4_CLASSIC_LARGE,
         theme = "android:ThemeOverlay.Material.Dark",
-        maxPercentDifference = 0.0,
-        snapshotHandler = WearSnapshotHandler(determineHandler(0.1))
+        maxPercentDifference = maxPercentDifference,
+        snapshotHandler = WearSnapshotHandler(determineHandler(maxPercentDifference))
     )
 
     @Test

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/TimePicker12hTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/TimePicker12hTest.kt
@@ -28,12 +28,14 @@ import java.time.LocalTime
 
 @Ignore("Waiting for interactive support for paparazzi")
 class TimePicker12hTest {
+    private val maxPercentDifference = 0.1
+
     @get:Rule
     val paparazzi = Paparazzi(
         deviceConfig = GALAXY_WATCH4_CLASSIC_LARGE,
         theme = "android:ThemeOverlay.Material.Dark",
-        maxPercentDifference = 0.0,
-        snapshotHandler = WearSnapshotHandler(determineHandler(0.1))
+        maxPercentDifference = maxPercentDifference,
+        snapshotHandler = WearSnapshotHandler(determineHandler(maxPercentDifference))
     )
 
     @Test

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/TimePickerTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/TimePickerTest.kt
@@ -28,12 +28,14 @@ import java.time.LocalTime
 
 @Ignore("Waiting for interactive support for paparazzi")
 class TimePickerTest {
+    private val maxPercentDifference = 0.1
+
     @get:Rule
     val paparazzi = Paparazzi(
         deviceConfig = GALAXY_WATCH4_CLASSIC_LARGE,
         theme = "android:ThemeOverlay.Material.Dark",
-        maxPercentDifference = 0.0,
-        snapshotHandler = WearSnapshotHandler(determineHandler(0.1))
+        maxPercentDifference = maxPercentDifference,
+        snapshotHandler = WearSnapshotHandler(determineHandler(maxPercentDifference))
     )
 
     @Test

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/FigmaPlayerScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/FigmaPlayerScreenTest.kt
@@ -51,15 +51,17 @@ import org.junit.runners.Parameterized
 class FigmaPlayerScreenTest(
     private val deviceConfig: DeviceConfig
 ) {
+    private val maxPercentDifference = 0.1
+
     @get:Rule
     val paparazzi = Paparazzi(
         deviceConfig = deviceConfig,
         theme = "android:ThemeOverlay.Material.Dark",
-        maxPercentDifference = 0.1,
+        maxPercentDifference = maxPercentDifference,
         snapshotHandler = if (deviceConfig == WEAR_OS_SQUARE) {
-            determineHandler(0.1)
+            determineHandler(maxPercentDifference)
         } else {
-            WearSnapshotHandler(determineHandler(0.1))
+            WearSnapshotHandler(determineHandler(maxPercentDifference))
         }
     )
 

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/FigmaVolumeScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/FigmaVolumeScreenTest.kt
@@ -33,12 +33,14 @@ import org.junit.Rule
 import org.junit.Test
 
 class FigmaVolumeScreenTest {
+    private val maxPercentDifference = 5.0
+
     @get:Rule
     val paparazzi = Paparazzi(
         deviceConfig = GALAXY_WATCH4_CLASSIC_LARGE,
         theme = "android:ThemeOverlay.Material.Dark",
-        maxPercentDifference = 5.0,
-        snapshotHandler = WearSnapshotHandler(determineHandler(5.0))
+        maxPercentDifference = maxPercentDifference,
+        snapshotHandler = WearSnapshotHandler(determineHandler(maxPercentDifference))
     )
 
     @Test

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerScreenTest.kt
@@ -41,12 +41,14 @@ import org.junit.runners.Parameterized
 class MediaPlayerScreenTest(
     private val themeValue: ThemeValues
 ) {
+    private val maxPercentDifference = 0.1
+
     @get:Rule
     val paparazzi = Paparazzi(
         deviceConfig = GALAXY_WATCH4_CLASSIC_LARGE,
         theme = "android:ThemeOverlay.Material.Dark",
-        maxPercentDifference = 0.0,
-        snapshotHandler = WearSnapshotHandler(determineHandler(0.1))
+        maxPercentDifference = maxPercentDifference,
+        snapshotHandler = WearSnapshotHandler(determineHandler(maxPercentDifference))
     )
 
     @Test

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerStatesScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerStatesScreenTest.kt
@@ -39,12 +39,14 @@ import org.junit.runners.Parameterized
 class MediaPlayerStatesScreenTest(
     private val state: State
 ) {
+    private val maxPercentDifference = 0.1
+
     @get:Rule
     val paparazzi = Paparazzi(
         deviceConfig = GALAXY_WATCH4_CLASSIC_LARGE,
         theme = "android:ThemeOverlay.Material.Dark",
-        maxPercentDifference = 0.0,
-        snapshotHandler = WearSnapshotHandler(determineHandler(0.1))
+        maxPercentDifference = maxPercentDifference,
+        snapshotHandler = WearSnapshotHandler(determineHandler(maxPercentDifference))
     )
 
     @Test

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/PodcastPlayerScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/PodcastPlayerScreenTest.kt
@@ -44,12 +44,14 @@ import org.junit.runners.Parameterized
 class PodcastPlayerScreenTest(
     private val options: PodcastOptions
 ) {
+    private val maxPercentDifference = 0.1
+
     @get:Rule
     val paparazzi = Paparazzi(
         deviceConfig = GALAXY_WATCH4_CLASSIC_LARGE,
         theme = "android:ThemeOverlay.Material.Dark",
-        maxPercentDifference = 0.0,
-        snapshotHandler = WearSnapshotHandler(determineHandler(0.1))
+        maxPercentDifference = maxPercentDifference,
+        snapshotHandler = WearSnapshotHandler(determineHandler(maxPercentDifference))
     )
 
     @Test

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/MediaChipTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/MediaChipTest.kt
@@ -36,12 +36,14 @@ import org.junit.Test
 
 class MediaChipTest {
 
+    private val maxPercentDifference = 0.1
+
     @get:Rule
     val paparazzi = Paparazzi(
         deviceConfig = GALAXY_WATCH4_CLASSIC_LARGE,
         theme = "android:ThemeOverlay.Material.Dark",
-        maxPercentDifference = 0.0,
-        snapshotHandler = WearSnapshotHandler(determineHandler(0.1))
+        maxPercentDifference = maxPercentDifference,
+        snapshotHandler = WearSnapshotHandler(determineHandler(maxPercentDifference))
     )
 
     @Test

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChipTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChipTest.kt
@@ -36,12 +36,14 @@ import org.junit.Test
 
 class ShowPlaylistChipTest {
 
+    private val maxPercentDifference = 0.1
+
     @get:Rule
     val paparazzi = Paparazzi(
         deviceConfig = GALAXY_WATCH4_CLASSIC_LARGE,
         theme = "android:ThemeOverlay.Material.Dark",
-        maxPercentDifference = 0.0,
-        snapshotHandler = WearSnapshotHandler(determineHandler(0.1))
+        maxPercentDifference = maxPercentDifference,
+        snapshotHandler = WearSnapshotHandler(determineHandler(maxPercentDifference))
     )
 
     @Test

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/base/SecondaryChipTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/base/SecondaryChipTest.kt
@@ -39,12 +39,14 @@ import org.junit.Test
 
 class SecondaryChipTest {
 
+    private val maxPercentDifference = 0.1
+
     @get:Rule
     val paparazzi = Paparazzi(
         deviceConfig = GALAXY_WATCH4_CLASSIC_LARGE,
         theme = "android:ThemeOverlay.Material.Dark",
-        maxPercentDifference = 0.0,
-        snapshotHandler = WearSnapshotHandler(determineHandler(0.1))
+        maxPercentDifference = maxPercentDifference,
+        snapshotHandler = WearSnapshotHandler(determineHandler(maxPercentDifference))
     )
 
     @Test

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/base/SecondaryPlaceholderChipTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/base/SecondaryPlaceholderChipTest.kt
@@ -33,12 +33,14 @@ import org.junit.Test
 
 class SecondaryPlaceholderChipTest {
 
+    private val maxPercentDifference = 0.1
+
     @get:Rule
     val paparazzi = Paparazzi(
         deviceConfig = GALAXY_WATCH4_CLASSIC_LARGE,
         theme = "android:ThemeOverlay.Material.Dark",
-        maxPercentDifference = 0.0,
-        snapshotHandler = WearSnapshotHandler(determineHandler(0.1))
+        maxPercentDifference = maxPercentDifference,
+        snapshotHandler = WearSnapshotHandler(determineHandler(maxPercentDifference))
     )
 
     @Test


### PR DESCRIPTION
#### WHAT

Fix maxPercentDifference discrepancies in tests

#### WHY

As per https://github.com/google/horologist/pull/338#discussion_r915893640, they were supposed to be the same value.

#### HOW

- Extract a variable in order to try to prevent similar issues in the future;

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
