### PR TITLE
Add failed dialog to UampPlaylistsScreen

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
@@ -134,6 +134,7 @@ fun UampWearApp(
                             playlistUiModel.title
                         )
                     },
+                    onErrorDialogCancelClick = { navController.popBackStack() },
                     focusRequester = focusRequester,
                     scalingLazyListState = scalingLazyListState
                 )

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/UampPlaylistsScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/UampPlaylistsScreenViewModel.kt
@@ -19,45 +19,27 @@ package com.google.android.horologist.mediasample.ui.playlists
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.android.horologist.media.ui.screens.playlists.PlaylistsScreenState
-import com.google.android.horologist.media.ui.snackbar.SnackbarManager
-import com.google.android.horologist.media.ui.snackbar.UiMessage
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
-import com.google.android.horologist.mediasample.R
 import com.google.android.horologist.mediasample.domain.PlaylistRepository
 import com.google.android.horologist.mediasample.ui.mapper.PlaylistUiModelMapper
-import com.google.android.horologist.mediasample.ui.util.ResourceProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import java.io.IOException
 import javax.inject.Inject
 
 @HiltViewModel
 class UampPlaylistsScreenViewModel @Inject constructor(
-    playlistRepository: PlaylistRepository,
-    private val snackbarManager: SnackbarManager,
-    private val resourceProvider: ResourceProvider
+    playlistRepository: PlaylistRepository
 ) : ViewModel() {
 
     val uiState: StateFlow<PlaylistsScreenState<PlaylistUiModel>> =
         playlistRepository.getAll().map {
             PlaylistsScreenState.Loaded(it.map(PlaylistUiModelMapper::map))
-        }.catch<PlaylistsScreenState<PlaylistUiModel>> { throwable ->
-            when (throwable) {
-                is IOException -> {
-                    snackbarManager.showMessage(
-                        UiMessage(
-                            message = resourceProvider.getString(R.string.sample_network_error),
-                            error = true
-                        )
-                    )
-                    emit(PlaylistsScreenState.Failed())
-                }
-                else -> throw throwable
-            }
+        }.catch<PlaylistsScreenState<PlaylistUiModel>> {
+            emit(PlaylistsScreenState.Failed())
         }.stateIn(
             viewModelScope,
             started = SharingStarted.Eagerly,

--- a/media-sample/src/main/res/values/strings.xml
+++ b/media-sample/src/main/res/values/strings.xml
@@ -53,4 +53,6 @@
     <string name="sync_notification_title">UAMP</string>
     <string name="sync_notification_channel_name">Sync</string>
     <string name="sync_notification_channel_description">Background tasks for UAMP</string>
+    <string name="playlists_no_playlists">No playlists available at the moment</string>
+    <string name="playlists_failed_dialog_cancel_button_content_description">Cancel</string>
 </resources>


### PR DESCRIPTION
#### WHAT

Add failed dialog to `UampPlaylistsScreen`.

![Screenshot_20220815_104238](https://user-images.githubusercontent.com/878134/184619181-64d21ed6-43a3-4f34-a8a9-e5019db2d486.png)


#### WHY

In order to have design closer to Figma specs.
In order to have user journey aligned with Figma specs.

#### HOW

- Change ViewModel to emit a "failed" state for any exception;
- Change screen to display a dialog on Failed state;
- Add `onErrorDialogCancelClick` param to screen so it can navigate back when the dialog is dismissed;

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
