### PR TITLE
Fix package name for playlists screen

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
@@ -40,10 +40,10 @@ import com.google.android.horologist.media.ui.screens.browse.BrowseScreen
 import com.google.android.horologist.media.ui.screens.browse.BrowseScreenState
 import com.google.android.horologist.mediasample.components.MediaActivity
 import com.google.android.horologist.mediasample.ui.debug.MediaInfoTimeText
-import com.google.android.horologist.mediasample.ui.library.UampPlaylistsScreen
-import com.google.android.horologist.mediasample.ui.library.UampPlaylistsScreenViewModel
 import com.google.android.horologist.mediasample.ui.player.MediaPlayerScreenViewModel
 import com.google.android.horologist.mediasample.ui.player.UampMediaPlayerScreen
+import com.google.android.horologist.mediasample.ui.playlists.UampPlaylistsScreen
+import com.google.android.horologist.mediasample.ui.playlists.UampPlaylistsScreenViewModel
 import com.google.android.horologist.mediasample.ui.settings.SettingsScreenViewModel
 import com.google.android.horologist.mediasample.ui.settings.UampSettingsScreen
 import com.google.android.horologist.mediasample.ui.settings.VolumeViewModelFactory

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/PlaylistUiModelMapper.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/PlaylistUiModelMapper.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.mediasample.ui.library
+package com.google.android.horologist.mediasample.ui.playlists
 
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
 import com.google.android.horologist.mediasample.domain.model.Playlist

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/UampPlaylistsScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/UampPlaylistsScreen.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.mediasample.ui.library
+package com.google.android.horologist.mediasample.ui.playlists
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/UampPlaylistsScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/UampPlaylistsScreenViewModel.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.mediasample.ui.library
+package com.google.android.horologist.mediasample.ui.playlists
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope


### PR DESCRIPTION
#### WHAT

Change package name for playlists screen from `library` to `playlists`.

#### WHY

In order to follow what's done for other screens (player, settings).
This class was renamed from `UampLibraryScreen` to `UampPlaylistsScreen` in #335 and package was not renamed.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
