### PR TITLE
Double the audio buffer sizes

### DIFF
--- a/media3-backend/src/main/java/com/google/android/horologist/media3/config/WearMedia3Factory.kt
+++ b/media3-backend/src/main/java/com/google/android/horologist/media3/config/WearMedia3Factory.kt
@@ -21,6 +21,7 @@ import androidx.media3.exoplayer.RenderersFactory
 import androidx.media3.exoplayer.audio.AudioCapabilities
 import androidx.media3.exoplayer.audio.AudioSink
 import androidx.media3.exoplayer.audio.DefaultAudioSink
+import androidx.media3.exoplayer.audio.DefaultAudioTrackBufferSizeProvider
 import androidx.media3.exoplayer.audio.MediaCodecAudioRenderer
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 
@@ -33,6 +34,12 @@ public open class WearMedia3Factory(private val context: Context) {
         return DefaultAudioSink.Builder()
             .setAudioCapabilities(AudioCapabilities.getCapabilities(context))
             .setAudioProcessorChain(DefaultAudioSink.DefaultAudioProcessorChain())
+            .setAudioTrackBufferSizeProvider(DefaultAudioTrackBufferSizeProvider.Builder()
+                .setMinPcmBufferDurationUs(500_000)
+                .setMaxPcmBufferDurationUs(1_500_000)
+                .build())
+            .setEnableFloatOutput(false) // default
+            .setEnableAudioTrackPlaybackParams(false) // default
             .setOffloadMode(
                 if (attemptOffload)
                     offloadMode

--- a/media3-backend/src/main/java/com/google/android/horologist/media3/config/WearMedia3Factory.kt
+++ b/media3-backend/src/main/java/com/google/android/horologist/media3/config/WearMedia3Factory.kt
@@ -34,10 +34,12 @@ public open class WearMedia3Factory(private val context: Context) {
         return DefaultAudioSink.Builder()
             .setAudioCapabilities(AudioCapabilities.getCapabilities(context))
             .setAudioProcessorChain(DefaultAudioSink.DefaultAudioProcessorChain())
-            .setAudioTrackBufferSizeProvider(DefaultAudioTrackBufferSizeProvider.Builder()
-                .setMinPcmBufferDurationUs(500_000)
-                .setMaxPcmBufferDurationUs(1_500_000)
-                .build())
+            .setAudioTrackBufferSizeProvider(
+                DefaultAudioTrackBufferSizeProvider.Builder()
+                    .setMinPcmBufferDurationUs(500_000)
+                    .setMaxPcmBufferDurationUs(1_500_000)
+                    .build()
+            )
             .setEnableFloatOutput(false) // default
             .setEnableAudioTrackPlaybackParams(false) // default
             .setOffloadMode(


### PR DESCRIPTION
#### WHAT

Double the audio buffer sizes.

#### WHY

Slightly increasing PCM buffer sizes which *may* reduce frequency of playback issues under load.
A part of this is just to show the defaults being changed, since they are a relevant tuning parameter even though we may not know the right values.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
