### PR TITLE
Fix player state after resume

### DIFF
--- a/media-data/src/main/java/com/google/android/horologist/media/data/PlayerRepositoryImpl.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/PlayerRepositoryImpl.kt
@@ -17,6 +17,7 @@
 package com.google.android.horologist.media.data
 
 import android.util.Log
+import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import com.google.android.horologist.media.model.Command
 import com.google.android.horologist.media.model.MediaItem
@@ -105,13 +106,19 @@ public class PlayerRepositoryImpl : PlayerRepository, Closeable {
             if (PlayerStateMapper.affectsState(events)) {
                 updateState(player)
             }
+        }
 
-            if (events.contains(Player.EVENT_PLAYBACK_PARAMETERS_CHANGED)) {
-                updatePlaybackSpeed(player)
+        // Not firing on onEvents
+        override fun onShuffleModeEnabledChanged(shuffleModeEnabled: Boolean) {
+            player.value?.let {
+                updateShuffleMode(it)
             }
+        }
 
-            if (events.contains(Player.EVENT_SHUFFLE_MODE_ENABLED_CHANGED)) {
-                updateShuffleMode(player)
+        // Not firing on onEvents
+        override fun onPlaybackParametersChanged(playbackParameters: PlaybackParameters) {
+            player.value?.let {
+                updatePlaybackSpeed(it)
             }
         }
     }

--- a/media-data/src/test/java/com/google/android/horologist/media/data/PlayerRepositoryImplTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/PlayerRepositoryImplTest.kt
@@ -148,7 +148,7 @@ class PlayerRepositoryImplTest {
     }
 
     @Test
-    fun `given is connected after prepared when play until position then state is correct`() {
+    fun `given is NOT connected and played until position when connect then state is correct`() {
         // given
         val player = TestExoPlayerBuilder(context).build()
 
@@ -158,11 +158,11 @@ class PlayerRepositoryImplTest {
         player.prepare()
 
         // when
+        sut.connect(player) {}
+        // and
         player.play()
         // and
         playUntilPosition(player, 0, 5.seconds.inWholeMilliseconds)
-
-        sut.connect(player) {}
 
         // then
         assertThat(sut.currentState.value).isEqualTo(PlayerState.Playing)

--- a/media-data/src/test/java/com/google/android/horologist/media/data/PlayerRepositoryImplTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/PlayerRepositoryImplTest.kt
@@ -148,6 +148,34 @@ class PlayerRepositoryImplTest {
     }
 
     @Test
+    fun `given is connected after prepared when play until position then state is correct`() {
+        // given
+        val player = TestExoPlayerBuilder(context).build()
+
+        val mediaItem = getStubMediaItem("id")
+
+        player.setMediaItem(Media3MediaItemMapper.map(mediaItem))
+        player.prepare()
+
+        // when
+        player.play()
+        // and
+        playUntilPosition(player, 0, 5.seconds.inWholeMilliseconds)
+
+        sut.connect(player) {}
+
+        // then
+        assertThat(sut.currentState.value).isEqualTo(PlayerState.Playing)
+        assertThat(sut.currentMediaItem.value).isEqualTo(mediaItem)
+        assertThat(sut.playbackSpeed.value).isEqualTo(1f)
+        assertThat(sut.shuffleModeEnabled.value).isFalse()
+        assertThat(sut.player.value).isSameInstanceAs(player)
+        assertThat(sut.availableCommands.value).containsExactlyElementsIn(
+            listOf(Command.PlayPause, Command.SeekBack, Command.SeekForward, Command.SetShuffle)
+        )
+    }
+
+    @Test
     fun `given is connected and prepared when play until end then state is correct`() {
         // given
         val player = TestExoPlayerBuilder(context).build()


### PR DESCRIPTION
#### WHAT

Player State was not being synced correctly after resume.  

TODO - test to confirm the issue

#### WHY

When ExoPlayer was already running, it didn't send events for current state.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
