### PR TITLE
Use onEvents consistently

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 affectedmoduledetector = "0.1.5"
 androidx-concurrent = "1.1.0"
 androidx-hilt = "1.0.0"
-androidx-media3 = "1.0.0-beta01"
+androidx-media3 = "1.0.0-beta02"
 androidx-test = "1.4.0"
 androidx-test-ext = "1.1.3"
 androidx-wear-watchface = "1.1.0"

--- a/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImpl.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImpl.kt
@@ -17,7 +17,6 @@
 package com.google.android.horologist.media.data.repository
 
 import android.util.Log
-import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import com.google.android.horologist.media.data.mapper.Media3MediaItemMapper
 import com.google.android.horologist.media.data.mapper.MediaItemMapper

--- a/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImpl.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImpl.kt
@@ -102,6 +102,14 @@ public class PlayerRepositoryImpl : PlayerRepository, Closeable {
                 updatePosition()
             }
 
+            if (events.contains(Player.EVENT_SHUFFLE_MODE_ENABLED_CHANGED)) {
+                updateShuffleMode(player)
+            }
+
+            if (events.contains(Player.EVENT_PLAYBACK_PARAMETERS_CHANGED)) {
+                updatePlaybackSpeed(player)
+            }
+
             // Reason for handling these events here, instead of using individual callbacks
             // (onIsLoadingChanged, onIsPlayingChanged, onPlaybackStateChanged, etc):
             // - The listener intends to use multiple state values that are reported through
@@ -110,20 +118,6 @@ public class PlayerRepositoryImpl : PlayerRepository, Closeable {
             // https://exoplayer.dev/listening-to-player-events.html#individual-callbacks-vs-onevents
             if (PlayerStateMapper.affectsState(events)) {
                 updateState(player)
-            }
-        }
-
-        // Not firing on onEvents
-        override fun onShuffleModeEnabledChanged(shuffleModeEnabled: Boolean) {
-            player.value?.let {
-                updateShuffleMode(it)
-            }
-        }
-
-        // Not firing on onEvents
-        override fun onPlaybackParametersChanged(playbackParameters: PlaybackParameters) {
-            player.value?.let {
-                updatePlaybackSpeed(it)
             }
         }
     }

--- a/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplTest.kt
@@ -38,6 +38,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -383,6 +384,9 @@ class PlayerRepositoryImplTest {
 
         // when
         sut.setShuffleModeEnabled(true)
+
+        // Allow events to propogate
+        ShadowLooper.idleMainLooper()
 
         // then
         assertThat(sut.currentState.value).isEqualTo(PlayerState.Idle)
@@ -935,6 +939,9 @@ class PlayerRepositoryImplTest {
 
         // when
         sut.setPlaybackSpeed(speed)
+
+        // Allow events to propogate
+        ShadowLooper.idleMainLooper()
 
         // then
         assertThat(sut.currentState.value).isEqualTo(PlayerState.Idle)


### PR DESCRIPTION
#### WHAT

Use Player.Listener.onEvents for onShuffleModeEnabledChanged and onPlaybackParametersChanged

#### WHY

More consistent approach.

Relates to https://github.com/androidx/media/issues/128

#### HOW

Use flags in the onEvents call, and ensure events can propogate in the test.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
