### PR TITLE
Add EntityScreen

### DIFF
--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -339,6 +339,32 @@ package com.google.android.horologist.media.ui.screens.browse {
 
 }
 
+package com.google.android.horologist.media.ui.screens.entity {
+
+  public final class EntityScreenKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void EntityScreen(com.google.android.horologist.media.ui.state.model.PlaylistUiModel playlistUiModel, com.google.android.horologist.media.ui.screens.entity.EntityScreenState entityScreenState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onDownloadClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel,kotlin.Unit> onDownloadItemClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onShuffleClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onPlayClick, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.wear.compose.material.ScalingLazyListState scalingLazyListState, optional androidx.compose.ui.Modifier modifier, optional String defaultMediaTitle, optional androidx.compose.ui.graphics.painter.Painter? downloadItemArtworkPlaceholder);
+  }
+
+  @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public abstract sealed class EntityScreenState {
+  }
+
+  public static final class EntityScreenState.Loaded extends com.google.android.horologist.media.ui.screens.entity.EntityScreenState {
+    ctor public EntityScreenState.Loaded(java.util.List<? extends com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel> downloadList, optional boolean downloading);
+    method public java.util.List<com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel> component1();
+    method public boolean component2();
+    method public com.google.android.horologist.media.ui.screens.entity.EntityScreenState.Loaded copy(java.util.List<? extends com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel> downloadList, boolean downloading);
+    method public java.util.List<com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel> getDownloadList();
+    method public boolean getDownloading();
+    property public final java.util.List<com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel> downloadList;
+    property public final boolean downloading;
+  }
+
+  public static final class EntityScreenState.Loading extends com.google.android.horologist.media.ui.screens.entity.EntityScreenState {
+    field public static final com.google.android.horologist.media.ui.screens.entity.EntityScreenState.Loading INSTANCE;
+  }
+
+}
+
 package com.google.android.horologist.media.ui.screens.playlist {
 
   public final class PlaylistScreenKt {
@@ -506,6 +532,25 @@ package com.google.android.horologist.media.ui.state.mapper {
 }
 
 package com.google.android.horologist.media.ui.state.model {
+
+  @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public abstract sealed class DownloadMediaItemUiModel {
+    method public com.google.android.horologist.media.ui.state.model.MediaItemUiModel getMediaItemUiModel();
+    property public com.google.android.horologist.media.ui.state.model.MediaItemUiModel mediaItemUiModel;
+  }
+
+  public static final class DownloadMediaItemUiModel.Available extends com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel {
+    ctor public DownloadMediaItemUiModel.Available(com.google.android.horologist.media.ui.state.model.MediaItemUiModel mediaItemUiModel);
+    method public com.google.android.horologist.media.ui.state.model.MediaItemUiModel component1();
+    method public com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel.Available copy(com.google.android.horologist.media.ui.state.model.MediaItemUiModel mediaItemUiModel);
+    property public com.google.android.horologist.media.ui.state.model.MediaItemUiModel mediaItemUiModel;
+  }
+
+  public static final class DownloadMediaItemUiModel.Unavailable extends com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel {
+    ctor public DownloadMediaItemUiModel.Unavailable(com.google.android.horologist.media.ui.state.model.MediaItemUiModel mediaItemUiModel);
+    method public com.google.android.horologist.media.ui.state.model.MediaItemUiModel component1();
+    method public com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel.Unavailable copy(com.google.android.horologist.media.ui.state.model.MediaItemUiModel mediaItemUiModel);
+    property public com.google.android.horologist.media.ui.state.model.MediaItemUiModel mediaItemUiModel;
+  }
 
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public abstract sealed class DownloadPlaylistUiModel {
     method public com.google.android.horologist.media.ui.state.model.PlaylistUiModel getPlaylistUiModel();

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/EntityScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/EntityScreenPreview.kt
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistMediaUiApi::class)
+
+package com.google.android.horologist.media.ui.screens.entity
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.wear.compose.material.rememberScalingLazyListState
+import com.google.android.horologist.compose.tools.WearPreviewDevices
+import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
+import com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel
+import com.google.android.horologist.media.ui.state.model.MediaItemUiModel
+import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
+import com.google.android.horologist.media.ui.utils.rememberVectorPainter
+
+@WearPreviewDevices
+@Composable
+fun EntityScreenPreviewLoading() {
+    EntityScreen(
+        playlistUiModel = playlistUiModel,
+        entityScreenState = EntityScreenState.Loading,
+        onDownloadClick = { },
+        onDownloadItemClick = { },
+        onShuffleClick = { },
+        onPlayClick = { },
+        focusRequester = FocusRequester(),
+        scalingLazyListState = rememberScalingLazyListState(),
+    )
+}
+
+@WearPreviewDevices
+@Composable
+fun EntityScreenPreviewLoadedNoneDownloaded() {
+    EntityScreen(
+        playlistUiModel = playlistUiModel,
+        entityScreenState = EntityScreenState.Loaded(
+            downloadList = unavailableDownloads,
+            downloading = false,
+        ),
+        onDownloadClick = { },
+        onDownloadItemClick = { },
+        onShuffleClick = { },
+        onPlayClick = { },
+        focusRequester = FocusRequester(),
+        scalingLazyListState = rememberScalingLazyListState(),
+        downloadItemArtworkPlaceholder = rememberVectorPainter(
+            image = Icons.Default.MusicNote,
+            tintColor = Color.Blue,
+        )
+    )
+}
+
+@WearPreviewDevices
+@Composable
+fun EntityScreenPreviewLoadedNoneDownloadedDownloading() {
+    EntityScreen(
+        playlistUiModel = playlistUiModel,
+        entityScreenState = EntityScreenState.Loaded(
+            downloadList = unavailableDownloads,
+            downloading = true,
+        ),
+        onDownloadClick = { },
+        onDownloadItemClick = { },
+        onShuffleClick = { },
+        onPlayClick = { },
+        focusRequester = FocusRequester(),
+        scalingLazyListState = rememberScalingLazyListState(),
+        downloadItemArtworkPlaceholder = rememberVectorPainter(
+            image = Icons.Default.MusicNote,
+            tintColor = Color.Blue,
+        )
+    )
+}
+
+@WearPreviewDevices
+@Composable
+fun EntityScreenPreviewLoadedPartiallyDownloaded() {
+    EntityScreen(
+        playlistUiModel = playlistUiModel,
+        entityScreenState = EntityScreenState.Loaded(
+            downloadList = mixedDownloads,
+            downloading = false,
+        ),
+        onDownloadClick = { },
+        onDownloadItemClick = { },
+        onShuffleClick = { },
+        onPlayClick = { },
+        focusRequester = FocusRequester(),
+        scalingLazyListState = rememberScalingLazyListState(),
+        downloadItemArtworkPlaceholder = rememberVectorPainter(
+            image = Icons.Default.MusicNote,
+            tintColor = Color.Blue,
+        )
+    )
+}
+
+@WearPreviewDevices
+@Composable
+fun EntityScreenPreviewLoadedPartiallyDownloadedDownloading() {
+    EntityScreen(
+        playlistUiModel = playlistUiModel,
+        entityScreenState = EntityScreenState.Loaded(
+            downloadList = mixedDownloads,
+            downloading = true,
+        ),
+        onDownloadClick = { },
+        onDownloadItemClick = { },
+        onShuffleClick = { },
+        onPlayClick = { },
+        focusRequester = FocusRequester(),
+        scalingLazyListState = rememberScalingLazyListState(),
+        downloadItemArtworkPlaceholder = rememberVectorPainter(
+            image = Icons.Default.MusicNote,
+            tintColor = Color.Blue,
+        )
+    )
+}
+
+@WearPreviewDevices
+@Composable
+fun EntityScreenPreviewLoadedFullyDownloaded() {
+    EntityScreen(
+        playlistUiModel = playlistUiModel,
+        entityScreenState = EntityScreenState.Loaded(
+            downloadList = availableDownloads,
+            downloading = false,
+        ),
+        onDownloadClick = { },
+        onDownloadItemClick = { },
+        onShuffleClick = { },
+        onPlayClick = { },
+        focusRequester = FocusRequester(),
+        scalingLazyListState = rememberScalingLazyListState(),
+        downloadItemArtworkPlaceholder = rememberVectorPainter(
+            image = Icons.Default.MusicNote,
+            tintColor = Color.Blue,
+        )
+    )
+}
+
+private val unavailableDownloads = listOf(
+    DownloadMediaItemUiModel.Unavailable(
+        MediaItemUiModel(
+            id = "id",
+            title = "Song name",
+            artist = "Artist name",
+            artworkUri = "artworkUri",
+        )
+    ),
+    DownloadMediaItemUiModel.Unavailable(
+        MediaItemUiModel(
+            id = "id 2",
+            title = "Song name 2",
+            artist = "Artist name 2",
+            artworkUri = "artworkUri",
+        )
+    ),
+)
+
+private val playlistUiModel = PlaylistUiModel(
+    id = "id",
+    title = "Playlist name"
+)
+
+private val mixedDownloads = listOf(
+    DownloadMediaItemUiModel.Available(
+        MediaItemUiModel(
+            id = "id",
+            title = "Song name",
+            artist = "Artist name",
+            artworkUri = "artworkUri",
+        )
+    ),
+    DownloadMediaItemUiModel.Unavailable(
+        MediaItemUiModel(
+            id = "id 2",
+            title = "Song name 2",
+            artist = "Artist name 2",
+            artworkUri = "artworkUri",
+        )
+    ),
+)
+
+private val availableDownloads = listOf(
+    DownloadMediaItemUiModel.Available(
+        MediaItemUiModel(
+            id = "id",
+            title = "Song name",
+            artist = "Artist name",
+            artworkUri = "artworkUri",
+        )
+    ),
+    DownloadMediaItemUiModel.Available(
+        MediaItemUiModel(
+            id = "id 2",
+            title = "Song name 2",
+            artist = "Artist name 2",
+            artworkUri = "artworkUri",
+        )
+    ),
+)

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/EntityScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/EntityScreen.kt
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.screens.entity
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.DownloadDone
+import androidx.compose.material.icons.filled.Downloading
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Shuffle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.ScalingLazyColumn
+import androidx.wear.compose.material.ScalingLazyListState
+import com.google.android.horologist.compose.navscaffold.scrollableColumn
+import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
+import com.google.android.horologist.media.ui.R
+import com.google.android.horologist.media.ui.components.base.SecondaryPlaceholderChip
+import com.google.android.horologist.media.ui.components.base.StandardButton
+import com.google.android.horologist.media.ui.components.base.StandardButtonType
+import com.google.android.horologist.media.ui.components.base.StandardChip
+import com.google.android.horologist.media.ui.components.base.Title
+import com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel
+import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
+
+@ExperimentalHorologistMediaUiApi
+@Composable
+public fun EntityScreen(
+    playlistUiModel: PlaylistUiModel,
+    entityScreenState: EntityScreenState,
+    onDownloadClick: (PlaylistUiModel) -> Unit,
+    onDownloadItemClick: (DownloadMediaItemUiModel) -> Unit,
+    onShuffleClick: (PlaylistUiModel) -> Unit,
+    onPlayClick: (PlaylistUiModel) -> Unit,
+    focusRequester: FocusRequester,
+    scalingLazyListState: ScalingLazyListState,
+    modifier: Modifier = Modifier,
+    defaultMediaTitle: String = "",
+    downloadItemArtworkPlaceholder: Painter? = null
+) {
+    ScalingLazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .scrollableColumn(focusRequester, scalingLazyListState),
+        state = scalingLazyListState,
+    ) {
+        item {
+            Title(
+                text = playlistUiModel.title,
+                modifier = Modifier.padding(bottom = 12.dp),
+            )
+        }
+
+        when (entityScreenState) {
+
+            is EntityScreenState.Loading -> {
+                item {
+                    DownloadButton(
+                        playlistUiModel = playlistUiModel,
+                        onDownloadClick = onDownloadClick,
+                        enabled = false
+                    )
+                }
+
+                items(count = 2) {
+                    SecondaryPlaceholderChip()
+                }
+            }
+
+            is EntityScreenState.Loaded -> {
+                if (entityScreenState.downloadsState == EntityScreenState.Loaded.DownloadsState.None) {
+                    if (entityScreenState.downloading) {
+                        item {
+                            StandardChip(
+                                label = stringResource(id = R.string.horologist_entity_button_downloading),
+                                onClick = { onDownloadClick(playlistUiModel) },
+                                modifier = Modifier.padding(bottom = 16.dp),
+                                icon = Icons.Default.Download,
+                            )
+                        }
+                    } else {
+                        item {
+                            DownloadButton(
+                                playlistUiModel = playlistUiModel,
+                                onDownloadClick = onDownloadClick
+                            )
+                        }
+                    }
+                } else {
+                    item {
+                        Row(
+                            modifier = Modifier
+                                .padding(bottom = 16.dp)
+                                .height(52.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            FirstButton(
+                                downloadsState = entityScreenState.downloadsState,
+                                downloading = entityScreenState.downloading,
+                                playlistUiModel = playlistUiModel,
+                                onDownloadClick = onDownloadClick,
+                                modifier = Modifier
+                                    .padding(start = 6.dp)
+                                    .weight(weight = 0.3F, fill = false)
+                            )
+
+                            StandardButton(
+                                imageVector = Icons.Default.Shuffle,
+                                contentDescription = stringResource(id = R.string.horologist_entity_button_shuffle_content_description),
+                                onClick = { onShuffleClick(playlistUiModel) },
+                                modifier = Modifier
+                                    .padding(start = 6.dp)
+                                    .weight(weight = 0.3F, fill = false)
+                            )
+
+                            StandardButton(
+                                imageVector = Icons.Filled.PlayArrow,
+                                contentDescription = stringResource(id = R.string.horologist_entity_button_play_content_description),
+                                onClick = { onPlayClick(playlistUiModel) },
+                                modifier = Modifier
+                                    .padding(start = 6.dp)
+                                    .weight(weight = 0.3F, fill = false)
+                            )
+                        }
+                    }
+                }
+
+                items(count = entityScreenState.downloadList.size) { index ->
+                    val downloadMediaItemUiModel = entityScreenState.downloadList[index]
+                    val mediaItemUiModel = downloadMediaItemUiModel.mediaItemUiModel
+
+                    StandardChip(
+                        label = mediaItemUiModel.title ?: defaultMediaTitle,
+                        onClick = { onDownloadItemClick(downloadMediaItemUiModel) },
+                        secondaryLabel = mediaItemUiModel.artist,
+                        icon = mediaItemUiModel.artworkUri,
+                        largeIcon = true,
+                        placeholder = downloadItemArtworkPlaceholder,
+                        enabled = downloadMediaItemUiModel is DownloadMediaItemUiModel.Available,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DownloadButton(
+    playlistUiModel: PlaylistUiModel,
+    onDownloadClick: (PlaylistUiModel) -> Unit,
+    enabled: Boolean = true,
+) {
+    StandardChip(
+        label = stringResource(id = R.string.horologist_entity_button_download),
+        onClick = { onDownloadClick(playlistUiModel) },
+        modifier = Modifier.padding(bottom = 16.dp),
+        icon = Icons.Default.Download,
+        enabled = enabled
+    )
+}
+
+@ExperimentalHorologistMediaUiApi
+@Composable
+private fun FirstButton(
+    downloadsState: EntityScreenState.Loaded.DownloadsState,
+    downloading: Boolean,
+    playlistUiModel: PlaylistUiModel,
+    onDownloadClick: (PlaylistUiModel) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val (icon, contentDescription) = when (downloadsState) {
+        EntityScreenState.Loaded.DownloadsState.Partially -> {
+            if (downloading) {
+                Pair(
+                    Icons.Default.Downloading,
+                    R.string.horologist_entity_button_downloading_content_description,
+                )
+            } else {
+                Pair(
+                    Icons.Default.Download,
+                    R.string.horologist_entity_button_download_content_description,
+                )
+            }
+        }
+        EntityScreenState.Loaded.DownloadsState.Fully -> {
+            Pair(
+                Icons.Default.DownloadDone,
+                R.string.horologist_entity_button_download_done_content_description,
+            )
+        }
+        else -> {
+            error("Invalid state to be used with this button")
+        }
+    }
+
+    StandardButton(
+        imageVector = icon,
+        contentDescription = stringResource(id = contentDescription),
+        onClick = { onDownloadClick(playlistUiModel) },
+        modifier = modifier,
+        buttonType = StandardButtonType.Secondary,
+    )
+}
+
+/**
+ * Represents the state of [EntityScreen].
+ */
+@ExperimentalHorologistMediaUiApi
+public sealed class EntityScreenState {
+
+    public object Loading : EntityScreenState()
+
+    public data class Loaded(
+        val downloadList: List<DownloadMediaItemUiModel>,
+        val downloading: Boolean = false
+    ) : EntityScreenState() {
+
+        internal val downloadsState: DownloadsState
+
+        init {
+            downloadsState = if (downloadList.isEmpty()) {
+                DownloadsState.Fully
+            } else {
+                var none = true
+                var fully = true
+
+                downloadList.forEach {
+                    if (it is DownloadMediaItemUiModel.Available) none = false
+                    if (it is DownloadMediaItemUiModel.Unavailable) fully = false
+                }
+
+                when {
+                    !none && !fully -> DownloadsState.Partially
+                    none -> DownloadsState.None
+                    else -> DownloadsState.Fully
+                }
+            }
+        }
+
+        /**
+         * Represents the state of the downloads.
+         */
+        internal enum class DownloadsState {
+            None,
+            Partially,
+            Fully
+        }
+    }
+}

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/DownloadMediaItemUiModel.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/DownloadMediaItemUiModel.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.state.model
+
+import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
+
+@ExperimentalHorologistMediaUiApi
+public sealed class DownloadMediaItemUiModel(
+    public open val mediaItemUiModel: MediaItemUiModel
+) {
+    public data class Available(
+        override val mediaItemUiModel: MediaItemUiModel
+    ) : DownloadMediaItemUiModel(mediaItemUiModel = mediaItemUiModel)
+
+    public data class Unavailable(
+        override val mediaItemUiModel: MediaItemUiModel
+    ) : DownloadMediaItemUiModel(mediaItemUiModel = mediaItemUiModel)
+}

--- a/media-ui/src/main/res/values/strings.xml
+++ b/media-ui/src/main/res/values/strings.xml
@@ -33,6 +33,13 @@
     <string name="horologist_browse_library_playlists">Playlists</string>
     <string name="horologist_browse_library_settings">Settings</string>
     <string name="horologist_browse_playlist_title">Playlist</string>
+    <string name="horologist_entity_button_download">Download to your watch</string>
+    <string name="horologist_entity_button_downloading">Downloading…</string>
+    <string name="horologist_entity_button_download_content_description">Download</string>
+    <string name="horologist_entity_button_downloading_content_description">Downloading</string>
+    <string name="horologist_entity_button_download_done_content_description">Download done</string>
+    <string name="horologist_entity_button_shuffle_content_description">Shuffle</string>
+    <string name="horologist_entity_button_play_content_description">Play</string>
     <string name="horologist_preview_app_name">UAMP</string>
     <string name="horologist_preview_favorites">Favorites</string>
 </resources>

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/screens/entity/EntityScreenStateTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/screens/entity/EntityScreenStateTest.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistMediaUiApi::class)
+
+package com.google.android.horologist.media.ui.screens.entity
+
+import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
+import com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel
+import com.google.android.horologist.media.ui.state.model.MediaItemUiModel
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class EntityScreenStateTest {
+
+    @Test
+    fun givenUnavailableDownloads_thenDownloadStateIsNone() {
+        // given
+        val downloads = listOf(
+            DownloadMediaItemUiModel.Unavailable(
+                MediaItemUiModel(
+                    id = "id",
+                    title = "Song name",
+                    artist = "Artist name",
+                    artworkUri = "artworkUri",
+                )
+            ),
+            DownloadMediaItemUiModel.Unavailable(
+                MediaItemUiModel(
+                    id = "id 2",
+                    title = "Song name 2",
+                    artist = "Artist name 2",
+                    artworkUri = "artworkUri",
+                )
+            ),
+        )
+
+        // when
+        val result = EntityScreenState.Loaded(
+            downloadList = downloads,
+            downloading = false
+        ).downloadsState
+
+        // then
+        assertThat(result).isEqualTo(EntityScreenState.Loaded.DownloadsState.None)
+    }
+
+    @Test
+    fun givenMixedDownloads_thenDownloadStateIsPartially() {
+        // given
+        val downloads = listOf(
+            DownloadMediaItemUiModel.Available(
+                MediaItemUiModel(
+                    id = "id",
+                    title = "Song name",
+                    artist = "Artist name",
+                    artworkUri = "artworkUri",
+                )
+            ),
+            DownloadMediaItemUiModel.Unavailable(
+                MediaItemUiModel(
+                    id = "id 2",
+                    title = "Song name 2",
+                    artist = "Artist name 2",
+                    artworkUri = "artworkUri",
+                )
+            ),
+        )
+
+        // when
+        val result = EntityScreenState.Loaded(
+            downloadList = downloads,
+            downloading = false
+        ).downloadsState
+
+        // then
+        assertThat(result).isEqualTo(EntityScreenState.Loaded.DownloadsState.Partially)
+    }
+
+    @Test
+    fun givenAvailableDownloads_thenDownloadStateIsFully() {
+        // given
+        val downloads = listOf(
+            DownloadMediaItemUiModel.Available(
+                MediaItemUiModel(
+                    id = "id",
+                    title = "Song name",
+                    artist = "Artist name",
+                    artworkUri = "artworkUri",
+                )
+            ),
+            DownloadMediaItemUiModel.Available(
+                MediaItemUiModel(
+                    id = "id 2",
+                    title = "Song name 2",
+                    artist = "Artist name 2",
+                    artworkUri = "artworkUri",
+                )
+            ),
+        )
+
+        // when
+        val result = EntityScreenState.Loaded(
+            downloadList = downloads,
+            downloading = false
+        ).downloadsState
+
+        // then
+        assertThat(result).isEqualTo(EntityScreenState.Loaded.DownloadsState.Fully)
+    }
+
+    @Test
+    fun givenEmptyDownloads_thenDownloadStateIsFully() {
+        // given
+        val downloads = emptyList<DownloadMediaItemUiModel>()
+
+        // when
+        val result = EntityScreenState.Loaded(
+            downloadList = downloads,
+            downloading = false
+        ).downloadsState
+
+        // then
+        assertThat(result).isEqualTo(EntityScreenState.Loaded.DownloadsState.Fully)
+    }
+}


### PR DESCRIPTION
#### WHAT

Add `EntityScreen`.

![Screen Shot 2022-07-15 at 17 45 03](https://user-images.githubusercontent.com/878134/179269895-13091631-93ab-44ed-a9d7-65d25cafde33.png)

<details>
<summary>Small rounded devices preview</summary>

<img src="https://user-images.githubusercontent.com/878134/179269934-7bbd7747-a353-48ae-8c8f-00b752ef8b9d.png" />

</details>

<details>
<summary>Square device previews</summary>

<img src="https://user-images.githubusercontent.com/878134/179269964-a945a148-f08f-42ad-84c7-0429ba05eb37.png" />

</details>

**Pending** to be implemented:
- Allow customisation (slot param for title / custom chip layouts / custom buttons);
- Tests (snapshots / instrumentation tests);

#### WHY

In order to provide common screens.

#### HOW
- Add `DownloadMediaItemUiModel`;
- Add `EntityScreen` implementation;
- Add previews in `debug` folder;
- Add unit tests for `DownloadsState`;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
