### PR TITLE
Add Dispatcher annotation

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/DataModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/DataModule.kt
@@ -30,6 +30,8 @@ import com.google.android.horologist.mediasample.data.datasource.PlaylistRemoteD
 import com.google.android.horologist.mediasample.data.repository.PlaylistDownloadRepositoryImpl
 import com.google.android.horologist.mediasample.data.repository.PlaylistRepositoryImpl
 import com.google.android.horologist.mediasample.data.service.download.MediaDownloadService
+import com.google.android.horologist.mediasample.di.annotation.Dispatcher
+import com.google.android.horologist.mediasample.di.annotation.UampDispatchers.IO
 import com.google.android.horologist.mediasample.domain.PlaylistDownloadRepository
 import com.google.android.horologist.mediasample.domain.PlaylistRepository
 import com.google.android.horologist.mediasample.domain.SettingsRepository
@@ -38,6 +40,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import javax.inject.Singleton
@@ -102,9 +105,14 @@ class DataModule {
     @Provides
     fun playlistRemoteDataSource(
         uampService: UampService,
+        @Dispatcher(IO) ioDispatcher: CoroutineDispatcher,
     ): PlaylistRemoteDataSource =
         PlaylistRemoteDataSource(
-            ioDispatcher = Dispatchers.IO,
+            ioDispatcher = ioDispatcher,
             uampService = uampService,
         )
+
+    @Provides
+    @Dispatcher(IO)
+    fun ioDispatcher(): CoroutineDispatcher = Dispatchers.IO
 }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/DownloadModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/DownloadModule.kt
@@ -30,7 +30,9 @@ import com.google.android.horologist.media3.logging.TransferListener
 import com.google.android.horologist.mediasample.data.datasource.MediaDownloadLocalDataSource
 import com.google.android.horologist.mediasample.data.service.download.DownloadManagerListener
 import com.google.android.horologist.mediasample.data.service.download.MediaDownloadService
+import com.google.android.horologist.mediasample.di.annotation.Dispatcher
 import com.google.android.horologist.mediasample.di.annotation.DownloadFeature
+import com.google.android.horologist.mediasample.di.annotation.UampDispatchers.IO
 import com.google.android.horologist.networks.data.RequestType
 import com.google.android.horologist.networks.okhttp.NetworkAwareCallFactory
 import dagger.Module
@@ -38,8 +40,8 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import okhttp3.Call
 import java.util.concurrent.ExecutorService
@@ -123,7 +125,9 @@ object DownloadModule {
     @DownloadFeature
     @Provides
     @Singleton
-    fun coroutineScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    fun coroutineScope(
+        @Dispatcher(IO) ioDispatcher: CoroutineDispatcher,
+    ): CoroutineScope = CoroutineScope(SupervisorJob() + ioDispatcher)
 
     @Provides
     @Singleton

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/annotation/Dispatcher.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/annotation/Dispatcher.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.di.annotation
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Dispatcher(val uampDispatchers: UampDispatchers)
+
+enum class UampDispatchers {
+    IO
+}


### PR DESCRIPTION
#### WHAT

Add `Dispatcher` annotation.

#### WHY

In order to allow the dispatchers injected in our code to be replaced by a dispatcher built with an appropriate executor that we control.

#### HOW

- Add `Dispatcher` annotation and `UampDispatchers` enum;
- Replace direct usages of `Dispatchers.IO` to use injected `CoroutineDispatcher` annotated with `UampDispatcher.IO`

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
