### PR TITLE
Fix play item by index

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreenViewModel.kt
@@ -79,10 +79,7 @@ class UampEntityScreenViewModel @Inject constructor(
 
             playerRepository.setShuffleModeEnabled(shuffled)
 
-            playerRepository.setMediaList(playlistDownload.playlist.mediaList)
-            playerRepository.seekToDefaultPosition(index)
-            playerRepository.prepare()
-            playerRepository.play()
+            playerRepository.setMediaListAndPlay(playlistDownload.playlist.mediaList, index)
         }
     }
 


### PR DESCRIPTION
#### WHAT

https://github.com/google/horologist/pull/497

#### WHY

In order to fix #495

#### HOW

- Change `UampEntityScreenViewModel` to call `PlayerRepository.setMediaListAndPlay` - it contains workaround for #495 implemented in #497

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
