### PR TITLE
Move to Ksp.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ plugins {
     alias(libs.plugins.kotlinGradle) apply false
     alias(libs.plugins.benManes)
     alias(libs.plugins.versionCatalogUpdate) apply false
+    alias(libs.plugins.ksp) apply false
     alias(libs.plugins.kapt) apply false
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ io-coil-kt = "2.1.0"
 junit = "4.13.2"
 kotlin = "1.6.21"
 kotlinxCoroutine = "1.6.3"
+ksp = "1.6.21-1.0.5"
 ktlint = "0.42.1"
 metalava = "0.2.1"
 moshi = "1.13.0"
@@ -133,3 +134,4 @@ kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlinGradle = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 versionCatalogUpdate = { id = "nl.littlerobots.version-catalog-update", version.ref = "versionCatalogUpdate" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/media-sample/build.gradle
+++ b/media-sample/build.gradle
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 plugins {
     id 'com.android.application'
     id 'kotlin-android'

--- a/media-sample/build.gradle
+++ b/media-sample/build.gradle
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-apply plugin: 'com.android.application'
 
-apply plugin: 'kotlin-android'
-apply plugin: "org.jetbrains.kotlin.kapt"
-
-apply plugin: 'dagger.hilt.android.plugin'
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+    id "org.jetbrains.kotlin.kapt"
+    id 'dagger.hilt.android.plugin'
+    id 'com.google.devtools.ksp'
+}
 
 Properties localProperties = new Properties()
 def localFile = project.rootProject.file('local.properties')
@@ -140,7 +142,7 @@ dependencies {
 
     implementation libs.moshi.adapters
     implementation libs.moshi.kotlin
-    kapt libs.moshi.kotlin.codegen
+    ksp libs.moshi.kotlin.codegen
 
     implementation libs.androidx.palette.ktx
 

--- a/network-awareness/build.gradle
+++ b/network-awareness/build.gradle
@@ -19,6 +19,7 @@ plugins {
     id 'kotlin-android'
     id 'org.jetbrains.dokka'
     id "org.jetbrains.kotlin.kapt"
+    id 'com.google.devtools.ksp'
 }
 
 android {
@@ -91,7 +92,7 @@ dependencies {
 
     implementation libs.room.common
     implementation libs.room.ktx
-    kapt libs.room.compiler
+    ksp libs.room.compiler
 
     debugImplementation libs.compose.ui.test.manifest
     debugImplementation libs.compose.ui.toolingpreview


### PR DESCRIPTION
#### WHAT

Advised by DevRel to move to Ksp, which would allow a Kotlin 1.7.0 upgrade at some point.
Working for Room, Moshi, but not for Dagger/Hilt.

#### WHY

https://issuetracker.google.com/issues/236612358

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
