### PR TITLE
Change MediaPlayerAppViewModel to use PlaylistRepository

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/database/dao/PlaylistDao.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/database/dao/PlaylistDao.kt
@@ -51,7 +51,16 @@ interface PlaylistDao {
         WHERE playlistId = :playlistId
     """
     )
-    fun getPopulated(playlistId: String): Flow<PopulatedPlaylist>
+    suspend fun getPopulated(playlistId: String): PopulatedPlaylist
+
+    @Transaction
+    @Query(
+        value = """
+        SELECT * FROM playlistentity
+        WHERE playlistId = :playlistId
+    """
+    )
+    fun getPopulatedStream(playlistId: String): Flow<PopulatedPlaylist>
 
     @Transaction
     @Query(

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/datasource/PlaylistLocalDataSource.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/datasource/PlaylistLocalDataSource.kt
@@ -39,8 +39,11 @@ class PlaylistLocalDataSource(
         }
     }
 
-    fun getPopulated(playlistId: String): Flow<PopulatedPlaylist> =
+    suspend fun getPopulated(playlistId: String): PopulatedPlaylist? =
         playlistDao.getPopulated(playlistId)
+
+    fun getPopulatedStream(playlistId: String): Flow<PopulatedPlaylist> =
+        playlistDao.getPopulatedStream(playlistId)
 
     fun getAllPopulated(): Flow<List<PopulatedPlaylist>> = playlistDao.getAllPopulated()
 

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/repository/PlaylistDownloadRepositoryImpl.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/repository/PlaylistDownloadRepositoryImpl.kt
@@ -41,7 +41,7 @@ class PlaylistDownloadRepositoryImpl(
 
     @OptIn(FlowPreview::class)
     override fun get(playlistId: String): Flow<PlaylistDownload> =
-        playlistLocalDataSource.getPopulated(playlistId).flatMapMerge { populatedPlaylist ->
+        playlistLocalDataSource.getPopulatedStream(playlistId).flatMapMerge { populatedPlaylist ->
             combine(
                 flowOf(populatedPlaylist),
                 mediaDownloadLocalDataSource.get(

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/PlaylistRepository.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/PlaylistRepository.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.horologist.mediasample.domain
 
+import com.google.android.horologist.media.model.Media
 import com.google.android.horologist.mediasample.domain.model.Playlist
 import kotlinx.coroutines.flow.Flow
 
@@ -24,7 +25,13 @@ import kotlinx.coroutines.flow.Flow
  */
 interface PlaylistRepository {
 
+    suspend fun get(playlistId: String): Playlist?
+
     fun getAll(): Flow<List<Playlist>>
 
+    /**
+     * Returns only [Playlist]s that contain at least one [Media] with download in progress or
+     * completed.
+     */
     fun getAllDownloaded(): Flow<List<Playlist>>
 }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/tile/MediaCollectionsTileService.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/tile/MediaCollectionsTileService.kt
@@ -32,13 +32,13 @@ import coil.ImageLoader
 import com.google.android.horologist.compose.tools.TileLayoutPreview
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 import com.google.android.horologist.compose.tools.WearPreviewFontSizes
-import com.google.android.horologist.media.model.Media
 import com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer
 import com.google.android.horologist.media.ui.tiles.toTileColors
 import com.google.android.horologist.mediasample.BuildConfig
 import com.google.android.horologist.mediasample.R
 import com.google.android.horologist.mediasample.components.MediaActivity
 import com.google.android.horologist.mediasample.data.api.UampService
+import com.google.android.horologist.mediasample.data.api.model.MusicApiModel
 import com.google.android.horologist.mediasample.ui.app.UampColors
 import com.google.android.horologist.tiles.CoroutinesTileService
 import com.google.android.horologist.tiles.ExperimentalHorologistTilesApi
@@ -81,7 +81,7 @@ class MediaCollectionsTileService : CoroutinesTileService() {
                     name = song.title,
                     artworkId = song.id,
                     action = appLauncher {
-                        addStringExtra(MediaActivity.CollectionKey, song.artist)
+                        addStringExtra(MediaActivity.CollectionKey, song.genre)
                         addStringExtra(MediaActivity.MediaIdKey, song.id)
                     }
                 ),
@@ -89,7 +89,7 @@ class MediaCollectionsTileService : CoroutinesTileService() {
                     name = album.title,
                     artworkId = album.id,
                     action = appLauncher {
-                        addStringExtra(MediaActivity.CollectionKey, album.artist)
+                        addStringExtra(MediaActivity.CollectionKey, album.genre)
                     }
                 )
             ),
@@ -97,10 +97,8 @@ class MediaCollectionsTileService : CoroutinesTileService() {
         )
     }
 
-    suspend fun loadItems(): Pair<Media, Media> {
-        val catalog = uampService.catalog().music.map {
-            it.toMedia()
-        }
+    suspend fun loadItems(): Pair<MusicApiModel, MusicApiModel> {
+        val catalog = uampService.catalog().music
 
         return Pair(catalog.first(), catalog.last())
     }
@@ -138,8 +136,8 @@ class MediaCollectionsTileService : CoroutinesTileService() {
     override suspend fun resourcesRequest(requestParams: ResourcesRequest): Resources {
         val (song, album) = loadItems()
 
-        val songResource = imageLoader.loadImageResource(this, song.artworkUri)
-        val albumResource = imageLoader.loadImageResource(this, album.artworkUri)
+        val songResource = imageLoader.loadImageResource(this, song.image)
+        val albumResource = imageLoader.loadImageResource(this, album.image)
 
         return renderer.produceRequestedResources(
             MediaCollectionsTileRenderer.ResourceState(

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/mapper/DownloadMediaUiModelMapper.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/mapper/DownloadMediaUiModelMapper.kt
@@ -16,7 +16,6 @@
 
 package com.google.android.horologist.mediasample.ui.mapper
 
-import com.google.android.horologist.media.model.Media
 import com.google.android.horologist.media.ui.state.mapper.MediaUiModelMapper
 import com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel
 import com.google.android.horologist.mediasample.domain.model.MediaDownload
@@ -34,14 +33,4 @@ object DownloadMediaUiModelMapper {
             DownloadMediaUiModel.Available(MediaUiModelMapper.map(mediaDownload.media))
         }
     }
-
-    fun mapList(mediaDownloadList: List<MediaDownload>): List<DownloadMediaUiModel> =
-        mediaDownloadList.map(DownloadMediaUiModelMapper::map)
-
-    fun map(media: Media): DownloadMediaUiModel =
-        DownloadMediaUiModel.Unavailable(MediaUiModelMapper.map(media))
-
-    fun map(mediaList: List<Media>): List<DownloadMediaUiModel> = mediaList.map(
-        DownloadMediaUiModelMapper::map
-    )
 }


### PR DESCRIPTION
#### WHAT

Change `MediaPlayerAppViewModel` to use `PlaylistRepository` instead of `UampService` directly.

#### WHY

In order to follow architecture. 
Also it would benefit from not hitting the API if the playlist were previously downloaded - offline first strategy.

#### HOW


#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
