### PR TITLE
Use Provider to avoid creating AudioOffloadManager when disabled.

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/MediaApplicationModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/MediaApplicationModule.kt
@@ -18,7 +18,6 @@ package com.google.android.horologist.mediasample.di
 
 import android.content.ComponentName
 import android.content.Context
-import android.os.Build
 import android.os.Vibrator
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
@@ -140,7 +139,7 @@ object MediaApplicationModule {
             logger,
             audioOffloadStrategyFlow
         ).also { audioOffloadManager ->
-            if (appConfig.offloadEnabled && Build.VERSION.SDK_INT >= 30) {
+            if (appConfig.offloadEnabled) {
                 coroutineScope.launch {
                     settingsRepository.settingsFlow.map { it.debugOffload }
                         .collectLatest { debug ->

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/MediaApplicationModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/MediaApplicationModule.kt
@@ -18,6 +18,7 @@ package com.google.android.horologist.mediasample.di
 
 import android.content.ComponentName
 import android.content.Context
+import android.os.Build
 import android.os.Vibrator
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
@@ -140,13 +141,15 @@ object MediaApplicationModule {
             audioOffloadStrategyFlow
         ).also { audioOffloadManager ->
             if (appConfig.offloadEnabled) {
-                coroutineScope.launch {
-                    settingsRepository.settingsFlow.map { it.debugOffload }
-                        .collectLatest { debug ->
-                            if (debug) {
-                                audioOffloadManager.printDebugLogsLoop()
+                if (Build.VERSION.SDK_INT >= 30) {
+                    coroutineScope.launch {
+                        settingsRepository.settingsFlow.map { it.debugOffload }
+                            .collectLatest { debug ->
+                                if (debug) {
+                                    audioOffloadManager.printDebugLogsLoop()
+                                }
                             }
-                        }
+                    }
                 }
             }
         }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/MediaApplicationModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/MediaApplicationModule.kt
@@ -140,16 +140,14 @@ object MediaApplicationModule {
             logger,
             audioOffloadStrategyFlow
         ).also { audioOffloadManager ->
-            if (appConfig.offloadEnabled) {
-                if (Build.VERSION.SDK_INT >= 30) {
-                    coroutineScope.launch {
-                        settingsRepository.settingsFlow.map { it.debugOffload }
-                            .collectLatest { debug ->
-                                if (debug) {
-                                    audioOffloadManager.printDebugLogsLoop()
-                                }
+            if (appConfig.offloadEnabled && Build.VERSION.SDK_INT >= 30) {
+                coroutineScope.launch {
+                    settingsRepository.settingsFlow.map { it.debugOffload }
+                        .collectLatest { debug ->
+                            if (debug) {
+                                audioOffloadManager.printDebugLogsLoop()
                             }
-                    }
+                        }
                 }
             }
         }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/PlaybackServiceModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/PlaybackServiceModule.kt
@@ -17,7 +17,6 @@
 package com.google.android.horologist.mediasample.di
 
 import android.app.Service
-import android.os.Build
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.media3.common.AudioAttributes
@@ -67,6 +66,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import okhttp3.Call
+import javax.inject.Provider
 
 @Module
 @InstallIn(ServiceComponent::class)
@@ -214,7 +214,7 @@ object PlaybackServiceModule {
         audioOutputSelector: AudioOutputSelector,
         playbackRules: PlaybackRules,
         logger: ErrorReporter,
-        audioOffloadManager: AudioOffloadManager,
+        audioOffloadManager: Provider<AudioOffloadManager>,
         appConfig: AppConfig
     ): Player =
         WearConfiguredPlayer(
@@ -229,9 +229,9 @@ object PlaybackServiceModule {
                 wearConfiguredPlayer.startNoiseDetection()
             }
 
-            if (appConfig.offloadEnabled && Build.VERSION.SDK_INT >= 30) {
+            if (appConfig.offloadEnabled) {
                 serviceCoroutineScope.launch {
-                    audioOffloadManager.connect(exoPlayer)
+                    audioOffloadManager.get().connect(exoPlayer)
                 }
             }
         }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/PlaybackServiceModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/PlaybackServiceModule.kt
@@ -17,6 +17,7 @@
 package com.google.android.horologist.mediasample.di
 
 import android.app.Service
+import android.os.Build
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.media3.common.AudioAttributes
@@ -229,7 +230,7 @@ object PlaybackServiceModule {
                 wearConfiguredPlayer.startNoiseDetection()
             }
 
-            if (appConfig.offloadEnabled) {
+            if (appConfig.offloadEnabled && Build.VERSION.SDK_INT >= 30) {
                 serviceCoroutineScope.launch {
                     audioOffloadManager.get().connect(exoPlayer)
                 }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/debug/AudioDebugScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/debug/AudioDebugScreenViewModel.kt
@@ -26,21 +26,32 @@ import com.google.android.horologist.media.repository.PlayerRepository
 import com.google.android.horologist.media3.offload.AudioOffloadManager
 import com.google.android.horologist.media3.offload.AudioOffloadStatus
 import com.google.android.horologist.media3.util.toAudioFormat
+import com.google.android.horologist.mediasample.ui.AppConfig
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
+import javax.inject.Provider
 
 @HiltViewModel
 class AudioDebugScreenViewModel @Inject constructor(
-    private val audioOffloadManager: AudioOffloadManager,
+    private val audioOffloadManager: Provider<AudioOffloadManager>,
+    private val appConfig: AppConfig,
     private val audioSink: DefaultAudioSink,
     playerRepository: PlayerRepository,
 ) : ViewModel() {
+    fun audioOffloadFlow(): Flow<AudioOffloadStatus> = if (appConfig.offloadEnabled)
+        audioOffloadManager.get().offloadStatus
+    else {
+        flowOf(AudioOffloadStatus.Disabled)
+    }
+
     val uiState: StateFlow<UiState?> = combine(
-        audioOffloadManager.offloadStatus,
+        audioOffloadFlow(),
         playerRepository.currentMedia
     ) { audioOffloadStatus, currentMedia ->
 

--- a/media3-backend/api/current.api
+++ b/media3-backend/api/current.api
@@ -169,6 +169,12 @@ package com.google.android.horologist.media3.offload {
     property public final com.google.android.horologist.media3.offload.AudioOffloadStrategy? strategy;
     property public final String? strategyStatus;
     property public final Boolean? trackOffload;
+    field public static final com.google.android.horologist.media3.offload.AudioOffloadStatus.Companion Companion;
+  }
+
+  public static final class AudioOffloadStatus.Companion {
+    method public com.google.android.horologist.media3.offload.AudioOffloadStatus getDisabled();
+    property public final com.google.android.horologist.media3.offload.AudioOffloadStatus Disabled;
   }
 
   @com.google.android.horologist.media3.ExperimentalHorologistMedia3BackendApi public interface AudioOffloadStrategy {

--- a/media3-backend/src/main/java/com/google/android/horologist/media3/offload/AudioOffloadStatus.kt
+++ b/media3-backend/src/main/java/com/google/android/horologist/media3/offload/AudioOffloadStatus.kt
@@ -50,4 +50,18 @@ public data class AudioOffloadStatus(
             null -> "N/A"
         }
     }
+
+    public companion object {
+        public val Disabled: AudioOffloadStatus = AudioOffloadStatus(
+            offloadSchedulingEnabled = false,
+            sleepingForOffload = false,
+            trackOffload = false,
+            format = null,
+            isPlaying = false,
+            errors = listOf(),
+            offloadTimes = OffloadTimes(),
+            strategyStatus = null,
+            strategy = null
+        )
+    }
 }


### PR DESCRIPTION
#### WHAT

Use Provider to avoid creating AudioOffloadManager when disabled.

#### WHY

Shouldn't be created at all if not required.

#### HOW

Use a Provider.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
