### PR TITLE
Fix bug when complication image is missing.

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/complication/MediaStatusComplicationService.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/complication/MediaStatusComplicationService.kt
@@ -80,7 +80,7 @@ class MediaStatusComplicationService :
                 size(64)
             }
         }
-        val icon = Icon.createWithBitmap(bitmap)
+        val icon = if (bitmap != null) Icon.createWithBitmap(bitmap) else null
         val mediaTitle = mediaItem.mediaMetadata.displayTitle.toString()
         val mediaArtist = mediaItem.mediaMetadata.artist.toString()
         return Data(


### PR DESCRIPTION
#### WHAT

Was crashing with NPE, because image wasn't loading in time.

#### WHY

Icon.createWithBitmap(bitmap) fails if bitmap is null.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
