### PR TITLE
Fix Phone label to "Watch Speaker"

### DIFF
--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/DeviceChip.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/DeviceChip.kt
@@ -52,6 +52,12 @@ public fun DeviceChip(
 
     val onClickLabel = stringResource(id = R.string.horologist_volume_screen_change_audio_output)
 
+    val deviceName = if (audioOutput is AudioOutput.WatchSpeaker) {
+        stringResource(id = R.string.horologist_speaker_name)
+    } else {
+        audioOutput.name
+    }
+
     Chip(
         modifier = modifier
             .width(intrinsicSize = IntrinsicSize.Max)
@@ -62,7 +68,7 @@ public fun DeviceChip(
         label = {
             Text(
                 modifier = Modifier.fillMaxWidth(),
-                text = audioOutput.name,
+                text = deviceName,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis
             )
@@ -70,7 +76,7 @@ public fun DeviceChip(
         icon = {
             Icon(
                 imageVector = audioOutput.icon(),
-                contentDescription = audioOutput.name,
+                contentDescription = deviceName,
                 tint = MaterialTheme.colors.onSurfaceVariant
             )
         },

--- a/audio-ui/src/main/res/values/strings.xml
+++ b/audio-ui/src/main/res/values/strings.xml
@@ -22,4 +22,5 @@
     <string name="horologist_volume_screen_change_audio_output">Change Audio Output</string>
     <string name="horologist_set_volume_content_description">Set Volume</string>
     <string name="horologist_audio_output_content_description">Audio Output</string>
+    <string name="horologist_speaker_name">Watch Speaker</string>
 </resources>

--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenIndividualTest.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenIndividualTest.kt
@@ -90,4 +90,22 @@ class VolumeScreenIndividualTest {
             )
         }
     }
+
+    @Test
+    fun volumeScreenWithWatchSpeaker() {
+        val volumeState = VolumeState(
+            current = 50,
+            max = 100,
+        )
+        // Media Router returns "Phone"
+        val audioOutput = AudioOutput.WatchSpeaker("id", "Phone")
+
+        paparazzi.snapshot {
+            VolumeScreenTestCase(
+                colors = MaterialTheme.colors,
+                volumeState = volumeState,
+                audioOutput = audioOutput
+            )
+        }
+    }
 }

--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenTestCase.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenTestCase.kt
@@ -28,7 +28,7 @@ import com.google.android.horologist.compose.tools.RoundPreview
 fun VolumeScreenTestCase(
     colors: Colors = MaterialTheme.colors,
     volumeState: VolumeState,
-    audioOutput: AudioOutput.BluetoothHeadset
+    audioOutput: AudioOutput
 ) {
     RoundPreview {
         MaterialTheme(colors = colors) {

--- a/audio-ui/src/test/snapshots/images/com.google.android.horologist.audio.ui_VolumeScreenIndividualTest_volumeScreenWithWatchSpeaker.png
+++ b/audio-ui/src/test/snapshots/images/com.google.android.horologist.audio.ui_VolumeScreenIndividualTest_volumeScreenWithWatchSpeaker.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0597f09a0d05ec06ab760ef9a622beb28d9fc1d90ab90975afabcc10b98946b7
+size 70849

--- a/audio/src/main/java/com/google/android/horologist/audio/SystemAudioRepository.kt
+++ b/audio/src/main/java/com/google/android/horologist/audio/SystemAudioRepository.kt
@@ -142,7 +142,7 @@ private inline val RouteInfo.device: AudioOutput
             isBluetooth -> {
                 AudioOutput.BluetoothHeadset(id, name)
             }
-            isDefault -> {
+            isDeviceSpeaker -> {
                 AudioOutput.WatchSpeaker(id, name)
             }
             else -> {


### PR DESCRIPTION
#### WHAT

Change display of "Phone" on volume screen to "Watch Speaker"

#### WHY

It's confusing seeing Phone returned here. Not sure where the problem comes from, see https://issuetracker.google.com/issues/240247462

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
