### PR TITLE
Reorganise packages of media-data

### DIFF
--- a/media-data/api/current.api
+++ b/media-data/api/current.api
@@ -1,29 +1,48 @@
 // Signature format: 4.0
 package com.google.android.horologist.media.data {
 
-  public final class CommandMapper {
-    method public com.google.android.horologist.media.model.Command map(@androidx.media3.common.Player.Command int command);
-    field public static final com.google.android.horologist.media.data.CommandMapper INSTANCE;
+  @kotlin.RequiresOptIn(message="Horologist Media is experimental. The API may be changed in the future.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention) public @interface ExperimentalHorologistMediaDataApi {
   }
 
-  @kotlin.RequiresOptIn(message="Horologist Media is experimental. The API may be changed in the future.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention) public @interface ExperimentalHorologistMediaDataApi {
+}
+
+package com.google.android.horologist.media.data.mapper {
+
+  public final class CommandMapper {
+    method public com.google.android.horologist.media.model.Command map(@androidx.media3.common.Player.Command int command);
+    field public static final com.google.android.horologist.media.data.mapper.CommandMapper INSTANCE;
   }
 
   public final class Media3MediaItemMapper {
     method public androidx.media3.common.MediaItem map(com.google.android.horologist.media.model.MediaItem mediaItem);
     method public java.util.List<androidx.media3.common.MediaItem> map(java.util.List<com.google.android.horologist.media.model.MediaItem> mediaItems);
-    field public static final com.google.android.horologist.media.data.Media3MediaItemMapper INSTANCE;
+    field public static final com.google.android.horologist.media.data.mapper.Media3MediaItemMapper INSTANCE;
   }
 
   public final class MediaItemMapper {
     method public com.google.android.horologist.media.model.MediaItem map(androidx.media3.common.MediaItem media3MediaItem, optional String defaultArtist);
-    field public static final com.google.android.horologist.media.data.MediaItemMapper INSTANCE;
+    field public static final com.google.android.horologist.media.data.mapper.MediaItemMapper INSTANCE;
   }
 
   public final class MediaItemPositionMapper {
     method public com.google.android.horologist.media.model.MediaItemPosition? map(androidx.media3.common.Player? player);
-    field public static final com.google.android.horologist.media.data.MediaItemPositionMapper INSTANCE;
+    field public static final com.google.android.horologist.media.data.mapper.MediaItemPositionMapper INSTANCE;
   }
+
+  public final class PlayerStateMapper {
+    method public boolean affectsState(androidx.media3.common.Player.Events events);
+    method public com.google.android.horologist.media.model.PlayerState map(androidx.media3.common.Player player);
+    field public static final com.google.android.horologist.media.data.mapper.PlayerStateMapper INSTANCE;
+  }
+
+  public final class SetCommandMapper {
+    method public java.util.Set<com.google.android.horologist.media.model.Command> map(androidx.media3.common.Player.Commands commands);
+    field public static final com.google.android.horologist.media.data.mapper.SetCommandMapper INSTANCE;
+  }
+
+}
+
+package com.google.android.horologist.media.data.repository {
 
   public final class PlayerRepositoryImpl implements java.io.Closeable com.google.android.horologist.media.repository.PlayerRepository {
     ctor public PlayerRepositoryImpl();
@@ -70,17 +89,6 @@ package com.google.android.horologist.media.data {
     property public final kotlinx.coroutines.flow.StateFlow<java.lang.Float> playbackSpeed;
     property public final kotlinx.coroutines.flow.StateFlow<androidx.media3.common.Player> player;
     property public kotlinx.coroutines.flow.StateFlow<java.lang.Boolean> shuffleModeEnabled;
-  }
-
-  public final class PlayerStateMapper {
-    method public boolean affectsState(androidx.media3.common.Player.Events events);
-    method public com.google.android.horologist.media.model.PlayerState map(androidx.media3.common.Player player);
-    field public static final com.google.android.horologist.media.data.PlayerStateMapper INSTANCE;
-  }
-
-  public final class SetCommandMapper {
-    method public java.util.Set<com.google.android.horologist.media.model.Command> map(androidx.media3.common.Player.Commands commands);
-    field public static final com.google.android.horologist.media.data.SetCommandMapper INSTANCE;
   }
 
 }

--- a/media-data/src/main/java/com/google/android/horologist/media/data/mapper/CommandMapper.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/mapper/CommandMapper.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.media.data
+package com.google.android.horologist.media.data.mapper
 
 import androidx.media3.common.Player
 import androidx.media3.common.Player.COMMAND_PLAY_PAUSE

--- a/media-data/src/main/java/com/google/android/horologist/media/data/mapper/Media3MediaItemMapper.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/mapper/Media3MediaItemMapper.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.media.data
+package com.google.android.horologist.media.data.mapper
 
 import android.net.Uri
 import androidx.media3.common.MediaItem.RequestMetadata

--- a/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaItemMapper.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaItemMapper.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.media.data
+package com.google.android.horologist.media.data.mapper
 
 import com.google.android.horologist.media.model.MediaItem
 import androidx.media3.common.MediaItem as Media3MediaItem

--- a/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaItemPositionMapper.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaItemPositionMapper.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.media.data
+package com.google.android.horologist.media.data.mapper
 
 import androidx.media3.common.C
 import androidx.media3.common.Player

--- a/media-data/src/main/java/com/google/android/horologist/media/data/mapper/PlayerStateMapper.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/mapper/PlayerStateMapper.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.media.data
+package com.google.android.horologist.media.data.mapper
 
 import androidx.media3.common.Player
 import com.google.android.horologist.media.model.PlayerState

--- a/media-data/src/main/java/com/google/android/horologist/media/data/mapper/SetCommandMapper.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/mapper/SetCommandMapper.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.media.data
+package com.google.android.horologist.media.data.mapper
 
 import androidx.media3.common.Player
 import com.google.android.horologist.media.model.Command

--- a/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImpl.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImpl.kt
@@ -14,11 +14,16 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.media.data
+package com.google.android.horologist.media.data.repository
 
 import android.util.Log
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
+import com.google.android.horologist.media.data.mapper.Media3MediaItemMapper
+import com.google.android.horologist.media.data.mapper.MediaItemMapper
+import com.google.android.horologist.media.data.mapper.MediaItemPositionMapper
+import com.google.android.horologist.media.data.mapper.PlayerStateMapper
+import com.google.android.horologist.media.data.mapper.SetCommandMapper
 import com.google.android.horologist.media.model.Command
 import com.google.android.horologist.media.model.MediaItem
 import com.google.android.horologist.media.model.MediaItemPosition

--- a/media-data/src/test/java/com/google/android/horologist/media/data/mapper/MediaItemPositionMapperTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/mapper/MediaItemPositionMapperTest.kt
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.media.data
+package com.google.android.horologist.media.data.mapper
 
 import androidx.media3.common.C
 import com.google.android.horologist.media.model.MediaItemPosition
+import com.google.android.horologist.test.toolbox.testdoubles.FakeStatePlayer
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import kotlin.time.Duration.Companion.milliseconds

--- a/media-data/src/test/java/com/google/android/horologist/media/data/mapper/PlayerStateMapperTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/mapper/PlayerStateMapperTest.kt
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.media.data
+package com.google.android.horologist.media.data.mapper
 
 import androidx.media3.common.Player
 import com.google.android.horologist.media.model.PlayerState
+import com.google.android.horologist.test.toolbox.testdoubles.FakeStatePlayer
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 

--- a/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplCloseTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplCloseTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.media.data
+package com.google.android.horologist.media.data.repository
 
 import android.content.Context
 import android.os.Looper.getMainLooper

--- a/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplNotConnectedTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplNotConnectedTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.media.data
+package com.google.android.horologist.media.data.repository
 
 import android.content.Context
 import android.os.Looper.getMainLooper

--- a/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.media.data
+package com.google.android.horologist.media.data.repository
 
 import android.content.Context
 import android.os.Looper.getMainLooper
@@ -24,6 +24,7 @@ import androidx.media3.test.utils.robolectric.TestPlayerRunHelper.playUntilPosit
 import androidx.media3.test.utils.robolectric.TestPlayerRunHelper.runUntilPendingCommandsAreFullyHandled
 import androidx.media3.test.utils.robolectric.TestPlayerRunHelper.runUntilPlaybackState
 import androidx.test.core.app.ApplicationProvider
+import com.google.android.horologist.media.data.mapper.Media3MediaItemMapper
 import com.google.android.horologist.media.model.Command
 import com.google.android.horologist.media.model.MediaItem
 import com.google.android.horologist.media.model.MediaItemPosition

--- a/media-data/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/FakeStatePlayer.kt
+++ b/media-data/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/FakeStatePlayer.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.media.data
+package com.google.android.horologist.test.toolbox.testdoubles
 
 import androidx.media3.common.AdPlaybackState
 import androidx.media3.common.C

--- a/media-sample/src/androidTest/java/com/google/android/horologist/mediasample/playback/PlaybackErrorTest.kt
+++ b/media-sample/src/androidTest/java/com/google/android/horologist/mediasample/playback/PlaybackErrorTest.kt
@@ -18,7 +18,7 @@ package com.google.android.horologist.mediasample.playback
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
-import com.google.android.horologist.media.data.Media3MediaItemMapper
+import com.google.android.horologist.media.data.mapper.Media3MediaItemMapper
 import com.google.android.horologist.media.model.MediaItem
 import com.google.common.truth.Truth.assertThat
 import dagger.hilt.android.testing.HiltAndroidTest

--- a/media-sample/src/androidTest/java/com/google/android/horologist/mediasample/playback/PlaybackNotificationTest.kt
+++ b/media-sample/src/androidTest/java/com/google/android/horologist/mediasample/playback/PlaybackNotificationTest.kt
@@ -20,7 +20,7 @@ import android.app.Notification
 import androidx.core.app.NotificationCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
-import com.google.android.horologist.media.data.Media3MediaItemMapper
+import com.google.android.horologist.media.data.mapper.Media3MediaItemMapper
 import com.google.android.horologist.media3.flows.waitForPlaying
 import com.google.common.truth.Truth.assertThat
 import dagger.hilt.android.testing.HiltAndroidTest

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/ViewModelModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/ViewModelModule.kt
@@ -22,7 +22,7 @@ import android.content.ComponentName
 import android.content.Context
 import androidx.media3.session.MediaBrowser
 import androidx.media3.session.SessionToken
-import com.google.android.horologist.media.data.PlayerRepositoryImpl
+import com.google.android.horologist.media.data.repository.PlayerRepositoryImpl
 import com.google.android.horologist.media.repository.PlayerRepository
 import com.google.android.horologist.media3.flows.buildSuspend
 import com.google.android.horologist.mediasample.components.PlaybackService

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/player/MediaPlayerScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/player/MediaPlayerScreenViewModel.kt
@@ -17,7 +17,7 @@
 package com.google.android.horologist.mediasample.ui.player
 
 import androidx.lifecycle.viewModelScope
-import com.google.android.horologist.media.data.PlayerRepositoryImpl
+import com.google.android.horologist.media.data.repository.PlayerRepositoryImpl
 import com.google.android.horologist.media.ui.state.PlayerViewModel
 import com.google.android.horologist.media3.audio.AudioOutputSelector
 import dagger.hilt.android.lifecycle.HiltViewModel


### PR DESCRIPTION
#### WHAT

Reorganise packages of classes in `media-data` module.

#### WHY

In order to organise them by function.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
