### PR TITLE
Revert "Don't use run-affected for unit tests"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,7 @@ jobs:
         run: |
           ./scripts/run-tests.sh \
               --unit-tests \
+              --run-affected \
               --affected-base-ref=$BASE_REF
 
       - name: Snapshot tests


### PR DESCRIPTION
#### WHAT

Revert https://github.com/google/horologist/pull/343

#### WHY

As per https://github.com/google/horologist/pull/343#issuecomment-1177785658, it got green due to [false positive](https://github.com/google/horologist/issues/339) results in CI.

This PR https://github.com/google/horologist/pull/345#issuecomment-1177898074 surfaces the issue again.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [N/A] Run tests
- [N/A] Update metalava's signature text files
