### PR TITLE
Change media sample to use EntityScreen

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/repository/PlaylistDownloadRepositoryImpl.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/repository/PlaylistDownloadRepositoryImpl.kt
@@ -16,24 +16,23 @@
 
 package com.google.android.horologist.mediasample.data.repository
 
-import com.google.android.horologist.mediasample.data.datasource.PlaylistRemoteDataSource
-import com.google.android.horologist.mediasample.domain.PlaylistRepository
+import com.google.android.horologist.mediasample.domain.PlaylistDownloadRepository
 import com.google.android.horologist.mediasample.domain.model.Playlist
+import com.google.android.horologist.mediasample.domain.model.PlaylistDownload
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.flowOf
 
-class PlaylistRepositoryImpl(
-    private val playlistRemoteDataSource: PlaylistRemoteDataSource
-) : PlaylistRepository {
+class PlaylistDownloadRepositoryImpl : PlaylistDownloadRepository {
 
-    // temporary implementation of cache
-    private lateinit var playlistCache: List<Playlist>
-
-    override suspend fun getPlaylist(id: String): Playlist? =
-        playlistCache.firstOrNull { it.id == id }
-
-    override fun getPlaylists(): Flow<List<Playlist>> =
-        playlistRemoteDataSource.getPlaylists().onEach {
-            playlistCache = it
-        }
+    override fun get(playlist: Playlist): Flow<PlaylistDownload> = flowOf(
+        PlaylistDownload(
+            playlist = playlist,
+            buildList {
+                playlist.mediaItems.forEach {
+                    // This is a fake implementation until downloads feature is implemented
+                    add(Pair(it, PlaylistDownload.Status.Idle))
+                }
+            }
+        )
+    )
 }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/MediaApplicationContainer.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/MediaApplicationContainer.kt
@@ -46,7 +46,9 @@ import com.google.android.horologist.mediasample.components.MediaApplication
 import com.google.android.horologist.mediasample.components.PlaybackService
 import com.google.android.horologist.mediasample.data.api.UampService
 import com.google.android.horologist.mediasample.data.datasource.PlaylistRemoteDataSource
+import com.google.android.horologist.mediasample.data.repository.PlaylistDownloadRepositoryImpl
 import com.google.android.horologist.mediasample.data.repository.PlaylistRepositoryImpl
+import com.google.android.horologist.mediasample.domain.PlaylistDownloadRepository
 import com.google.android.horologist.mediasample.domain.PlaylistRepository
 import com.google.android.horologist.mediasample.domain.SettingsRepository
 import com.google.android.horologist.mediasample.system.Logging
@@ -206,6 +208,10 @@ class MediaApplicationContainer(
         )
     }
 
+    val playlistDownloadRepository: PlaylistDownloadRepository by lazy {
+        PlaylistDownloadRepositoryImpl()
+    }
+
     val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 
     // Confusingly the result of allowThreadDiskWrites is the old policy,
@@ -242,5 +248,7 @@ class MediaApplicationContainer(
         val VibratorKey = object : CreationExtras.Key<Vibrator> {}
         val SettingsRepositoryKey = object : CreationExtras.Key<SettingsRepository> {}
         val PlaylistRepositoryKey = object : CreationExtras.Key<PlaylistRepository> {}
+        val PlaylistDownloadRepositoryKey =
+            object : CreationExtras.Key<PlaylistDownloadRepository> {}
     }
 }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/ViewModelModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/ViewModelModule.kt
@@ -94,6 +94,8 @@ class ViewModelModule(
             mediaApplicationContainer.snackbarManager
         creationExtras[MediaApplicationContainer.PlaylistRepositoryKey] =
             mediaApplicationContainer.playlistRepository
+        creationExtras[MediaApplicationContainer.PlaylistDownloadRepositoryKey] =
+            mediaApplicationContainer.playlistDownloadRepository
     }
 
     override fun close() {

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/PlaylistDownloadRepository.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/PlaylistDownloadRepository.kt
@@ -14,26 +14,16 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.mediasample.ui.playlists
+package com.google.android.horologist.mediasample.domain
 
-import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
 import com.google.android.horologist.mediasample.domain.model.Playlist
+import com.google.android.horologist.mediasample.domain.model.PlaylistDownload
+import kotlinx.coroutines.flow.Flow
 
 /**
- * Maps a [Playlist] into a [PlaylistUiModel].
+ * A repository of [PlaylistDownload].
  */
-object PlaylistUiModelMapper {
+interface PlaylistDownloadRepository {
 
-    fun map(
-        playlist: Playlist,
-        shouldMapArtworkUri: Boolean = true,
-    ): PlaylistUiModel = PlaylistUiModel(
-        id = playlist.id,
-        title = playlist.name,
-        artworkUri = if (shouldMapArtworkUri) {
-            playlist.artworkUri
-        } else {
-            null
-        }
-    )
+    fun get(playlist: Playlist): Flow<PlaylistDownload>
 }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/model/PlaylistDownload.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/model/PlaylistDownload.kt
@@ -14,17 +14,18 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.mediasample.domain
+package com.google.android.horologist.mediasample.domain.model
 
-import com.google.android.horologist.mediasample.domain.model.Playlist
-import kotlinx.coroutines.flow.Flow
+import com.google.android.horologist.media.model.MediaItem
 
-/**
- * A repository of [Playlist].
- */
-interface PlaylistRepository {
+data class PlaylistDownload(
+    val playlist: Playlist,
+    val mediaList: List<Pair<MediaItem, Status>>
+) {
 
-    suspend fun getPlaylist(id: String): Playlist?
-
-    fun getPlaylists(): Flow<List<Playlist>>
+    enum class Status {
+        Idle,
+        InProgress,
+        Completed
+    }
 }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
@@ -30,6 +30,7 @@ import androidx.navigation.NavHostController
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.audio.ui.VolumeViewModel
 import com.google.android.horologist.compose.layout.StateUtils.rememberStateWithLifecycle
+import com.google.android.horologist.media.ui.navigation.MediaNavController.navigateToCollection
 import com.google.android.horologist.media.ui.navigation.MediaNavController.navigateToCollections
 import com.google.android.horologist.media.ui.navigation.MediaNavController.navigateToLibrary
 import com.google.android.horologist.media.ui.navigation.MediaNavController.navigateToPlayer
@@ -40,6 +41,8 @@ import com.google.android.horologist.media.ui.screens.browse.BrowseScreen
 import com.google.android.horologist.media.ui.screens.browse.BrowseScreenState
 import com.google.android.horologist.mediasample.components.MediaActivity
 import com.google.android.horologist.mediasample.ui.debug.MediaInfoTimeText
+import com.google.android.horologist.mediasample.ui.entity.UampEntityScreen
+import com.google.android.horologist.mediasample.ui.entity.UampEntityScreenViewModel
 import com.google.android.horologist.mediasample.ui.player.MediaPlayerScreenViewModel
 import com.google.android.horologist.mediasample.ui.player.UampMediaPlayerScreen
 import com.google.android.horologist.mediasample.ui.playlists.UampPlaylistsScreen
@@ -103,10 +106,23 @@ fun UampWearApp(
                     scalingLazyListState = scalingLazyListState,
                 )
             },
-            categoryEntityScreen = { _, _ ->
-                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Text("Category XXX")
-                }
+            categoryEntityScreen = { collectionId, collectionName, focusRequester, scalingLazyListState ->
+                val uampEntityScreenViewModel: UampEntityScreenViewModel = viewModel(
+                    factory = UampEntityScreenViewModel.getFactory(
+                        playlistId = collectionId,
+                        playlistName = collectionName
+                    ),
+                    extras = creationExtras(),
+                )
+
+                UampEntityScreen(
+                    uampEntityScreenViewModel = uampEntityScreenViewModel,
+                    onDownloadItemClick = { },
+                    onShuffleClick = { navController.navigateToPlayer() },
+                    onPlayClick = { navController.navigateToPlayer() },
+                    focusRequester = focusRequester,
+                    scalingLazyListState = scalingLazyListState,
+                )
             },
             mediaEntityScreen = { _, _ ->
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -122,8 +138,11 @@ fun UampWearApp(
 
                 UampPlaylistsScreen(
                     uampPlaylistsScreenViewModel = uampPlaylistsScreenViewModel,
-                    onPlaylistItemClick = {
-                        navController.navigateToPlayer()
+                    onPlaylistItemClick = { playlistUiModel ->
+                        navController.navigateToCollection(
+                            playlistUiModel.id,
+                            playlistUiModel.title
+                        )
                     },
                     focusRequester = focusRequester,
                     scalingLazyListState = scalingLazyListState

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/DownloadMediaItemUiModelMapper.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/DownloadMediaItemUiModelMapper.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.ui.entity
+
+import com.google.android.horologist.media.model.MediaItem
+import com.google.android.horologist.media.ui.state.mapper.MediaItemUiModelMapper
+import com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel
+import com.google.android.horologist.mediasample.domain.model.PlaylistDownload
+
+object DownloadMediaItemUiModelMapper {
+
+    fun map(
+        mediaItem: MediaItem,
+        status: PlaylistDownload.Status
+    ): DownloadMediaItemUiModel = when (status) {
+        PlaylistDownload.Status.Idle,
+        PlaylistDownload.Status.InProgress -> {
+            // TODO: it should map to Unavailable - this is temporary until downloads are implemented
+            DownloadMediaItemUiModel.Available(MediaItemUiModelMapper.map(mediaItem))
+        }
+        PlaylistDownload.Status.Completed -> {
+            DownloadMediaItemUiModel.Available(MediaItemUiModelMapper.map(mediaItem))
+        }
+    }
+
+    fun map(list: List<Pair<MediaItem, PlaylistDownload.Status>>): List<DownloadMediaItemUiModel> =
+        list.map { map(it.first, it.second) }
+}

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.ui.entity
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.focus.FocusRequester
+import androidx.wear.compose.material.ScalingLazyListState
+import com.google.android.horologist.compose.layout.StateUtils
+import com.google.android.horologist.media.ui.screens.entity.EntityScreen
+import com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel
+import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
+
+@Composable
+fun UampEntityScreen(
+    uampEntityScreenViewModel: UampEntityScreenViewModel,
+    onDownloadItemClick: (DownloadMediaItemUiModel) -> Unit,
+    onShuffleClick: (PlaylistUiModel) -> Unit,
+    onPlayClick: (PlaylistUiModel) -> Unit,
+    focusRequester: FocusRequester,
+    scalingLazyListState: ScalingLazyListState,
+) {
+    val uiState by StateUtils.rememberStateWithLifecycle(flow = uampEntityScreenViewModel.uiState)
+
+    EntityScreen(
+        entityScreenState = uiState,
+        onDownloadClick = {
+            // TODO - to be implemented
+        },
+        onDownloadItemClick = onDownloadItemClick,
+        onShuffleClick = {
+            uampEntityScreenViewModel.shufflePlay()
+            onShuffleClick(it)
+        },
+        onPlayClick = {
+            uampEntityScreenViewModel.play()
+            onPlayClick(it)
+        },
+        focusRequester = focusRequester,
+        scalingLazyListState = scalingLazyListState,
+    )
+}

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreenViewModel.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.ui.entity
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.google.android.horologist.media.repository.PlayerRepository
+import com.google.android.horologist.media.ui.screens.entity.EntityScreenState
+import com.google.android.horologist.mediasample.di.MediaApplicationContainer
+import com.google.android.horologist.mediasample.domain.PlaylistDownloadRepository
+import com.google.android.horologist.mediasample.domain.PlaylistRepository
+import com.google.android.horologist.mediasample.domain.model.Playlist
+import com.google.android.horologist.mediasample.domain.model.PlaylistDownload
+import com.google.android.horologist.mediasample.ui.mapper.PlaylistUiModelMapper
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+class UampEntityScreenViewModel(
+    private val playlistId: String,
+    private val playlistName: String,
+    private val playlistRepository: PlaylistRepository,
+    private val playlistDownloadRepository: PlaylistDownloadRepository,
+    private val playerRepository: PlayerRepository,
+) : ViewModel() {
+
+    private lateinit var playlistCached: Playlist
+
+    val uiState: StateFlow<EntityScreenState> = flow<EntityScreenState> {
+
+        playlistRepository.getPlaylist(playlistId)?.let { playlist ->
+            playlistCached = playlist
+
+            emitAll(
+                playlistDownloadRepository.get(playlist)
+                    .map {
+                        EntityScreenState.Loaded(
+                            playlistUiModel = PlaylistUiModelMapper.map(it.playlist),
+                            downloadList = DownloadMediaItemUiModelMapper.map(it.mediaList),
+                            downloading = it.mediaList.any { pair -> pair.second == PlaylistDownload.Status.InProgress },
+                        )
+                    }
+            )
+        }
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5000),
+        EntityScreenState.Loading(playlistName)
+    )
+
+    fun play() {
+        playerRepository.setShuffleModeEnabled(false)
+        playerRepository.setMediaItems(playlistCached.mediaItems)
+        playerRepository.prepare()
+        playerRepository.play()
+    }
+
+    fun shufflePlay() {
+        playerRepository.setShuffleModeEnabled(true)
+        playerRepository.setMediaItems(playlistCached.mediaItems)
+        playerRepository.prepare()
+        playerRepository.play()
+    }
+
+    companion object {
+        fun getFactory(playlistId: String, playlistName: String) = viewModelFactory {
+            initializer {
+                UampEntityScreenViewModel(
+                    playlistId = playlistId,
+                    playlistName = playlistName,
+                    playlistRepository = this[MediaApplicationContainer.PlaylistRepositoryKey]!!,
+                    playlistDownloadRepository = this[MediaApplicationContainer.PlaylistDownloadRepositoryKey]!!,
+                    playerRepository = this[MediaApplicationContainer.PlayerRepositoryImplKey]!!,
+                )
+            }
+        }
+    }
+}

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/mapper/PlaylistUiModelMapper.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/mapper/PlaylistUiModelMapper.kt
@@ -14,17 +14,26 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.mediasample.domain
+package com.google.android.horologist.mediasample.ui.mapper
 
+import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
 import com.google.android.horologist.mediasample.domain.model.Playlist
-import kotlinx.coroutines.flow.Flow
 
 /**
- * A repository of [Playlist].
+ * Maps a [Playlist] into a [PlaylistUiModel].
  */
-interface PlaylistRepository {
+object PlaylistUiModelMapper {
 
-    suspend fun getPlaylist(id: String): Playlist?
-
-    fun getPlaylists(): Flow<List<Playlist>>
+    fun map(
+        playlist: Playlist,
+        shouldMapArtworkUri: Boolean = true,
+    ): PlaylistUiModel = PlaylistUiModel(
+        id = playlist.id,
+        title = playlist.name,
+        artworkUri = if (shouldMapArtworkUri) {
+            playlist.artworkUri
+        } else {
+            null
+        }
+    )
 }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/UampPlaylistsScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/UampPlaylistsScreen.kt
@@ -25,12 +25,13 @@ import androidx.wear.compose.material.ScalingLazyListState
 import com.google.android.horologist.compose.layout.StateUtils.rememberStateWithLifecycle
 import com.google.android.horologist.media.ui.screens.playlist.PlaylistScreen
 import com.google.android.horologist.media.ui.screens.playlist.PlaylistScreenState
+import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
 import com.google.android.horologist.mediasample.R
 
 @Composable
 fun UampPlaylistsScreen(
     uampPlaylistsScreenViewModel: UampPlaylistsScreenViewModel,
-    onPlaylistItemClick: () -> Unit,
+    onPlaylistItemClick: (PlaylistUiModel) -> Unit,
     focusRequester: FocusRequester,
     scalingLazyListState: ScalingLazyListState,
     modifier: Modifier = Modifier,
@@ -54,8 +55,7 @@ fun UampPlaylistsScreen(
     PlaylistScreen(
         playlistScreenState = playlistScreenState,
         onPlaylistItemClick = {
-            uampPlaylistsScreenViewModel.play(it.id)
-            onPlaylistItemClick()
+            onPlaylistItemClick(it)
         },
         focusRequester = focusRequester,
         scalingLazyListState = scalingLazyListState,

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/UampPlaylistsScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/UampPlaylistsScreenViewModel.kt
@@ -20,12 +20,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import com.google.android.horologist.media.repository.PlayerRepository
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
 import com.google.android.horologist.mediasample.di.MediaApplicationContainer
 import com.google.android.horologist.mediasample.domain.PlaylistRepository
 import com.google.android.horologist.mediasample.domain.SettingsRepository
 import com.google.android.horologist.mediasample.domain.model.Playlist
+import com.google.android.horologist.mediasample.ui.mapper.PlaylistUiModelMapper
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -34,7 +34,6 @@ import kotlinx.coroutines.flow.stateIn
 
 class UampPlaylistsScreenViewModel(
     private val playlistRepository: PlaylistRepository,
-    private val playerRepository: PlayerRepository,
     private val settingsRepository: SettingsRepository,
 ) : ViewModel() {
 
@@ -62,21 +61,6 @@ class UampPlaylistsScreenViewModel(
         }
     }.stateIn(viewModelScope, started = SharingStarted.Eagerly, initialValue = UiState.Loading)
 
-    fun play(playlistId: String) {
-        val playlistList = playlists.value
-
-        if (playlistList != null) {
-            val playlist = playlistList.find { it.id == playlistId }
-                ?: playlistList.first()
-
-            playerRepository.setMediaItems(playlist.mediaItems)
-            playerRepository.prepare()
-            playerRepository.play()
-        } else {
-            // TODO warning
-        }
-    }
-
     sealed class UiState {
         object Loading : UiState()
 
@@ -90,7 +74,6 @@ class UampPlaylistsScreenViewModel(
             initializer {
                 UampPlaylistsScreenViewModel(
                     playlistRepository = this[MediaApplicationContainer.PlaylistRepositoryKey]!!,
-                    playerRepository = this[MediaApplicationContainer.PlayerRepositoryImplKey]!!,
                     settingsRepository = this[MediaApplicationContainer.SettingsRepositoryKey]!!,
                 )
             }

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -229,7 +229,7 @@ package com.google.android.horologist.media.ui.components.controls {
 package com.google.android.horologist.media.ui.navigation {
 
   public final class MediaNavController {
-    method public void navigateToCollection(androidx.navigation.NavController, String collectionId);
+    method public void navigateToCollection(androidx.navigation.NavController, String collectionId, String collectionName);
     method public void navigateToCollections(androidx.navigation.NavController);
     method public void navigateToLibrary(androidx.navigation.NavController);
     method public void navigateToMediaItem(androidx.navigation.NavController, String mediaItemId, String? collectionId);
@@ -240,7 +240,7 @@ package com.google.android.horologist.media.ui.navigation {
   }
 
   public final class MediaPlayerScaffoldKt {
-    method @androidx.compose.runtime.Composable public static void MediaPlayerScaffold(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.media.ui.snackbar.SnackbarViewModel snackbarViewModel, optional com.google.android.horologist.audio.ui.VolumeViewModel volumeViewModel, kotlin.jvm.functions.Function1<? super androidx.compose.ui.focus.FocusRequester,kotlin.Unit> playerScreen, kotlin.jvm.functions.Function2<? super androidx.compose.ui.focus.FocusRequester,? super androidx.wear.compose.material.ScalingLazyListState,kotlin.Unit> libraryScreen, kotlin.jvm.functions.Function2<? super androidx.compose.ui.focus.FocusRequester,? super androidx.wear.compose.material.ScalingLazyListState,kotlin.Unit> categoryEntityScreen, kotlin.jvm.functions.Function2<? super androidx.compose.ui.focus.FocusRequester,? super androidx.wear.compose.material.ScalingLazyListState,kotlin.Unit> mediaEntityScreen, kotlin.jvm.functions.Function2<? super androidx.compose.ui.focus.FocusRequester,? super androidx.wear.compose.material.ScalingLazyListState,kotlin.Unit> playlistsScreen, kotlin.jvm.functions.Function2<? super androidx.compose.ui.focus.FocusRequester,? super androidx.wear.compose.material.ScalingLazyListState,kotlin.Unit> settingsScreen, optional kotlin.jvm.functions.Function1<? super androidx.compose.ui.focus.FocusRequester,kotlin.Unit> volumeScreen, optional kotlin.jvm.functions.Function1<? super androidx.compose.ui.Modifier,kotlin.Unit> timeText, optional com.google.accompanist.pager.PagerState pagerState, String deepLinkPrefix, androidx.navigation.NavHostController navController, optional kotlin.jvm.functions.Function1<? super androidx.navigation.NavGraphBuilder,kotlin.Unit> additionalNavRoutes);
+    method @androidx.compose.runtime.Composable public static void MediaPlayerScaffold(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.media.ui.snackbar.SnackbarViewModel snackbarViewModel, optional com.google.android.horologist.audio.ui.VolumeViewModel volumeViewModel, kotlin.jvm.functions.Function1<? super androidx.compose.ui.focus.FocusRequester,kotlin.Unit> playerScreen, kotlin.jvm.functions.Function2<? super androidx.compose.ui.focus.FocusRequester,? super androidx.wear.compose.material.ScalingLazyListState,kotlin.Unit> libraryScreen, kotlin.jvm.functions.Function4<? super java.lang.String,? super java.lang.String,? super androidx.compose.ui.focus.FocusRequester,? super androidx.wear.compose.material.ScalingLazyListState,kotlin.Unit> categoryEntityScreen, kotlin.jvm.functions.Function2<? super androidx.compose.ui.focus.FocusRequester,? super androidx.wear.compose.material.ScalingLazyListState,kotlin.Unit> mediaEntityScreen, kotlin.jvm.functions.Function2<? super androidx.compose.ui.focus.FocusRequester,? super androidx.wear.compose.material.ScalingLazyListState,kotlin.Unit> playlistsScreen, kotlin.jvm.functions.Function2<? super androidx.compose.ui.focus.FocusRequester,? super androidx.wear.compose.material.ScalingLazyListState,kotlin.Unit> settingsScreen, optional kotlin.jvm.functions.Function1<? super androidx.compose.ui.focus.FocusRequester,kotlin.Unit> volumeScreen, optional kotlin.jvm.functions.Function1<? super androidx.compose.ui.Modifier,kotlin.Unit> timeText, optional com.google.accompanist.pager.PagerState pagerState, String deepLinkPrefix, androidx.navigation.NavHostController navController, optional kotlin.jvm.functions.Function1<? super androidx.navigation.NavGraphBuilder,kotlin.Unit> additionalNavRoutes);
   }
 
   public abstract sealed class NavigationScreens {
@@ -252,11 +252,11 @@ package com.google.android.horologist.media.ui.navigation {
   }
 
   public static final class NavigationScreens.Collection extends com.google.android.horologist.media.ui.navigation.NavigationScreens {
-    method public String destination(String id);
-    method public String getId();
+    method public String destination(String id, String name);
     property public java.util.List<androidx.navigation.NamedNavArgument> arguments;
-    property public final String id;
     field public static final com.google.android.horologist.media.ui.navigation.NavigationScreens.Collection INSTANCE;
+    field public static final String id = "id";
+    field public static final String name = "name";
   }
 
   public static final class NavigationScreens.Collections extends com.google.android.horologist.media.ui.navigation.NavigationScreens {
@@ -342,25 +342,32 @@ package com.google.android.horologist.media.ui.screens.browse {
 package com.google.android.horologist.media.ui.screens.entity {
 
   public final class EntityScreenKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void EntityScreen(com.google.android.horologist.media.ui.state.model.PlaylistUiModel playlistUiModel, com.google.android.horologist.media.ui.screens.entity.EntityScreenState entityScreenState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onDownloadClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel,kotlin.Unit> onDownloadItemClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onShuffleClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onPlayClick, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.wear.compose.material.ScalingLazyListState scalingLazyListState, optional androidx.compose.ui.Modifier modifier, optional String defaultMediaTitle, optional androidx.compose.ui.graphics.painter.Painter? downloadItemArtworkPlaceholder);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void EntityScreen(com.google.android.horologist.media.ui.screens.entity.EntityScreenState entityScreenState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onDownloadClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel,kotlin.Unit> onDownloadItemClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onShuffleClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onPlayClick, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.wear.compose.material.ScalingLazyListState scalingLazyListState, optional androidx.compose.ui.Modifier modifier, optional String defaultMediaTitle, optional androidx.compose.ui.graphics.painter.Painter? downloadItemArtworkPlaceholder);
   }
 
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public abstract sealed class EntityScreenState {
   }
 
   public static final class EntityScreenState.Loaded extends com.google.android.horologist.media.ui.screens.entity.EntityScreenState {
-    ctor public EntityScreenState.Loaded(java.util.List<? extends com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel> downloadList, optional boolean downloading);
-    method public java.util.List<com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel> component1();
-    method public boolean component2();
-    method public com.google.android.horologist.media.ui.screens.entity.EntityScreenState.Loaded copy(java.util.List<? extends com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel> downloadList, boolean downloading);
+    ctor public EntityScreenState.Loaded(com.google.android.horologist.media.ui.state.model.PlaylistUiModel playlistUiModel, java.util.List<? extends com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel> downloadList, optional boolean downloading);
+    method public com.google.android.horologist.media.ui.state.model.PlaylistUiModel component1();
+    method public java.util.List<com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel> component2();
+    method public boolean component3();
+    method public com.google.android.horologist.media.ui.screens.entity.EntityScreenState.Loaded copy(com.google.android.horologist.media.ui.state.model.PlaylistUiModel playlistUiModel, java.util.List<? extends com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel> downloadList, boolean downloading);
     method public java.util.List<com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel> getDownloadList();
     method public boolean getDownloading();
+    method public com.google.android.horologist.media.ui.state.model.PlaylistUiModel getPlaylistUiModel();
     property public final java.util.List<com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel> downloadList;
     property public final boolean downloading;
+    property public final com.google.android.horologist.media.ui.state.model.PlaylistUiModel playlistUiModel;
   }
 
   public static final class EntityScreenState.Loading extends com.google.android.horologist.media.ui.screens.entity.EntityScreenState {
-    field public static final com.google.android.horologist.media.ui.screens.entity.EntityScreenState.Loading INSTANCE;
+    ctor public EntityScreenState.Loading(String playlistName);
+    method public String component1();
+    method public com.google.android.horologist.media.ui.screens.entity.EntityScreenState.Loading copy(String playlistName);
+    method public String getPlaylistName();
+    property public final String playlistName;
   }
 
 }

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/EntityScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/EntityScreenPreview.kt
@@ -35,8 +35,7 @@ import com.google.android.horologist.media.ui.utils.rememberVectorPainter
 @Composable
 fun EntityScreenPreviewLoading() {
     EntityScreen(
-        playlistUiModel = playlistUiModel,
-        entityScreenState = EntityScreenState.Loading,
+        entityScreenState = EntityScreenState.Loading("Artist name"),
         onDownloadClick = { },
         onDownloadItemClick = { },
         onShuffleClick = { },
@@ -50,8 +49,8 @@ fun EntityScreenPreviewLoading() {
 @Composable
 fun EntityScreenPreviewLoadedNoneDownloaded() {
     EntityScreen(
-        playlistUiModel = playlistUiModel,
         entityScreenState = EntityScreenState.Loaded(
+            playlistUiModel = playlistUiModel,
             downloadList = unavailableDownloads,
             downloading = false,
         ),
@@ -72,8 +71,8 @@ fun EntityScreenPreviewLoadedNoneDownloaded() {
 @Composable
 fun EntityScreenPreviewLoadedNoneDownloadedDownloading() {
     EntityScreen(
-        playlistUiModel = playlistUiModel,
         entityScreenState = EntityScreenState.Loaded(
+            playlistUiModel = playlistUiModel,
             downloadList = unavailableDownloads,
             downloading = true,
         ),
@@ -94,8 +93,8 @@ fun EntityScreenPreviewLoadedNoneDownloadedDownloading() {
 @Composable
 fun EntityScreenPreviewLoadedPartiallyDownloaded() {
     EntityScreen(
-        playlistUiModel = playlistUiModel,
         entityScreenState = EntityScreenState.Loaded(
+            playlistUiModel = playlistUiModel,
             downloadList = mixedDownloads,
             downloading = false,
         ),
@@ -116,8 +115,8 @@ fun EntityScreenPreviewLoadedPartiallyDownloaded() {
 @Composable
 fun EntityScreenPreviewLoadedPartiallyDownloadedDownloading() {
     EntityScreen(
-        playlistUiModel = playlistUiModel,
         entityScreenState = EntityScreenState.Loaded(
+            playlistUiModel = playlistUiModel,
             downloadList = mixedDownloads,
             downloading = true,
         ),
@@ -138,8 +137,8 @@ fun EntityScreenPreviewLoadedPartiallyDownloadedDownloading() {
 @Composable
 fun EntityScreenPreviewLoadedFullyDownloaded() {
     EntityScreen(
-        playlistUiModel = playlistUiModel,
         entityScreenState = EntityScreenState.Loaded(
+            playlistUiModel = playlistUiModel,
             downloadList = availableDownloads,
             downloading = false,
         ),

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/navigation/MediaNavController.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/navigation/MediaNavController.kt
@@ -17,16 +17,24 @@
 package com.google.android.horologist.media.ui.navigation
 
 import androidx.navigation.NavController
+import java.net.URLEncoder
 
 /**
  * Domain focused NavController extensions that links to the screens of a typical Media app.
  */
 public object MediaNavController {
+    private const val UTF_8 = "UTF-8"
+
     /**
      * Navigate to a single collection such as a playlist.
      */
-    public fun NavController.navigateToCollection(collectionId: String) {
-        navigate(NavigationScreens.Collection.destination(collectionId))
+    public fun NavController.navigateToCollection(collectionId: String, collectionName: String) {
+        navigate(
+            NavigationScreens.Collection.destination(
+                collectionId,
+                URLEncoder.encode(collectionName, UTF_8),
+            )
+        )
     }
 
     /**

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/navigation/MediaPlayerScaffold.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/navigation/MediaPlayerScaffold.kt
@@ -63,7 +63,7 @@ public fun MediaPlayerScaffold(
     volumeViewModel: VolumeViewModel = viewModel(factory = VolumeViewModel.Factory),
     playerScreen: @Composable (FocusRequester) -> Unit,
     libraryScreen: @Composable (FocusRequester, ScalingLazyListState) -> Unit,
-    categoryEntityScreen: @Composable (FocusRequester, ScalingLazyListState) -> Unit,
+    categoryEntityScreen: @Composable (String, String, FocusRequester, ScalingLazyListState) -> Unit,
     mediaEntityScreen: @Composable (FocusRequester, ScalingLazyListState) -> Unit,
     playlistsScreen: @Composable (FocusRequester, ScalingLazyListState) -> Unit,
     settingsScreen: @Composable (FocusRequester, ScalingLazyListState) -> Unit,
@@ -159,8 +159,19 @@ public fun MediaPlayerScaffold(
             arguments = NavigationScreens.Collection.arguments,
             deepLinks = NavigationScreens.Collection.deepLinks(deepLinkPrefix),
             scrollStateBuilder = { ScalingLazyListState() }
-        ) {
-            categoryEntityScreen(it.viewModel.focusRequester, it.scrollableState)
+        ) { scaffoldContext ->
+            val arguments = scaffoldContext.backStackEntry.arguments
+            val id = arguments?.getString(NavigationScreens.Collection.id)
+            val name = arguments?.getString(NavigationScreens.Collection.name)
+            checkNotNull(id)
+            checkNotNull(name)
+
+            categoryEntityScreen(
+                id,
+                name,
+                scaffoldContext.viewModel.focusRequester,
+                scaffoldContext.scrollableState
+            )
         }
 
         additionalNavRoutes()

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/navigation/NavigationScreens.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/navigation/NavigationScreens.kt
@@ -106,20 +106,25 @@ public sealed class NavigationScreens(
         public fun destination(): String = navRoute
     }
 
-    public object Collection : NavigationScreens("collection?id={id}") {
-        public fun destination(id: String): String = "collection?&id=$id"
+    public object Collection : NavigationScreens("collection?id={id}&name={name}") {
 
-        public val id: String = "id"
+        public const val id: String = "id"
+        public const val name: String = "name"
+
+        public fun destination(id: String, name: String): String = "collection?&id=$id&name=$name"
 
         override fun deepLinks(deepLinkPrefix: String): List<NavDeepLink> = listOf(
             navDeepLink {
-                uriPattern = "$deepLinkPrefix/collection?id={id}"
+                uriPattern = "$deepLinkPrefix/collection?id={id}&name={name}"
             }
         )
 
         override val arguments: List<NamedNavArgument>
             get() = listOf(
                 navArgument(id) {
+                    type = NavType.StringType
+                },
+                navArgument(name) {
                     type = NavType.StringType
                 }
             )

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/screens/entity/EntityScreenStateTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/screens/entity/EntityScreenStateTest.kt
@@ -21,6 +21,7 @@ package com.google.android.horologist.media.ui.screens.entity
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.state.model.DownloadMediaItemUiModel
 import com.google.android.horologist.media.ui.state.model.MediaItemUiModel
+import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
@@ -50,6 +51,10 @@ class EntityScreenStateTest {
 
         // when
         val result = EntityScreenState.Loaded(
+            playlistUiModel = PlaylistUiModel(
+                id = "id",
+                title = "title",
+            ),
             downloadList = downloads,
             downloading = false
         ).downloadsState
@@ -82,6 +87,10 @@ class EntityScreenStateTest {
 
         // when
         val result = EntityScreenState.Loaded(
+            playlistUiModel = PlaylistUiModel(
+                id = "id",
+                title = "title",
+            ),
             downloadList = downloads,
             downloading = false
         ).downloadsState
@@ -114,6 +123,10 @@ class EntityScreenStateTest {
 
         // when
         val result = EntityScreenState.Loaded(
+            playlistUiModel = PlaylistUiModel(
+                id = "id",
+                title = "title",
+            ),
             downloadList = downloads,
             downloading = false
         ).downloadsState
@@ -129,6 +142,10 @@ class EntityScreenStateTest {
 
         // when
         val result = EntityScreenState.Loaded(
+            playlistUiModel = PlaylistUiModel(
+                id = "id",
+                title = "title",
+            ),
             downloadList = downloads,
             downloading = false
         ).downloadsState


### PR DESCRIPTION
#### WHAT

Change media sample app to use `EntityScreen`.

![Screenshot_20220718_210317](https://user-images.githubusercontent.com/878134/179607554-b103a434-2a28-46c5-bc3b-0042aee97d6b.png)

Download is **not** implemented yet.

#### HOW

<details>
<summary>Change song chip style of `EntityScreen` to Secondary to match Figma design</summary>

<img src="https://user-images.githubusercontent.com/878134/179606437-ff99c793-17dd-40e3-8897-ac4e6cb02a1d.png" />

</details>

- Add `UampEntityScreen`;
- Add `PlaylistDownload` domain model;
- Add `PlaylistDownloadRepository` and `PlaylistDownloadRepositoryImpl` with a fake implementation of retrieval of downloads;
- Add a temporary "caching" mechanism to `PlaylistRepositoryImpl` in order to be able to retrieve playlist when navigating to `EntityScreen`;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
