### PR TITLE
Fix double call to sanitize

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/mapper/PlaylistMapper.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/mapper/PlaylistMapper.kt
@@ -29,7 +29,7 @@ object PlaylistMapper {
             .groupBy { it.genre }
             .map { entry ->
                 Playlist(
-                    id = sanitize(sanitize(entry.key)),
+                    id = sanitize(entry.key),
                     name = entry.key,
                     mediaItems = MediaItemMapper.map(entry.value),
                     artworkUri = entry.value.firstOrNull()?.image


### PR DESCRIPTION
#### WHAT

Fix double call to sanitize, probably introduced during merge.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
