### PR TITLE
Avoid staying in playing state at end of track.

### DIFF
--- a/media3-backend/src/main/java/com/google/android/horologist/media3/WearConfiguredPlayer.kt
+++ b/media3-backend/src/main/java/com/google/android/horologist/media3/WearConfiguredPlayer.kt
@@ -49,6 +49,17 @@ public class WearConfiguredPlayer(
 ) : ForwardingPlayer(player) {
     private var playAttempt: Job? = null
 
+    init {
+        player.addListener(object : Player.Listener {
+            override fun onPlaybackStateChanged(playbackState: Int) {
+                if (playWhenReady && playbackState == STATE_ENDED) {
+                    player.stop()
+                    player.seekToDefaultPosition(0)
+                }
+            }
+        })
+    }
+
     /**
      * Start proactive noise detection, unlike ExoPlayer setHandleAudioBecomingNoisy
      * this also handles when accidentally started in the wrong mode due to race conditions.


### PR DESCRIPTION
#### WHAT

Avoid staying in playing state at end of track.

I'm not 100% confident of the product spec, or where to put it in, so for discussion.

#### WHY

Player should stop.

#### HOW

Detect playing and state == ENDED, and move to the start.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
