### PR TITLE
Implement downloads feature to media sample app

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,6 +64,7 @@ androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", versi
 androidx-media3-exoplayerdash = { module = "androidx.media3:media3-exoplayer-dash", version.ref = "androidx-media3" }
 androidx-media3-exoplayerhls = { module = "androidx.media3:media3-exoplayer-hls", version.ref = "androidx-media3" }
 androidx-media3-exoplayerrtsp = { module = "androidx.media3:media3-exoplayer-rtsp", version.ref = "androidx-media3" }
+androidx-media3-exoplayerworkmanager = { module = "androidx.media3:media3-exoplayer-workmanager", version.ref = "androidx-media3" }
 androidx-media3-session = { module = "androidx.media3:media3-session", version.ref = "androidx-media3" }
 androidx-media3-testutils = { module = "androidx.media3:media3-test-utils", version.ref = "androidx-media3" }
 androidx-media3-testutils-robolectric = { module = "androidx.media3:media3-test-utils-robolectric", version.ref = "androidx-media3" }

--- a/media-sample/build.gradle
+++ b/media-sample/build.gradle
@@ -159,6 +159,12 @@ dependencies {
     kapt libs.dagger.hiltandroidcompiler
     implementation libs.hilt.navigationcompose
 
+    implementation libs.androidx.media3.exoplayerworkmanager
+
+    implementation libs.room.common
+    implementation libs.room.ktx
+    ksp libs.room.compiler
+
     testImplementation libs.junit
     testImplementation libs.truth
     testImplementation libs.androidx.test.ext.ktx

--- a/media-sample/src/main/AndroidManifest.xml
+++ b/media-sample/src/main/AndroidManifest.xml
@@ -123,6 +123,14 @@
                 android:name="androidx.wear.tiles.PREVIEW"
                 android:resource="@drawable/ic_uamp" />
         </service>
+
+        <service android:name=".data.service.download.MediaDownloadService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.android.exoplayer.downloadService.action.RESTART"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/database/DownloadDatabase.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/database/DownloadDatabase.kt
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.mediasample.domain
+package com.google.android.horologist.mediasample.data.database
 
-import com.google.android.horologist.mediasample.domain.model.Playlist
-import com.google.android.horologist.mediasample.domain.model.PlaylistDownload
-import kotlinx.coroutines.flow.Flow
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.google.android.horologist.mediasample.data.database.dao.PlaylistDownloadDao
+import com.google.android.horologist.mediasample.data.database.model.PlaylistDownloadEntity
 
-/**
- * A repository of [PlaylistDownload].
- */
-interface PlaylistDownloadRepository {
+@Database(
+    entities = [PlaylistDownloadEntity::class],
+    version = 1,
+    exportSchema = false
+)
+abstract class DownloadDatabase : RoomDatabase() {
 
-    fun get(playlist: Playlist): Flow<PlaylistDownload>
-
-    fun download(playlist: Playlist)
+    abstract fun playlistDownloadDao(): PlaylistDownloadDao
 }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/database/dao/PlaylistDownloadDao.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/database/dao/PlaylistDownloadDao.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.data.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.google.android.horologist.mediasample.data.database.model.PlaylistDownloadEntity
+import com.google.android.horologist.mediasample.data.database.model.PlaylistDownloadState
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface PlaylistDownloadDao {
+
+    @Query(
+        value = """
+        SELECT * FROM playlist_download
+        WHERE playlistId = :playlistId
+    """
+    )
+    fun getStream(playlistId: String): Flow<List<PlaylistDownloadEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insert(playlistDownloadEntities: PlaylistDownloadEntity): Long
+
+    @Query(
+        value = """
+            DELETE FROM playlist_download
+            WHERE mediaItemId = :mediaItemId
+        """
+    )
+    suspend fun deleteByMediaItemId(mediaItemId: String)
+
+    @Query(
+        value = """
+        UPDATE playlist_download
+        SET status = :status
+        WHERE mediaItemId = :mediaItemId
+    """
+    )
+    suspend fun updateStatusByMediaItemId(mediaItemId: String, status: PlaylistDownloadState)
+}

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/database/model/PlaylistDownloadEntity.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/database/model/PlaylistDownloadEntity.kt
@@ -14,18 +14,23 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.mediasample.domain
+package com.google.android.horologist.mediasample.data.database.model
 
-import com.google.android.horologist.mediasample.domain.model.Playlist
-import com.google.android.horologist.mediasample.domain.model.PlaylistDownload
-import kotlinx.coroutines.flow.Flow
+import androidx.room.Entity
 
-/**
- * A repository of [PlaylistDownload].
- */
-interface PlaylistDownloadRepository {
+@Entity(
+    tableName = "playlist_download",
+    primaryKeys = ["playlistId", "mediaItemId"]
+)
+data class PlaylistDownloadEntity(
+    val playlistId: String,
+    val mediaItemId: String,
+    val status: PlaylistDownloadState,
+)
 
-    fun get(playlist: Playlist): Flow<PlaylistDownload>
-
-    fun download(playlist: Playlist)
+enum class PlaylistDownloadState {
+    NotDownloaded,
+    Downloading,
+    Downloaded,
+    Failed
 }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/datasource/Media3DownloadDataSource.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/datasource/Media3DownloadDataSource.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.data.datasource
+
+import android.content.Context
+import android.net.Uri
+import androidx.media3.exoplayer.offline.Download
+import androidx.media3.exoplayer.offline.DownloadIndex
+import androidx.media3.exoplayer.offline.DownloadRequest
+import androidx.media3.exoplayer.offline.DownloadService
+
+class Media3DownloadDataSource(
+    private val context: Context,
+    private val downloadService: Class<out DownloadService>,
+    private val downloadIndex: DownloadIndex,
+) {
+
+    fun download(id: String, uri: Uri) {
+        val downloadRequest = DownloadRequest.Builder(id, uri).build()
+
+        DownloadService.sendAddDownload(
+            context,
+            downloadService,
+            downloadRequest,
+            true
+        )
+    }
+
+    fun removeDownload(id: String) {
+        DownloadService.sendRemoveDownload(
+            context,
+            downloadService,
+            id,
+            false
+        )
+    }
+
+    fun getDownload(id: String): Download? = downloadIndex.getDownload(id)
+}

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/datasource/PlaylistDownloadLocalDataSource.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/datasource/PlaylistDownloadLocalDataSource.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.data.datasource
+
+import com.google.android.horologist.mediasample.data.database.dao.PlaylistDownloadDao
+import com.google.android.horologist.mediasample.data.database.model.PlaylistDownloadEntity
+import com.google.android.horologist.mediasample.data.database.model.PlaylistDownloadState
+import com.google.android.horologist.mediasample.data.mapper.PlaylistDownloadMapper
+import com.google.android.horologist.mediasample.domain.model.Playlist
+import com.google.android.horologist.mediasample.domain.model.PlaylistDownload
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class PlaylistDownloadLocalDataSource(
+    private val playlistDownloadDao: PlaylistDownloadDao,
+) {
+
+    fun get(playlist: Playlist): Flow<PlaylistDownload> =
+        playlistDownloadDao.getStream(playlistId = playlist.id)
+            .map { PlaylistDownloadMapper.map(playlist, it) }
+
+    suspend fun add(playlistId: String, mediaItemId: String) {
+        playlistDownloadDao.insert(
+            PlaylistDownloadEntity(
+                playlistId = playlistId,
+                mediaItemId = mediaItemId,
+                status = PlaylistDownloadState.NotDownloaded
+            )
+        )
+    }
+}

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/mapper/PlaylistDownloadMapper.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/mapper/PlaylistDownloadMapper.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.data.mapper
+
+import com.google.android.horologist.mediasample.data.database.model.PlaylistDownloadEntity
+import com.google.android.horologist.mediasample.domain.model.Playlist
+import com.google.android.horologist.mediasample.domain.model.PlaylistDownload
+
+object PlaylistDownloadMapper {
+
+    fun map(
+        playlist: Playlist,
+        playlistDownloadEntityList: List<PlaylistDownloadEntity>
+    ): PlaylistDownload = PlaylistDownload(
+        playlist = playlist,
+        buildList {
+            playlist.mediaItems.forEach { mediaItem ->
+                val status =
+                    playlistDownloadEntityList.firstOrNull { it.mediaItemId == mediaItem.id }
+                        ?.let { PlaylistDownloadStatusMapper.map(it.status) }
+                        ?: PlaylistDownload.Status.Idle
+
+                add(Pair(mediaItem, status))
+            }
+        }
+    )
+}

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/mapper/PlaylistDownloadStateMapper.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/mapper/PlaylistDownloadStateMapper.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.data.mapper
+
+import androidx.media3.exoplayer.offline.Download
+import com.google.android.horologist.mediasample.data.database.model.PlaylistDownloadState
+
+object PlaylistDownloadStateMapper {
+
+    fun map(@Download.State state: Int): PlaylistDownloadState = when (state) {
+        Download.STATE_QUEUED, Download.STATE_DOWNLOADING, Download.STATE_RESTARTING -> PlaylistDownloadState.Downloading
+        Download.STATE_COMPLETED -> PlaylistDownloadState.Downloaded
+        Download.STATE_FAILED -> PlaylistDownloadState.Failed
+        else -> PlaylistDownloadState.NotDownloaded
+    }
+}

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/mapper/PlaylistDownloadStatusMapper.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/mapper/PlaylistDownloadStatusMapper.kt
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.mediasample.domain
+package com.google.android.horologist.mediasample.data.mapper
 
-import com.google.android.horologist.mediasample.domain.model.Playlist
+import com.google.android.horologist.mediasample.data.database.model.PlaylistDownloadState
 import com.google.android.horologist.mediasample.domain.model.PlaylistDownload
-import kotlinx.coroutines.flow.Flow
 
-/**
- * A repository of [PlaylistDownload].
- */
-interface PlaylistDownloadRepository {
+object PlaylistDownloadStatusMapper {
 
-    fun get(playlist: Playlist): Flow<PlaylistDownload>
-
-    fun download(playlist: Playlist)
+    fun map(playlistDownloadState: PlaylistDownloadState): PlaylistDownload.Status = when (playlistDownloadState) {
+        PlaylistDownloadState.NotDownloaded -> PlaylistDownload.Status.Idle
+        PlaylistDownloadState.Downloading -> PlaylistDownload.Status.InProgress
+        PlaylistDownloadState.Downloaded -> PlaylistDownload.Status.Completed
+        PlaylistDownloadState.Failed -> PlaylistDownload.Status.Idle
+    }
 }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/service/download/DownloadManagerListener.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/service/download/DownloadManagerListener.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.data.service.download
+
+import androidx.media3.exoplayer.offline.Download
+import androidx.media3.exoplayer.offline.DownloadManager
+import com.google.android.horologist.mediasample.data.database.dao.PlaylistDownloadDao
+import com.google.android.horologist.mediasample.data.mapper.PlaylistDownloadStateMapper
+import com.google.android.horologist.mediasample.di.annotation.DownloadFeature
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+class DownloadManagerListener(
+    @DownloadFeature private val coroutineScope: CoroutineScope,
+    private val playlistDownloadDao: PlaylistDownloadDao,
+) : DownloadManager.Listener {
+
+    override fun onDownloadChanged(
+        downloadManager: DownloadManager,
+        download: Download,
+        finalException: Exception?
+    ) {
+        coroutineScope.launch {
+            val mediaItemId = download.request.id
+            val status = PlaylistDownloadStateMapper.map(download.state)
+            playlistDownloadDao.updateStatusByMediaItemId(mediaItemId, status)
+        }
+    }
+
+    override fun onDownloadRemoved(downloadManager: DownloadManager, download: Download) {
+        coroutineScope.launch {
+            val mediaItemId = download.request.id
+            playlistDownloadDao.deleteByMediaItemId(mediaItemId)
+        }
+    }
+}

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/service/download/MediaDownloadService.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/service/download/MediaDownloadService.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.data.service.download
+
+import android.app.Notification
+import androidx.media3.exoplayer.offline.Download
+import androidx.media3.exoplayer.offline.DownloadManager
+import androidx.media3.exoplayer.offline.DownloadNotificationHelper
+import androidx.media3.exoplayer.offline.DownloadService
+import androidx.media3.exoplayer.scheduler.Scheduler
+import androidx.media3.exoplayer.workmanager.WorkManagerScheduler
+import com.google.android.horologist.media3.navigation.IntentBuilder
+import com.google.android.horologist.mediasample.R
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class MediaDownloadService : DownloadService(
+    MEDIA_DOWNLOAD_FOREGROUND_NOTIFICATION_ID,
+    DEFAULT_FOREGROUND_NOTIFICATION_UPDATE_INTERVAL,
+    MEDIA_DOWNLOAD_CHANNEL_ID,
+    MEDIA_DOWNLOAD_CHANNEL_NAME,
+    MEDIA_DOWNLOAD_CHANNEL_DESCRIPTION_NOT_PROVIDED,
+) {
+    @Inject
+    lateinit var downloadManagerParam: DownloadManager
+
+    @Inject
+    lateinit var workManagerScheduler: WorkManagerScheduler
+
+    @Inject
+    lateinit var downloadNotificationHelper: DownloadNotificationHelper
+
+    @Inject
+    lateinit var intentBuilder: IntentBuilder
+
+    override fun getDownloadManager(): DownloadManager = downloadManagerParam
+
+    override fun getScheduler(): Scheduler = workManagerScheduler
+
+    override fun getForegroundNotification(
+        downloads: MutableList<Download>,
+        notMetRequirements: Int
+    ): Notification = downloadNotificationHelper.buildProgressNotification(
+        this,
+        MEDIA_DOWNLOAD_NOTIFICATION_ICON,
+        intentBuilder.buildDownloadIntent(),
+        null,
+        downloads,
+        notMetRequirements
+    )
+
+    companion object {
+        private const val MEDIA_DOWNLOAD_FOREGROUND_NOTIFICATION_ID = 1
+        const val MEDIA_DOWNLOAD_CHANNEL_ID = "download_channel"
+        private const val MEDIA_DOWNLOAD_CHANNEL_NAME =
+            R.string.horologist_media_download_channel_name
+        private const val MEDIA_DOWNLOAD_CHANNEL_DESCRIPTION_NOT_PROVIDED = 0
+        private const val MEDIA_DOWNLOAD_NOTIFICATION_ICON =
+            R.drawable.ic_baseline_music_note_24_white
+    }
+}

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/DownloadModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/DownloadModule.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.di
+
+import android.content.Context
+import androidx.media3.database.DatabaseProvider
+import androidx.media3.database.StandaloneDatabaseProvider
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.cache.Cache
+import androidx.media3.datasource.okhttp.OkHttpDataSource
+import androidx.media3.exoplayer.offline.DownloadIndex
+import androidx.media3.exoplayer.offline.DownloadManager
+import androidx.media3.exoplayer.offline.DownloadNotificationHelper
+import androidx.media3.exoplayer.workmanager.WorkManagerScheduler
+import androidx.room.Room
+import com.google.android.horologist.media3.logging.ErrorReporter
+import com.google.android.horologist.media3.logging.TransferListener
+import com.google.android.horologist.mediasample.data.database.DownloadDatabase
+import com.google.android.horologist.mediasample.data.database.dao.PlaylistDownloadDao
+import com.google.android.horologist.mediasample.data.datasource.Media3DownloadDataSource
+import com.google.android.horologist.mediasample.data.datasource.PlaylistDownloadLocalDataSource
+import com.google.android.horologist.mediasample.data.service.download.DownloadManagerListener
+import com.google.android.horologist.mediasample.data.service.download.MediaDownloadService
+import com.google.android.horologist.mediasample.di.annotation.DownloadFeature
+import com.google.android.horologist.networks.data.RequestType
+import com.google.android.horologist.networks.okhttp.NetworkAwareCallFactory
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import okhttp3.Call
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DownloadModule {
+
+    private const val DOWNLOAD_WORK_MANAGER_SCHEDULER_WORK_NAME = "mediasample_download"
+    private const val DOWNLOAD_DATABASE_NAME = "download-database"
+
+    @DownloadFeature
+    @Singleton
+    @Provides
+    fun downloadDataSourceFactory(
+        okHttp: Call.Factory,
+        @DownloadFeature transferListener: TransferListener,
+    ): DataSource.Factory = OkHttpDataSource.Factory(
+        NetworkAwareCallFactory(
+            delegate = okHttp,
+            defaultRequestType = RequestType.MediaRequest(RequestType.MediaRequest.MediaRequestType.Download)
+        )
+    ).setTransferListener(transferListener)
+
+    @DownloadFeature
+    @Provides
+    fun transferListener(errorReporter: ErrorReporter): TransferListener =
+        TransferListener(errorReporter)
+
+    @DownloadFeature
+    @Singleton
+    @Provides
+    fun threadPool(): ExecutorService = Executors.newCachedThreadPool()
+
+    @Singleton
+    @Provides
+    fun downloadNotificationHelper(
+        @ApplicationContext applicationContext: Context,
+    ): DownloadNotificationHelper =
+        DownloadNotificationHelper(
+            applicationContext,
+            MediaDownloadService.MEDIA_DOWNLOAD_CHANNEL_ID
+        )
+
+    @DownloadFeature
+    @Singleton
+    @Provides
+    fun databaseProvider(
+        @ApplicationContext application: Context,
+    ): DatabaseProvider = StandaloneDatabaseProvider(application)
+
+    @Singleton
+    @Provides
+    fun downloadManager(
+        @ApplicationContext applicationContext: Context,
+        @DownloadFeature databaseProvider: DatabaseProvider,
+        downloadCache: Cache,
+        @DownloadFeature dataSourceFactory: DataSource.Factory,
+        @DownloadFeature threadPool: ExecutorService,
+        downloadManagerListener: DownloadManagerListener,
+    ) = DownloadManager(
+        applicationContext,
+        databaseProvider,
+        downloadCache,
+        dataSourceFactory,
+        threadPool
+    ).also {
+        it.addListener(downloadManagerListener)
+    }
+
+    @Provides
+    fun downloadIndex(downloadManager: DownloadManager) = downloadManager.downloadIndex
+
+    @Singleton
+    @Provides
+    fun workManagerScheduler(
+        @ApplicationContext applicationContext: Context,
+    ) = WorkManagerScheduler(applicationContext, DOWNLOAD_WORK_MANAGER_SCHEDULER_WORK_NAME)
+
+    @Singleton
+    @Provides
+    fun downloadDataSource(
+        @ApplicationContext applicationContext: Context,
+        downloadIndex: DownloadIndex
+    ) = Media3DownloadDataSource(
+        applicationContext,
+        MediaDownloadService::class.java,
+        downloadIndex
+    )
+
+    @Provides
+    @Singleton
+    fun downloadDatabase(
+        @ApplicationContext context: Context,
+    ): DownloadDatabase {
+        return Room.databaseBuilder(
+            context,
+            DownloadDatabase::class.java,
+            DOWNLOAD_DATABASE_NAME
+        ).build()
+    }
+
+    @Provides
+    @Singleton
+    fun playlistDownloadLocalDataSource(
+        playlistDownloadDao: PlaylistDownloadDao,
+    ): PlaylistDownloadLocalDataSource = PlaylistDownloadLocalDataSource(playlistDownloadDao)
+
+    @Provides
+    @Singleton
+    fun playlistDownloadDao(
+        database: DownloadDatabase,
+    ): PlaylistDownloadDao = database.playlistDownloadDao()
+
+    @DownloadFeature
+    @Provides
+    @Singleton
+    fun coroutineScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    @Provides
+    @Singleton
+    fun downloadManagerListener(
+        @DownloadFeature coroutineScope: CoroutineScope,
+        playlistDownloadDao: PlaylistDownloadDao,
+    ): DownloadManagerListener = DownloadManagerListener(coroutineScope, playlistDownloadDao)
+}

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/MediaApplicationModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/MediaApplicationModule.kt
@@ -41,6 +41,8 @@ import com.google.android.horologist.mediasample.AppConfig
 import com.google.android.horologist.mediasample.complication.DataUpdates
 import com.google.android.horologist.mediasample.complication.MediaStatusComplicationService
 import com.google.android.horologist.mediasample.data.api.UampService
+import com.google.android.horologist.mediasample.data.datasource.Media3DownloadDataSource
+import com.google.android.horologist.mediasample.data.datasource.PlaylistDownloadLocalDataSource
 import com.google.android.horologist.mediasample.data.datasource.PlaylistRemoteDataSource
 import com.google.android.horologist.mediasample.data.repository.PlaylistDownloadRepositoryImpl
 import com.google.android.horologist.mediasample.data.repository.PlaylistRepositoryImpl
@@ -168,7 +170,7 @@ object MediaApplicationModule {
 
     @Singleton
     @Provides
-    fun downloadCache(
+    fun media3Cache(
         @CacheDir cacheDir: File,
         cacheDatabaseProvider: DatabaseProvider
     ): Cache =
@@ -213,8 +215,16 @@ object MediaApplicationModule {
 
     @Singleton
     @Provides
-    fun playlistDownloadRepository(): PlaylistDownloadRepository =
-        PlaylistDownloadRepositoryImpl()
+    fun playlistDownloadRepository(
+        @ForApplicationScope coroutineScope: CoroutineScope,
+        playlistDownloadLocalDataSource: PlaylistDownloadLocalDataSource,
+        media3DownloadDataSource: Media3DownloadDataSource
+    ): PlaylistDownloadRepository =
+        PlaylistDownloadRepositoryImpl(
+            coroutineScope,
+            playlistDownloadLocalDataSource,
+            media3DownloadDataSource
+        )
 
     @Singleton
     @Provides

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/annotation/DownloadFeature.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/annotation/DownloadFeature.kt
@@ -14,18 +14,10 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.mediasample.domain
+package com.google.android.horologist.mediasample.di.annotation
 
-import com.google.android.horologist.mediasample.domain.model.Playlist
-import com.google.android.horologist.mediasample.domain.model.PlaylistDownload
-import kotlinx.coroutines.flow.Flow
+import javax.inject.Qualifier
 
-/**
- * A repository of [PlaylistDownload].
- */
-interface PlaylistDownloadRepository {
-
-    fun get(playlist: Playlist): Flow<PlaylistDownload>
-
-    fun download(playlist: Playlist)
-}
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DownloadFeature

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/DownloadMediaItemUiModelMapper.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/DownloadMediaItemUiModelMapper.kt
@@ -29,8 +29,7 @@ object DownloadMediaItemUiModelMapper {
     ): DownloadMediaItemUiModel = when (status) {
         PlaylistDownload.Status.Idle,
         PlaylistDownload.Status.InProgress -> {
-            // TODO: it should map to Unavailable - this is temporary until downloads are implemented
-            DownloadMediaItemUiModel.Available(MediaItemUiModelMapper.map(mediaItem))
+            DownloadMediaItemUiModel.Unavailable(MediaItemUiModelMapper.map(mediaItem))
         }
         PlaylistDownload.Status.Completed -> {
             DownloadMediaItemUiModel.Available(MediaItemUiModelMapper.map(mediaItem))

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
@@ -39,7 +39,7 @@ fun UampEntityScreen(
     EntityScreen(
         entityScreenState = uiState,
         onDownloadClick = {
-            // TODO - to be implemented
+            uampEntityScreenViewModel.download()
         },
         onDownloadItemClick = onDownloadItemClick,
         onShuffleClick = {

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreenViewModel.kt
@@ -59,7 +59,7 @@ class UampEntityScreenViewModel @Inject constructor(
                     EntityScreenState.Loaded(
                         playlistUiModel = PlaylistUiModelMapper.map(it.playlist),
                         downloadList = DownloadMediaItemUiModelMapper.map(it.mediaList),
-                        downloading = it.mediaList.any { pair -> pair.second == PlaylistDownload.Status.InProgress },
+                        downloading = it.mediaList.any { (_, status) -> status == PlaylistDownload.Status.InProgress },
                     )
                 }
         } else {
@@ -88,4 +88,6 @@ class UampEntityScreenViewModel @Inject constructor(
             playerRepository.play()
         }
     }
+
+    fun download() = playlist.value?.let(playlistDownloadRepository::download)
 }

--- a/media-sample/src/main/res/drawable/ic_baseline_music_note_24_white.xml
+++ b/media-sample/src/main/res/drawable/ic_baseline_music_note_24_white.xml
@@ -1,0 +1,21 @@
+<!--
+  ~ Copyright 2022 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector android:height="24dp" android:tint="@android:color/white"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,3v10.55c-0.59,-0.34 -1.27,-0.55 -2,-0.55 -2.21,0 -4,1.79 -4,4s1.79,4 4,4 4,-1.79 4,-4V7h4V3h-6z"/>
+</vector>

--- a/media-sample/src/main/res/values/strings.xml
+++ b/media-sample/src/main/res/values/strings.xml
@@ -34,4 +34,5 @@
     <string name="horologist_show_time_text_info">Show TimeText Info</string>
     <string name="horologist_animated">Animated UI</string>
     <string name="horologist_sample_network_error">Network error</string>
+    <string name="horologist_media_download_channel_name">Downloads</string>
 </resources>


### PR DESCRIPTION
#### WHAT

Implement downloads feature to media sample app

https://user-images.githubusercontent.com/878134/180799185-00523a62-6c21-406b-b778-d033562fcd80.mp4

Not implemented yet:
- Individual media download progress;
- Cancel download functionality;
- Display list of downloads in Browse screen;

#### HOW

- Add `DownloadDatabase`, `PlaylistDownloadDao`, and `PlaylistDownloadEntity` in order to store in a database the progress status of each individual media item from a playlist;
- Add `MediaDownloadService` to download media using media3 API;
- Add `DownloadManagerListener` to update the database with the download status;

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
