### PR TITLE
Remove Ignore annotation from SnackbarHostTest (#66)

### DIFF
--- a/compose-layout/src/androidTest/java/com/google/android/horologist/compose/snackbar/SnackbarHostTest.kt
+++ b/compose-layout/src/androidTest/java/com/google/android/horologist/compose/snackbar/SnackbarHostTest.kt
@@ -41,14 +41,12 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.junit.Assert.assertEquals
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @MediumTest
 @RunWith(AndroidJUnit4::class)
-@Ignore("https://github.com/google/horologist/issues/66")
 class SnackbarHostTest {
 
     @get:Rule
@@ -110,7 +108,6 @@ class SnackbarHostTest {
     }
 
     @Test
-    @Ignore("ComposeTimeoutException: Condition still not satisfied after 5000 ms")
     fun snackbarHost_returnedResult() {
         val hostState = SnackbarHostState()
         lateinit var scope: CoroutineScope


### PR DESCRIPTION
#### WHAT
Remove Ignore annotation from SnackbarHostTest

#### WHY
As the test `snackbarHost_returnedResult` is not failing `@Ignore` annotation should be removed

#### HOW

- Remove `@Ignore` annotation from `snackbarHost_returnedResult()` and `SnackbarHostTest`

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
