### PR TITLE
Make Pickers non Experimental

### DIFF
--- a/composables/api/current.api
+++ b/composables/api/current.api
@@ -2,15 +2,15 @@
 package com.google.android.horologist.composables {
 
   public final class DatePickerKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public static void DatePicker(kotlin.jvm.functions.Function1<? super java.time.LocalDate,kotlin.Unit> onDateConfirm, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalDate date);
+    method @androidx.compose.runtime.Composable public static void DatePicker(kotlin.jvm.functions.Function1<? super java.time.LocalDate,kotlin.Unit> onDateConfirm, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalDate date);
   }
 
   @kotlin.RequiresOptIn(message="Composables is experimental. The API may be changed in the future.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention) public @interface ExperimentalHorologistComposablesApi {
   }
 
   public final class TimePickerKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public static void TimePicker(kotlin.jvm.functions.Function1<? super java.time.LocalTime,kotlin.Unit> onTimeConfirm, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalTime time, optional boolean showSeconds);
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public static void TimePickerWith12HourClock(kotlin.jvm.functions.Function1<? super java.time.LocalTime,kotlin.Unit> onTimeConfirm, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalTime time);
+    method @androidx.compose.runtime.Composable public static void TimePicker(kotlin.jvm.functions.Function1<? super java.time.LocalTime,kotlin.Unit> onTimeConfirm, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalTime time, optional boolean showSeconds);
+    method @androidx.compose.runtime.Composable public static void TimePickerWith12HourClock(kotlin.jvm.functions.Function1<? super java.time.LocalTime,kotlin.Unit> onTimeConfirm, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalTime time);
   }
 
 }

--- a/composables/src/main/java/com/google/android/horologist/composables/DatePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/DatePicker.kt
@@ -66,7 +66,6 @@ import java.time.temporal.TemporalAdjusters
  * @param modifier the modifiers for the `Box` containing the UI elements.
  * @param date the initial value to seed the picker with.
  */
-@ExperimentalHorologistComposablesApi
 @Composable
 public fun DatePicker(
     onDateConfirm: (LocalDate) -> Unit,

--- a/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
@@ -83,7 +83,6 @@ import java.time.temporal.ChronoField
  * seconds picker will be shown and the seconds will be set to 0 in the time returned in
  * onTimeConfirm.
  */
-@ExperimentalHorologistComposablesApi
 @Composable
 public fun TimePicker(
     onTimeConfirm: (LocalTime) -> Unit,
@@ -236,7 +235,6 @@ public fun TimePicker(
  * @param modifier the modifiers for the `Column` containing the UI elements.
  * @param time the initial value to seed the picker with.
  */
-@ExperimentalHorologistComposablesApi
 @Composable
 public fun TimePickerWith12HourClock(
     onTimeConfirm: (LocalTime) -> Unit,


### PR DESCRIPTION
#### WHAT

Make these APIs non experimental.

#### WHY

No plans to change external APIs, should require warnings.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
