### PR TITLE
Filter out tests annotated with FlakyTest for instrumented tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           target: android-wear
           profile: wear_round_454
-          script: ./scripts/run-instrumented-tests.sh --ignore-large-tests --log-file=logcat.txt --run-affected --affected-base-ref=$BASE_REF --shard-index=${{ matrix.shard }} --shard-count=2
+          script: ./scripts/run-instrumented-tests.sh --log-file=logcat.txt --run-affected --affected-base-ref=$BASE_REF --shard-index=${{ matrix.shard }} --shard-count=2
 
       - name: Upload logs
         if: always()

--- a/scripts/run-instrumented-tests.sh
+++ b/scripts/run-instrumented-tests.sh
@@ -43,8 +43,12 @@ for i in "$@"; do
     RUN_AFFECTED=true
     shift
     ;;
-  --ignore-large-tests)
-    IGNORE_LARGE_TESTS=true
+  --run-large-tests)
+    RUN_LARGE_TESTS=true
+    shift
+    ;;
+  --run-flaky-tests)
+    RUN_FLAKY_TESTS=true
     shift
     ;;
   --affected-base-ref=*)
@@ -65,9 +69,15 @@ fi
 
 SIZE_OPTS=""
 # Ignore large tests if we're not set to run them
-if [[ -z "$IGNORE_LARGE_TESTS" ]]; then
+if [[ -z "$RUN_LARGE_TESTS" ]]; then
   SIZE_OPTS="$SIZE_OPTS -Pandroid.testInstrumentationRunnerArguments.size=small"
   SIZE_OPTS="$SIZE_OPTS -Pandroid.testInstrumentationRunnerArguments.size=medium"
+fi
+
+FILTER_OPTS=""
+# Filter out flaky tests if we're not set to run them
+if [[ -z "$RUN_FLAKY_TESTS" ]]; then
+  FILTER_OPTS="$FILTER_OPTS -Pandroid.testInstrumentationRunnerArguments.notAnnotation=androidx.test.filters.FlakyTest"
 fi
 
 # If we're set to only run affected test, update the Gradle task
@@ -94,4 +104,4 @@ if [ "$SHARD_COUNT" -gt "0" ]; then
   SHARD_OPTS="$SHARD_OPTS -Pandroid.testInstrumentationRunnerArguments.shardIndex=$SHARD_INDEX"
 fi
 
-./gradlew --scan --continue --no-configuration-cache --stacktrace --no-parallel $TASK $SIZE_OPTS $SHARD_OPTS
+./gradlew --scan --continue --no-configuration-cache --stacktrace --no-parallel $TASK $SIZE_OPTS $FILTER_OPTS $SHARD_OPTS

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -29,7 +29,7 @@ for i in "$@"; do
     shift
     ;;
   --run-flaky-tests)
-    RUN_FLAKY=true
+    RUN_FLAKY_TESTS=true
     shift
     ;;
   *)
@@ -41,7 +41,7 @@ done
 
 FILTER_OPTS=""
 # Filter out flaky tests if we're not set to run them
-if [[ -z "$RUN_FLAKY" ]]; then
+if [[ -z "$RUN_FLAKY_TESTS" ]]; then
   FILTER_OPTS="$FILTER_OPTS -Pandroid.testInstrumentationRunnerArguments.notAnnotation=androidx.test.filters.FlakyTest"
 fi
 


### PR DESCRIPTION
#### WHAT

Filter out tests annotated with FlakyTest for instrumented tests.

#### WHY

So they can be addressed separately without impacting our daily builds.

#### HOW

- Add script to filter in `run-instrumented-tests.sh`;
- Remove param `--ignore-large-tests` to call to `run-instrumented-tests.sh` in order to also fix https://github.com/google/horologist/issues/333#issuecomment-1190018243;

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
