### PR TITLE
Rename SecondaryChip to StandardChip

### DIFF
--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -98,10 +98,10 @@ package com.google.android.horologist.media.ui.components.background {
 
 package com.google.android.horologist.media.ui.components.base {
 
-  public final class SecondaryChipKt {
+  public final class SecondaryPlaceholderChipKt {
   }
 
-  public final class SecondaryPlaceholderChipKt {
+  public final class StandardChipKt {
   }
 
   public final class TitleKt {

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/base/PrimaryChipPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/base/PrimaryChipPreview.kt
@@ -31,12 +31,8 @@ import com.google.android.horologist.media.ui.utils.rememberVectorPainter
     showBackground = true,
 )
 @Composable
-fun SecondaryChipPreview() {
-    StandardChip(
-        label = "Primary label",
-        onClick = { },
-        chipType = StandardChipType.Secondary,
-    )
+fun PrimaryChipPreview() {
+    StandardChip(label = "Primary label", onClick = { })
 }
 
 @Preview(
@@ -45,12 +41,11 @@ fun SecondaryChipPreview() {
     showBackground = true,
 )
 @Composable
-fun SecondaryChipPreviewWithSecondaryLabel() {
+fun PrimaryChipPreviewWithSecondaryLabel() {
     StandardChip(
         label = "Primary label",
         onClick = { },
         secondaryLabel = "Secondary label",
-        chipType = StandardChipType.Secondary,
     )
 }
 
@@ -60,16 +55,15 @@ fun SecondaryChipPreviewWithSecondaryLabel() {
     showBackground = true,
 )
 @Composable
-fun SecondaryChipPreviewWithIcon() {
+fun PrimaryChipPreviewWithIcon() {
     StandardChip(
         label = "Primary label",
         onClick = { },
         icon = "iconUri",
         placeholder = rememberVectorPainter(
             image = Icons.Default.Add,
-            tintColor = Color.White,
-        ),
-        chipType = StandardChipType.Secondary,
+            tintColor = Color.Black,
+        )
     )
 }
 
@@ -79,12 +73,11 @@ fun SecondaryChipPreviewWithIcon() {
     showBackground = true,
 )
 @Composable
-fun SecondaryChipPreviewWithImageVectorAsIcon() {
+fun PrimaryChipPreviewWithImageVectorAsIcon() {
     StandardChip(
         label = "Primary label",
         onClick = { },
-        icon = Icons.Default.Add,
-        chipType = StandardChipType.Secondary,
+        icon = Icons.Default.Add
     )
 }
 
@@ -94,7 +87,7 @@ fun SecondaryChipPreviewWithImageVectorAsIcon() {
     showBackground = true,
 )
 @Composable
-fun SecondaryChipPreviewWithLargeIcon() {
+fun PrimaryChipPreviewWithLargeIcon() {
     StandardChip(
         label = "Primary label",
         onClick = { },
@@ -102,9 +95,8 @@ fun SecondaryChipPreviewWithLargeIcon() {
         largeIcon = true,
         placeholder = rememberVectorPainter(
             image = Icon32dp,
-            tintColor = Color.White,
-        ),
-        chipType = StandardChipType.Secondary,
+            tintColor = Color.Black,
+        )
     )
 }
 
@@ -114,7 +106,7 @@ fun SecondaryChipPreviewWithLargeIcon() {
     showBackground = true,
 )
 @Composable
-fun SecondaryChipPreviewWithSecondaryLabelAndIcon() {
+fun PrimaryChipPreviewWithSecondaryLabelAndIcon() {
     StandardChip(
         label = "Primary label",
         onClick = { },
@@ -122,9 +114,8 @@ fun SecondaryChipPreviewWithSecondaryLabelAndIcon() {
         icon = "iconUri",
         placeholder = rememberVectorPainter(
             image = Icons.Default.Add,
-            tintColor = Color.White,
-        ),
-        chipType = StandardChipType.Secondary,
+            tintColor = Color.Black,
+        )
     )
 }
 
@@ -134,7 +125,7 @@ fun SecondaryChipPreviewWithSecondaryLabelAndIcon() {
     showBackground = true,
 )
 @Composable
-fun SecondaryChipPreviewWithSecondaryLabelAndLargeIcon() {
+fun PrimaryChipPreviewWithSecondaryLabelAndLargeIcon() {
     StandardChip(
         label = "Primary label",
         onClick = { },
@@ -143,9 +134,8 @@ fun SecondaryChipPreviewWithSecondaryLabelAndLargeIcon() {
         largeIcon = true,
         placeholder = rememberVectorPainter(
             image = Icon32dp,
-            tintColor = Color.White,
-        ),
-        chipType = StandardChipType.Secondary,
+            tintColor = Color.Black,
+        )
     )
 }
 
@@ -155,7 +145,7 @@ fun SecondaryChipPreviewWithSecondaryLabelAndLargeIcon() {
     showBackground = true,
 )
 @Composable
-fun SecondaryChipPreviewDisabled() {
+fun PrimaryChipPreviewDisabled() {
     StandardChip(
         label = "Primary label",
         onClick = { },
@@ -163,9 +153,8 @@ fun SecondaryChipPreviewDisabled() {
         icon = "iconUri",
         placeholder = rememberVectorPainter(
             image = Icons.Default.Add,
-            tintColor = Color.White,
+            tintColor = Color.Black,
         ),
-        chipType = StandardChipType.Secondary,
         enabled = false,
     )
 }
@@ -176,11 +165,10 @@ fun SecondaryChipPreviewDisabled() {
     showBackground = true,
 )
 @Composable
-fun SecondaryChipPreviewWithLongText() {
+fun PrimaryChipPreviewWithLongText() {
     StandardChip(
         label = "Primary label very very very very very very very very very very very very very very very very very long text",
-        onClick = { },
-        chipType = StandardChipType.Secondary,
+        onClick = { }
     )
 }
 
@@ -190,7 +178,7 @@ fun SecondaryChipPreviewWithLongText() {
     showBackground = true,
 )
 @Composable
-fun SecondaryChipPreviewWithSecondaryLabelAndLongText() {
+fun PrimaryChipPreviewWithSecondaryLabelAndLongText() {
     StandardChip(
         label = "Primary label very very very very very very very very long text",
         onClick = { },
@@ -198,9 +186,8 @@ fun SecondaryChipPreviewWithSecondaryLabelAndLongText() {
         icon = "iconUri",
         placeholder = rememberVectorPainter(
             image = Icons.Default.Add,
-            tintColor = Color.White,
+            tintColor = Color.Black,
         ),
-        chipType = StandardChipType.Secondary,
     )
 }
 
@@ -210,16 +197,15 @@ fun SecondaryChipPreviewWithSecondaryLabelAndLongText() {
     showBackground = true,
 )
 @Composable
-fun SecondaryChipPreviewUsingSmallIcon() {
+fun PrimaryChipPreviewUsingSmallIcon() {
     StandardChip(
         label = "Primary label",
         onClick = { },
         icon = "iconUri",
         placeholder = rememberVectorPainter(
             image = Icon12dp,
-            tintColor = Color.White,
-        ),
-        chipType = StandardChipType.Secondary,
+            tintColor = Color.Black,
+        )
     )
 }
 
@@ -229,7 +215,7 @@ fun SecondaryChipPreviewUsingSmallIcon() {
     showBackground = true,
 )
 @Composable
-fun SecondaryChipPreviewWithLargeIconUsingSmallIcon() {
+fun PrimaryChipPreviewWithLargeIconUsingSmallIcon() {
     StandardChip(
         label = "Primary label",
         onClick = { },
@@ -237,9 +223,8 @@ fun SecondaryChipPreviewWithLargeIconUsingSmallIcon() {
         largeIcon = true,
         placeholder = rememberVectorPainter(
             image = Icon12dp,
-            tintColor = Color.White,
-        ),
-        chipType = StandardChipType.Secondary,
+            tintColor = Color.Black,
+        )
     )
 }
 
@@ -249,16 +234,15 @@ fun SecondaryChipPreviewWithLargeIconUsingSmallIcon() {
     showBackground = true,
 )
 @Composable
-fun SecondaryChipPreviewUsingExtraLargeIcon() {
+fun PrimaryChipPreviewUsingExtraLargeIcon() {
     StandardChip(
         label = "Primary label",
         onClick = { },
         icon = "iconUri",
         placeholder = rememberVectorPainter(
             image = Icon48dp,
-            tintColor = Color.White,
-        ),
-        chipType = StandardChipType.Secondary,
+            tintColor = Color.Black,
+        )
     )
 }
 
@@ -268,7 +252,7 @@ fun SecondaryChipPreviewUsingExtraLargeIcon() {
     showBackground = true,
 )
 @Composable
-fun SecondaryChipPreviewWithLargeIconUsingExtraLargeIcon() {
+fun PrimaryChipPreviewWithLargeIconUsingExtraLargeIcon() {
     StandardChip(
         label = "Primary label",
         onClick = { },
@@ -276,9 +260,8 @@ fun SecondaryChipPreviewWithLargeIconUsingExtraLargeIcon() {
         largeIcon = true,
         placeholder = rememberVectorPainter(
             image = Icon48dp,
-            tintColor = Color.White,
-        ),
-        chipType = StandardChipType.Secondary,
+            tintColor = Color.Black,
+        )
     )
 }
 

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/base/StandardChip.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/base/StandardChip.kt
@@ -40,11 +40,12 @@ import coil.compose.rememberAsyncImagePainter
 
 /**
  * This composable fulfils the redlines of the following components:
- * - Secondary standard chip - when [largeIcon] value is `false`;
+ * - Primary or Secondary chip - according to [chipType] value;
+ * - Standard chip - when [largeIcon] value is `false`;
  * - Chip with small or large avatar - according to [largeIcon] value;
  */
 @Composable
-internal fun SecondaryChip(
+internal fun StandardChip(
     label: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -52,6 +53,7 @@ internal fun SecondaryChip(
     icon: Any? = null,
     largeIcon: Boolean = false,
     placeholder: Painter? = null,
+    chipType: StandardChipType = StandardChipType.Primary,
     enabled: Boolean = true,
 ) {
     val hasSecondaryLabel = secondaryLabel != null
@@ -120,7 +122,15 @@ internal fun SecondaryChip(
         modifier = modifier.fillMaxWidth(),
         secondaryLabel = secondaryLabelParam,
         icon = iconParam,
-        colors = ChipDefaults.secondaryChipColors(),
+        colors = when (chipType) {
+            StandardChipType.Primary -> ChipDefaults.primaryChipColors()
+            StandardChipType.Secondary -> ChipDefaults.secondaryChipColors()
+        },
         enabled = enabled,
     )
+}
+
+internal enum class StandardChipType {
+    Primary,
+    Secondary
 }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreen.kt
@@ -36,8 +36,9 @@ import androidx.wear.compose.material.Text
 import com.google.android.horologist.compose.navscaffold.scrollableColumn
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.R
-import com.google.android.horologist.media.ui.components.base.SecondaryChip
 import com.google.android.horologist.media.ui.components.base.SecondaryPlaceholderChip
+import com.google.android.horologist.media.ui.components.base.StandardChip
+import com.google.android.horologist.media.ui.components.base.StandardChipType
 import com.google.android.horologist.media.ui.components.base.Title
 import com.google.android.horologist.media.ui.state.model.DownloadPlaylistUiModel
 
@@ -88,16 +89,17 @@ public fun BrowseScreen(
                 items(count = downloadList.size) { index ->
                     when (val download = downloadList[index]) {
                         is DownloadPlaylistUiModel.Completed -> {
-                            SecondaryChip(
+                            StandardChip(
                                 label = download.playlistUiModel.title,
                                 onClick = { onDownloadItemClick(download) },
                                 icon = download.playlistUiModel.artworkUri,
                                 largeIcon = true,
-                                placeholder = downloadItemArtworkPlaceholder
+                                placeholder = downloadItemArtworkPlaceholder,
+                                chipType = StandardChipType.Secondary,
                             )
                         }
                         is DownloadPlaylistUiModel.InProgress -> {
-                            SecondaryChip(
+                            StandardChip(
                                 label = download.playlistUiModel.title,
                                 onClick = { onDownloadItemClick(download) },
                                 secondaryLabel = stringResource(
@@ -105,7 +107,8 @@ public fun BrowseScreen(
                                     download.percentage
                                 ),
                                 icon = Icons.Default.Downloading,
-                                placeholder = downloadItemArtworkPlaceholder
+                                placeholder = downloadItemArtworkPlaceholder,
+                                chipType = StandardChipType.Secondary,
                             )
                         }
                     }
@@ -125,18 +128,20 @@ public fun BrowseScreen(
         }
 
         item {
-            SecondaryChip(
+            StandardChip(
                 label = stringResource(id = R.string.horologist_browse_library_playlists),
                 icon = Icons.Default.PlaylistPlay,
-                onClick = onPlaylistsClick
+                onClick = onPlaylistsClick,
+                chipType = StandardChipType.Secondary,
             )
         }
 
         item {
-            SecondaryChip(
+            StandardChip(
                 label = stringResource(id = R.string.horologist_browse_library_settings),
                 icon = Icons.Default.Settings,
-                onClick = onSettingsClick
+                onClick = onSettingsClick,
+                chipType = StandardChipType.Secondary,
             )
         }
     }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/playlist/PlaylistScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/playlist/PlaylistScreen.kt
@@ -28,8 +28,9 @@ import androidx.wear.compose.material.ScalingLazyListState
 import com.google.android.horologist.compose.navscaffold.scrollableColumn
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.R
-import com.google.android.horologist.media.ui.components.base.SecondaryChip
 import com.google.android.horologist.media.ui.components.base.SecondaryPlaceholderChip
+import com.google.android.horologist.media.ui.components.base.StandardChip
+import com.google.android.horologist.media.ui.components.base.StandardChipType
 import com.google.android.horologist.media.ui.components.base.Title
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
 
@@ -61,12 +62,13 @@ public fun PlaylistScreen(
 
                 val playlist = playlistScreenState.playlistList[index]
 
-                SecondaryChip(
+                StandardChip(
                     label = playlist.title,
                     onClick = { onPlaylistItemClick(playlist) },
                     icon = playlist.artworkUri,
                     largeIcon = true,
-                    placeholder = playlistItemArtworkPlaceholder
+                    placeholder = playlistItemArtworkPlaceholder,
+                    chipType = StandardChipType.Secondary,
                 )
             }
         } else if (playlistScreenState is PlaylistScreenState.Loading) {

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/base/PrimaryChipTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/base/PrimaryChipTest.kt
@@ -34,7 +34,7 @@ import com.google.android.horologist.paparazzi.determineHandler
 import org.junit.Rule
 import org.junit.Test
 
-class SecondaryChipTest {
+class PrimaryChipTest {
 
     private val maxPercentDifference = 0.1
 
@@ -50,11 +50,7 @@ class SecondaryChipTest {
     fun withPrimaryLabel() {
         paparazzi.snapshot {
             Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    chipType = StandardChipType.Secondary,
-                )
+                StandardChip(label = "Primary label", onClick = { })
             }
         }
     }
@@ -67,7 +63,6 @@ class SecondaryChipTest {
                     label = "Primary label",
                     onClick = { },
                     secondaryLabel = "Secondary label",
-                    chipType = StandardChipType.Secondary,
                 )
             }
         }
@@ -83,9 +78,8 @@ class SecondaryChipTest {
                     icon = "iconUri",
                     placeholder = rememberVectorPainter(
                         image = Icons.Default.Add,
-                        tintColor = Color.White,
-                    ),
-                    chipType = StandardChipType.Secondary,
+                        tintColor = Color.Black,
+                    )
                 )
             }
         }
@@ -99,7 +93,6 @@ class SecondaryChipTest {
                     label = "Primary label",
                     onClick = { },
                     icon = Icons.Default.Add,
-                    chipType = StandardChipType.Secondary,
                 )
             }
         }
@@ -116,9 +109,8 @@ class SecondaryChipTest {
                     largeIcon = true,
                     placeholder = rememberVectorPainter(
                         image = Icon32dp,
-                        tintColor = Color.White,
-                    ),
-                    chipType = StandardChipType.Secondary,
+                        tintColor = Color.Black,
+                    )
                 )
             }
         }
@@ -135,9 +127,8 @@ class SecondaryChipTest {
                     icon = "iconUri",
                     placeholder = rememberVectorPainter(
                         image = Icons.Default.Add,
-                        tintColor = Color.White,
-                    ),
-                    chipType = StandardChipType.Secondary,
+                        tintColor = Color.Black,
+                    )
                 )
             }
         }
@@ -155,9 +146,8 @@ class SecondaryChipTest {
                     largeIcon = true,
                     placeholder = rememberVectorPainter(
                         image = Icon32dp,
-                        tintColor = Color.White,
-                    ),
-                    chipType = StandardChipType.Secondary,
+                        tintColor = Color.Black,
+                    )
                 )
             }
         }
@@ -174,9 +164,8 @@ class SecondaryChipTest {
                     icon = "iconUri",
                     placeholder = rememberVectorPainter(
                         image = Icons.Default.Add,
-                        tintColor = Color.White,
+                        tintColor = Color.Black,
                     ),
-                    chipType = StandardChipType.Secondary,
                     enabled = false,
                 )
             }
@@ -189,8 +178,7 @@ class SecondaryChipTest {
             Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
                 StandardChip(
                     label = "Primary label very very very very very very very very very very very very very very very very very long text",
-                    onClick = { },
-                    chipType = StandardChipType.Secondary,
+                    onClick = { }
                 )
             }
         }
@@ -207,9 +195,8 @@ class SecondaryChipTest {
                     icon = "iconUri",
                     placeholder = rememberVectorPainter(
                         image = Icons.Default.Add,
-                        tintColor = Color.White,
+                        tintColor = Color.Black,
                     ),
-                    chipType = StandardChipType.Secondary,
                 )
             }
         }
@@ -225,9 +212,8 @@ class SecondaryChipTest {
                     icon = "iconUri",
                     placeholder = rememberVectorPainter(
                         image = Icon12dp,
-                        tintColor = Color.White,
-                    ),
-                    chipType = StandardChipType.Secondary,
+                        tintColor = Color.Black,
+                    )
                 )
             }
         }
@@ -244,9 +230,8 @@ class SecondaryChipTest {
                     largeIcon = true,
                     placeholder = rememberVectorPainter(
                         image = Icon12dp,
-                        tintColor = Color.White,
-                    ),
-                    chipType = StandardChipType.Secondary,
+                        tintColor = Color.Black,
+                    )
                 )
             }
         }
@@ -262,9 +247,8 @@ class SecondaryChipTest {
                     icon = "iconUri",
                     placeholder = rememberVectorPainter(
                         image = Icon48dp,
-                        tintColor = Color.White,
-                    ),
-                    chipType = StandardChipType.Secondary,
+                        tintColor = Color.Black,
+                    )
                 )
             }
         }
@@ -281,9 +265,8 @@ class SecondaryChipTest {
                     largeIcon = true,
                     placeholder = rememberVectorPainter(
                         image = Icon48dp,
-                        tintColor = Color.White,
-                    ),
-                    chipType = StandardChipType.Secondary,
+                        tintColor = Color.Black,
+                    )
                 )
             }
         }

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_disabled.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_disabled.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3e6b87155c5ac4789964025aa8625430094b3abf90a6326781d0a485dc14fb6
+size 42010

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_usingExtraLargeIcon.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_usingExtraLargeIcon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74a1c5e9a4f0c83dd064fbe1277fe0ce950ddbc7c3489e3fc0677d047270cb89
+size 40792

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_usingSmallIcon.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_usingSmallIcon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74a1c5e9a4f0c83dd064fbe1277fe0ce950ddbc7c3489e3fc0677d047270cb89
+size 40792

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_withIcon.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_withIcon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2136eb9b7c8d0607b3fb98e66513c916ec60293dddb95b40e5450a2bf010e96
+size 40659

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_withImageVectorAsIcon.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_withImageVectorAsIcon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6b0a01149d0b846a2559a327e3efed4b7c6a5842d591485c4d427371eafcb6c
+size 40596

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_withLargeIcon.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_withLargeIcon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26072a46d46b52eca596516f86dda24511a5b37d1544094524c0450d1a9b17a9
+size 40896

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_withLargeIconUsingExtraLargeIcon.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_withLargeIconUsingExtraLargeIcon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26072a46d46b52eca596516f86dda24511a5b37d1544094524c0450d1a9b17a9
+size 40896

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_withLargeIconUsingSmallIcon.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_withLargeIconUsingSmallIcon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26072a46d46b52eca596516f86dda24511a5b37d1544094524c0450d1a9b17a9
+size 40896

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_withLongText.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_withLongText.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d045538ed4790d947fd84dd0562e5e58c23aaa7b28e61227ed0c02ae7ee6f15
+size 87896

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_withPrimaryLabel.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_withPrimaryLabel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:236d492cce5490e8c059c2815ef85450b009e4fdea2b8c0c7b212d9db2499ae2
+size 40132

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_withSecondaryLabel.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_withSecondaryLabel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3ad892d09abf742e6427bfefc6bb90b69ee2f9b466d07cd65f10585aa298a3e
+size 57825

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_withSecondaryLabelAndIcon.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_withSecondaryLabelAndIcon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e5a5a099ebb6500796df9e38bdbef930bc10addd2e8069b1662b1065f47ffc7
+size 58356

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_withSecondaryLabelAndLargeIcon.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_withSecondaryLabelAndLargeIcon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:105c21245c49199891e2ed7cc7f369e747dc694ae9c60053ebf0d4e3199a57ee
+size 58750

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_withSecondaryLabelAndLongText.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_withSecondaryLabelAndLongText.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:783a414854c18748133a98e293662c9515003a7e27a636cdd127f8da9f4bb653
+size 79776


### PR DESCRIPTION
#### WHAT

Rename `SecondaryChip` to `StandardChip`.

![Screen Shot 2022-07-08 at 16 59 40](https://user-images.githubusercontent.com/878134/178029833-70a0a3f3-a832-497c-bf22-bdda49501975.png)

![Screen Shot 2022-07-08 at 17 10 16](https://user-images.githubusercontent.com/878134/178030298-d46197c8-e52e-4e86-b6f9-708c2ed801d3.png)


#### WHY

In order to allow it to also be used for primary chip.

#### HOW

- Rename `SecondaryChip` to `StandardChip`;
- Add `StandardChipType` enum;
- Add `chipType: StandardChipType` param to `StandardChip`;
- Add preview and snapshot tests for primary chip type;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
