### PR TITLE
Allow custom layout to be provided for playlist items in PlaylistsScreen

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/UampPlaylistsScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/UampPlaylistsScreenViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.viewModelScope
 import com.google.android.horologist.media.ui.screens.playlist.PlaylistsScreenState
 import com.google.android.horologist.media.ui.snackbar.SnackbarManager
 import com.google.android.horologist.media.ui.snackbar.UiMessage
+import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
 import com.google.android.horologist.mediasample.R
 import com.google.android.horologist.mediasample.domain.PlaylistRepository
 import com.google.android.horologist.mediasample.ui.mapper.PlaylistUiModelMapper
@@ -41,10 +42,10 @@ class UampPlaylistsScreenViewModel @Inject constructor(
     private val resourceProvider: ResourceProvider
 ) : ViewModel() {
 
-    val uiState: StateFlow<PlaylistsScreenState> =
+    val uiState: StateFlow<PlaylistsScreenState<PlaylistUiModel>> =
         playlistRepository.getAll().map {
             PlaylistsScreenState.Loaded(it.map(PlaylistUiModelMapper::map))
-        }.catch<PlaylistsScreenState> { throwable ->
+        }.catch<PlaylistsScreenState<PlaylistUiModel>> { throwable ->
             when (throwable) {
                 is IOException -> {
                     snackbarManager.showMessage(
@@ -53,13 +54,13 @@ class UampPlaylistsScreenViewModel @Inject constructor(
                             error = true
                         )
                     )
-                    emit(PlaylistsScreenState.Failed(R.string.sample_network_error))
+                    emit(PlaylistsScreenState.Failed())
                 }
                 else -> throw throwable
             }
         }.stateIn(
             viewModelScope,
             started = SharingStarted.Eagerly,
-            initialValue = PlaylistsScreenState.Loading
+            initialValue = PlaylistsScreenState.Loading()
         )
 }

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -376,30 +376,28 @@ package com.google.android.horologist.media.ui.screens.entity {
 package com.google.android.horologist.media.ui.screens.playlist {
 
   public final class PlaylistsScreenKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PlaylistsScreen(com.google.android.horologist.media.ui.screens.playlist.PlaylistsScreenState playlistsScreenState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onPlaylistItemClick, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.wear.compose.material.ScalingLazyListState scalingLazyListState, optional androidx.compose.ui.Modifier modifier, optional androidx.compose.ui.graphics.painter.Painter? playlistItemArtworkPlaceholder);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static <T> void PlaylistsScreen(java.util.List<? extends T> playlists, kotlin.jvm.functions.Function1<? super T,kotlin.Unit> playlistContent, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.wear.compose.material.ScalingLazyListState scalingLazyListState, optional androidx.compose.ui.Modifier modifier);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static <T> void PlaylistsScreen(com.google.android.horologist.media.ui.screens.playlist.PlaylistsScreenState<T> playlistsScreenState, kotlin.jvm.functions.Function1<? super T,kotlin.Unit> playlistContent, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.wear.compose.material.ScalingLazyListState scalingLazyListState, optional androidx.compose.ui.Modifier modifier);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PlaylistsScreen(com.google.android.horologist.media.ui.screens.playlist.PlaylistsScreenState<com.google.android.horologist.media.ui.state.model.PlaylistUiModel> playlistsScreenState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onPlaylistItemClick, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.wear.compose.material.ScalingLazyListState scalingLazyListState, optional androidx.compose.ui.Modifier modifier, optional androidx.compose.ui.graphics.painter.Painter? playlistItemArtworkPlaceholder);
   }
 
-  @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public abstract sealed class PlaylistsScreenState {
+  @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public abstract sealed class PlaylistsScreenState<T> {
   }
 
-  public static final class PlaylistsScreenState.Failed extends com.google.android.horologist.media.ui.screens.playlist.PlaylistsScreenState {
-    ctor public PlaylistsScreenState.Failed(@StringRes int errorMessage);
-    method public int component1();
-    method public com.google.android.horologist.media.ui.screens.playlist.PlaylistsScreenState.Failed copy(@StringRes int errorMessage);
-    method public int getErrorMessage();
-    property public final int errorMessage;
+  public static final class PlaylistsScreenState.Failed<T> extends com.google.android.horologist.media.ui.screens.playlist.PlaylistsScreenState<T> {
+    ctor public PlaylistsScreenState.Failed();
   }
 
-  public static final class PlaylistsScreenState.Loaded extends com.google.android.horologist.media.ui.screens.playlist.PlaylistsScreenState {
-    ctor public PlaylistsScreenState.Loaded(java.util.List<com.google.android.horologist.media.ui.state.model.PlaylistUiModel> playlistList);
-    method public java.util.List<com.google.android.horologist.media.ui.state.model.PlaylistUiModel> component1();
-    method public com.google.android.horologist.media.ui.screens.playlist.PlaylistsScreenState.Loaded copy(java.util.List<com.google.android.horologist.media.ui.state.model.PlaylistUiModel> playlistList);
-    method public java.util.List<com.google.android.horologist.media.ui.state.model.PlaylistUiModel> getPlaylistList();
-    property public final java.util.List<com.google.android.horologist.media.ui.state.model.PlaylistUiModel> playlistList;
+  public static final class PlaylistsScreenState.Loaded<T> extends com.google.android.horologist.media.ui.screens.playlist.PlaylistsScreenState<T> {
+    ctor public PlaylistsScreenState.Loaded(java.util.List<? extends T> playlistList);
+    method public java.util.List<T> component1();
+    method public com.google.android.horologist.media.ui.screens.playlist.PlaylistsScreenState.Loaded<T> copy(java.util.List<? extends T> playlistList);
+    method public java.util.List<T> getPlaylistList();
+    property public final java.util.List<T> playlistList;
   }
 
-  public static final class PlaylistsScreenState.Loading extends com.google.android.horologist.media.ui.screens.playlist.PlaylistsScreenState {
-    field public static final com.google.android.horologist.media.ui.screens.playlist.PlaylistsScreenState.Loading INSTANCE;
+  public static final class PlaylistsScreenState.Loading<T> extends com.google.android.horologist.media.ui.screens.playlist.PlaylistsScreenState<T> {
+    ctor public PlaylistsScreenState.Loading();
   }
 
 }

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/playlist/PlaylistScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/playlist/PlaylistScreenPreview.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.wear.compose.material.rememberScalingLazyListState
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
+import com.google.android.horologist.media.ui.components.base.StandardChip
+import com.google.android.horologist.media.ui.components.base.StandardChipType
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
 import com.google.android.horologist.media.ui.utils.rememberVectorPainter
 
@@ -65,8 +67,29 @@ fun PlaylistScreenPreview() {
 @Composable
 fun PlaylistScreenPreviewLoading() {
     PlaylistsScreen(
-        playlistsScreenState = PlaylistsScreenState.Loading,
+        playlistsScreenState = PlaylistsScreenState.Loading(),
         onPlaylistItemClick = { },
+        focusRequester = FocusRequester(),
+        scalingLazyListState = rememberScalingLazyListState()
+    )
+}
+
+@WearPreviewDevices
+@Composable
+fun PlaylistScreenPreviewCustomLayout() {
+    PlaylistsScreen(
+        playlists = listOf(
+            Pair("Rock Classics", "Downloading 73%.."),
+            Pair("Pop Punk", "Completed")
+        ),
+        playlistContent = { (name, status) ->
+            StandardChip(
+                label = name,
+                onClick = { },
+                secondaryLabel = status,
+                chipType = StandardChipType.Primary
+            )
+        },
         focusRequester = FocusRequester(),
         scalingLazyListState = rememberScalingLazyListState()
     )

--- a/media-ui/src/main/res/values/strings.xml
+++ b/media-ui/src/main/res/values/strings.xml
@@ -32,7 +32,7 @@
     <string name="horologist_browse_library_title">Library</string>
     <string name="horologist_browse_library_playlists">Playlists</string>
     <string name="horologist_browse_library_settings">Settings</string>
-    <string name="horologist_browse_playlist_title">Playlist</string>
+    <string name="horologist_browse_playlist_title">Playlists</string>
     <string name="horologist_entity_button_download">Download to your watch</string>
     <string name="horologist_entity_button_downloading">Downloading…</string>
     <string name="horologist_entity_button_download_content_description">Download</string>


### PR DESCRIPTION
#### WHAT

Allow custom layout to be provided for playlist items in `PlaylistsScreen`.

![Screen Shot 2022-08-12 at 15 12 23](https://user-images.githubusercontent.com/878134/184373879-dd69c1d3-359e-496f-ba1d-73c78d2ae1de.png)

#### WHY

In order to provide flexibility so `PlaylistsScreen` can be used with any model, not just `PlaylistUiModel` and any custom layout to display the playlist items.

#### HOW

- Add overloaded function to `PlaylistsScreen` with a type parameter for the type of the model and a `playlistContent` parameter for the custom layout;
- Change `PlaylistsScreenState` to also have a type parameter;
- Add overloaded function to `PlaylistsScreen` that allow a list of playlists to be passed without a state, for a more straight forward usage when state is not needed;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
