### PR TITLE
Add mappers for Media.extras

### DIFF
--- a/media-data/api/current.api
+++ b/media-data/api/current.api
@@ -13,14 +13,32 @@ package com.google.android.horologist.media.data.mapper {
     field public static final com.google.android.horologist.media.data.mapper.CommandMapper INSTANCE;
   }
 
+  @com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi public interface MediaExtrasMapper {
+    method public java.util.Map<java.lang.String,java.lang.Object> map(androidx.media3.common.MediaItem mediaItem);
+  }
+
+  @com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi public final class MediaExtrasMapperNoopImpl implements com.google.android.horologist.media.data.mapper.MediaExtrasMapper {
+    method public java.util.Map<java.lang.String,java.lang.Object> map(androidx.media3.common.MediaItem mediaItem);
+    field public static final com.google.android.horologist.media.data.mapper.MediaExtrasMapperNoopImpl INSTANCE;
+  }
+
+  @com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi public interface MediaItemExtrasMapper {
+    method public void map(com.google.android.horologist.media.model.Media media, androidx.media3.common.MediaItem.Builder mediaItemBuilder, androidx.media3.common.MediaMetadata.Builder mediaMetadataBuilder, androidx.media3.common.MediaItem.RequestMetadata.Builder requestMetadataBuilder);
+  }
+
+  @com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi public final class MediaItemExtrasMapperNoopImpl implements com.google.android.horologist.media.data.mapper.MediaItemExtrasMapper {
+    method public void map(com.google.android.horologist.media.model.Media media, androidx.media3.common.MediaItem.Builder mediaItemBuilder, androidx.media3.common.MediaMetadata.Builder mediaMetadataBuilder, androidx.media3.common.MediaItem.RequestMetadata.Builder requestMetadataBuilder);
+    field public static final com.google.android.horologist.media.data.mapper.MediaItemExtrasMapperNoopImpl INSTANCE;
+  }
+
   @com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi public final class MediaItemMapper {
-    method public androidx.media3.common.MediaItem map(com.google.android.horologist.media.model.Media media);
-    field public static final com.google.android.horologist.media.data.mapper.MediaItemMapper INSTANCE;
+    ctor public MediaItemMapper(com.google.android.horologist.media.data.mapper.MediaItemExtrasMapper mediaItemExtrasMapper);
+    method public androidx.media3.common.MediaItem map(com.google.android.horologist.media.model.Media mediaItem);
   }
 
   @com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi public final class MediaMapper {
+    ctor public MediaMapper(com.google.android.horologist.media.data.mapper.MediaExtrasMapper mediaExtrasMapper);
     method public com.google.android.horologist.media.model.Media map(androidx.media3.common.MediaItem mediaItem, optional String defaultArtist);
-    field public static final com.google.android.horologist.media.data.mapper.MediaMapper INSTANCE;
   }
 
   @com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi public final class MediaPositionMapper {
@@ -44,7 +62,7 @@ package com.google.android.horologist.media.data.mapper {
 package com.google.android.horologist.media.data.repository {
 
   @com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi public final class PlayerRepositoryImpl implements java.io.Closeable com.google.android.horologist.media.repository.PlayerRepository {
-    ctor public PlayerRepositoryImpl();
+    ctor public PlayerRepositoryImpl(com.google.android.horologist.media.data.mapper.MediaMapper mediaMapper, com.google.android.horologist.media.data.mapper.MediaItemMapper mediaItemMapper);
     method public void addMedia(com.google.android.horologist.media.model.Media media);
     method public void addMedia(int index, com.google.android.horologist.media.model.Media media);
     method public void clearMediaList();

--- a/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaExtrasMapper.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaExtrasMapper.kt
@@ -21,26 +21,16 @@ import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataA
 import com.google.android.horologist.media.model.Media
 
 /**
- * Maps a [MediaItem] into a [Media].
+ * Custom implementation to populate [Media.extras] with values from [MediaItem].
  */
 @ExperimentalHorologistMediaDataApi
-public class MediaMapper(
-    private val mediaExtrasMapper: MediaExtrasMapper,
-) {
+public interface MediaExtrasMapper {
 
-    /**
-     * @param mediaItem [MediaItem] to be mapped.
-     * @param defaultArtist value for [Media.artist].
-     */
-    public fun map(
-        mediaItem: MediaItem,
-        defaultArtist: String = ""
-    ): Media = Media(
-        id = mediaItem.mediaId,
-        uri = mediaItem.localConfiguration?.uri?.toString() ?: "",
-        title = mediaItem.mediaMetadata.displayTitle?.toString() ?: "",
-        artist = mediaItem.mediaMetadata.artist?.toString() ?: defaultArtist,
-        artworkUri = mediaItem.mediaMetadata.artworkUri?.toString(),
-        extras = mediaExtrasMapper.map(mediaItem),
-    )
+    public fun map(mediaItem: MediaItem): Map<String, Any>
+}
+
+@ExperimentalHorologistMediaDataApi
+public object MediaExtrasMapperNoopImpl : MediaExtrasMapper {
+
+    override fun map(mediaItem: MediaItem): Map<String, Any> = emptyMap()
 }

--- a/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaItemExtrasMapper.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaItemExtrasMapper.kt
@@ -17,30 +17,32 @@
 package com.google.android.horologist.media.data.mapper
 
 import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
 import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi
 import com.google.android.horologist.media.model.Media
 
 /**
- * Maps a [MediaItem] into a [Media].
+ * Custom implementation to populate [MediaItem] with values from [Media.extras].
  */
 @ExperimentalHorologistMediaDataApi
-public class MediaMapper(
-    private val mediaExtrasMapper: MediaExtrasMapper,
-) {
+public interface MediaItemExtrasMapper {
 
-    /**
-     * @param mediaItem [MediaItem] to be mapped.
-     * @param defaultArtist value for [Media.artist].
-     */
     public fun map(
-        mediaItem: MediaItem,
-        defaultArtist: String = ""
-    ): Media = Media(
-        id = mediaItem.mediaId,
-        uri = mediaItem.localConfiguration?.uri?.toString() ?: "",
-        title = mediaItem.mediaMetadata.displayTitle?.toString() ?: "",
-        artist = mediaItem.mediaMetadata.artist?.toString() ?: defaultArtist,
-        artworkUri = mediaItem.mediaMetadata.artworkUri?.toString(),
-        extras = mediaExtrasMapper.map(mediaItem),
+        media: Media,
+        mediaItemBuilder: MediaItem.Builder,
+        mediaMetadataBuilder: MediaMetadata.Builder,
+        requestMetadataBuilder: MediaItem.RequestMetadata.Builder
     )
+}
+
+@ExperimentalHorologistMediaDataApi
+public object MediaItemExtrasMapperNoopImpl : MediaItemExtrasMapper {
+    override fun map(
+        media: Media,
+        mediaItemBuilder: MediaItem.Builder,
+        mediaMetadataBuilder: MediaMetadata.Builder,
+        requestMetadataBuilder: MediaItem.RequestMetadata.Builder
+    ) {
+        // do nothing
+    }
 }

--- a/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaItemMapper.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaItemMapper.kt
@@ -27,27 +27,41 @@ import com.google.android.horologist.media.model.Media
  * Maps a [Media] into a [MediaItem].
  */
 @ExperimentalHorologistMediaDataApi
-public object MediaItemMapper {
+public class MediaItemMapper(
+    private val mediaItemExtrasMapper: MediaItemExtrasMapper,
+) {
 
-    public fun map(media: Media): MediaItem {
-        val parsedUri = Uri.parse(media.uri)
-        val artworkUri = media.artworkUri?.let(Uri::parse)
+    public fun map(mediaItem: Media): MediaItem {
+        val parsedUri = Uri.parse(mediaItem.uri)
+        val artworkUri = mediaItem.artworkUri?.let(Uri::parse)
 
-        return MediaItem.Builder()
-            .setMediaId(media.id)
+        val mediaItemBuilder = MediaItem.Builder()
+        val mediaMetadataBuilder = MediaMetadata.Builder()
+        val requestMetadataBuilder = RequestMetadata.Builder()
+
+        mediaItemBuilder
+            .setMediaId(mediaItem.id)
             .setUri(parsedUri)
-            .setRequestMetadata(
-                RequestMetadata.Builder()
-                    .setMediaUri(parsedUri)
-                    .build()
-            )
-            .setMediaMetadata(
-                MediaMetadata.Builder()
-                    .setDisplayTitle(media.title)
-                    .setArtist(media.artist)
-                    .setArtworkUri(artworkUri)
-                    .build()
-            )
-            .build()
+
+        mediaMetadataBuilder
+            .setDisplayTitle(mediaItem.title)
+            .setArtist(mediaItem.artist)
+            .setArtworkUri(artworkUri)
+
+        requestMetadataBuilder
+            .setMediaUri(parsedUri)
+
+        mediaItemExtrasMapper.map(
+            mediaItem,
+            mediaItemBuilder,
+            mediaMetadataBuilder,
+            requestMetadataBuilder
+        )
+
+        mediaItemBuilder
+            .setMediaMetadata(mediaMetadataBuilder.build())
+            .setRequestMetadata(requestMetadataBuilder.build())
+
+        return mediaItemBuilder.build()
     }
 }

--- a/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImpl.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImpl.kt
@@ -45,7 +45,10 @@ import kotlin.time.toDuration
  * to connect to the MediaSession completes.
  */
 @ExperimentalHorologistMediaDataApi
-public class PlayerRepositoryImpl : PlayerRepository, Closeable {
+public class PlayerRepositoryImpl(
+    private val mediaMapper: MediaMapper,
+    private val mediaItemMapper: MediaItemMapper,
+) : PlayerRepository, Closeable {
 
     private var onClose: (() -> Unit)? = null
     private var closed = false
@@ -133,7 +136,7 @@ public class PlayerRepositoryImpl : PlayerRepository, Closeable {
     }
 
     private fun updateCurrentMediaItem(player: Player) {
-        _currentMedia.value = player.currentMediaItem?.let(MediaMapper::map)
+        _currentMedia.value = player.currentMediaItem?.let(mediaMapper::map)
     }
 
     /**
@@ -298,7 +301,7 @@ public class PlayerRepositoryImpl : PlayerRepository, Closeable {
         checkNotClosed()
 
         player.value?.let {
-            it.setMediaItem(MediaItemMapper.map(media))
+            it.setMediaItem(mediaItemMapper.map(media))
             updatePosition()
         }
     }
@@ -311,7 +314,7 @@ public class PlayerRepositoryImpl : PlayerRepository, Closeable {
         checkNotClosed()
 
         player.value?.let {
-            it.setMediaItems(mediaList.map(MediaItemMapper::map))
+            it.setMediaItems(mediaList.map(mediaItemMapper::map))
             updatePosition()
         }
     }
@@ -319,13 +322,13 @@ public class PlayerRepositoryImpl : PlayerRepository, Closeable {
     override fun addMedia(media: Media) {
         checkNotClosed()
 
-        player.value?.addMediaItem(MediaItemMapper.map(media))
+        player.value?.addMediaItem(mediaItemMapper.map(media))
     }
 
     override fun addMedia(index: Int, media: Media) {
         checkNotClosed()
 
-        player.value?.addMediaItem(index, MediaItemMapper.map(media))
+        player.value?.addMediaItem(index, mediaItemMapper.map(media))
     }
 
     override fun removeMedia(index: Int) {
@@ -349,7 +352,7 @@ public class PlayerRepositoryImpl : PlayerRepository, Closeable {
     override fun getMediaAt(index: Int): Media? {
         checkNotClosed()
 
-        return player.value?.getMediaItemAt(index)?.let(MediaMapper::map)
+        return player.value?.getMediaItemAt(index)?.let(mediaMapper::map)
     }
 
     override fun getCurrentMediaIndex(): Int {

--- a/media-data/src/test/java/com/google/android/horologist/media/data/mapper/MediaItemMapperTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/mapper/MediaItemMapperTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistMediaDataApi::class)
+
+package com.google.android.horologist.media.data.mapper
+
+import android.net.Uri
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaItem.RequestMetadata
+import androidx.media3.common.MediaMetadata
+import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi
+import com.google.android.horologist.media.model.Media
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class MediaItemMapperTest {
+
+    private lateinit var sut: MediaItemMapper
+
+    @Before
+    fun setUp() {
+        sut = MediaItemMapper(MediaItemExtrasMapperNoopImpl)
+    }
+
+    @Test
+    fun `given MediaItem then maps correctly`() {
+        // given
+        val id = "id"
+        val uri = "uri"
+        val title = "title"
+        val artist = "artist"
+        val artworkUri = "artworkUri"
+
+        val mediaItem = Media(
+            id = id,
+            uri = uri,
+            title = title,
+            artist = artist,
+            artworkUri = artworkUri,
+        )
+
+        // when
+        val result = sut.map(mediaItem)
+
+        // then
+        assertThat(result.mediaId).isEqualTo(id)
+        assertThat(result.localConfiguration!!.uri).isEqualTo((Uri.parse(uri)))
+        assertThat(result.requestMetadata.mediaUri).isEqualTo((Uri.parse(uri)))
+        assertThat(result.mediaMetadata.displayTitle).isEqualTo(title)
+        assertThat(result.mediaMetadata.artist).isEqualTo(artist)
+        assertThat(result.mediaMetadata.artworkUri).isEqualTo(Uri.parse(artworkUri))
+    }
+
+    @Test
+    fun `given MediaItem with null values then maps correctly`() {
+        // given
+        val id = "id"
+        val uri = "uri"
+        val artist = "artist"
+        val title = "title"
+
+        val mediaItem = Media(
+            id = id,
+            uri = uri,
+            artist = artist,
+            title = title
+        )
+
+        // when
+        val result = sut.map(mediaItem)
+
+        // then
+        assertThat(result.mediaId).isEqualTo(id)
+        assertThat(result.localConfiguration!!.uri).isEqualTo((Uri.parse(uri)))
+        assertThat(result.requestMetadata.mediaUri).isEqualTo((Uri.parse(uri)))
+        assertThat(result.mediaMetadata.displayTitle).isEqualTo(title)
+        assertThat(result.mediaMetadata.artist).isEqualTo(artist)
+        assertThat(result.mediaMetadata.artworkUri).isNull()
+    }
+
+    @Test
+    fun `given custom extras mapper implementation then implementation is executed`() {
+        // given
+        val customId = "customId"
+        val customIdValue = "customIdValue"
+        val customArtist = "customArtist"
+        val customArtistValue = "customArtistValue"
+        val customUri = "customUri"
+        val customUriValue = "customUriValue"
+
+        val mediaItem = Media(
+            id = "id",
+            uri = "uri",
+            artist = "artist",
+            title = "title",
+            extras = mapOf(
+                customId to customIdValue,
+                customArtist to customArtistValue,
+                customUri to customUriValue
+            )
+        )
+
+        val sut = MediaItemMapper(object : MediaItemExtrasMapper {
+            override fun map(
+                media: Media,
+                mediaItemBuilder: MediaItem.Builder,
+                mediaMetadataBuilder: MediaMetadata.Builder,
+                requestMetadataBuilder: RequestMetadata.Builder
+            ) {
+                mediaItemBuilder.setMediaId(media.extras[customId].toString())
+                mediaMetadataBuilder.setArtist(media.extras[customArtist].toString())
+                requestMetadataBuilder.setMediaUri(Uri.parse(media.extras[customUri].toString()))
+            }
+        })
+
+        // when
+        val result = sut.map(mediaItem)
+
+        // then
+        assertThat(result.mediaId).isEqualTo(customIdValue)
+        assertThat(result.mediaMetadata.artist).isEqualTo(customArtistValue)
+        assertThat(result.requestMetadata.mediaUri).isEqualTo(Uri.parse(customUriValue))
+    }
+}

--- a/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplCloseTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplCloseTest.kt
@@ -23,6 +23,10 @@ import android.os.Looper.getMainLooper
 import androidx.media3.test.utils.TestExoPlayerBuilder
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi
+import com.google.android.horologist.media.data.mapper.MediaExtrasMapperNoopImpl
+import com.google.android.horologist.media.data.mapper.MediaItemExtrasMapperNoopImpl
+import com.google.android.horologist.media.data.mapper.MediaItemMapper
+import com.google.android.horologist.media.data.mapper.MediaMapper
 import com.google.android.horologist.media.model.Media
 import org.junit.Assert.assertThrows
 import org.junit.Before
@@ -50,7 +54,10 @@ class PlayerRepositoryImplCloseTest(
         shadowOf(getMainLooper()).idle()
 
         context = ApplicationProvider.getApplicationContext()
-        sut = PlayerRepositoryImpl()
+        sut = PlayerRepositoryImpl(
+            mediaMapper = MediaMapper(MediaExtrasMapperNoopImpl),
+            mediaItemMapper = MediaItemMapper(MediaItemExtrasMapperNoopImpl)
+        )
     }
 
     @Test

--- a/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplNotConnectedTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplNotConnectedTest.kt
@@ -22,6 +22,10 @@ import android.content.Context
 import android.os.Looper.getMainLooper
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi
+import com.google.android.horologist.media.data.mapper.MediaExtrasMapperNoopImpl
+import com.google.android.horologist.media.data.mapper.MediaItemExtrasMapperNoopImpl
+import com.google.android.horologist.media.data.mapper.MediaItemMapper
+import com.google.android.horologist.media.data.mapper.MediaMapper
 import com.google.android.horologist.media.model.Media
 import com.google.android.horologist.media.model.PlayerState
 import com.google.common.truth.Truth.assertThat
@@ -50,7 +54,10 @@ class PlayerRepositoryImplNotConnectedTest(
         shadowOf(getMainLooper()).idle()
 
         context = ApplicationProvider.getApplicationContext()
-        sut = PlayerRepositoryImpl()
+        sut = PlayerRepositoryImpl(
+            mediaMapper = MediaMapper(MediaExtrasMapperNoopImpl),
+            mediaItemMapper = MediaItemMapper(MediaItemExtrasMapperNoopImpl)
+        )
     }
 
     @Test

--- a/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplTest.kt
@@ -27,7 +27,10 @@ import androidx.media3.test.utils.robolectric.TestPlayerRunHelper.runUntilPendin
 import androidx.media3.test.utils.robolectric.TestPlayerRunHelper.runUntilPlaybackState
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi
+import com.google.android.horologist.media.data.mapper.MediaExtrasMapperNoopImpl
+import com.google.android.horologist.media.data.mapper.MediaItemExtrasMapperNoopImpl
 import com.google.android.horologist.media.data.mapper.MediaItemMapper
+import com.google.android.horologist.media.data.mapper.MediaMapper
 import com.google.android.horologist.media.model.Command
 import com.google.android.horologist.media.model.Media
 import com.google.android.horologist.media.model.MediaPosition
@@ -53,13 +56,20 @@ class PlayerRepositoryImplTest {
 
     private lateinit var context: Context
 
+    private lateinit var mediaItemMapper: MediaItemMapper
+
     @Before
     fun setUp() {
         // execute all tasks posted to main looper
         shadowOf(getMainLooper()).idle()
 
+        mediaItemMapper = MediaItemMapper(MediaItemExtrasMapperNoopImpl)
+
         context = ApplicationProvider.getApplicationContext()
-        sut = PlayerRepositoryImpl()
+        sut = PlayerRepositoryImpl(
+            mediaMapper = MediaMapper(MediaExtrasMapperNoopImpl),
+            mediaItemMapper = mediaItemMapper
+        )
     }
 
     @Test
@@ -159,7 +169,7 @@ class PlayerRepositoryImplTest {
 
         val media = getStubMedia("id")
 
-        player.setMediaItem(MediaItemMapper.map(media))
+        player.setMediaItem(mediaItemMapper.map(media))
         player.prepare()
 
         // when

--- a/media-sample/src/androidTest/java/com/google/android/horologist/mediasample/playback/PlaybackErrorTest.kt
+++ b/media-sample/src/androidTest/java/com/google/android/horologist/mediasample/playback/PlaybackErrorTest.kt
@@ -18,6 +18,7 @@ package com.google.android.horologist.mediasample.playback
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
+import com.google.android.horologist.media.data.mapper.MediaItemExtrasMapperNoopImpl
 import com.google.android.horologist.media.data.mapper.MediaItemMapper
 import com.google.android.horologist.media.model.Media
 import com.google.common.truth.Truth.assertThat
@@ -33,6 +34,9 @@ import org.junit.runner.RunWith
 @LargeTest
 @HiltAndroidTest
 class PlaybackErrorTest : BasePlaybackTest() {
+
+    private val mediaItemMapper: MediaItemMapper = MediaItemMapper(MediaItemExtrasMapperNoopImpl)
+
     @Test
     fun testFailingItem() = runTest {
         withContext(Dispatchers.Main) {
@@ -47,7 +51,7 @@ class PlaybackErrorTest : BasePlaybackTest() {
             )
 
             browser.setMediaItem(
-                MediaItemMapper.map(badContent),
+                mediaItemMapper.map(badContent),
             )
             browser.prepare()
             browser.play()

--- a/media-sample/src/androidTest/java/com/google/android/horologist/mediasample/playback/PlaybackNotificationTest.kt
+++ b/media-sample/src/androidTest/java/com/google/android/horologist/mediasample/playback/PlaybackNotificationTest.kt
@@ -20,6 +20,7 @@ import android.app.Notification
 import androidx.core.app.NotificationCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
+import com.google.android.horologist.media.data.mapper.MediaItemExtrasMapperNoopImpl
 import com.google.android.horologist.media.data.mapper.MediaItemMapper
 import com.google.android.horologist.media3.flows.waitForPlaying
 import com.google.common.truth.Truth.assertThat
@@ -38,14 +39,17 @@ import kotlin.time.Duration.Companion.seconds
 @HiltAndroidTest
 @Ignore("Broken after hilt change")
 class PlaybackNotificationTest : BasePlaybackTest() {
+
+    private val mediaItemMapper: MediaItemMapper = MediaItemMapper(MediaItemExtrasMapperNoopImpl)
+
     @Test
     fun testCausesNotification() = runTest {
         withContext(Dispatchers.Main) {
             val browser = browser()
 
-            val mediaItem = MediaItemMapper.map(TestMedia.songMp3)
+            val mediaItem = mediaItemMapper.map(TestMedia.songMp3)
             assertThat(mediaItem).isNotNull()
-            browser.setMediaItem(mediaItem,)
+            browser.setMediaItem(mediaItem)
             assertThat(browser.currentMediaItem).isNotNull()
             browser.prepare()
             browser.play()

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/ViewModelModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/ViewModelModule.kt
@@ -22,6 +22,12 @@ import android.content.ComponentName
 import android.content.Context
 import androidx.media3.session.MediaBrowser
 import androidx.media3.session.SessionToken
+import com.google.android.horologist.media.data.mapper.MediaExtrasMapper
+import com.google.android.horologist.media.data.mapper.MediaExtrasMapperNoopImpl
+import com.google.android.horologist.media.data.mapper.MediaItemExtrasMapper
+import com.google.android.horologist.media.data.mapper.MediaItemExtrasMapperNoopImpl
+import com.google.android.horologist.media.data.mapper.MediaItemMapper
+import com.google.android.horologist.media.data.mapper.MediaMapper
 import com.google.android.horologist.media.data.repository.PlayerRepositoryImpl
 import com.google.android.horologist.media.repository.PlayerRepository
 import com.google.android.horologist.media3.flows.buildSuspend
@@ -82,11 +88,16 @@ object ViewModelModule {
     @Provides
     @ActivityRetainedScoped
     fun playerRepositoryImpl(
+        mediaMapper: MediaMapper,
+        mediaItemMapper: MediaItemMapper,
         activityRetainedLifecycle: ActivityRetainedLifecycle,
         coroutineScope: CoroutineScope,
         mediaController: Deferred<MediaBrowser>
     ): PlayerRepositoryImpl =
-        PlayerRepositoryImpl().also { playerRepository ->
+        PlayerRepositoryImpl(
+            mediaMapper = mediaMapper,
+            mediaItemMapper = mediaItemMapper,
+        ).also { playerRepository ->
             activityRetainedLifecycle.addOnClearedListener {
                 playerRepository.close()
             }
@@ -105,4 +116,20 @@ object ViewModelModule {
     fun playerRepository(
         playerRepositoryImpl: PlayerRepositoryImpl
     ): PlayerRepository = playerRepositoryImpl
+
+    @Provides
+    fun mediaExtrasMapper(): MediaExtrasMapper = MediaExtrasMapperNoopImpl
+
+    @Provides
+    fun mediaItemExtrasMapper(): MediaItemExtrasMapper = MediaItemExtrasMapperNoopImpl
+
+    @Provides
+    @ActivityRetainedScoped
+    fun mediaMapper(mediaExtrasMapper: MediaExtrasMapper): MediaMapper =
+        MediaMapper(mediaExtrasMapper)
+
+    @Provides
+    @ActivityRetainedScoped
+    fun mediaItemMapper(mediaItemExtrasMapper: MediaItemExtrasMapper): MediaItemMapper =
+        MediaItemMapper(mediaItemExtrasMapper)
 }


### PR DESCRIPTION
#### WHAT

Add mapper classes for `Media.extras`.

#### WHY

In order to allow `PlayerRepositoryImpl` to map back and forth the values in `Media.extras` based on client's custom implementation.

#### HOW

- Add interfaces `MediaItemExtrasMapper` and `MediaExtrasMapper` and default noop implementations;
- Change `MediaMapper` to class and to require a `MediaExtrasMapper`;
- Change `MediaItemMapper` to class and to require a `MediaItemExtrasMapper`;
- Add unit tests;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
