### PR TITLE
Add SectionedScreen

### DIFF
--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -404,6 +404,63 @@ package com.google.android.horologist.media.ui.screens.playlist {
 
 }
 
+package com.google.android.horologist.media.ui.screens.sectioned {
+
+  @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public final class Section {
+    ctor public Section(com.google.android.horologist.media.ui.screens.sectioned.Section.State state, kotlin.jvm.functions.Function1<? super androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit>? headerContent, optional kotlin.jvm.functions.Function1<? super androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit>? footerContent);
+    method public com.google.android.horologist.media.ui.screens.sectioned.Section.State component1();
+    method public kotlin.jvm.functions.Function1<androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit>? component2();
+    method public kotlin.jvm.functions.Function1<androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit>? component3();
+    method public com.google.android.horologist.media.ui.screens.sectioned.Section copy(com.google.android.horologist.media.ui.screens.sectioned.Section.State state, kotlin.jvm.functions.Function1<? super androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit>? headerContent, kotlin.jvm.functions.Function1<? super androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit>? footerContent);
+    method public kotlin.jvm.functions.Function1<androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit>? getFooterContent();
+    method public kotlin.jvm.functions.Function1<androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit>? getHeaderContent();
+    method public com.google.android.horologist.media.ui.screens.sectioned.Section.State getState();
+    property public final kotlin.jvm.functions.Function1<androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit>? footerContent;
+    property public final kotlin.jvm.functions.Function1<androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit>? headerContent;
+    property public final com.google.android.horologist.media.ui.screens.sectioned.Section.State state;
+  }
+
+  public abstract static sealed class Section.State {
+  }
+
+  public static final class Section.State.Empty extends com.google.android.horologist.media.ui.screens.sectioned.Section.State {
+    ctor public Section.State.Empty(kotlin.jvm.functions.Function1<? super androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit> content);
+    method public kotlin.jvm.functions.Function1<androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit> component1();
+    method public com.google.android.horologist.media.ui.screens.sectioned.Section.State.Empty copy(kotlin.jvm.functions.Function1<? super androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit> content);
+    method public kotlin.jvm.functions.Function1<androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit> getContent();
+    property public final kotlin.jvm.functions.Function1<androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit> content;
+  }
+
+  public static final class Section.State.Failed extends com.google.android.horologist.media.ui.screens.sectioned.Section.State {
+    ctor public Section.State.Failed(kotlin.jvm.functions.Function1<? super androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit> content);
+    method public kotlin.jvm.functions.Function1<androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit> component1();
+    method public com.google.android.horologist.media.ui.screens.sectioned.Section.State.Failed copy(kotlin.jvm.functions.Function1<? super androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit> content);
+    method public kotlin.jvm.functions.Function1<androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit> getContent();
+    property public final kotlin.jvm.functions.Function1<androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit> content;
+  }
+
+  public static final class Section.State.Loaded extends com.google.android.horologist.media.ui.screens.sectioned.Section.State {
+    ctor public Section.State.Loaded(java.util.List<? extends kotlin.jvm.functions.Function1<? super androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit>> contentItems);
+    method public java.util.List<kotlin.jvm.functions.Function1<androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit>> component1();
+    method public com.google.android.horologist.media.ui.screens.sectioned.Section.State.Loaded copy(java.util.List<? extends kotlin.jvm.functions.Function1<? super androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit>> contentItems);
+    method public java.util.List<kotlin.jvm.functions.Function1<androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit>> getContentItems();
+    property public final java.util.List<kotlin.jvm.functions.Function1<androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit>> contentItems;
+  }
+
+  public static final class Section.State.Loading extends com.google.android.horologist.media.ui.screens.sectioned.Section.State {
+    ctor public Section.State.Loading(kotlin.jvm.functions.Function1<? super androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit> content);
+    method public kotlin.jvm.functions.Function1<androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit> component1();
+    method public com.google.android.horologist.media.ui.screens.sectioned.Section.State.Loading copy(kotlin.jvm.functions.Function1<? super androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit> content);
+    method public kotlin.jvm.functions.Function1<androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit> getContent();
+    property public final kotlin.jvm.functions.Function1<androidx.wear.compose.material.ScalingLazyListItemScope,kotlin.Unit> content;
+  }
+
+  public final class SectionedScreenKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void SectionedScreen(java.util.List<com.google.android.horologist.media.ui.screens.sectioned.Section> sections, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.wear.compose.material.ScalingLazyListState scalingLazyListState, optional androidx.compose.ui.Modifier modifier);
+  }
+
+}
+
 package com.google.android.horologist.media.ui.semantics {
 
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public final class CustomSemanticsProperties {

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/sectioned/SectionedScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/sectioned/SectionedScreenPreview.kt
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistMediaUiApi::class)
+
+package com.google.android.horologist.media.ui.screens.sectioned
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Downloading
+import androidx.compose.material.icons.filled.FeaturedPlayList
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
+import androidx.wear.compose.material.rememberScalingLazyListState
+import com.google.android.horologist.compose.tools.WearPreviewDevices
+import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
+import com.google.android.horologist.media.ui.components.base.SecondaryPlaceholderChip
+import com.google.android.horologist.media.ui.components.base.StandardChip
+import com.google.android.horologist.media.ui.components.base.StandardChipType
+import com.google.android.horologist.media.ui.components.base.Title
+import com.google.android.horologist.media.ui.utils.rememberVectorPainter
+
+@WearPreviewDevices
+@Composable
+fun SectionedScreenPreviewLoadingSection() {
+    SectionedScreen(
+        sections = listOf(
+            downloadsLoadingSection,
+            favouritesEmptySection
+        ),
+        focusRequester = FocusRequester(),
+        scalingLazyListState = rememberScalingLazyListState()
+    )
+}
+
+@WearPreviewDevices
+@Composable
+fun SectionedScreenPreviewLoadedSection() {
+    SectionedScreen(
+        sections = listOf(
+            downloadsLoadedSection,
+            favouritesFailedSection
+        ),
+        focusRequester = FocusRequester(),
+        scalingLazyListState = rememberScalingLazyListState()
+    )
+}
+
+@WearPreviewDevices
+@Composable
+fun SectionedScreenPreviewFailedSection() {
+    SectionedScreen(
+        sections = listOf(
+            downloadsFailedSection,
+            favouritesLoadedSection
+        ),
+        focusRequester = FocusRequester(),
+        scalingLazyListState = rememberScalingLazyListState()
+    )
+}
+
+@WearPreviewDevices
+@Composable
+fun SectionedScreenPreviewEmptySection() {
+    SectionedScreen(
+        sections = listOf(
+            downloadsEmptySection,
+            favouritesLoadingSection
+        ),
+        focusRequester = FocusRequester(),
+        scalingLazyListState = rememberScalingLazyListState()
+    )
+}
+
+private val downloadsLoadingSection = Section(
+    state = Section.State.Loading {
+        SecondaryPlaceholderChip()
+    },
+    headerContent = { DownloadsTitle() }
+)
+
+private val downloadsLoadedSection = Section(
+    state = Section.State.Loaded(
+        listOf(
+            {
+                StandardChip(
+                    label = "Nu Metal Essentials",
+                    onClick = { },
+                    icon = "icon",
+                    largeIcon = true,
+                    placeholder = rememberVectorPainter(
+                        image = Icons.Default.FeaturedPlayList,
+                        tintColor = Color.Green
+                    ),
+                    chipType = StandardChipType.Secondary
+                )
+            },
+            {
+                StandardChip(
+                    label = "00s Rock",
+                    onClick = { },
+                    secondaryLabel = "15%",
+                    icon = Icons.Default.Downloading,
+                    chipType = StandardChipType.Secondary
+                )
+            }
+        )
+    ),
+    headerContent = { DownloadsTitle() }
+)
+
+private val downloadsFailedSection = Section(
+    state = Section.State.Empty {
+        Text(
+            text = "Failed to load downloads. Please try again later.",
+            modifier = Modifier.padding(top = 8.dp, bottom = 8.dp),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.body2
+        )
+    },
+    headerContent = { DownloadsTitle() }
+)
+
+private val downloadsEmptySection = Section(
+    state = Section.State.Empty {
+        Text(
+            text = "Download music to start listening",
+            modifier = Modifier.padding(top = 8.dp, bottom = 8.dp),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.body2
+        )
+    },
+    headerContent = { DownloadsTitle() }
+)
+
+@Composable
+private fun DownloadsTitle() {
+    Title(
+        text = "Downloads",
+        modifier = Modifier.padding(bottom = 12.dp)
+    )
+}
+
+private val favouritesLoadingSection = Section(
+    state = Section.State.Empty {
+        SecondaryPlaceholderChip()
+    },
+    headerContent = { FavouritesTitle() }
+)
+
+private val favouritesLoadedSection = Section(
+    state = Section.State.Loaded(
+        listOf(
+            {
+                StandardChip(
+                    label = "Dance Anthems",
+                    onClick = { },
+                    icon = "icon",
+                    largeIcon = true,
+                    placeholder = rememberVectorPainter(
+                        image = Icons.Default.FeaturedPlayList,
+                        tintColor = Color.Green
+                    ),
+                    chipType = StandardChipType.Secondary
+                )
+            },
+            {
+                StandardChip(
+                    label = "Indie Jukebox",
+                    onClick = { },
+                    icon = "icon",
+                    largeIcon = true,
+                    placeholder = rememberVectorPainter(
+                        image = Icons.Default.FeaturedPlayList,
+                        tintColor = Color.Green
+                    ),
+                    chipType = StandardChipType.Secondary
+                )
+            }
+        )
+    ),
+    headerContent = { FavouritesTitle() }
+)
+
+private val favouritesFailedSection = Section(
+    state = Section.State.Empty {
+        Text(
+            text = "Failed to load favourites. Please try again later.",
+            modifier = Modifier.padding(top = 8.dp, bottom = 8.dp),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.body2
+        )
+    },
+    headerContent = { FavouritesTitle() }
+)
+
+private val favouritesEmptySection = Section(
+    state = Section.State.Empty {
+        Text(
+            text = "Mark songs or albums as favourites to see them here",
+            modifier = Modifier.padding(top = 8.dp, bottom = 8.dp),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.body2
+        )
+    },
+    headerContent = { FavouritesTitle() }
+)
+
+@Composable
+private fun FavouritesTitle() {
+    Title(
+        text = "Favourites",
+        modifier = Modifier.padding(bottom = 12.dp)
+    )
+}

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/sectioned/SectionedScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/sectioned/SectionedScreen.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.screens.sectioned
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.wear.compose.material.ScalingLazyColumn
+import androidx.wear.compose.material.ScalingLazyListItemScope
+import androidx.wear.compose.material.ScalingLazyListState
+import com.google.android.horologist.compose.navscaffold.scrollableColumn
+import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
+
+/**
+ * A screen that is split into [sections][Section].
+ * Each [Section] has its own [state][Section.State] controlled individually.
+ */
+@ExperimentalHorologistMediaUiApi
+@Composable
+public fun SectionedScreen(
+    sections: List<Section>,
+    focusRequester: FocusRequester,
+    scalingLazyListState: ScalingLazyListState,
+    modifier: Modifier = Modifier
+) {
+    ScalingLazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .scrollableColumn(focusRequester, scalingLazyListState),
+        state = scalingLazyListState
+    ) {
+        sections.forEach { section ->
+            section.headerContent?.let { content ->
+                item { content() }
+            }
+
+            when (val sectionState = section.state) {
+                is Section.State.Loading -> {
+                    item { sectionState.content(this) }
+                }
+                is Section.State.Loaded -> {
+                    sectionState.contentItems.forEach { content ->
+                        item { content() }
+                    }
+                }
+                is Section.State.Failed -> {
+                    item { sectionState.content(this) }
+                }
+                is Section.State.Empty -> {
+                    item { sectionState.content(this) }
+                }
+            }
+
+            section.footerContent?.let { content ->
+                item { content() }
+            }
+        }
+    }
+}
+
+/**
+ * A section in [SectionedScreen].
+ */
+@ExperimentalHorologistMediaUiApi
+public data class Section(
+    val state: State,
+    val headerContent: (@Composable ScalingLazyListItemScope.() -> Unit)?,
+    val footerContent: (@Composable ScalingLazyListItemScope.() -> Unit)? = null
+) {
+
+    /**
+     * A state of a [Section].
+     */
+    public sealed class State {
+
+        public data class Loading(
+            val content: @Composable ScalingLazyListItemScope.() -> Unit
+        ) : State()
+
+        public data class Loaded(
+            val contentItems: List<@Composable ScalingLazyListItemScope.() -> Unit>
+        ) : State()
+
+        public data class Failed(
+            val content: @Composable ScalingLazyListItemScope.() -> Unit
+        ) : State()
+
+        public data class Empty(
+            val content: @Composable ScalingLazyListItemScope.() -> Unit
+        ) : State()
+    }
+}


### PR DESCRIPTION
#### WHAT

Add `SectionedScreen`.

![Screen Shot 2022-08-10 at 11 25 56](https://user-images.githubusercontent.com/878134/183879801-5827ba3a-d915-42c8-b4ce-c6dbf2d7435f.png)

<details>
<summary>Small rounded devices preview</summary>

<img src="https://user-images.githubusercontent.com/878134/183879815-233fad53-6b87-4e22-bf05-c2d24808336b.png" />

</details>

<details>
<summary>Square device previews</summary>

<img src="https://user-images.githubusercontent.com/878134/183879829-d5b9963d-4cae-408e-945b-83bdae7492e6.png" />

</details>


#### WHY

In order to provide screens that contain sections with individual states.

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
