### PR TITLE
Add experimental annotation to classes in media-data

### DIFF
--- a/media-data/api/current.api
+++ b/media-data/api/current.api
@@ -8,34 +8,33 @@ package com.google.android.horologist.media.data {
 
 package com.google.android.horologist.media.data.mapper {
 
-  public final class CommandMapper {
+  @com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi public final class CommandMapper {
     method public com.google.android.horologist.media.model.Command map(@androidx.media3.common.Player.Command int command);
     field public static final com.google.android.horologist.media.data.mapper.CommandMapper INSTANCE;
   }
 
-  public final class MediaItemMapper {
+  @com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi public final class MediaItemMapper {
     method public androidx.media3.common.MediaItem map(com.google.android.horologist.media.model.Media media);
-    method public java.util.List<androidx.media3.common.MediaItem> map(java.util.List<com.google.android.horologist.media.model.Media> media);
     field public static final com.google.android.horologist.media.data.mapper.MediaItemMapper INSTANCE;
   }
 
-  public final class MediaMapper {
+  @com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi public final class MediaMapper {
     method public com.google.android.horologist.media.model.Media map(androidx.media3.common.MediaItem mediaItem, optional String defaultArtist);
     field public static final com.google.android.horologist.media.data.mapper.MediaMapper INSTANCE;
   }
 
-  public final class MediaPositionMapper {
+  @com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi public final class MediaPositionMapper {
     method public com.google.android.horologist.media.model.MediaPosition? map(androidx.media3.common.Player? player);
     field public static final com.google.android.horologist.media.data.mapper.MediaPositionMapper INSTANCE;
   }
 
-  public final class PlayerStateMapper {
+  @com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi public final class PlayerStateMapper {
     method public boolean affectsState(androidx.media3.common.Player.Events events);
     method public com.google.android.horologist.media.model.PlayerState map(androidx.media3.common.Player player);
     field public static final com.google.android.horologist.media.data.mapper.PlayerStateMapper INSTANCE;
   }
 
-  public final class SetCommandMapper {
+  @com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi public final class SetCommandMapper {
     method public java.util.Set<com.google.android.horologist.media.model.Command> map(androidx.media3.common.Player.Commands commands);
     field public static final com.google.android.horologist.media.data.mapper.SetCommandMapper INSTANCE;
   }
@@ -44,7 +43,7 @@ package com.google.android.horologist.media.data.mapper {
 
 package com.google.android.horologist.media.data.repository {
 
-  public final class PlayerRepositoryImpl implements java.io.Closeable com.google.android.horologist.media.repository.PlayerRepository {
+  @com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi public final class PlayerRepositoryImpl implements java.io.Closeable com.google.android.horologist.media.repository.PlayerRepository {
     ctor public PlayerRepositoryImpl();
     method public void addMedia(com.google.android.horologist.media.model.Media media);
     method public void addMedia(int index, com.google.android.horologist.media.model.Media media);

--- a/media-data/src/main/java/com/google/android/horologist/media/data/mapper/CommandMapper.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/mapper/CommandMapper.kt
@@ -23,11 +23,13 @@ import androidx.media3.common.Player.COMMAND_SEEK_FORWARD
 import androidx.media3.common.Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM
 import androidx.media3.common.Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM
 import androidx.media3.common.Player.COMMAND_SET_SHUFFLE_MODE
+import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi
 import com.google.android.horologist.media.model.Command
 
 /**
  * Maps [Player.Command] into a [Command].
  */
+@ExperimentalHorologistMediaDataApi
 public object CommandMapper {
 
     public fun map(@Player.Command command: Int): Command =

--- a/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaItemMapper.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaItemMapper.kt
@@ -20,11 +20,13 @@ import android.net.Uri
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaItem.RequestMetadata
 import androidx.media3.common.MediaMetadata
+import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi
 import com.google.android.horologist.media.model.Media
 
 /**
  * Maps a [Media] into a [MediaItem].
  */
+@ExperimentalHorologistMediaDataApi
 public object MediaItemMapper {
 
     public fun map(media: Media): MediaItem {
@@ -48,8 +50,4 @@ public object MediaItemMapper {
             )
             .build()
     }
-
-    public fun map(media: List<Media>): List<MediaItem> = media.map(
-        MediaItemMapper::map
-    )
 }

--- a/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaMapper.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaMapper.kt
@@ -17,11 +17,13 @@
 package com.google.android.horologist.media.data.mapper
 
 import androidx.media3.common.MediaItem
+import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi
 import com.google.android.horologist.media.model.Media
 
 /**
  * Maps a [MediaItem] into a [Media].
  */
+@ExperimentalHorologistMediaDataApi
 public object MediaMapper {
 
     /**

--- a/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaPositionMapper.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaPositionMapper.kt
@@ -18,12 +18,14 @@ package com.google.android.horologist.media.data.mapper
 
 import androidx.media3.common.C
 import androidx.media3.common.Player
+import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi
 import com.google.android.horologist.media.model.MediaPosition
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Maps a [Media3 player][Player] position into a [MediaPosition].
  */
+@ExperimentalHorologistMediaDataApi
 public object MediaPositionMapper {
     public fun map(player: Player?): MediaPosition? {
         return if (player == null || player.currentMediaItem == null) {

--- a/media-data/src/main/java/com/google/android/horologist/media/data/mapper/PlayerStateMapper.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/mapper/PlayerStateMapper.kt
@@ -17,11 +17,13 @@
 package com.google.android.horologist.media.data.mapper
 
 import androidx.media3.common.Player
+import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi
 import com.google.android.horologist.media.model.PlayerState
 
 /**
  * Maps a [Media3 player][Player] into a [PlayerState].
  */
+@ExperimentalHorologistMediaDataApi
 public object PlayerStateMapper {
     public fun map(player: Player): PlayerState {
         return if ((

--- a/media-data/src/main/java/com/google/android/horologist/media/data/mapper/SetCommandMapper.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/mapper/SetCommandMapper.kt
@@ -17,11 +17,13 @@
 package com.google.android.horologist.media.data.mapper
 
 import androidx.media3.common.Player
+import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi
 import com.google.android.horologist.media.model.Command
 
 /**
  * Maps [Player.Commands] into a [Set] of [Command].
  */
+@ExperimentalHorologistMediaDataApi
 public object SetCommandMapper {
 
     public fun map(commands: Player.Commands): Set<Command> = buildSet {

--- a/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImpl.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImpl.kt
@@ -19,6 +19,7 @@ package com.google.android.horologist.media.data.repository
 import android.util.Log
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
+import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi
 import com.google.android.horologist.media.data.mapper.MediaItemMapper
 import com.google.android.horologist.media.data.mapper.MediaMapper
 import com.google.android.horologist.media.data.mapper.MediaPositionMapper
@@ -43,6 +44,7 @@ import kotlin.time.toDuration
  * The current implementation is available as soon as the ListenableFuture
  * to connect to the MediaSession completes.
  */
+@ExperimentalHorologistMediaDataApi
 public class PlayerRepositoryImpl : PlayerRepository, Closeable {
 
     private var onClose: (() -> Unit)? = null
@@ -309,7 +311,7 @@ public class PlayerRepositoryImpl : PlayerRepository, Closeable {
         checkNotClosed()
 
         player.value?.let {
-            it.setMediaItems(MediaItemMapper.map(mediaList))
+            it.setMediaItems(mediaList.map(MediaItemMapper::map))
             updatePosition()
         }
     }

--- a/media-data/src/test/java/com/google/android/horologist/media/data/mapper/MediaPositionMapperTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/mapper/MediaPositionMapperTest.kt
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalHorologistMediaDataApi::class)
+
 package com.google.android.horologist.media.data.mapper
 
 import androidx.media3.common.C
+import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi
 import com.google.android.horologist.media.model.MediaPosition
 import com.google.android.horologist.test.toolbox.testdoubles.FakeStatePlayer
 import com.google.common.truth.Truth.assertThat

--- a/media-data/src/test/java/com/google/android/horologist/media/data/mapper/PlayerStateMapperTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/mapper/PlayerStateMapperTest.kt
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalHorologistMediaDataApi::class)
+
 package com.google.android.horologist.media.data.mapper
 
 import androidx.media3.common.Player
+import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi
 import com.google.android.horologist.media.model.PlayerState
 import com.google.android.horologist.test.toolbox.testdoubles.FakeStatePlayer
 import com.google.common.truth.Truth.assertThat

--- a/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplCloseTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplCloseTest.kt
@@ -14,12 +14,15 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalHorologistMediaDataApi::class)
+
 package com.google.android.horologist.media.data.repository
 
 import android.content.Context
 import android.os.Looper.getMainLooper
 import androidx.media3.test.utils.TestExoPlayerBuilder
 import androidx.test.core.app.ApplicationProvider
+import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi
 import com.google.android.horologist.media.model.Media
 import org.junit.Assert.assertThrows
 import org.junit.Before

--- a/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplNotConnectedTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplNotConnectedTest.kt
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalHorologistMediaDataApi::class)
+
 package com.google.android.horologist.media.data.repository
 
 import android.content.Context
 import android.os.Looper.getMainLooper
 import androidx.test.core.app.ApplicationProvider
+import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi
 import com.google.android.horologist.media.model.Media
 import com.google.android.horologist.media.model.PlayerState
 import com.google.common.truth.Truth.assertThat

--- a/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplTest.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalHorologistMediaDataApi::class)
+
 package com.google.android.horologist.media.data.repository
 
 import android.content.Context
@@ -24,6 +26,7 @@ import androidx.media3.test.utils.robolectric.TestPlayerRunHelper.playUntilPosit
 import androidx.media3.test.utils.robolectric.TestPlayerRunHelper.runUntilPendingCommandsAreFullyHandled
 import androidx.media3.test.utils.robolectric.TestPlayerRunHelper.runUntilPlaybackState
 import androidx.test.core.app.ApplicationProvider
+import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi
 import com.google.android.horologist.media.data.mapper.MediaItemMapper
 import com.google.android.horologist.media.model.Command
 import com.google.android.horologist.media.model.Media

--- a/media-sample/build.gradle
+++ b/media-sample/build.gradle
@@ -81,6 +81,7 @@ android {
         freeCompilerArgs += "-opt-in=com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.media.ExperimentalHorologistMediaApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi"
+        freeCompilerArgs += "-opt-in=com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.media3.ExperimentalHorologistMedia3BackendApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.networks.ExperimentalHorologistNetworksApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.tiles.ExperimentalHorologistTilesApi"


### PR DESCRIPTION
#### WHAT

Add experimental annotation to classes in `media-data`.

#### WHY

In order to warn developers that they are still in experimental phase.

#### HOW

Add `ExperimentalHorologistMediaDataApi` annotation to classes and opt-in for their usages.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
