### PR TITLE
Add setMediaListAndPlay to PlayerRepository

### DIFF
--- a/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplCloseTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplCloseTest.kt
@@ -122,6 +122,9 @@ class PlayerRepositoryImplCloseTest(
             param("setMediaList") { sut: PlayerRepositoryImpl, _: Context ->
                 sut.setMediaList(listOf(getDummyMedia()))
             },
+            param("setMediaListAndPlay") { sut: PlayerRepositoryImpl, _: Context ->
+                sut.setMediaListAndPlay(listOf(getDummyMedia(), getDummyMedia()), 1)
+            },
             param("addMedia") { sut: PlayerRepositoryImpl, _: Context ->
                 sut.addMedia(getDummyMedia())
             },

--- a/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplNotConnectedTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplNotConnectedTest.kt
@@ -123,6 +123,9 @@ class PlayerRepositoryImplNotConnectedTest(
             param("setMedia") { sut: PlayerRepositoryImpl ->
                 sut.setMedia(getDummyMedia())
             },
+            param("setMediaListAndPlay") { sut: PlayerRepositoryImpl ->
+                sut.setMediaListAndPlay(listOf(getDummyMedia(), getDummyMedia()), 1)
+            },
             param("setMediaList") { sut: PlayerRepositoryImpl ->
                 sut.setMediaList(listOf(getDummyMedia()))
             },

--- a/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplTest.kt
@@ -39,6 +39,7 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -561,6 +562,36 @@ class PlayerRepositoryImplTest {
         assertThat(sut.mediaPosition.value).isEqualTo(MediaPosition.UnknownDuration(0.seconds))
         assertThat(sut.availableCommands.value).containsExactlyElementsIn(
             listOf(Command.PlayPause, Command.SkipToNextMedia, Command.SetShuffle)
+        )
+    }
+
+    @Ignore("Fix test once this issue is fixed: https://github.com/androidx/media/issues/85")
+    @Test
+    fun `given NO previous MediaList is set when setMediaListAndPlay then state is correct`() {
+        // given
+        val player = TestExoPlayerBuilder(context).build()
+        sut.connect(player) {}
+
+        val media1 = getStubMedia("id1")
+        val media2 = getStubMedia("id2")
+        val mediaList = listOf(media1, media2)
+
+        // when
+        sut.setMediaListAndPlay(mediaList, 1)
+        runUntilPendingCommandsAreFullyHandled(player)
+
+        // then
+        assertThat(sut.getMediaCount()).isEqualTo(2)
+        assertThat(sut.getMediaAt(0)).isEqualTo(media1)
+        assertThat(sut.getMediaAt(1)).isEqualTo(media2)
+        assertThat(sut.currentState.value).isEqualTo(PlayerState.Playing)
+        assertThat(sut.currentMedia.value).isEqualTo(media2)
+        assertThat(sut.playbackSpeed.value).isEqualTo(1f)
+        assertThat(sut.shuffleModeEnabled.value).isFalse()
+        assertThat(sut.player.value).isSameInstanceAs(player)
+        assertThat(sut.mediaPosition.value).isEqualTo(MediaPosition.UnknownDuration(0.seconds))
+        assertThat(sut.availableCommands.value).containsExactlyElementsIn(
+            listOf(Command.PlayPause, Command.SkipToPreviousMedia, Command.SetShuffle)
         )
     }
 

--- a/media-ui/src/androidTest/java/com/google/android/horologist/test/toolbox/testdoubles/FakePlayerRepository.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/test/toolbox/testdoubles/FakePlayerRepository.kt
@@ -112,6 +112,10 @@ class FakePlayerRepository : PlayerRepository {
         _currentMedia.value = mediaList[currentItemIndex]
     }
 
+    override fun setMediaListAndPlay(mediaList: List<Media>, index: Int) {
+        // do nothing
+    }
+
     override fun addMedia(media: Media) {
         // do nothing
     }

--- a/media-ui/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/StubPlayerRepository.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/StubPlayerRepository.kt
@@ -29,6 +29,7 @@ import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalHorologistMediaApi::class)
 class StubPlayerRepository : PlayerRepository {
+
     override val connected: StateFlow<Boolean>
         get() = MutableStateFlow(false)
 
@@ -96,6 +97,10 @@ class StubPlayerRepository : PlayerRepository {
     }
 
     override fun setMediaList(mediaList: List<Media>) {
+        // do nothing
+    }
+
+    override fun setMediaListAndPlay(mediaList: List<Media>, index: Int) {
         // do nothing
     }
 

--- a/media/api/current.api
+++ b/media/api/current.api
@@ -110,6 +110,7 @@ package com.google.android.horologist.media.repository {
     method public void seekToDefaultPosition(int mediaIndex);
     method public void setMedia(com.google.android.horologist.media.model.Media media);
     method public void setMediaList(java.util.List<com.google.android.horologist.media.model.Media> mediaList);
+    method public void setMediaListAndPlay(java.util.List<com.google.android.horologist.media.model.Media> mediaList, int index);
     method public void setShuffleModeEnabled(boolean shuffleModeEnabled);
     method public void skipToNextMedia();
     method public void skipToPreviousMedia();

--- a/media/src/main/java/com/google/android/horologist/media/repository/PlayerRepository.kt
+++ b/media/src/main/java/com/google/android/horologist/media/repository/PlayerRepository.kt
@@ -132,9 +132,18 @@ public interface PlayerRepository {
      * Clears the playlist, adds the specified [Media] list and resets the position to
      * the default position.
      *
-     * @param mediaList The new [Media].
+     * @param mediaList The new [Media] list.
      */
     public fun setMediaList(mediaList: List<Media>)
+
+    /**
+     * Clears the playlist, adds the specified [Media] list and plays the [Media] at the position of
+     * the index passed as param.
+     *
+     * @param mediaList The new [Media] list.
+     * @param index The new position.
+     */
+    public fun setMediaListAndPlay(mediaList: List<Media>, index: Int)
 
     /**
      * Adds a [Media] to the end of the playlist.


### PR DESCRIPTION
#### WHAT

Add `setMediaListAndPlay` to `PlayerRepository` with a workaround implementation for #495.

#### WHY

In order to be able to play an item at specific index.
In order to be able to set the media list and seek to a specific index without having an intermediate emission from `PlayerRepository.mediaPosition`.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
