### PR TITLE
Enable VolumeScreenIndividualTest and VolumeScreenThemeTest

### DIFF
--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenIndividualTest.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenIndividualTest.kt
@@ -26,11 +26,9 @@ import com.google.android.horologist.audio.VolumeState
 import com.google.android.horologist.paparazzi.GALAXY_WATCH4_CLASSIC_LARGE
 import com.google.android.horologist.paparazzi.WearSnapshotHandler
 import com.google.android.horologist.paparazzi.determineHandler
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
-@Ignore("https://github.com/google/horologist/issues/323")
 class VolumeScreenIndividualTest {
     @get:Rule
     val paparazzi = Paparazzi(

--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenThemeTest.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenThemeTest.kt
@@ -28,13 +28,11 @@ import com.google.android.horologist.compose.tools.themeValues
 import com.google.android.horologist.paparazzi.GALAXY_WATCH4_CLASSIC_LARGE
 import com.google.android.horologist.paparazzi.WearSnapshotHandler
 import com.google.android.horologist.paparazzi.determineHandler
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
-@Ignore("https://github.com/google/horologist/issues/323")
 @RunWith(Parameterized::class)
 class VolumeScreenThemeTest(
     private val themeValue: ThemeValues


### PR DESCRIPTION
#### WHAT

Enable VolumeScreenIndividualTest and VolumeScreenThemeTest

#### WHY

As per https://github.com/google/horologist/issues/323, they are not causing the NPE. The NPE issue is being tracked in https://github.com/google/horologist/issues/340

#### HOW

- Remove Ignore annotation;

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
