### PR TITLE
Add padding to bottom of playlists header

### DIFF
--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreen.kt
@@ -123,7 +123,7 @@ public fun BrowseScreen(
         item {
             Title(
                 textId = R.string.horologist_browse_library_playlists,
-                modifier = Modifier.padding(top = 12.dp)
+                modifier = Modifier.padding(top = 12.dp, bottom = 12.dp)
             )
         }
 


### PR DESCRIPTION
#### WHAT

Add padding to bottom of playlists header in browse screen.

<img width="277" alt="Screen Shot 2022-08-11 at 09 46 44" src="https://user-images.githubusercontent.com/878134/184097273-e0535c29-5fa7-4b53-a67b-5bbd5390b8c5.png">

#### WHY

In order to align with Figma specs.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
