### PR TITLE
Call clean task with verifyPaparazziDebug 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,11 +63,6 @@ jobs:
               --unit-tests \
               --affected-base-ref=$BASE_REF
 
-      - name: Snapshot tests
-        run: |
-          ./gradlew --scan --stacktrace \
-              verifyPaparazziDebug
-
       - name: Upload test results and reports
         if: always()
         uses: actions/upload-artifact@v2
@@ -76,15 +71,25 @@ jobs:
           path: |
             **/build/test-results/*
             **/build/reports/*
-            **/build/reports/paparazzi/*
             **/build/reports/affectedModuleDetector/*
 
-      - name: Upload snapshot test failures
-        if: failure()
+      # Once this (https://github.com/cashapp/paparazzi/issues/388) is fixed, the changes introduced
+      # by this commit should be reverted to speed up and simplify the script again.
+      - name: Snapshot tests
+        run: |
+          ./gradlew --scan --stacktrace \
+              clean \
+              verifyPaparazziDebug            
+
+      - name: Upload snapshot tests results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: snapshot-test-failures
+          name: snapshot-test-results
           path: |
+            **/build/test-results/*
+            **/build/reports/*
+            **/build/reports/paparazzi/*
             **/out/failures/
 
   test:


### PR DESCRIPTION
#### WHAT

Call clean task with verifyPaparazziDebug 


#### WHY

In order to prevent it using cache, in an attempt to fix https://github.com/google/horologist/issues/339

#### HOW

- add clean task to be called with verifyPaparazziDebug;
- move "snapshot test" step to be executed after "upload test reports" step, due to the clean task that would delete the previously generated reports;
- change "upload snapshot tests failures" step to also archive the test results and to run "always";


#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
