### PR TITLE
Workaround to fix play item by index

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
@@ -22,19 +22,24 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.wear.compose.material.ScalingLazyListState
 import com.google.android.horologist.compose.layout.StateUtils
 import com.google.android.horologist.media.ui.screens.entity.EntityScreen
-import com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
 
 @Composable
 fun UampEntityScreen(
     uampEntityScreenViewModel: UampEntityScreenViewModel,
-    onDownloadItemClick: (DownloadMediaUiModel) -> Unit,
+    onDownloadItemClick: () -> Unit,
     onShuffleClick: (PlaylistUiModel) -> Unit,
     onPlayClick: (PlaylistUiModel) -> Unit,
     focusRequester: FocusRequester,
     scalingLazyListState: ScalingLazyListState
 ) {
     val uiState by StateUtils.rememberStateWithLifecycle(flow = uampEntityScreenViewModel.uiState)
+
+    // https://github.com/google/horologist/issues/496
+    val finishedPlayExecution by StateUtils.rememberStateWithLifecycle(flow = uampEntityScreenViewModel.finishedPlayExecution)
+    if (finishedPlayExecution) {
+        onDownloadItemClick()
+    }
 
     EntityScreen(
         entityScreenState = uiState,
@@ -43,7 +48,6 @@ fun UampEntityScreen(
         },
         onDownloadItemClick = {
             uampEntityScreenViewModel.play(it.mediaUiModel.id)
-            onDownloadItemClick(it)
         },
         onShuffleClick = {
             uampEntityScreenViewModel.shufflePlay()

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreenViewModel.kt
@@ -28,10 +28,13 @@ import com.google.android.horologist.mediasample.domain.model.PlaylistDownload
 import com.google.android.horologist.mediasample.ui.mapper.DownloadMediaUiModelMapper
 import com.google.android.horologist.mediasample.ui.mapper.PlaylistUiModelMapper
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -63,6 +66,9 @@ class UampEntityScreenViewModel @Inject constructor(
         EntityScreenState.Loading(playlistName)
     )
 
+    // https://github.com/google/horologist/issues/496
+    val finishedPlayExecution: MutableStateFlow<Boolean> = MutableStateFlow(false)
+
     fun play(mediaId: String? = null) {
         play(shuffled = false, mediaId = mediaId)
     }
@@ -78,11 +84,18 @@ class UampEntityScreenViewModel @Inject constructor(
                 .coerceAtLeast(0)
 
             playerRepository.setShuffleModeEnabled(shuffled)
-
             playerRepository.setMediaList(playlistDownload.playlist.mediaList)
-            playerRepository.seekToDefaultPosition(index)
-            playerRepository.prepare()
-            playerRepository.play()
+
+            // https://github.com/google/horologist/issues/496
+            viewModelScope.launch {
+                delay(100)
+
+                playerRepository.seekToDefaultPosition(index)
+                playerRepository.prepare()
+                playerRepository.play()
+
+                finishedPlayExecution.value = true
+            }
         }
     }
 


### PR DESCRIPTION
#### WHAT

Workaround to fix play item by index until issue https://github.com/androidx/media/issues/85 is fixed in media3.

Fixes https://github.com/google/horologist/issues/495

#### WHY

So the app can play the specific song selected by the user.

#### HOW

- Add a delay after call to `setMediaList`

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
