### PR TITLE
Add PlaylistRepository

### DIFF
--- a/media-sample/build.gradle
+++ b/media-sample/build.gradle
@@ -148,6 +148,11 @@ dependencies {
     implementation libs.androidx.datastore.preferences
     implementation libs.androidx.complications.rendering
 
+    testImplementation libs.junit
+    testImplementation libs.truth
+    testImplementation libs.androidx.test.ext.ktx
+    testImplementation libs.kotlinx.coroutines.test
+
     androidTestImplementation libs.compose.ui.test.junit4
     androidTestImplementation libs.espresso.core
     androidTestImplementation libs.junit

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/api/UampService.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/api/UampService.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.data.api
+
+import com.google.android.horologist.mediasample.data.api.model.CatalogApiModel
+import retrofit2.http.GET
+
+interface UampService {
+
+    @GET("catalog.json")
+    suspend fun catalog(): CatalogApiModel
+
+    companion object {
+        const val BASE_URL = "https://storage.googleapis.com/uamp/"
+    }
+}

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/api/model/CatalogApiModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/api/model/CatalogApiModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,11 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.mediasample.catalog
+package com.google.android.horologist.mediasample.data.api.model
 
-import com.google.android.horologist.mediasample.catalog.model.Catalog
-import retrofit2.http.GET
+import com.squareup.moshi.JsonClass
 
-interface UampService {
-    @GET("catalog.json")
-    suspend fun catalog(): Catalog
-
-    companion object {
-        const val BaseUrl = "https://storage.googleapis.com/uamp/"
-    }
-}
+@JsonClass(generateAdapter = true)
+data class CatalogApiModel(
+    val music: List<MusicApiModel>
+)

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/api/model/MusicApiModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/api/model/MusicApiModel.kt
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.mediasample.catalog.model
+package com.google.android.horologist.mediasample.data.api.model
 
 import com.google.android.horologist.media.model.MediaItem
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
-data class Music(
+data class MusicApiModel(
     val album: String,
     val artist: String,
     val duration: Int,

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/datasource/PlaylistRemoteDataSource.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/datasource/PlaylistRemoteDataSource.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.data.datasource
+
+import com.google.android.horologist.mediasample.data.api.UampService
+import com.google.android.horologist.mediasample.data.mapper.PlaylistMapper
+import com.google.android.horologist.mediasample.domain.model.Playlist
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+
+class PlaylistRemoteDataSource(
+    private val ioDispatcher: CoroutineDispatcher,
+    private val uampService: UampService,
+) {
+
+    fun getPlaylists(): Flow<List<Playlist>> = flow {
+        emit(PlaylistMapper.map(uampService.catalog()))
+    }.flowOn(ioDispatcher)
+}

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/mapper/MediaItemMapper.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/mapper/MediaItemMapper.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.data.mapper
+
+import com.google.android.horologist.media.model.MediaItem
+import com.google.android.horologist.mediasample.data.api.model.MusicApiModel
+
+/**
+ * Maps a [MusicApiModel] into [MediaItem].
+ */
+object MediaItemMapper {
+
+    fun map(musicApiModel: MusicApiModel): MediaItem = MediaItem(
+        id = musicApiModel.id,
+        uri = musicApiModel.source,
+        title = musicApiModel.title,
+        artist = musicApiModel.artist,
+        artworkUri = musicApiModel.image
+    )
+
+    fun map(musicApiModels: List<MusicApiModel>): List<MediaItem> = musicApiModels.map(::map)
+}

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/mapper/PlaylistMapper.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/mapper/PlaylistMapper.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.data.mapper
+
+import com.google.android.horologist.mediasample.data.api.model.CatalogApiModel
+import com.google.android.horologist.mediasample.domain.model.Playlist
+
+/**
+ * Maps a [CatalogApiModel] into a [List] of [Playlist].
+ */
+object PlaylistMapper {
+
+    fun map(catalog: CatalogApiModel): List<Playlist> =
+        catalog.music
+            .groupBy { it.genre }
+            .map { entry ->
+                Playlist(
+                    id = sanitize(sanitize(entry.key)),
+                    name = entry.key,
+                    mediaItems = MediaItemMapper.map(entry.value)
+                )
+            }
+
+    private fun sanitize(it: String): String {
+        return it.replace("[^A-Za-z]".toRegex(), "")
+    }
+}

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/repository/PlaylistRepositoryImpl.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/repository/PlaylistRepositoryImpl.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.data.repository
+
+import com.google.android.horologist.mediasample.data.datasource.PlaylistRemoteDataSource
+import com.google.android.horologist.mediasample.domain.PlaylistRepository
+import com.google.android.horologist.mediasample.domain.model.Playlist
+import kotlinx.coroutines.flow.Flow
+
+class PlaylistRepositoryImpl(
+    private val playlistRemoteDataSource: PlaylistRemoteDataSource
+) : PlaylistRepository {
+
+    override fun getPlaylists(): Flow<List<Playlist>> = playlistRemoteDataSource.getPlaylists()
+}

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/MediaApplicationContainer.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/MediaApplicationContainer.kt
@@ -39,12 +39,12 @@ import com.google.android.horologist.media3.navigation.NavDeepLinkIntentBuilder
 import com.google.android.horologist.media3.offload.AudioOffloadManager
 import com.google.android.horologist.media3.rules.PlaybackRules
 import com.google.android.horologist.mediasample.AppConfig
-import com.google.android.horologist.mediasample.catalog.UampService
 import com.google.android.horologist.mediasample.complication.DataUpdates
 import com.google.android.horologist.mediasample.complication.MediaStatusComplicationService
 import com.google.android.horologist.mediasample.components.MediaActivity
 import com.google.android.horologist.mediasample.components.MediaApplication
 import com.google.android.horologist.mediasample.components.PlaybackService
+import com.google.android.horologist.mediasample.data.api.UampService
 import com.google.android.horologist.mediasample.domain.SettingsRepository
 import com.google.android.horologist.mediasample.system.Logging
 import com.google.android.horologist.mediasample.tile.MediaCollectionsTileService

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/NetworkModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/NetworkModule.kt
@@ -23,7 +23,7 @@ import coil.ImageLoader
 import coil.decode.SvgDecoder
 import coil.disk.DiskCache
 import coil.request.CachePolicy
-import com.google.android.horologist.mediasample.catalog.UampService
+import com.google.android.horologist.mediasample.data.api.UampService
 import com.google.android.horologist.networks.data.DataRequestRepository
 import com.google.android.horologist.networks.data.RequestType
 import com.google.android.horologist.networks.logging.NetworkStatusLogger
@@ -138,7 +138,7 @@ class NetworkModule(
     val retrofit by lazy {
         Retrofit.Builder()
             .addConverterFactory(MoshiConverterFactory.create(moshi))
-            .baseUrl("https://storage.googleapis.com/uamp/")
+            .baseUrl(UampService.BASE_URL)
             .callFactory(NetworkAwareCallFactory(networkAwareCallFactory, RequestType.ApiRequest))
             .build()
     }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/PlaylistRepository.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/PlaylistRepository.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.domain
+
+import com.google.android.horologist.mediasample.domain.model.Playlist
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * A repository of [Playlist].
+ */
+interface PlaylistRepository {
+
+    fun getPlaylists(): Flow<List<Playlist>>
+}

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/SettingsRepository.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/SettingsRepository.kt
@@ -21,6 +21,7 @@ import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import com.google.android.horologist.mediasample.domain.model.Settings
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/model/Playlist.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/model/Playlist.kt
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.mediasample.catalog.model
+package com.google.android.horologist.mediasample.domain.model
 
-import com.squareup.moshi.JsonClass
+import com.google.android.horologist.media.model.MediaItem
 
-@JsonClass(generateAdapter = true)
-data class Catalog(
-    val music: List<Music>
+data class Playlist(
+    val id: String,
+    val name: String,
+    val mediaItems: List<MediaItem>
 )

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/model/Settings.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/model/Settings.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.mediasample.domain
+package com.google.android.horologist.mediasample.domain.model
 
 data class Settings(
     val showTimeTextInfo: Boolean = false,

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/tile/MediaCollectionsTileService.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/tile/MediaCollectionsTileService.kt
@@ -37,8 +37,8 @@ import com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer
 import com.google.android.horologist.media.ui.tiles.toTileColors
 import com.google.android.horologist.mediasample.BuildConfig
 import com.google.android.horologist.mediasample.R
-import com.google.android.horologist.mediasample.catalog.UampService
 import com.google.android.horologist.mediasample.components.MediaActivity
+import com.google.android.horologist.mediasample.data.api.UampService
 import com.google.android.horologist.mediasample.di.ServiceContainer
 import com.google.android.horologist.mediasample.ui.app.UampColors
 import com.google.android.horologist.tiles.CoroutinesTileService

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/MediaPlayerAppViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/MediaPlayerAppViewModel.kt
@@ -23,10 +23,10 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import com.google.android.horologist.media.repository.PlayerRepository
 import com.google.android.horologist.media3.offload.AudioOffloadManager
 import com.google.android.horologist.mediasample.AppConfig
-import com.google.android.horologist.mediasample.catalog.UampService
+import com.google.android.horologist.mediasample.data.api.UampService
 import com.google.android.horologist.mediasample.di.MediaApplicationContainer
-import com.google.android.horologist.mediasample.domain.Settings
 import com.google.android.horologist.mediasample.domain.SettingsRepository
+import com.google.android.horologist.mediasample.domain.model.Settings
 import com.google.android.horologist.mediasample.ui.debug.OffloadState
 import com.google.android.horologist.networks.data.DataRequestRepository
 import com.google.android.horologist.networks.data.DataUsageReport

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/library/UampPlaylistsScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/library/UampPlaylistsScreen.kt
@@ -26,7 +26,7 @@ import com.google.android.horologist.compose.layout.StateUtils.rememberStateWith
 import com.google.android.horologist.media.ui.screens.playlist.PlaylistScreen
 import com.google.android.horologist.media.ui.screens.playlist.PlaylistScreenState
 import com.google.android.horologist.mediasample.R
-import com.google.android.horologist.mediasample.domain.Settings
+import com.google.android.horologist.mediasample.domain.model.Settings
 
 @Composable
 fun UampPlaylistsScreen(

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/library/UampPlaylistsScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/library/UampPlaylistsScreenViewModel.kt
@@ -27,7 +27,7 @@ import com.google.android.horologist.media.ui.snackbar.SnackbarViewModel
 import com.google.android.horologist.media.ui.snackbar.UiMessage
 import com.google.android.horologist.media.ui.state.mapper.MediaItemUiModelMapper
 import com.google.android.horologist.media.ui.state.model.MediaItemUiModel
-import com.google.android.horologist.mediasample.catalog.UampService
+import com.google.android.horologist.mediasample.data.api.UampService
 import com.google.android.horologist.mediasample.di.MediaApplicationContainer
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/player/UampMediaPlayerScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/player/UampMediaPlayerScreen.kt
@@ -34,7 +34,7 @@ import com.google.android.horologist.media.ui.screens.DefaultPlayerScreenControl
 import com.google.android.horologist.media.ui.screens.PlayerScreen
 import com.google.android.horologist.media.ui.state.PlayerUiState
 import com.google.android.horologist.media.ui.state.PlayerViewModel
-import com.google.android.horologist.mediasample.domain.Settings
+import com.google.android.horologist.mediasample.domain.model.Settings
 
 @Composable
 fun UampMediaPlayerScreen(

--- a/media-sample/src/test/java/com/google/android/horologist/mediasample/data/datasource/PlaylistRemoteDataSourceTest.kt
+++ b/media-sample/src/test/java/com/google/android/horologist/mediasample/data/datasource/PlaylistRemoteDataSourceTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.data.datasource
+
+import com.google.android.horologist.mediasample.data.mapper.PlaylistMapper
+import com.google.android.horologist.test.toolbox.testdoubles.FakeUampService
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class PlaylistRemoteDataSourceTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private val uampService = FakeUampService()
+
+    private lateinit var sut: PlaylistRemoteDataSource
+
+    @Before
+    fun setUp() {
+        sut = PlaylistRemoteDataSource(
+            ioDispatcher = testDispatcher,
+            uampService = uampService
+        )
+    }
+
+    @Test
+    fun getPlaylists_backedByUampServiceCatalog() = runTest(testDispatcher) {
+        // given
+        val uampServiceCatalogResult = PlaylistMapper.map(uampService.catalog())
+
+        // when
+        val result = sut.getPlaylists().first()
+
+        // then
+        assertThat(result).isEqualTo(uampServiceCatalogResult)
+    }
+}

--- a/media-sample/src/test/java/com/google/android/horologist/mediasample/data/mapper/MediaItemMapperTest.kt
+++ b/media-sample/src/test/java/com/google/android/horologist/mediasample/data/mapper/MediaItemMapperTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.data.mapper
+
+import com.google.android.horologist.mediasample.data.api.model.MusicApiModel
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class MediaItemMapperTest {
+
+    @Test
+    fun givenMusicApiModel_thenMapsCorrectly() {
+        // given
+        val id = "id"
+        val title = "title"
+        val uri = "uri"
+        val artist = "artist"
+        val artworkUri = "artworkUri"
+
+        val musicApiModel = MusicApiModel(
+            album = "album",
+            artist = artist,
+            duration = 1,
+            genre = "genre",
+            id = id,
+            image = artworkUri,
+            site = "site",
+            source = uri,
+            title = title,
+            totalTrackCount = 1,
+            trackNumber = 1,
+        )
+
+        // when
+        val result = MediaItemMapper.map(musicApiModel)
+
+        // then
+        assertThat(result.id).isEqualTo(id)
+        assertThat(result.uri).isEqualTo(uri)
+        assertThat(result.title).isEqualTo(title)
+        assertThat(result.artist).isEqualTo(artist)
+        assertThat(result.artworkUri).isEqualTo(artworkUri)
+        assertThat(result.extras).isEmpty()
+    }
+
+    @Test
+    fun givenListOfMusicApiModel_thenMapsCorrectly() {
+        // given
+        val musicApiModel1 = MusicApiModel(
+            album = "album1",
+            artist = "artist1",
+            duration = 1,
+            genre = "genre1",
+            id = "id1",
+            image = "artworkUri1",
+            site = "site1",
+            source = "source1",
+            title = "title1",
+            totalTrackCount = 1,
+            trackNumber = 1,
+        )
+
+        val musicApiModel2 = MusicApiModel(
+            album = "album2",
+            artist = "artist2",
+            duration = 2,
+            genre = "genre2",
+            id = "id2",
+            image = "artworkUri2",
+            site = "site2",
+            source = "source2",
+            title = "title2",
+            totalTrackCount = 2,
+            trackNumber = 2,
+        )
+
+        val list = listOf(musicApiModel1, musicApiModel2)
+
+        // when
+        val result = MediaItemMapper.map(list)
+
+        // then
+        assertThat(result).hasSize(2)
+        assertThat(result[0].id).isEqualTo(musicApiModel1.id)
+        assertThat(result[0].uri).isEqualTo(musicApiModel1.source)
+        assertThat(result[0].title).isEqualTo(musicApiModel1.title)
+        assertThat(result[0].artist).isEqualTo(musicApiModel1.artist)
+        assertThat(result[0].artworkUri).isEqualTo(musicApiModel1.image)
+        assertThat(result[0].extras).isEmpty()
+
+        assertThat(result).hasSize(2)
+        assertThat(result[1].id).isEqualTo(musicApiModel2.id)
+        assertThat(result[1].uri).isEqualTo(musicApiModel2.source)
+        assertThat(result[1].title).isEqualTo(musicApiModel2.title)
+        assertThat(result[1].artist).isEqualTo(musicApiModel2.artist)
+        assertThat(result[1].artworkUri).isEqualTo(musicApiModel2.image)
+        assertThat(result[1].extras).isEmpty()
+    }
+}

--- a/media-sample/src/test/java/com/google/android/horologist/mediasample/data/mapper/PlaylistMapperTest.kt
+++ b/media-sample/src/test/java/com/google/android/horologist/mediasample/data/mapper/PlaylistMapperTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.data.mapper
+
+import com.google.android.horologist.mediasample.data.api.model.CatalogApiModel
+import com.google.android.horologist.mediasample.data.api.model.MusicApiModel
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class PlaylistMapperTest {
+
+    @Test
+    fun map() {
+        // given
+        val catalog = getCatalog()
+
+        // when
+        val result = PlaylistMapper.map(catalog)
+
+        // then
+        assertThat(result).hasSize(3)
+        assertThat(result[0].mediaItems).hasSize(1)
+        assertThat(result[0].name).isEqualTo("genre1")
+        assertThat(result[0].mediaItems[0].id).isEqualTo("id1_1")
+
+        assertThat(result[1].mediaItems).hasSize(2)
+        assertThat(result[1].name).isEqualTo("genre2")
+        assertThat(result[1].mediaItems[0].id).isEqualTo("id2_1")
+        assertThat(result[1].mediaItems[1].id).isEqualTo("id2_2")
+
+        assertThat(result[2].mediaItems).hasSize(3)
+        assertThat(result[2].name).isEqualTo("genre3")
+        assertThat(result[2].mediaItems[0].id).isEqualTo("id3_1")
+        assertThat(result[2].mediaItems[1].id).isEqualTo("id3_2")
+        assertThat(result[2].mediaItems[2].id).isEqualTo("id3_3")
+    }
+
+    private fun getCatalog(): CatalogApiModel {
+        val list = mutableListOf<MusicApiModel>()
+
+        for (genreIdx in 1..3) {
+            for (musicIdx in 1..genreIdx) {
+                val suffix = "${genreIdx}_$musicIdx"
+                list.add(
+                    MusicApiModel(
+                        album = "album$suffix",
+                        artist = "artist$suffix",
+                        duration = musicIdx,
+                        genre = "genre$genreIdx",
+                        id = "id$suffix",
+                        image = "artworkUri$suffix",
+                        site = "site$suffix",
+                        source = "source$suffix",
+                        title = "title$suffix",
+                        totalTrackCount = genreIdx,
+                        trackNumber = musicIdx,
+                    )
+                )
+            }
+        }
+
+        return CatalogApiModel(list)
+    }
+}

--- a/media-sample/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/FakeUampService.kt
+++ b/media-sample/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/FakeUampService.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.test.toolbox.testdoubles
+
+import com.google.android.horologist.mediasample.data.api.UampService
+import com.google.android.horologist.mediasample.data.api.model.CatalogApiModel
+import com.google.android.horologist.mediasample.data.api.model.MusicApiModel
+
+class FakeUampService : UampService {
+
+    override suspend fun catalog(): CatalogApiModel = CatalogApiModel(
+        music = listOf(
+            MusicApiModel(
+                album = "album1",
+                artist = "artist1",
+                duration = 1,
+                genre = "genre1",
+                id = "id1",
+                image = "artworkUri1",
+                site = "site1",
+                source = "source1",
+                title = "title1",
+                totalTrackCount = 1,
+                trackNumber = 1,
+            )
+        )
+    )
+}


### PR DESCRIPTION
#### WHAT

Add `PlaylistRepository` to `media-sample`.

#### WHY

- In order to have a better abstraction to support caching and offline first;
- In order to follow the Android architecture guidelines.

#### HOW

- Rename `catalog` package to `data.api`;
- Rename `Catalog` and `Music` to `CatalogUiModel` and `MusicUiModel`;
- Add `Playlist` domain model;
- Add `PlaylistRepository` to `domain` package and `PlaylistRepositoryImpl` to `data` package;
- Add `PlaylistRemoteDataSource`;
- Add mappers;
- Add tests;

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
