### PR TITLE
Add missing code snippet language

### DIFF
--- a/docs/compose-layout.md
+++ b/docs/compose-layout.md
@@ -5,7 +5,7 @@
 Syncs the TimeText, PositionIndicator and Scaffold to the current navigation destination
 state. The TimeText will scroll out of the way of content automatically.
 
-```
+```kotlin
 WearNavScaffold(
     startDestination = "home",
     navController = navController


### PR DESCRIPTION
#### WHAT
Add `kotlin`, as the language of a code snippet was missing.

#### WHY
To get syntactic coloration on both the website and GitHub