### PR TITLE
Do not run tests with LargeTest annotation in CI

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -100,7 +100,8 @@ if [[ -z "$TASK" ]]; then
 fi
 
 if [ "$DEVICE" = true ]; then
-  TEST_OPTIONS="-Pandroid.testInstrumentationRunnerArguments.size=small,medium --no-parallel"
+  TEST_OPTIONS="-Pandroid.testInstrumentationRunnerArguments.size=small"
+  TEST_OPTIONS="$TEST_OPTIONS -Pandroid.testInstrumentationRunnerArguments.size=medium --no-parallel"
 else
   TEST_OPTIONS=""
 fi


### PR DESCRIPTION
#### WHAT

Do not run tests with LargeTest annotation in CI

#### WHY

Fixes https://github.com/google/horologist/issues/333

#### HOW

Pass two params for "size" argument, instead of a single one with two values.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
