### PR TITLE
Run instrumentation tests concurrently

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,6 @@ jobs:
 
   test:
     runs-on: macos-latest
-    needs: build
     timeout-minutes: 50
 
     strategy:
@@ -134,6 +133,11 @@ jobs:
             ~/.gradle/caches/jars-*
             ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
+
+      - name: Quick Compile
+        run: |
+          ./gradlew --scan --stacktrace \
+              compileDebugAndroidTestSources
 
       - name: Run tests
         uses: reactivecircus/android-emulator-runner@v2


### PR DESCRIPTION
#### WHAT

Run instrumentation tests earlier, but abort on any compilation issues.

#### WHY

The sequenced build, test makes CI much slower. Lint checks can fail, but we still would like signal from the tests.

#### HOW

Make the jobs independent, but avoid wasting too much time if we having a non compiling. 

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
