### PR TITLE
Add Icon only variant for StandardButton

### DIFF
--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/base/IconOnlyButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/base/IconOnlyButtonPreview.kt
@@ -19,12 +19,9 @@ package com.google.android.horologist.media.ui.components.base
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
+import com.google.android.horologist.compose.tools.WearPreview
 
-@Preview(
-    backgroundColor = 0xff000000,
-    showBackground = true,
-)
+@WearPreview
 @Composable
 fun IconOnlyButtonPreview() {
     StandardButton(
@@ -35,10 +32,7 @@ fun IconOnlyButtonPreview() {
     )
 }
 
-@Preview(
-    backgroundColor = 0xff000000,
-    showBackground = true,
-)
+@WearPreview
 @Composable
 fun IconOnlyButtonPreviewLarge() {
     StandardButton(
@@ -50,10 +44,7 @@ fun IconOnlyButtonPreviewLarge() {
     )
 }
 
-@Preview(
-    backgroundColor = 0xff000000,
-    showBackground = true,
-)
+@WearPreview
 @Composable
 fun IconOnlyButtonPreviewSmall() {
     StandardButton(
@@ -65,10 +56,7 @@ fun IconOnlyButtonPreviewSmall() {
     )
 }
 
-@Preview(
-    backgroundColor = 0xff000000,
-    showBackground = true,
-)
+@WearPreview
 @Composable
 fun IconOnlyButtonPreviewExtraSmall() {
     StandardButton(
@@ -80,10 +68,7 @@ fun IconOnlyButtonPreviewExtraSmall() {
     )
 }
 
-@Preview(
-    backgroundColor = 0xff000000,
-    showBackground = true,
-)
+@WearPreview
 @Composable
 fun IconOnlyButtonPreviewDisabled() {
     StandardButton(

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/base/IconOnlyButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/base/IconOnlyButtonPreview.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.components.base
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(
+    backgroundColor = 0xff000000,
+    showBackground = true,
+)
+@Composable
+fun IconOnlyButtonPreview() {
+    StandardButton(
+        imageVector = Icons.Default.Check,
+        contentDescription = "contentDescription",
+        onClick = { },
+        buttonType = StandardButtonType.IconOnly,
+    )
+}
+
+@Preview(
+    backgroundColor = 0xff000000,
+    showBackground = true,
+)
+@Composable
+fun IconOnlyButtonPreviewLarge() {
+    StandardButton(
+        imageVector = Icons.Default.Check,
+        contentDescription = "contentDescription",
+        onClick = { },
+        buttonType = StandardButtonType.IconOnly,
+        buttonSize = StandardButtonSize.Large,
+    )
+}
+
+@Preview(
+    backgroundColor = 0xff000000,
+    showBackground = true,
+)
+@Composable
+fun IconOnlyButtonPreviewSmall() {
+    StandardButton(
+        imageVector = Icons.Default.Check,
+        contentDescription = "contentDescription",
+        onClick = { },
+        buttonType = StandardButtonType.IconOnly,
+        buttonSize = StandardButtonSize.Small,
+    )
+}
+
+@Preview(
+    backgroundColor = 0xff000000,
+    showBackground = true,
+)
+@Composable
+fun IconOnlyButtonPreviewExtraSmall() {
+    StandardButton(
+        imageVector = Icons.Default.Check,
+        contentDescription = "contentDescription",
+        onClick = { },
+        buttonType = StandardButtonType.IconOnly,
+        buttonSize = StandardButtonSize.ExtraSmall,
+    )
+}
+
+@Preview(
+    backgroundColor = 0xff000000,
+    showBackground = true,
+)
+@Composable
+fun IconOnlyButtonPreviewDisabled() {
+    StandardButton(
+        imageVector = Icons.Default.Check,
+        contentDescription = "contentDescription",
+        onClick = { },
+        buttonType = StandardButtonType.IconOnly,
+        enabled = false,
+    )
+}

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/base/PrimaryButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/base/PrimaryButtonPreview.kt
@@ -19,12 +19,9 @@ package com.google.android.horologist.media.ui.components.base
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
+import com.google.android.horologist.compose.tools.WearPreview
 
-@Preview(
-    backgroundColor = 0xff000000,
-    showBackground = true,
-)
+@WearPreview
 @Composable
 fun PrimaryButtonPreview() {
     StandardButton(
@@ -34,10 +31,7 @@ fun PrimaryButtonPreview() {
     )
 }
 
-@Preview(
-    backgroundColor = 0xff000000,
-    showBackground = true,
-)
+@WearPreview
 @Composable
 fun PrimaryButtonPreviewLarge() {
     StandardButton(
@@ -48,10 +42,7 @@ fun PrimaryButtonPreviewLarge() {
     )
 }
 
-@Preview(
-    backgroundColor = 0xff000000,
-    showBackground = true,
-)
+@WearPreview
 @Composable
 fun PrimaryButtonPreviewSmall() {
     StandardButton(
@@ -62,10 +53,7 @@ fun PrimaryButtonPreviewSmall() {
     )
 }
 
-@Preview(
-    backgroundColor = 0xff000000,
-    showBackground = true,
-)
+@WearPreview
 @Composable
 fun PrimaryButtonPreviewExtraSmall() {
     StandardButton(
@@ -76,10 +64,7 @@ fun PrimaryButtonPreviewExtraSmall() {
     )
 }
 
-@Preview(
-    backgroundColor = 0xff000000,
-    showBackground = true,
-)
+@WearPreview
 @Composable
 fun PrimaryButtonPreviewDisabled() {
     StandardButton(

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/base/SecondaryButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/base/SecondaryButtonPreview.kt
@@ -19,12 +19,9 @@ package com.google.android.horologist.media.ui.components.base
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
+import com.google.android.horologist.compose.tools.WearPreview
 
-@Preview(
-    backgroundColor = 0xff000000,
-    showBackground = true,
-)
+@WearPreview
 @Composable
 fun SecondaryButtonPreview() {
     StandardButton(
@@ -35,10 +32,7 @@ fun SecondaryButtonPreview() {
     )
 }
 
-@Preview(
-    backgroundColor = 0xff000000,
-    showBackground = true,
-)
+@WearPreview
 @Composable
 fun SecondaryButtonPreviewLarge() {
     StandardButton(
@@ -50,10 +44,7 @@ fun SecondaryButtonPreviewLarge() {
     )
 }
 
-@Preview(
-    backgroundColor = 0xff000000,
-    showBackground = true,
-)
+@WearPreview
 @Composable
 fun SecondaryButtonPreviewSmall() {
     StandardButton(
@@ -65,10 +56,7 @@ fun SecondaryButtonPreviewSmall() {
     )
 }
 
-@Preview(
-    backgroundColor = 0xff000000,
-    showBackground = true,
-)
+@WearPreview
 @Composable
 fun SecondaryButtonPreviewExtraSmall() {
     StandardButton(
@@ -80,10 +68,7 @@ fun SecondaryButtonPreviewExtraSmall() {
     )
 }
 
-@Preview(
-    backgroundColor = 0xff000000,
-    showBackground = true,
-)
+@WearPreview
 @Composable
 fun SecondaryButtonPreviewDisabled() {
     StandardButton(

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/base/StandardButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/base/StandardButton.kt
@@ -29,7 +29,7 @@ import androidx.wear.compose.material.Icon
 
 /**
  * This composable fulfils the redlines of the following components:
- * - Primary or Secondary button - according to [buttonType] value;
+ * - Primary, Secondary or Icon only button - according to [buttonType] value;
  * - Default, Large, Small and Extra Small button - according to [buttonSize] value;
  */
 @Composable
@@ -49,6 +49,7 @@ internal fun StandardButton(
         colors = when (buttonType) {
             StandardButtonType.Primary -> ButtonDefaults.primaryButtonColors()
             StandardButtonType.Secondary -> ButtonDefaults.secondaryButtonColors()
+            StandardButtonType.IconOnly -> ButtonDefaults.iconButtonColors()
         }
     ) {
         Icon(
@@ -63,7 +64,8 @@ internal fun StandardButton(
 
 internal enum class StandardButtonType {
     Primary,
-    Secondary
+    Secondary,
+    IconOnly,
 }
 
 internal enum class StandardButtonSize(

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/base/StandardButtonTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/base/StandardButtonTest.kt
@@ -34,6 +34,7 @@ import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class StandardButtonTest(
+    @Suppress("unused") // it's used by junit to display the test name
     private val description: String,
     private val buttonType: StandardButtonType,
     private val buttonSize: StandardButtonSize,
@@ -125,6 +126,36 @@ internal class StandardButtonTest(
             arrayOf(
                 "Secondary Default Disabled",
                 StandardButtonType.Secondary,
+                StandardButtonSize.Default,
+                false
+            ),
+            arrayOf(
+                "Icon only Default",
+                StandardButtonType.IconOnly,
+                StandardButtonSize.Default,
+                true
+            ),
+            arrayOf(
+                "Icon only Large",
+                StandardButtonType.IconOnly,
+                StandardButtonSize.Large,
+                true
+            ),
+            arrayOf(
+                "Icon only Small",
+                StandardButtonType.IconOnly,
+                StandardButtonSize.Small,
+                true
+            ),
+            arrayOf(
+                "Icon only Extra Small",
+                StandardButtonType.IconOnly,
+                StandardButtonSize.ExtraSmall,
+                true
+            ),
+            arrayOf(
+                "Icon only Default Disabled",
+                StandardButtonType.IconOnly,
                 StandardButtonSize.Default,
                 false
             ),

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_StandardButtonTest_variants[Icon only Default Disabled].png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_StandardButtonTest_variants[Icon only Default Disabled].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a1f9acb91e0797da6098b5d29921c34dd7db8e25bd738673f32eb857410066b
+size 12515

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_StandardButtonTest_variants[Icon only Default].png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_StandardButtonTest_variants[Icon only Default].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b78b68637e50fd16ba7436a89eea00b7c6ab9cef6552aad55936095088b7636
+size 13573

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_StandardButtonTest_variants[Icon only Extra Small].png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_StandardButtonTest_variants[Icon only Extra Small].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:713b43a088f85d186b34552664a38c8c785bc2d0911c73984b664c22266daaa1
+size 12929

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_StandardButtonTest_variants[Icon only Large].png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_StandardButtonTest_variants[Icon only Large].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87a32aa58497406441f3788c7abcc919ca06f2da8a60be43d15a39f9161d53bd
+size 13381

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_StandardButtonTest_variants[Icon only Small].png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_StandardButtonTest_variants[Icon only Small].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:713b43a088f85d186b34552664a38c8c785bc2d0911c73984b664c22266daaa1
+size 12929


### PR DESCRIPTION
#### WHAT

Add "Icon only" variant for `StandardButton`.

![Screen Shot 2022-07-15 at 14 11 11](https://user-images.githubusercontent.com/878134/179230570-6eaa2f93-74e4-42f9-b962-b8fdd52a54ad.png)

#### WHY

In order to have our base building blocks aligned with specs in Figma.

#### HOW

- Add implementation;
- Add previews in the debug folder;
- Add snapshot tests;

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
