### PR TITLE
Change UampPlaylistScreen to use PlaylistRepository

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/mapper/PlaylistMapper.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/mapper/PlaylistMapper.kt
@@ -31,7 +31,8 @@ object PlaylistMapper {
                 Playlist(
                     id = sanitize(sanitize(entry.key)),
                     name = entry.key,
-                    mediaItems = MediaItemMapper.map(entry.value)
+                    mediaItems = MediaItemMapper.map(entry.value),
+                    artworkUri = entry.value.getOrNull(0)?.image
                 )
             }
 

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/mapper/PlaylistMapper.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/mapper/PlaylistMapper.kt
@@ -32,7 +32,7 @@ object PlaylistMapper {
                     id = sanitize(sanitize(entry.key)),
                     name = entry.key,
                     mediaItems = MediaItemMapper.map(entry.value),
-                    artworkUri = entry.value.getOrNull(0)?.image
+                    artworkUri = entry.value.firstOrNull()?.image
                 )
             }
 

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/MediaApplicationContainer.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/MediaApplicationContainer.kt
@@ -45,11 +45,15 @@ import com.google.android.horologist.mediasample.components.MediaActivity
 import com.google.android.horologist.mediasample.components.MediaApplication
 import com.google.android.horologist.mediasample.components.PlaybackService
 import com.google.android.horologist.mediasample.data.api.UampService
+import com.google.android.horologist.mediasample.data.datasource.PlaylistRemoteDataSource
+import com.google.android.horologist.mediasample.data.repository.PlaylistRepositoryImpl
+import com.google.android.horologist.mediasample.domain.PlaylistRepository
 import com.google.android.horologist.mediasample.domain.SettingsRepository
 import com.google.android.horologist.mediasample.system.Logging
 import com.google.android.horologist.mediasample.tile.MediaCollectionsTileService
 import com.google.android.horologist.networks.data.DataRequestRepository
 import com.google.android.horologist.networks.status.NetworkRepository
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -191,6 +195,22 @@ class MediaApplicationContainer(
         DataUpdates(updater)
     }
 
+    fun getPlaylistRepository(playlistRepositoryImpl: PlaylistRepositoryImpl): PlaylistRepository =
+        playlistRepositoryImpl
+
+    fun getPlaylistRepositoryImpl(playlistRemoteDataSource: PlaylistRemoteDataSource): PlaylistRepositoryImpl =
+        PlaylistRepositoryImpl(playlistRemoteDataSource = playlistRemoteDataSource)
+
+    fun getPlaylistRemoteDataSource(
+        ioDispatcher: CoroutineDispatcher,
+        uampService: UampService,
+    ): PlaylistRemoteDataSource = PlaylistRemoteDataSource(
+        ioDispatcher = ioDispatcher,
+        uampService = uampService
+    )
+
+    fun getIODispatcher(): CoroutineDispatcher = Dispatchers.IO
+
     // Confusingly the result of allowThreadDiskWrites is the old policy,
     // while allow* methods immediately apply the change.
     // So `this` is the policy before we overrode it.
@@ -224,5 +244,6 @@ class MediaApplicationContainer(
         val SystemAudioRepositoryKey = object : CreationExtras.Key<SystemAudioRepository> {}
         val VibratorKey = object : CreationExtras.Key<Vibrator> {}
         val SettingsRepositoryKey = object : CreationExtras.Key<SettingsRepository> {}
+        val PlaylistRepositoryKey = object : CreationExtras.Key<PlaylistRepository> {}
     }
 }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/ViewModelModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/ViewModelModule.kt
@@ -26,6 +26,7 @@ import com.google.android.horologist.media.data.PlayerRepositoryImpl
 import com.google.android.horologist.media.ui.snackbar.SnackbarViewModel
 import com.google.android.horologist.media3.flows.buildSuspend
 import com.google.android.horologist.mediasample.components.PlaybackService
+import com.google.android.horologist.mediasample.domain.PlaylistRepository
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -92,7 +93,19 @@ class ViewModelModule(
             mediaApplicationContainer.settingsRepository
         creationExtras[SnackbarViewModel.SnackbarManagerKey] =
             mediaApplicationContainer.snackbarManager
+        creationExtras[MediaApplicationContainer.PlaylistRepositoryKey] =
+            getPlaylistRepository()
     }
+
+    private fun getPlaylistRepository(): PlaylistRepository =
+        mediaApplicationContainer.getPlaylistRepository(
+            mediaApplicationContainer.getPlaylistRepositoryImpl(
+                mediaApplicationContainer.getPlaylistRemoteDataSource(
+                    mediaApplicationContainer.getIODispatcher(),
+                    mediaApplicationContainer.networkModule.uampService
+                )
+            )
+        )
 
     override fun close() {
         _playerRepository?.close()

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/model/Playlist.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/model/Playlist.kt
@@ -21,5 +21,6 @@ import com.google.android.horologist.media.model.MediaItem
 data class Playlist(
     val id: String,
     val name: String,
-    val mediaItems: List<MediaItem>
+    val mediaItems: List<MediaItem>,
+    val artworkUri: String? = null,
 )

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
@@ -125,7 +125,6 @@ fun UampWearApp(
                     onPlaylistItemClick = {
                         navController.navigateToPlayer()
                     },
-                    settingsState = settingsState,
                     focusRequester = focusRequester,
                     scalingLazyListState = scalingLazyListState
                 )

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/library/PlaylistUiModelMapper.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/library/PlaylistUiModelMapper.kt
@@ -16,19 +16,22 @@
 
 package com.google.android.horologist.mediasample.ui.library
 
-import com.google.android.horologist.media.ui.state.model.MediaItemUiModel
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
+import com.google.android.horologist.mediasample.domain.model.Playlist
 
+/**
+ * Maps a [Playlist] into a [PlaylistUiModel].
+ */
 object PlaylistUiModelMapper {
 
     fun map(
-        mediaItemUiModel: MediaItemUiModel,
-        defaultTitle: String = "",
+        playlist: Playlist,
         shouldMapArtworkUri: Boolean = true,
     ): PlaylistUiModel = PlaylistUiModel(
-        title = mediaItemUiModel.title ?: defaultTitle,
+        id = playlist.id,
+        title = playlist.name,
         artworkUri = if (shouldMapArtworkUri) {
-            mediaItemUiModel.artworkUri
+            playlist.artworkUri
         } else {
             null
         }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/library/UampPlaylistsScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/library/UampPlaylistsScreen.kt
@@ -26,13 +26,11 @@ import com.google.android.horologist.compose.layout.StateUtils.rememberStateWith
 import com.google.android.horologist.media.ui.screens.playlist.PlaylistScreen
 import com.google.android.horologist.media.ui.screens.playlist.PlaylistScreenState
 import com.google.android.horologist.mediasample.R
-import com.google.android.horologist.mediasample.domain.model.Settings
 
 @Composable
 fun UampPlaylistsScreen(
     uampPlaylistsScreenViewModel: UampPlaylistsScreenViewModel,
     onPlaylistItemClick: () -> Unit,
-    settingsState: Settings?,
     focusRequester: FocusRequester,
     scalingLazyListState: ScalingLazyListState,
     modifier: Modifier = Modifier,
@@ -44,23 +42,21 @@ fun UampPlaylistsScreen(
         is UampPlaylistsScreenViewModel.UiState.Loading -> PlaylistScreenState.Loading
 
         is UampPlaylistsScreenViewModel.UiState.Loaded -> {
-            val items = (uiState as UampPlaylistsScreenViewModel.UiState.Loaded).items
+            val items = (uiState as UampPlaylistsScreenViewModel.UiState.Loaded).items.map {
+                it.takeIf { it.title.isNotEmpty() }
+                    ?: it.copy(title = stringResource(id = R.string.horologist_no_title))
+            }
 
-            PlaylistScreenState.Loaded(
-                items.map {
-                    PlaylistUiModelMapper.map(
-                        mediaItemUiModel = it,
-                        defaultTitle = stringResource(id = R.string.horologist_no_title),
-                        shouldMapArtworkUri = settingsState?.showArtworkOnChip == true
-                    )
-                }
-            )
+            PlaylistScreenState.Loaded(items)
         }
     }
 
     PlaylistScreen(
         playlistScreenState = playlistScreenState,
-        onPlaylistItemClick = { onPlaylistItemClick() },
+        onPlaylistItemClick = {
+            uampPlaylistsScreenViewModel.play(it.id)
+            onPlaylistItemClick()
+        },
         focusRequester = focusRequester,
         scalingLazyListState = scalingLazyListState,
         modifier = modifier,

--- a/media-sample/src/test/java/com/google/android/horologist/mediasample/data/mapper/PlaylistMapperTest.kt
+++ b/media-sample/src/test/java/com/google/android/horologist/mediasample/data/mapper/PlaylistMapperTest.kt
@@ -35,15 +35,18 @@ class PlaylistMapperTest {
         assertThat(result).hasSize(3)
         assertThat(result[0].mediaItems).hasSize(1)
         assertThat(result[0].name).isEqualTo("genre1")
+        assertThat(result[0].artworkUri).isEqualTo("image1_1")
         assertThat(result[0].mediaItems[0].id).isEqualTo("id1_1")
 
         assertThat(result[1].mediaItems).hasSize(2)
         assertThat(result[1].name).isEqualTo("genre2")
+        assertThat(result[1].artworkUri).isEqualTo("image2_1")
         assertThat(result[1].mediaItems[0].id).isEqualTo("id2_1")
         assertThat(result[1].mediaItems[1].id).isEqualTo("id2_2")
 
         assertThat(result[2].mediaItems).hasSize(3)
         assertThat(result[2].name).isEqualTo("genre3")
+        assertThat(result[2].artworkUri).isEqualTo("image3_1")
         assertThat(result[2].mediaItems[0].id).isEqualTo("id3_1")
         assertThat(result[2].mediaItems[1].id).isEqualTo("id3_2")
         assertThat(result[2].mediaItems[2].id).isEqualTo("id3_3")
@@ -62,7 +65,7 @@ class PlaylistMapperTest {
                         duration = musicIdx,
                         genre = "genre$genreIdx",
                         id = "id$suffix",
-                        image = "artworkUri$suffix",
+                        image = "image$suffix",
                         site = "site$suffix",
                         source = "source$suffix",
                         title = "title$suffix",

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -540,13 +540,16 @@ package com.google.android.horologist.media.ui.state.model {
   }
 
   public final class PlaylistUiModel {
-    ctor public PlaylistUiModel(String title, optional String? artworkUri);
+    ctor public PlaylistUiModel(String id, String title, optional String? artworkUri);
     method public String component1();
-    method public String? component2();
-    method public com.google.android.horologist.media.ui.state.model.PlaylistUiModel copy(String title, String? artworkUri);
+    method public String component2();
+    method public String? component3();
+    method public com.google.android.horologist.media.ui.state.model.PlaylistUiModel copy(String id, String title, String? artworkUri);
     method public String? getArtworkUri();
+    method public String getId();
     method public String getTitle();
     property public final String? artworkUri;
+    property public final String id;
     property public final String title;
   }
 

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreenPreview.kt
@@ -97,6 +97,7 @@ private val downloadList = buildList {
     add(
         DownloadPlaylistUiModel.InProgress(
             PlaylistUiModel(
+                id = "id",
                 title = "Rock Classics",
                 artworkUri = "https://www.example.com/album1.png",
             ),
@@ -107,6 +108,7 @@ private val downloadList = buildList {
     add(
         DownloadPlaylistUiModel.Completed(
             PlaylistUiModel(
+                id = "id",
                 title = "Pop Punk",
                 artworkUri = "https://www.example.com/album2.png"
             )

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/playlist/PlaylistScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/playlist/PlaylistScreenPreview.kt
@@ -37,12 +37,14 @@ fun PlaylistScreenPreview() {
             buildList {
                 add(
                     PlaylistUiModel(
+                        id = "id",
                         title = "Rock Classics",
                         artworkUri = "https://www.example.com/album1.png",
                     )
                 )
                 add(
                     PlaylistUiModel(
+                        id = "id",
                         title = "Pop Punk",
                         artworkUri = "https://www.example.com/album2.png"
                     )

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/PlaylistUiModel.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/PlaylistUiModel.kt
@@ -17,6 +17,7 @@
 package com.google.android.horologist.media.ui.state.model
 
 public data class PlaylistUiModel(
-    public val title: String,
-    public val artworkUri: String? = null,
+    val id: String,
+    val title: String,
+    val artworkUri: String? = null,
 )


### PR DESCRIPTION
#### WHAT

Change `UampPlaylistScreen` to use `PlaylistRepository`.

#### WHY

So the ViewModel hits a repository instead of retrofit service directly.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
