### PR TITLE
Allow local dependency for exoplayer-workmanager

### DIFF
--- a/media-sample/build.gradle
+++ b/media-sample/build.gradle
@@ -160,7 +160,7 @@ dependencies {
     kapt libs.dagger.hiltandroidcompiler
     implementation libs.hilt.navigationcompose
 
-    implementation libs.androidx.media3.exoplayerworkmanager
+    implementation projectOrDependency(":media-lib-exoplayer-workmanager", libs.androidx.media3.exoplayerworkmanager)
 
     implementation libs.room.common
     implementation libs.room.ktx


### PR DESCRIPTION
#### WHAT

Allow local dependency for exoplayer-workmanager.

#### WHY

Can't build the release APK with both jars and local checkouts present.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
