### PR TITLE
Stop Flaky tests in CI

### DIFF
--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/controls/SeekBackButtonTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/controls/SeekBackButtonTest.kt
@@ -25,11 +25,13 @@ import androidx.compose.material.icons.filled.Replay30
 import androidx.compose.material.icons.filled.Replay5
 import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.filters.FlakyTest
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.test.toolbox.matchers.hasIconImageVector
 import org.junit.Rule
 import org.junit.Test
 
+@FlakyTest(detail = "https://github.com/google/horologist/issues/407")
 class SeekBackButtonTest {
 
     @get:Rule

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/controls/SeekForwardButtonTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/controls/SeekForwardButtonTest.kt
@@ -25,11 +25,13 @@ import androidx.compose.material.icons.filled.Forward5
 import androidx.compose.material.icons.filled.Replay
 import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.filters.FlakyTest
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.test.toolbox.matchers.hasIconImageVector
 import org.junit.Rule
 import org.junit.Test
 
+@FlakyTest(detail = "https://github.com/google/horologist/issues/407")
 class SeekForwardButtonTest {
 
     @get:Rule

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -28,12 +28,22 @@ for i in "$@"; do
     BASE_REF="${i#*=}"
     shift
     ;;
+  --run-flaky-tests)
+    RUN_FLAKY=true
+    shift
+    ;;
   *)
     echo "Unknown option"
     exit 1
     ;;
   esac
 done
+
+FILTER_OPTS=""
+# Filter out flaky tests if we're not set to run them
+if [[ -z "$RUN_FLAKY" ]]; then
+  FILTER_OPTS="$FILTER_OPTS -Pandroid.testInstrumentationRunnerArguments.notAnnotation=androidx.test.filters.FlakyTest"
+fi
 
 # If we're set to only run affected test, update the Gradle task
 if [[ ! -z "$RUN_AFFECTED" ]]; then
@@ -51,4 +61,4 @@ if [[ -z "$TASK" ]]; then
   TASK="testDebug"
 fi
 
-./gradlew --scan --continue --no-configuration-cache --stacktrace $TASK
+./gradlew --scan --continue --no-configuration-cache --stacktrace $TASK $FILTER_OPTS


### PR DESCRIPTION
#### WHAT

Skip flaky test in CI.

#### WHY

Avoid wasted times, clicking on failed builds to re-run or risk from landing with real issues.

#### HOW

From https://github.com/google/accompanist/blob/4d35f711c34abea2c79c90a11fd1ce87a63e0ffe/scripts/run-tests.sh

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
