### PR TITLE
Split CI scripts for unit and instrumented tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,8 +60,7 @@ jobs:
 
       - name: Unit Tests
         run: |
-          ./scripts/run-tests.sh \
-              --unit-tests \
+          ./scripts/run-unit-tests.sh \
               --run-affected \
               --affected-base-ref=$BASE_REF
 
@@ -141,7 +140,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           target: android-wear
           profile: wear_round_454
-          script: ./scripts/run-tests.sh --log-file=logcat.txt --run-affected --affected-base-ref=$BASE_REF --shard-index=${{ matrix.shard }} --shard-count=2
+          script: ./scripts/run-instrumented-tests.sh --ignore-large-tests --log-file=logcat.txt --run-affected --affected-base-ref=$BASE_REF --shard-index=${{ matrix.shard }} --shard-count=2
 
       - name: Upload logs
         if: always()

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Copyright 2022 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Fail on error and print out commands
+set -ex
+
+# Parse parameters
+for i in "$@"; do
+  case $i in
+  --run-affected)
+    RUN_AFFECTED=true
+    shift
+    ;;
+  --affected-base-ref=*)
+    BASE_REF="${i#*=}"
+    shift
+    ;;
+  *)
+    echo "Unknown option"
+    exit 1
+    ;;
+  esac
+done
+
+# If we're set to only run affected test, update the Gradle task
+if [[ ! -z "$RUN_AFFECTED" ]]; then
+  TASK="runAffectedUnitTests"
+  TASK="$TASK -Paffected_module_detector.enable"
+
+  # If we have a base branch set, add the Gradle property
+  if [[ ! -z "$BASE_REF" ]]; then
+    TASK="$TASK -Paffected_base_ref=$BASE_REF"
+  fi
+fi
+
+# If we don't have a task yet, use the defaults
+if [[ -z "$TASK" ]]; then
+  TASK="testDebug"
+fi
+
+./gradlew --scan --continue --no-configuration-cache --stacktrace $TASK


### PR DESCRIPTION
#### WHAT

Split CI scripts for unit and instrumented tests

#### WHY

Simplify script, avoid too many if conditions.

#### HOW

- Add `run-unit-tests.sh` and `run-instrumented-tests.sh`;
- Move relevant code from `run-tests.sh` into these two new files;
- Remove `run-tests.sh`;
- Update `build.yml` to call these two new files;

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
