### PR TITLE
Remove experimental from some fairly stable APIs.

### DIFF
--- a/audio-ui/api/current.api
+++ b/audio-ui/api/current.api
@@ -5,7 +5,7 @@ package com.google.android.horologist.audio.ui {
   }
 
   public final class VolumePositionIndicatorKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi public static void VolumePositionIndicator(kotlin.jvm.functions.Function0<com.google.android.horologist.audio.VolumeState> volumeState, optional androidx.compose.ui.Modifier modifier, optional boolean autoHide);
+    method @androidx.compose.runtime.Composable public static void VolumePositionIndicator(kotlin.jvm.functions.Function0<com.google.android.horologist.audio.VolumeState> volumeState, optional androidx.compose.ui.Modifier modifier, optional boolean autoHide);
   }
 
   public final class VolumeScreenDefaults {
@@ -15,11 +15,11 @@ package com.google.android.horologist.audio.ui {
   }
 
   public final class VolumeScreenKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi public static void VolumeScreen(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.audio.ui.VolumeViewModel volumeViewModel, optional boolean showVolumeIndicator, optional androidx.compose.ui.focus.FocusRequester focusRequester, optional kotlin.jvm.functions.Function0<kotlin.Unit> increaseIcon, optional kotlin.jvm.functions.Function0<kotlin.Unit> decreaseIcon);
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi public static void VolumeScreen(kotlin.jvm.functions.Function0<com.google.android.horologist.audio.VolumeState> volume, com.google.android.horologist.audio.AudioOutput audioOutput, kotlin.jvm.functions.Function0<kotlin.Unit> increaseVolume, kotlin.jvm.functions.Function0<kotlin.Unit> decreaseVolume, kotlin.jvm.functions.Function0<kotlin.Unit> onAudioOutputClick, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit> increaseIcon, optional kotlin.jvm.functions.Function0<kotlin.Unit> decreaseIcon, optional boolean showVolumeIndicator, optional androidx.compose.ui.focus.FocusRequester focusRequester, optional androidx.compose.foundation.gestures.ScrollableState? scrollableState);
+    method @androidx.compose.runtime.Composable public static void VolumeScreen(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.audio.ui.VolumeViewModel volumeViewModel, optional boolean showVolumeIndicator, optional androidx.compose.ui.focus.FocusRequester focusRequester, optional kotlin.jvm.functions.Function0<kotlin.Unit> increaseIcon, optional kotlin.jvm.functions.Function0<kotlin.Unit> decreaseIcon);
+    method @androidx.compose.runtime.Composable public static void VolumeScreen(kotlin.jvm.functions.Function0<com.google.android.horologist.audio.VolumeState> volume, com.google.android.horologist.audio.AudioOutput audioOutput, kotlin.jvm.functions.Function0<kotlin.Unit> increaseVolume, kotlin.jvm.functions.Function0<kotlin.Unit> decreaseVolume, kotlin.jvm.functions.Function0<kotlin.Unit> onAudioOutputClick, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit> increaseIcon, optional kotlin.jvm.functions.Function0<kotlin.Unit> decreaseIcon, optional boolean showVolumeIndicator, optional androidx.compose.ui.focus.FocusRequester focusRequester, optional androidx.compose.foundation.gestures.ScrollableState? scrollableState);
   }
 
-  @com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi public final class VolumeScrollableState implements androidx.compose.foundation.gestures.ScrollableState {
+  public final class VolumeScrollableState implements androidx.compose.foundation.gestures.ScrollableState {
     ctor public VolumeScrollableState(com.google.android.horologist.audio.VolumeRepository volumeRepository, android.os.Vibrator vibrator);
     method public float dispatchRawDelta(float delta);
     method public boolean isScrollInProgress();
@@ -51,8 +51,8 @@ package com.google.android.horologist.audio.ui {
 package com.google.android.horologist.audio.ui.components {
 
   public final class DeviceChipKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi public static void DeviceChip(com.google.android.horologist.audio.VolumeState volumeState, com.google.android.horologist.audio.AudioOutput audioOutput, kotlin.jvm.functions.Function0<kotlin.Unit> onAudioOutputClick, optional androidx.compose.ui.Modifier modifier);
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi public static androidx.compose.ui.graphics.vector.ImageVector icon(com.google.android.horologist.audio.AudioOutput);
+    method @androidx.compose.runtime.Composable public static void DeviceChip(com.google.android.horologist.audio.VolumeState volumeState, com.google.android.horologist.audio.AudioOutput audioOutput, kotlin.jvm.functions.Function0<kotlin.Unit> onAudioOutputClick, optional androidx.compose.ui.Modifier modifier);
+    method @androidx.compose.runtime.Composable public static androidx.compose.ui.graphics.vector.ImageVector icon(com.google.android.horologist.audio.AudioOutput);
   }
 
   public final class SettingsButtonsDefaults {
@@ -61,7 +61,7 @@ package com.google.android.horologist.audio.ui.components {
   }
 
   public final class SettingsButtonsKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi public static void SettingsButtons(com.google.android.horologist.audio.VolumeState volumeState, kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, kotlin.jvm.functions.Function0<kotlin.Unit> onOutputClick, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit> brandIcon, optional boolean enabled);
+    method @androidx.compose.runtime.Composable public static void SettingsButtons(com.google.android.horologist.audio.VolumeState volumeState, kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, kotlin.jvm.functions.Function0<kotlin.Unit> onOutputClick, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit> brandIcon, optional boolean enabled);
   }
 
 }
@@ -69,15 +69,15 @@ package com.google.android.horologist.audio.ui.components {
 package com.google.android.horologist.audio.ui.components.actions {
 
   public final class AudioOutputButtonKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi public static void AudioOutputButton(kotlin.jvm.functions.Function0<kotlin.Unit> onOutputClick, optional androidx.compose.ui.Modifier modifier, optional boolean enabled);
+    method @androidx.compose.runtime.Composable public static void AudioOutputButton(kotlin.jvm.functions.Function0<kotlin.Unit> onOutputClick, optional androidx.compose.ui.Modifier modifier, optional boolean enabled);
   }
 
   public final class SetVolumeButtonKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi public static void SetVolumeButton(kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, com.google.android.horologist.audio.VolumeState volumeState, optional androidx.compose.ui.Modifier modifier, optional boolean enabled);
+    method @androidx.compose.runtime.Composable public static void SetVolumeButton(kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, com.google.android.horologist.audio.VolumeState volumeState, optional androidx.compose.ui.Modifier modifier, optional boolean enabled);
   }
 
   public final class SettingsButtonKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi public static void SettingsButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, androidx.compose.ui.graphics.vector.ImageVector imageVector, String contentDescription, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional float iconSize, optional float tapTargetSize);
+    method @androidx.compose.runtime.Composable public static void SettingsButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, androidx.compose.ui.graphics.vector.ImageVector imageVector, String contentDescription, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional float iconSize, optional float tapTargetSize);
   }
 
 }
@@ -85,7 +85,7 @@ package com.google.android.horologist.audio.ui.components.actions {
 package com.google.android.horologist.audio.ui.components.animated {
 
   public final class AnimatedSetVolumeButtonKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi public static void AnimatedSetVolumeButton(kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, com.google.android.horologist.audio.VolumeState volumeState, optional androidx.compose.ui.Modifier modifier);
+    method @androidx.compose.runtime.Composable public static void AnimatedSetVolumeButton(kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, com.google.android.horologist.audio.VolumeState volumeState, optional androidx.compose.ui.Modifier modifier);
   }
 
   public final class InteractivePreviewAwareKt {
@@ -98,7 +98,7 @@ package com.google.android.horologist.audio.ui.components.animated {
 
 package com.google.android.horologist.audio.ui.semantics {
 
-  @com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi public final class CustomSemanticsProperties {
+  public final class CustomSemanticsProperties {
     method public androidx.compose.ui.graphics.vector.ImageVector getIconImageVector(androidx.compose.ui.semantics.SemanticsPropertyReceiver);
     method public androidx.compose.ui.semantics.SemanticsPropertyKey<androidx.compose.ui.graphics.vector.ImageVector> getIconImageVectorKey();
     method public void setIconImageVector(androidx.compose.ui.semantics.SemanticsPropertyReceiver, androidx.compose.ui.graphics.vector.ImageVector iconImageVector);

--- a/audio-ui/api/current.api
+++ b/audio-ui/api/current.api
@@ -98,7 +98,7 @@ package com.google.android.horologist.audio.ui.components.animated {
 
 package com.google.android.horologist.audio.ui.semantics {
 
-  public final class CustomSemanticsProperties {
+  @com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi public final class CustomSemanticsProperties {
     method public androidx.compose.ui.graphics.vector.ImageVector getIconImageVector(androidx.compose.ui.semantics.SemanticsPropertyReceiver);
     method public androidx.compose.ui.semantics.SemanticsPropertyKey<androidx.compose.ui.graphics.vector.ImageVector> getIconImageVectorKey();
     method public void setIconImageVector(androidx.compose.ui.semantics.SemanticsPropertyReceiver, androidx.compose.ui.graphics.vector.ImageVector iconImageVector);

--- a/audio-ui/build.gradle
+++ b/audio-ui/build.gradle
@@ -43,11 +43,6 @@ android {
 
     kotlinOptions {
         jvmTarget = "1.8"
-        // Allow for widescale experimental APIs in Alpha libraries we build upon
-        freeCompilerArgs += "-opt-in=androidx.wear.compose.material.ExperimentalWearMaterialApi"
-        freeCompilerArgs += "-opt-in=androidx.compose.ui.ExperimentalComposeUiApi"
-        freeCompilerArgs += "-opt-in=com.google.android.horologist.audio.ExperimentalHorologistAudioApi"
-        freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
     }
 
     composeOptions {

--- a/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/VolumePositionIndicatorTest.kt
+++ b/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/VolumePositionIndicatorTest.kt
@@ -27,12 +27,10 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.printToLog
 import androidx.test.filters.MediumTest
-import com.google.android.horologist.audio.ExperimentalHorologistAudioApi
 import com.google.android.horologist.audio.VolumeState
 import org.junit.Rule
 import org.junit.Test
 
-@OptIn(ExperimentalHorologistAudioApi::class, ExperimentalHorologistAudioUiApi::class)
 @MediumTest
 class VolumePositionIndicatorTest {
     @get:Rule

--- a/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/VolumeScreenTest.kt
+++ b/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/VolumeScreenTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistAudioUiApi::class)
+@file:OptIn(ExperimentalHorologistAudioUiApi::class, ExperimentalCoroutinesApi::class)
 
 package com.google.android.horologist.audio.ui
 
@@ -31,6 +31,7 @@ import androidx.test.filters.MediumTest
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.android.horologist.audio.VolumeState
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test

--- a/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/VolumeScreenTest.kt
+++ b/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/VolumeScreenTest.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalHorologistAudioUiApi::class)
+
 package com.google.android.horologist.audio.ui
 
 import android.os.Vibrator
@@ -27,19 +29,13 @@ import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performRotaryScrollInput
 import androidx.test.filters.MediumTest
 import androidx.test.platform.app.InstrumentationRegistry
-import com.google.android.horologist.audio.ExperimentalHorologistAudioApi
 import com.google.android.horologist.audio.VolumeState
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 
-@OptIn(
-    ExperimentalHorologistAudioApi::class,
-    ExperimentalHorologistAudioUiApi::class,
-    ExperimentalTestApi::class,
-    kotlinx.coroutines.ExperimentalCoroutinesApi::class
-)
+@OptIn(ExperimentalTestApi::class)
 @MediumTest
 class VolumeScreenTest {
     @get:Rule

--- a/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/VolumeScreenTestCase.kt
+++ b/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/VolumeScreenTestCase.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistAudioUiApi::class)
-
 package com.google.android.horologist.audio.ui
 
 import androidx.compose.runtime.Composable

--- a/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonTest.kt
+++ b/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonTest.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalHorologistAudioUiApi::class)
+
 package com.google.android.horologist.audio.ui.components.actions
 
 import androidx.compose.material.icons.Icons
@@ -25,6 +27,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.test.filters.MediumTest
 import com.google.android.horologist.audio.VolumeState
+import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
 import com.google.android.horologist.test.toolbox.matchers.hasIconImageVector
 import org.junit.Rule
 import org.junit.Test

--- a/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonTest.kt
+++ b/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonTest.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistAudioUiApi::class)
-
 package com.google.android.horologist.audio.ui.components.actions
 
 import androidx.compose.material.icons.Icons
@@ -27,7 +25,6 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.test.filters.MediumTest
 import com.google.android.horologist.audio.VolumeState
-import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
 import com.google.android.horologist.test.toolbox.matchers.hasIconImageVector
 import org.junit.Rule
 import org.junit.Test

--- a/audio-ui/src/androidTest/java/com/google/android/horologist/test/toolbox/matchers/SemanticsMatchers.kt
+++ b/audio-ui/src/androidTest/java/com/google/android/horologist/test/toolbox/matchers/SemanticsMatchers.kt
@@ -24,8 +24,10 @@ import androidx.compose.ui.test.SemanticsMatcher.Companion.expectValue
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.hasStateDescription
+import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
 import com.google.android.horologist.audio.ui.semantics.CustomSemanticsProperties.IconImageVectorKey
 
+@ExperimentalHorologistAudioUiApi
 fun hasIconImageVector(imageVector: ImageVector): SemanticsMatcher =
     expectValue(IconImageVectorKey, imageVector)
 

--- a/audio-ui/src/androidTest/java/com/google/android/horologist/test/toolbox/matchers/SemanticsMatchers.kt
+++ b/audio-ui/src/androidTest/java/com/google/android/horologist/test/toolbox/matchers/SemanticsMatchers.kt
@@ -24,10 +24,8 @@ import androidx.compose.ui.test.SemanticsMatcher.Companion.expectValue
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.hasStateDescription
-import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
 import com.google.android.horologist.audio.ui.semantics.CustomSemanticsProperties.IconImageVectorKey
 
-@OptIn(ExperimentalHorologistAudioUiApi::class)
 fun hasIconImageVector(imageVector: ImageVector): SemanticsMatcher =
     expectValue(IconImageVectorKey, imageVector)
 

--- a/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/DeviceChipPreview.kt
+++ b/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/DeviceChipPreview.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistAudioUiApi::class, ExperimentalHorologistComposeToolsApi::class)
-
 package com.google.android.horologist.audio.ui
 
 import androidx.compose.runtime.Composable
@@ -23,7 +21,6 @@ import androidx.compose.ui.unit.dp
 import com.google.android.horologist.audio.AudioOutput
 import com.google.android.horologist.audio.VolumeState
 import com.google.android.horologist.audio.ui.components.DeviceChip
-import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.WearPreview
 import com.google.android.horologist.compose.tools.WidthConstrainedBox
 

--- a/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/VolumeScreenPreview.kt
+++ b/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/VolumeScreenPreview.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistAudioUiApi::class, ExperimentalHorologistComposeToolsApi::class)
-
 package com.google.android.horologist.audio.ui
 
 import androidx.compose.foundation.layout.Box
@@ -28,7 +26,6 @@ import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Scaffold
 import com.google.android.horologist.audio.AudioOutput
 import com.google.android.horologist.audio.VolumeState
-import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.ThemeValues
 import com.google.android.horologist.compose.tools.WearLargeRoundDevicePreview
 import com.google.android.horologist.compose.tools.WearPreviewDevices

--- a/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/actions/AudioOutputButtonPreview.kt
+++ b/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/actions/AudioOutputButtonPreview.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistAudioUiApi::class)
-
 package com.google.android.horologist.audio.ui.components.actions
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
 
 @Preview
 @Composable

--- a/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonPreview.kt
+++ b/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonPreview.kt
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistAudioUiApi::class)
-
 package com.google.android.horologist.audio.ui.components.actions
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import com.google.android.horologist.audio.VolumeState
-import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
 
 @Preview(
     name = "Other volume",

--- a/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/actions/SettingsButtonsPreview.kt
+++ b/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/actions/SettingsButtonsPreview.kt
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistAudioUiApi::class)
-
 package com.google.android.horologist.audio.ui.components.actions
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import com.google.android.horologist.audio.VolumeState
-import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
 import com.google.android.horologist.audio.ui.R
 import com.google.android.horologist.audio.ui.components.SettingsButtons
 import com.google.android.horologist.audio.ui.components.SettingsButtonsDefaults.BrandIcon

--- a/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/animated/AnimatedSetVolumeButtonPreview.kt
+++ b/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/animated/AnimatedSetVolumeButtonPreview.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistAudioUiApi::class, ExperimentalHorologistComposeToolsApi::class)
-
 package com.google.android.horologist.audio.ui.components.animated
 
 import androidx.compose.runtime.Composable
@@ -25,10 +23,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.wear.compose.material.Stepper
 import com.google.android.horologist.audio.VolumeState
-import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
 import com.google.android.horologist.audio.ui.VolumeScreenDefaults.DecreaseIcon
 import com.google.android.horologist.audio.ui.VolumeScreenDefaults.IncreaseIcon
-import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.WearSmallRoundDevicePreview
 
 @WearSmallRoundDevicePreview

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumePositionIndicator.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumePositionIndicator.kt
@@ -28,7 +28,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.PositionIndicator
-import com.google.android.horologist.audio.ExperimentalHorologistAudioApi
 import com.google.android.horologist.audio.VolumeState
 import kotlinx.coroutines.delay
 
@@ -39,8 +38,6 @@ import kotlinx.coroutines.delay
  * for 2 seconds after any volume change, including when a new
  * output device is selected.
  */
-@ExperimentalHorologistAudioUiApi
-@OptIn(ExperimentalHorologistAudioApi::class)
 @Composable
 public fun VolumePositionIndicator(
     volumeState: () -> VolumeState,

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeScreen.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeScreen.kt
@@ -46,7 +46,6 @@ import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.InlineSlider
 import androidx.wear.compose.material.Stepper
 import com.google.android.horologist.audio.AudioOutput
-import com.google.android.horologist.audio.ExperimentalHorologistAudioApi
 import com.google.android.horologist.audio.VolumeState
 import com.google.android.horologist.audio.ui.VolumeScreenDefaults.DecreaseIcon
 import com.google.android.horologist.audio.ui.VolumeScreenDefaults.IncreaseIcon
@@ -65,8 +64,7 @@ import kotlinx.coroutines.launch
  * See [VolumeViewModel]
  * See [AudioManager.STREAM_MUSIC]
  */
-@ExperimentalHorologistAudioUiApi
-@OptIn(ExperimentalHorologistAudioApi::class)
+@OptIn(ExperimentalHorologistAudioUiApi::class)
 @Composable
 public fun VolumeScreen(
     modifier: Modifier = Modifier,
@@ -94,8 +92,6 @@ public fun VolumeScreen(
     )
 }
 
-@ExperimentalHorologistAudioUiApi
-@OptIn(ExperimentalHorologistAudioApi::class)
 @Composable
 public fun VolumeScreen(
     volume: () -> VolumeState,

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeScrollableState.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeScrollableState.kt
@@ -25,15 +25,12 @@ import android.util.Log
 import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.gestures.ScrollScope
 import androidx.compose.foundation.gestures.ScrollableState
-import com.google.android.horologist.audio.ExperimentalHorologistAudioApi
 import com.google.android.horologist.audio.VolumeRepository
 
 /**
  * ScrollableState integration for VolumeControl to scroll events
  * via RSB/Bezel to trigger volume changes.
  */
-@ExperimentalHorologistAudioUiApi
-@OptIn(ExperimentalHorologistAudioApi::class)
 public class VolumeScrollableState(
     private val volumeRepository: VolumeRepository,
     private val vibrator: Vibrator

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/DeviceChip.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/DeviceChip.kt
@@ -38,12 +38,9 @@ import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.audio.AudioOutput
-import com.google.android.horologist.audio.ExperimentalHorologistAudioApi
 import com.google.android.horologist.audio.VolumeState
-import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
 import com.google.android.horologist.audio.ui.R
 
-@ExperimentalHorologistAudioUiApi
 @Composable
 public fun DeviceChip(
     volumeState: VolumeState,
@@ -83,8 +80,6 @@ public fun DeviceChip(
     )
 }
 
-@ExperimentalHorologistAudioUiApi
-@OptIn(ExperimentalHorologistAudioApi::class)
 @Composable
 public fun AudioOutput.icon(): ImageVector {
     return when (this) {

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/SettingsButtons.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/SettingsButtons.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.google.android.horologist.audio.VolumeState
-import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
 import com.google.android.horologist.audio.ui.components.actions.AudioOutputButton
 import com.google.android.horologist.audio.ui.components.actions.SetVolumeButton
 
@@ -37,7 +36,6 @@ import com.google.android.horologist.audio.ui.components.actions.SetVolumeButton
  * Settings buttons for a typical media app.
  * Set Volume and Select Audio Output.
  */
-@ExperimentalHorologistAudioUiApi
 @Composable
 public fun SettingsButtons(
     volumeState: VolumeState,

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/AudioOutputButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/AudioOutputButton.kt
@@ -23,13 +23,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.wear.compose.material.ButtonDefaults
-import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
 import com.google.android.horologist.audio.ui.R
 
 /**
  * A button to launch the system bluetooth settings to connect to a headset.
  */
-@ExperimentalHorologistAudioUiApi
 @Composable
 public fun AudioOutputButton(
     onOutputClick: () -> Unit,

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.wear.compose.material.ButtonDefaults
 import com.google.android.horologist.audio.VolumeState
-import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
 import com.google.android.horologist.audio.ui.R
 
 /**
@@ -34,7 +33,6 @@ import com.google.android.horologist.audio.ui.R
  *
  * See [VolumeState]
  */
-@ExperimentalHorologistAudioUiApi
 @Composable
 public fun SetVolumeButton(
     onVolumeClick: () -> Unit,

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SettingsButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SettingsButton.kt
@@ -30,7 +30,6 @@ import androidx.wear.compose.material.ButtonDefaults.buttonColors
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import com.google.android.horologist.audio.VolumeState
-import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
 import com.google.android.horologist.audio.ui.semantics.CustomSemanticsProperties.iconImageVector
 
 /**
@@ -38,7 +37,6 @@ import com.google.android.horologist.audio.ui.semantics.CustomSemanticsPropertie
  *
  * See [VolumeState]
  */
-@ExperimentalHorologistAudioUiApi
 @Composable
 public fun SettingsButton(
     onClick: () -> Unit,

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SettingsButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SettingsButton.kt
@@ -30,6 +30,7 @@ import androidx.wear.compose.material.ButtonDefaults.buttonColors
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import com.google.android.horologist.audio.VolumeState
+import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
 import com.google.android.horologist.audio.ui.semantics.CustomSemanticsProperties.iconImageVector
 
 /**
@@ -37,6 +38,7 @@ import com.google.android.horologist.audio.ui.semantics.CustomSemanticsPropertie
  *
  * See [VolumeState]
  */
+@OptIn(ExperimentalHorologistAudioUiApi::class)
 @Composable
 public fun SettingsButton(
     onClick: () -> Unit,

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/animated/AnimatedSetVolumeButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/animated/AnimatedSetVolumeButton.kt
@@ -32,7 +32,6 @@ import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.rememberLottieAnimatable
 import com.airbnb.lottie.compose.rememberLottieComposition
 import com.google.android.horologist.audio.VolumeState
-import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
 import com.google.android.horologist.audio.ui.components.actions.SetVolumeButton
 
 /**
@@ -40,7 +39,6 @@ import com.google.android.horologist.audio.ui.components.actions.SetVolumeButton
  *
  * See [VolumeState]
  */
-@ExperimentalHorologistAudioUiApi
 @Composable
 public fun AnimatedSetVolumeButton(
     onVolumeClick: () -> Unit,

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/semantics/CustomSemanticsProperties.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/semantics/CustomSemanticsProperties.kt
@@ -19,10 +19,12 @@ package com.google.android.horologist.audio.ui.semantics
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
 
 /**
  * Custom semantic properties, mainly used for accessibility and testing.
  */
+@ExperimentalHorologistAudioUiApi
 public object CustomSemanticsProperties {
 
     public val IconImageVectorKey: SemanticsPropertyKey<ImageVector> =

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/semantics/CustomSemanticsProperties.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/semantics/CustomSemanticsProperties.kt
@@ -19,12 +19,10 @@ package com.google.android.horologist.audio.ui.semantics
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.SemanticsPropertyReceiver
-import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
 
 /**
  * Custom semantic properties, mainly used for accessibility and testing.
  */
-@ExperimentalHorologistAudioUiApi
 public object CustomSemanticsProperties {
 
     public val IconImageVectorKey: SemanticsPropertyKey<ImageVector> =

--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenTestCase.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenTestCase.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistAudioUiApi::class, ExperimentalHorologistComposeToolsApi::class)
-
 package com.google.android.horologist.audio.ui
 
 import androidx.compose.runtime.Composable
@@ -24,7 +22,6 @@ import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Scaffold
 import com.google.android.horologist.audio.AudioOutput
 import com.google.android.horologist.audio.VolumeState
-import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.RoundPreview
 
 @Composable

--- a/audio/api/current.api
+++ b/audio/api/current.api
@@ -1,7 +1,7 @@
 // Signature format: 4.0
 package com.google.android.horologist.audio {
 
-  @com.google.android.horologist.audio.ExperimentalHorologistAudioApi public interface AudioOutput {
+  public interface AudioOutput {
     method public String getId();
     method public String getName();
     property public abstract String id;
@@ -49,7 +49,7 @@ package com.google.android.horologist.audio {
     property public String name;
   }
 
-  @com.google.android.horologist.audio.ExperimentalHorologistAudioApi public interface AudioOutputRepository extends java.lang.AutoCloseable {
+  public interface AudioOutputRepository extends java.lang.AutoCloseable {
     method public kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.AudioOutput> getAudioOutput();
     method public kotlinx.coroutines.flow.StateFlow<java.util.List<com.google.android.horologist.audio.AudioOutput>> getAvailable();
     method public void launchOutputSelection(boolean closeOnConnect);
@@ -57,7 +57,7 @@ package com.google.android.horologist.audio {
     property public abstract kotlinx.coroutines.flow.StateFlow<java.util.List<com.google.android.horologist.audio.AudioOutput>> available;
   }
 
-  @com.google.android.horologist.audio.ExperimentalHorologistAudioApi public final class BluetoothSettings {
+  public final class BluetoothSettings {
     method public void launchBluetoothSettings(android.content.Context, optional boolean closeOnConnect);
     field public static final com.google.android.horologist.audio.BluetoothSettings INSTANCE;
   }
@@ -65,7 +65,7 @@ package com.google.android.horologist.audio {
   @kotlin.RequiresOptIn(message="Horologist Audio is experimental. The API may be changed in the future.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention) public @interface ExperimentalHorologistAudioApi {
   }
 
-  @com.google.android.horologist.audio.ExperimentalHorologistAudioApi public final class SystemAudioRepository implements com.google.android.horologist.audio.AudioOutputRepository com.google.android.horologist.audio.VolumeRepository {
+  public final class SystemAudioRepository implements com.google.android.horologist.audio.AudioOutputRepository com.google.android.horologist.audio.VolumeRepository {
     ctor public SystemAudioRepository(android.content.Context application, androidx.mediarouter.media.MediaRouter mediaRouter, optional androidx.mediarouter.media.MediaRouteSelector selector);
     method public void close();
     method public void decreaseVolume();
@@ -87,14 +87,14 @@ package com.google.android.horologist.audio {
   public final class SystemAudioRepositoryKt {
   }
 
-  @com.google.android.horologist.audio.ExperimentalHorologistAudioApi public interface VolumeRepository extends java.lang.AutoCloseable {
+  public interface VolumeRepository extends java.lang.AutoCloseable {
     method public void decreaseVolume();
     method public kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.VolumeState> getVolumeState();
     method public void increaseVolume();
     property public abstract kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.VolumeState> volumeState;
   }
 
-  @com.google.android.horologist.audio.ExperimentalHorologistAudioApi public final class VolumeState {
+  public final class VolumeState {
     ctor public VolumeState(int current, int max);
     method public int component1();
     method public int component2();

--- a/audio/src/main/java/com/google/android/horologist/audio/AudioOutput.kt
+++ b/audio/src/main/java/com/google/android/horologist/audio/AudioOutput.kt
@@ -21,7 +21,6 @@ package com.google.android.horologist.audio
  *
  * This interface is intentionally open to allow other targets to be defined in future.
  */
-@ExperimentalHorologistAudioApi
 public interface AudioOutput {
     /**
      * A unique audio output id.

--- a/audio/src/main/java/com/google/android/horologist/audio/AudioOutputRepository.kt
+++ b/audio/src/main/java/com/google/android/horologist/audio/AudioOutputRepository.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.flow.StateFlow
 /**
  * Audio Output Repository for identifying available audio devices in a simple manner.
  */
-@ExperimentalHorologistAudioApi
 public interface AudioOutputRepository : AutoCloseable {
     /**
      * The current audio output.

--- a/audio/src/main/java/com/google/android/horologist/audio/BluetoothSettings.kt
+++ b/audio/src/main/java/com/google/android/horologist/audio/BluetoothSettings.kt
@@ -26,7 +26,6 @@ import android.provider.Settings
  *
  * https://developer.android.com/training/wearables/overlays/audio?hl=ca
  */
-@ExperimentalHorologistAudioApi
 public object BluetoothSettings {
     /**
      * Open the bluetooth settings activity and optionally close after connection established.

--- a/audio/src/main/java/com/google/android/horologist/audio/SystemAudioRepository.kt
+++ b/audio/src/main/java/com/google/android/horologist/audio/SystemAudioRepository.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.flow.StateFlow
 /**
  * Audio Repository for identifying and controlling available audio devices in a simple manner.
  */
-@ExperimentalHorologistAudioApi
 public class SystemAudioRepository(
     private val application: Context,
     private val mediaRouter: MediaRouter,
@@ -117,31 +116,26 @@ private fun MediaRouter.fixInconsistency() {
     }
 }
 
-@ExperimentalHorologistAudioApi
 private inline val MediaRouter.volume: VolumeState
     get() {
         return selectedRoute.volumeState
     }
 
-@ExperimentalHorologistAudioApi
 private inline val MediaRouter.output: AudioOutput
     get() {
         return selectedRoute.device
     }
 
-@ExperimentalHorologistAudioApi
 private inline val MediaRouter.devices: List<AudioOutput>
     get() {
         return routes.map { it.device }
     }
 
-@ExperimentalHorologistAudioApi
 private inline val RouteInfo.volumeState: VolumeState
     get() {
         return VolumeState(current = volume, max = volumeMax)
     }
 
-@ExperimentalHorologistAudioApi
 private inline val RouteInfo.device: AudioOutput
     get() {
         return when {

--- a/audio/src/main/java/com/google/android/horologist/audio/VolumeRepository.kt
+++ b/audio/src/main/java/com/google/android/horologist/audio/VolumeRepository.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.flow.StateFlow
  * A state repository for audio volume, typically the system AudioManager,
  * but possibly a remote app in paired situations.
  */
-@ExperimentalHorologistAudioApi
 public interface VolumeRepository : AutoCloseable {
     /**
      * The current volume state, including volume, min, max.

--- a/audio/src/main/java/com/google/android/horologist/audio/VolumeState.kt
+++ b/audio/src/main/java/com/google/android/horologist/audio/VolumeState.kt
@@ -19,7 +19,6 @@ package com.google.android.horologist.audio
 /**
  * Data class holding the current state of the volume system.
  */
-@ExperimentalHorologistAudioApi
 public data class VolumeState(
     public val current: Int,
     public val max: Int

--- a/compose-layout/build.gradle
+++ b/compose-layout/build.gradle
@@ -42,13 +42,6 @@ android {
 
     kotlinOptions {
         jvmTarget = "1.8"
-        // Allow for widescale experimental APIs in Alpha libraries we build upon
-        freeCompilerArgs += "-opt-in=androidx.wear.compose.material.ExperimentalWearMaterialApi"
-        freeCompilerArgs += "-opt-in=androidx.compose.foundation.ExperimentalFoundationApi"
-        freeCompilerArgs += "-opt-in=androidx.compose.ui.ExperimentalComposeUiApi"
-        freeCompilerArgs += "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
-        freeCompilerArgs += "-opt-in=com.google.accompanist.pager.ExperimentalPagerApi"
-        freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
     }
 
     composeOptions {

--- a/compose-layout/src/androidTest/java/com/google/android/horologist/compose/navscaffold/NavScaffoldTest.kt
+++ b/compose-layout/src/androidTest/java/com/google/android/horologist/compose/navscaffold/NavScaffoldTest.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
 package com.google.android.horologist.compose.navscaffold
 
 import androidx.compose.foundation.ScrollState
@@ -47,13 +49,13 @@ import androidx.wear.compose.material.rememberScalingLazyListState
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import org.junit.Assert.assertSame
 import org.junit.Rule
 import org.junit.Test
 
-@OptIn(ExperimentalHorologistComposeLayoutApi::class)
 @MediumTest
 class NavScaffoldTest {
     @get:Rule

--- a/compose-layout/src/androidTest/java/com/google/android/horologist/compose/pager/PagerScreenTest.kt
+++ b/compose-layout/src/androidTest/java/com/google/android/horologist/compose/pager/PagerScreenTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalPagerApi::class)
+@file:OptIn(ExperimentalPagerApi::class, ExperimentalCoroutinesApi::class)
 
 package com.google.android.horologist.compose.pager
 
@@ -40,13 +40,13 @@ import com.google.accompanist.pager.PagerState
 import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import org.junit.Rule
 import org.junit.Test
 
-@OptIn(ExperimentalHorologistComposeLayoutApi::class)
 @MediumTest
 class PagerScreenTest {
     @get:Rule

--- a/compose-layout/src/androidTest/java/com/google/android/horologist/compose/pager/PagerScreenTest.kt
+++ b/compose-layout/src/androidTest/java/com/google/android/horologist/compose/pager/PagerScreenTest.kt
@@ -37,7 +37,6 @@ import androidx.test.filters.MediumTest
 import androidx.wear.compose.material.Text
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.PagerState
-import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/compose-layout/src/androidTest/java/com/google/android/horologist/compose/pager/PagerScreenTest.kt
+++ b/compose-layout/src/androidTest/java/com/google/android/horologist/compose/pager/PagerScreenTest.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalPagerApi::class)
+
 package com.google.android.horologist.compose.pager
 
 import androidx.compose.foundation.layout.Box
@@ -33,6 +35,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.lifecycle.whenResumed
 import androidx.test.filters.MediumTest
 import androidx.wear.compose.material.Text
+import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.PagerState
 import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 import com.google.common.truth.Truth.assertThat

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/ScrollableColumn.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/ScrollableColumn.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalComposeUiApi::class)
+
 package com.google.android.horologist.compose.navscaffold
 
 import androidx.compose.foundation.focusable
@@ -21,6 +23,7 @@ import androidx.compose.foundation.gestures.ScrollableState
 import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.focus.FocusRequester

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/pager/PagerScreen.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/pager/PagerScreen.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalPagerApi::class)
+
 package com.google.android.horologist.compose.pager
 
 import android.util.Log
@@ -40,6 +42,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.wear.compose.material.HorizontalPageIndicator
 import androidx.wear.compose.material.PageIndicatorState
+import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.PagerScope
 import com.google.accompanist.pager.PagerState

--- a/compose-tools/api/current.api
+++ b/compose-tools/api/current.api
@@ -5,16 +5,16 @@ package com.google.android.horologist.compose.tools {
   }
 
   public final class InteractivePreviewAwareKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi public static void InteractivePreviewAware(kotlin.jvm.functions.Function0<kotlin.Unit> block);
+    method @androidx.compose.runtime.Composable public static void InteractivePreviewAware(kotlin.jvm.functions.Function0<kotlin.Unit> block);
     method public static androidx.compose.runtime.ProvidableCompositionLocal<java.lang.Boolean> getLocalInteractivePreview();
     method public static androidx.compose.runtime.ProvidableCompositionLocal<java.lang.Boolean> getLocalStaticPreview();
   }
 
   public final class RoundPreviewKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi public static void RoundPreview(optional boolean round, kotlin.jvm.functions.Function0<kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable public static void RoundPreview(optional boolean round, kotlin.jvm.functions.Function0<kotlin.Unit> content);
   }
 
-  @com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi public final class ThemeValues {
+  public final class ThemeValues {
     ctor public ThemeValues(String name, int index, androidx.wear.compose.material.Colors colors);
     method public String component1();
     method public int component2();
@@ -31,16 +31,14 @@ package com.google.android.horologist.compose.tools {
   }
 
   public final class ThemeValuesKt {
-    method public static androidx.wear.compose.material.Colors getOrangey();
     method public static java.util.List<com.google.android.horologist.compose.tools.ThemeValues> getThemeValues();
-    method public static androidx.wear.compose.material.Colors getUampColors();
   }
 
   public final class TilePreviewKt {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi public static void LayoutElementPreview(androidx.wear.tiles.LayoutElementBuilders.LayoutElement element, optional @ColorInt int windowBackgroundColor, optional kotlin.jvm.functions.Function1<? super androidx.wear.tiles.ResourceBuilders.Resources.Builder,kotlin.Unit> tileResourcesFn);
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi public static void LayoutRootPreview(androidx.wear.tiles.LayoutElementBuilders.LayoutElement root, optional kotlin.jvm.functions.Function1<? super androidx.wear.tiles.ResourceBuilders.Resources.Builder,kotlin.Unit> tileResourcesFn);
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi public static <T, R> void TileLayoutPreview(T? state, R? resourceState, com.google.android.horologist.tiles.render.TileLayoutRenderer<T,R> renderer);
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi public static void TilePreview(androidx.wear.tiles.TileBuilders.Tile tile, androidx.wear.tiles.ResourceBuilders.Resources tileResources);
+    method @androidx.compose.runtime.Composable public static void LayoutRootPreview(androidx.wear.tiles.LayoutElementBuilders.LayoutElement root, optional kotlin.jvm.functions.Function1<? super androidx.wear.tiles.ResourceBuilders.Resources.Builder,kotlin.Unit> tileResourcesFn);
+    method @androidx.compose.runtime.Composable public static <T, R> void TileLayoutPreview(T? state, R? resourceState, com.google.android.horologist.tiles.render.TileLayoutRenderer<T,R> renderer);
+    method @androidx.compose.runtime.Composable public static void TilePreview(androidx.wear.tiles.TileBuilders.Tile tile, androidx.wear.tiles.ResourceBuilders.Resources tileResources);
     method public static androidx.wear.tiles.DeviceParametersBuilders.DeviceParameters buildDeviceParameters(android.content.res.Resources resources);
   }
 
@@ -56,7 +54,7 @@ package com.google.android.horologist.compose.tools {
   @androidx.compose.ui.tooling.preview.Preview(device=androidx.compose.ui.tooling.preview.Devices.WEAR_OS_SMALL_ROUND, showSystemUi=true, backgroundColor=4278190080L, showBackground=true, group="Fonts - Small", fontScale=0.94f) @androidx.compose.ui.tooling.preview.Preview(device=androidx.compose.ui.tooling.preview.Devices.WEAR_OS_SMALL_ROUND, showSystemUi=true, backgroundColor=4278190080L, showBackground=true, group="Fonts - Normal", fontScale=1.0f) @androidx.compose.ui.tooling.preview.Preview(device=androidx.compose.ui.tooling.preview.Devices.WEAR_OS_SMALL_ROUND, showSystemUi=true, backgroundColor=4278190080L, showBackground=true, group="Fonts - Medium", fontScale=1.06f) @androidx.compose.ui.tooling.preview.Preview(device=androidx.compose.ui.tooling.preview.Devices.WEAR_OS_SMALL_ROUND, showSystemUi=true, backgroundColor=4278190080L, showBackground=true, group="Fonts - Large", fontScale=1.12f) @androidx.compose.ui.tooling.preview.Preview(device=androidx.compose.ui.tooling.preview.Devices.WEAR_OS_SMALL_ROUND, showSystemUi=true, backgroundColor=4278190080L, showBackground=true, group="Fonts - Larger", fontScale=1.18f) @androidx.compose.ui.tooling.preview.Preview(device=androidx.compose.ui.tooling.preview.Devices.WEAR_OS_SMALL_ROUND, showSystemUi=true, backgroundColor=4278190080L, showBackground=true, group="Fonts - Largest", fontScale=1.24f) public @interface WearPreviewFontSizes {
   }
 
-  @com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi public final class WearPreviewThemes implements androidx.compose.ui.tooling.preview.PreviewParameterProvider<com.google.android.horologist.compose.tools.ThemeValues> {
+  public final class WearPreviewThemes implements androidx.compose.ui.tooling.preview.PreviewParameterProvider<com.google.android.horologist.compose.tools.ThemeValues> {
     ctor public WearPreviewThemes();
     method public kotlin.sequences.Sequence<com.google.android.horologist.compose.tools.ThemeValues> getValues();
     property public kotlin.sequences.Sequence<com.google.android.horologist.compose.tools.ThemeValues> values;
@@ -69,7 +67,7 @@ package com.google.android.horologist.compose.tools {
   }
 
   public final class WidthConstrainedBoxKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi public static void WidthConstrainedBox(optional java.util.List<androidx.compose.ui.unit.Dp> widths, optional float comfortableHeight, kotlin.jvm.functions.Function0<kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable public static void WidthConstrainedBox(optional java.util.List<androidx.compose.ui.unit.Dp> widths, optional float comfortableHeight, kotlin.jvm.functions.Function0<kotlin.Unit> content);
   }
 
 }

--- a/compose-tools/src/main/java/com/google/android/horologist/compose/tools/InteractivePreviewAware.kt
+++ b/compose-tools/src/main/java/com/google/android/horologist/compose/tools/InteractivePreviewAware.kt
@@ -38,7 +38,6 @@ public val LocalStaticPreview: ProvidableCompositionLocal<Boolean> = composition
  * correctly.
  */
 @Composable
-@ExperimentalHorologistComposeToolsApi
 public fun InteractivePreviewAware(block: @Composable () -> Unit) {
     if (LocalInspectionMode.current) {
         var interactive by remember { mutableStateOf(false) }

--- a/compose-tools/src/main/java/com/google/android/horologist/compose/tools/RoundPreview.kt
+++ b/compose-tools/src/main/java/com/google/android/horologist/compose/tools/RoundPreview.kt
@@ -21,7 +21,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalConfiguration
 
-@ExperimentalHorologistComposeToolsApi
+/**
+ * Round Preview, typical useful when using previews without explicit round device support
+ * such as paparazzi.
+ */
 @Composable
 public fun RoundPreview(round: Boolean = true, content: @Composable () -> Unit) {
     if (round) {

--- a/compose-tools/src/main/java/com/google/android/horologist/compose/tools/ThemeValues.kt
+++ b/compose-tools/src/main/java/com/google/android/horologist/compose/tools/ThemeValues.kt
@@ -19,29 +19,11 @@ package com.google.android.horologist.compose.tools
 import androidx.compose.ui.graphics.Color
 import androidx.wear.compose.material.Colors
 
-@ExperimentalHorologistComposeToolsApi
 public data class ThemeValues(val name: String, val index: Int, val colors: Colors) {
     val safeName: String
         get() = name.replace("[^A-Za-z0-9]".toRegex(), "")
 }
 
-public val Orangey: Colors = Colors(
-    secondary = Color(0xFFED612B), // Used for RSB
-    surface = Color(0xFF202124), // Used for Device Chip
-    onPrimary = Color(0xFFED612B),
-    onSurface = Color(0xFFED612B),
-)
-
-public val UampColors: Colors = Colors(
-    primary = Color(0xFF981F68),
-    primaryVariant = Color(0xFF66003d),
-    secondary = Color(0xFF981F68),
-    error = Color(0xFFE24444),
-    onPrimary = Color.White,
-    onSurfaceVariant = Color(0xFFDADCE0),
-)
-
-@ExperimentalHorologistComposeToolsApi
 public val themeValues: List<ThemeValues> = listOf(
     ThemeValues("Blue (Default - AECBFA)", 0, Colors()),
     ThemeValues(
@@ -96,11 +78,23 @@ public val themeValues: List<ThemeValues> = listOf(
     ThemeValues(
         "Orange-y",
         5,
-        Orangey
+        Colors(
+            secondary = Color(0xFFED612B), // Used for RSB
+            surface = Color(0xFF202124), // Used for Device Chip
+            onPrimary = Color(0xFFED612B),
+            onSurface = Color(0xFFED612B),
+        )
     ),
     ThemeValues(
         "Uamp",
         6,
-        UampColors
+        Colors(
+            primary = Color(0xFF981F68),
+            primaryVariant = Color(0xFF66003d),
+            secondary = Color(0xFF981F68),
+            error = Color(0xFFE24444),
+            onPrimary = Color.White,
+            onSurfaceVariant = Color(0xFFDADCE0),
+        )
     ),
 )

--- a/compose-tools/src/main/java/com/google/android/horologist/compose/tools/TilePreview.kt
+++ b/compose-tools/src/main/java/com/google/android/horologist/compose/tools/TilePreview.kt
@@ -55,7 +55,6 @@ import kotlin.math.roundToInt
  * Any bitmaps should be preloaded from test resources and passed in via [resourceState] as
  * Bitmap or ImageResource.
  */
-@ExperimentalHorologistComposeToolsApi
 @Composable
 public fun <T, R> TileLayoutPreview(state: T, resourceState: R, renderer: TileLayoutRenderer<T, R>) {
     val context = LocalContext.current
@@ -75,7 +74,6 @@ public fun <T, R> TileLayoutPreview(state: T, resourceState: R, renderer: TileLa
 /**
  * Preview a Tile by providing the final proto representation of tiles and resources.
  */
-@ExperimentalHorologistComposeToolsApi
 @Composable
 public fun TilePreview(
     tile: TileBuilders.Tile,
@@ -134,7 +132,6 @@ public fun LayoutElementPreview(
 /**
  * Preview a root layout component such as a PrimaryLayout, that is full screen.
  */
-@ExperimentalHorologistComposeToolsApi
 @Composable
 public fun LayoutRootPreview(
     root: LayoutElement,

--- a/compose-tools/src/main/java/com/google/android/horologist/compose/tools/WearPreviewThemes.kt
+++ b/compose-tools/src/main/java/com/google/android/horologist/compose/tools/WearPreviewThemes.kt
@@ -18,7 +18,6 @@ package com.google.android.horologist.compose.tools
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 
-@ExperimentalHorologistComposeToolsApi
 public class WearPreviewThemes : PreviewParameterProvider<ThemeValues> {
     public override val values: Sequence<ThemeValues>
         get() = themeValues.asSequence()

--- a/compose-tools/src/main/java/com/google/android/horologist/compose/tools/WidthConstrainedBox.kt
+++ b/compose-tools/src/main/java/com/google/android/horologist/compose/tools/WidthConstrainedBox.kt
@@ -36,7 +36,6 @@ import androidx.wear.compose.material.Text
  * A repeated preview to allow seeing the same component at multiple widths.
  */
 @Composable
-@ExperimentalHorologistComposeToolsApi
 public fun WidthConstrainedBox(
     widths: List<Dp> = listOf(192.dp, 227.dp),
     comfortableHeight: Dp = 101.dp,

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/player/UampSettingsButtons.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/player/UampSettingsButtons.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.google.android.horologist.audio.VolumeState
-import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
 import com.google.android.horologist.audio.ui.components.SettingsButtonsDefaults
 import com.google.android.horologist.audio.ui.components.actions.SetVolumeButton
 import com.google.android.horologist.mediasample.R
@@ -30,7 +29,6 @@ import com.google.android.horologist.mediasample.R
  * Settings buttons for the UAMP media app.
  * Favorite item and Set Volume.
  */
-@ExperimentalHorologistAudioUiApi
 @Composable
 public fun UampSettingsButtons(
     volumeState: VolumeState,

--- a/media-ui/src/androidTest/java/com/google/android/horologist/test/toolbox/matchers/SemanticsMatchers.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/test/toolbox/matchers/SemanticsMatchers.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.test.SemanticsMatcher
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.semantics.CustomSemanticsProperties.IconImageVectorKey
 
-@OptIn(ExperimentalHorologistMediaUiApi::class)
+@ExperimentalHorologistMediaUiApi
 fun hasIconImageVector(imageVector: ImageVector): SemanticsMatcher =
     SemanticsMatcher.expectValue(IconImageVectorKey, imageVector)
 


### PR DESCRIPTION
#### WHAT

This stops callers from opting in, so remove experimental from
APIs that have been used enough to have come confidence.

#### WHY

Let callers opt-in to APIs like Accompanist Pager, but also our own, but only when actually changing.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
