### PR TITLE
Make EntityScreen generic and add PlaylistDownloadScreen

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/api/WearArtworkUampService.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/api/WearArtworkUampService.kt
@@ -25,7 +25,7 @@ class WearArtworkUampService(
     private val uampService: UampService
 ) : UampService {
     private val githubPrefix =
-        "https://media.githubusercontent.com/media/google/horologist/main/media-sample/backend/images/"
+        "https://media.githubusercontent.com/media/google/horologist/main/media-sample/backend/images"
 
     override suspend fun catalog(): CatalogApiModel {
         val originalCatalog = uampService.catalog()

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
@@ -103,10 +103,11 @@ fun UampWearApp(
                     scalingLazyListState = scalingLazyListState
                 )
             },
-            categoryEntityScreen = { _, _, focusRequester, scalingLazyListState ->
+            categoryEntityScreen = { _, name, focusRequester, scalingLazyListState ->
                 val uampEntityScreenViewModel: UampEntityScreenViewModel = hiltViewModel()
 
                 UampEntityScreen(
+                    playlistName = name,
                     uampEntityScreenViewModel = uampEntityScreenViewModel,
                     onDownloadItemClick = {
                         navController.navigateToPlayer()

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
@@ -21,12 +21,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.focus.FocusRequester
 import androidx.wear.compose.material.ScalingLazyListState
 import com.google.android.horologist.compose.layout.StateUtils
-import com.google.android.horologist.media.ui.screens.entity.EntityScreen
+import com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreen
 import com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
 
 @Composable
 fun UampEntityScreen(
+    playlistName: String,
     uampEntityScreenViewModel: UampEntityScreenViewModel,
     onDownloadItemClick: (DownloadMediaUiModel) -> Unit,
     onShuffleClick: (PlaylistUiModel) -> Unit,
@@ -36,8 +37,9 @@ fun UampEntityScreen(
 ) {
     val uiState by StateUtils.rememberStateWithLifecycle(flow = uampEntityScreenViewModel.uiState)
 
-    EntityScreen(
-        entityScreenState = uiState,
+    PlaylistDownloadScreen(
+        playlistName = playlistName,
+        playlistDownloadScreenState = uiState,
         onDownloadClick = {
             uampEntityScreenViewModel.download()
         },

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -328,32 +328,64 @@ package com.google.android.horologist.media.ui.screens.browse {
 package com.google.android.horologist.media.ui.screens.entity {
 
   public final class EntityScreenKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void EntityScreen(com.google.android.horologist.media.ui.screens.entity.EntityScreenState entityScreenState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onDownloadClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel,kotlin.Unit> onDownloadItemClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onShuffleClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onPlayClick, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.wear.compose.material.ScalingLazyListState scalingLazyListState, optional androidx.compose.ui.Modifier modifier, optional String defaultMediaTitle, optional androidx.compose.ui.graphics.painter.Painter? downloadItemArtworkPlaceholder);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void DefaultEntityScreenHeader(String title);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void EntityScreen(kotlin.jvm.functions.Function0<kotlin.Unit> headerContent, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.wear.compose.material.ScalingLazyListState scalingLazyListState, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit>? buttonsContent, optional kotlin.jvm.functions.Function1<? super androidx.wear.compose.material.ScalingLazyListScope,kotlin.Unit>? content);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static <Media> void EntityScreen(kotlin.jvm.functions.Function0<kotlin.Unit> headerContent, java.util.List<? extends Media> mediaList, kotlin.jvm.functions.Function1<? super Media,kotlin.Unit> mediaContent, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.wear.compose.material.ScalingLazyListState scalingLazyListState, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit>? buttonsContent);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static <Media> void EntityScreen(com.google.android.horologist.media.ui.screens.entity.EntityScreenState<Media> entityScreenState, kotlin.jvm.functions.Function0<kotlin.Unit> headerContent, kotlin.jvm.functions.Function1<? super Media,kotlin.Unit> mediaContent, kotlin.jvm.functions.Function0<kotlin.Unit> mediaLoadingContent, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.wear.compose.material.ScalingLazyListState scalingLazyListState, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit>? buttonsContent, optional kotlin.jvm.functions.Function0<kotlin.Unit>? failedContent);
   }
 
-  @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public abstract sealed class EntityScreenState {
+  @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public abstract sealed class EntityScreenState<Media> {
   }
 
-  public static final class EntityScreenState.Loaded extends com.google.android.horologist.media.ui.screens.entity.EntityScreenState {
-    ctor public EntityScreenState.Loaded(com.google.android.horologist.media.ui.state.model.PlaylistUiModel playlistUiModel, java.util.List<? extends com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel> downloadList, optional boolean downloading);
-    method public com.google.android.horologist.media.ui.state.model.PlaylistUiModel component1();
-    method public java.util.List<com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel> component2();
-    method public boolean component3();
-    method public com.google.android.horologist.media.ui.screens.entity.EntityScreenState.Loaded copy(com.google.android.horologist.media.ui.state.model.PlaylistUiModel playlistUiModel, java.util.List<? extends com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel> downloadList, boolean downloading);
-    method public java.util.List<com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel> getDownloadList();
+  public static final class EntityScreenState.Failed<Media> extends com.google.android.horologist.media.ui.screens.entity.EntityScreenState<Media> {
+    ctor public EntityScreenState.Failed();
+  }
+
+  public static final class EntityScreenState.Loaded<Media> extends com.google.android.horologist.media.ui.screens.entity.EntityScreenState<Media> {
+    ctor public EntityScreenState.Loaded(java.util.List<? extends Media> mediaList);
+    method public java.util.List<Media> component1();
+    method public com.google.android.horologist.media.ui.screens.entity.EntityScreenState.Loaded<Media> copy(java.util.List<? extends Media> mediaList);
+    method public java.util.List<Media> getMediaList();
+    property public final java.util.List<Media> mediaList;
+  }
+
+  public static final class EntityScreenState.Loading<Media> extends com.google.android.horologist.media.ui.screens.entity.EntityScreenState<Media> {
+    ctor public EntityScreenState.Loading();
+  }
+
+  public final class PlaylistDownloadScreenKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PlaylistDownloadScreen(String playlistName, com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState<com.google.android.horologist.media.ui.state.model.PlaylistUiModel,com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel> playlistDownloadScreenState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onDownloadClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel,kotlin.Unit> onDownloadItemClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onShuffleClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onPlayClick, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.wear.compose.material.ScalingLazyListState scalingLazyListState, optional androidx.compose.ui.Modifier modifier, optional String defaultMediaTitle, optional androidx.compose.ui.graphics.painter.Painter? downloadItemArtworkPlaceholder);
+    method @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded<com.google.android.horologist.media.ui.state.model.PlaylistUiModel,com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel> createPlaylistDownloadScreenStateLoaded(com.google.android.horologist.media.ui.state.model.PlaylistUiModel playlistModel, java.util.List<? extends com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel> downloadMediaList, optional boolean downloading);
+  }
+
+  @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public abstract sealed class PlaylistDownloadScreenState<Collection, Media> {
+  }
+
+  public static final class PlaylistDownloadScreenState.Loaded<Collection, Media> extends com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState<Collection,Media> {
+    ctor public PlaylistDownloadScreenState.Loaded(Collection? collectionModel, java.util.List<? extends Media> mediaList, com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadMediaListState downloadsState, optional boolean downloading);
+    method public Collection! component1();
+    method public java.util.List<Media> component2();
+    method public com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadMediaListState component3();
+    method public boolean component4();
+    method public com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded<Collection,Media> copy(Collection! collectionModel, java.util.List<? extends Media> mediaList, com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadMediaListState downloadsState, boolean downloading);
+    method public Collection! getCollectionModel();
     method public boolean getDownloading();
-    method public com.google.android.horologist.media.ui.state.model.PlaylistUiModel getPlaylistUiModel();
-    property public final java.util.List<com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel> downloadList;
+    method public com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadMediaListState getDownloadsState();
+    method public java.util.List<Media> getMediaList();
+    property public final Collection! collectionModel;
     property public final boolean downloading;
-    property public final com.google.android.horologist.media.ui.state.model.PlaylistUiModel playlistUiModel;
+    property public final com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadMediaListState downloadsState;
+    property public final java.util.List<Media> mediaList;
   }
 
-  public static final class EntityScreenState.Loading extends com.google.android.horologist.media.ui.screens.entity.EntityScreenState {
-    ctor public EntityScreenState.Loading(String playlistName);
-    method public String component1();
-    method public com.google.android.horologist.media.ui.screens.entity.EntityScreenState.Loading copy(String playlistName);
-    method public String getPlaylistName();
-    property public final String playlistName;
+  public enum PlaylistDownloadScreenState.Loaded.DownloadMediaListState {
+    enum_constant public static final com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadMediaListState Fully;
+    enum_constant public static final com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadMediaListState None;
+    enum_constant public static final com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadMediaListState Partially;
+  }
+
+  public static final class PlaylistDownloadScreenState.Loading<Collection, Media> extends com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState<Collection,Media> {
+    ctor public PlaylistDownloadScreenState.Loading();
   }
 
 }

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/EntityScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/EntityScreenPreview.kt
@@ -18,201 +18,190 @@
 
 package com.google.android.horologist.media.ui.screens.entity
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.PlaylistPlay
+import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.rememberScalingLazyListState
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
-import com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel
-import com.google.android.horologist.media.ui.state.model.MediaUiModel
-import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
-import com.google.android.horologist.media.ui.utils.rememberVectorPainter
+import com.google.android.horologist.media.ui.components.base.SecondaryPlaceholderChip
+import com.google.android.horologist.media.ui.components.base.StandardButton
+import com.google.android.horologist.media.ui.components.base.StandardChip
 
 @WearPreviewDevices
 @Composable
-fun EntityScreenPreviewLoading() {
+fun EntityScreenPreview() {
     EntityScreen(
-        entityScreenState = EntityScreenState.Loading("Artist name"),
-        onDownloadClick = { },
-        onDownloadItemClick = { },
-        onShuffleClick = { },
-        onPlayClick = { },
-        focusRequester = FocusRequester(),
-        scalingLazyListState = rememberScalingLazyListState()
-    )
-}
-
-@WearPreviewDevices
-@Composable
-fun EntityScreenPreviewLoadedNoneDownloaded() {
-    EntityScreen(
-        entityScreenState = EntityScreenState.Loaded(
-            playlistUiModel = playlistUiModel,
-            downloadList = unavailableDownloads,
-            downloading = false
-        ),
-        onDownloadClick = { },
-        onDownloadItemClick = { },
-        onShuffleClick = { },
-        onPlayClick = { },
+        headerContent = {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp)
+                    .background(
+                        Brush.radialGradient(
+                            listOf(
+                                (Color.Green).copy(alpha = 0.3f),
+                                Color.Transparent
+                            )
+                        )
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Text("Playlist name")
+            }
+        },
         focusRequester = FocusRequester(),
         scalingLazyListState = rememberScalingLazyListState(),
-        downloadItemArtworkPlaceholder = rememberVectorPainter(
-            image = Icons.Default.MusicNote,
-            tintColor = Color.Blue
-        )
+        buttonsContent = {
+            Row(
+                modifier = Modifier
+                    .padding(bottom = 16.dp)
+                    .height(52.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                StandardButton(
+                    imageVector = Icons.Default.Favorite,
+                    contentDescription = "Favorite",
+                    onClick = { },
+                    modifier = Modifier
+                        .padding(start = 6.dp)
+                        .weight(weight = 0.3F, fill = false)
+                )
+
+                StandardButton(
+                    imageVector = Icons.Default.PlaylistPlay,
+                    contentDescription = "Play",
+                    onClick = { },
+                    modifier = Modifier
+                        .padding(start = 6.dp)
+                        .weight(weight = 0.3F, fill = false)
+                )
+            }
+        },
+        content = {
+            item { StandardChip(label = "Song 1", onClick = { }) }
+            item { StandardChip(label = "Song 2", onClick = { }) }
+        }
     )
 }
 
 @WearPreviewDevices
 @Composable
-fun EntityScreenPreviewLoadedNoneDownloadedDownloading() {
+fun EntityScreenPreviewLoadedState() {
     EntityScreen(
-        entityScreenState = EntityScreenState.Loaded(
-            playlistUiModel = playlistUiModel,
-            downloadList = unavailableDownloads,
-            downloading = true
-        ),
-        onDownloadClick = { },
-        onDownloadItemClick = { },
-        onShuffleClick = { },
-        onPlayClick = { },
+        entityScreenState = EntityScreenState.Loaded(listOf("Song 1", "Song 2")),
+        headerContent = { DefaultEntityScreenHeader(title = "Playlist name") },
+        mediaContent = { song -> StandardChip(label = song, onClick = { }) },
+        mediaLoadingContent = { },
         focusRequester = FocusRequester(),
         scalingLazyListState = rememberScalingLazyListState(),
-        downloadItemArtworkPlaceholder = rememberVectorPainter(
-            image = Icons.Default.MusicNote,
-            tintColor = Color.Blue
-        )
+        buttonsContent = { ButtonContentForStatePreview() }
     )
 }
 
 @WearPreviewDevices
 @Composable
-fun EntityScreenPreviewLoadedPartiallyDownloaded() {
+fun EntityScreenPreviewLoadingState() {
     EntityScreen(
-        entityScreenState = EntityScreenState.Loaded(
-            playlistUiModel = playlistUiModel,
-            downloadList = mixedDownloads,
-            downloading = false
-        ),
-        onDownloadClick = { },
-        onDownloadItemClick = { },
-        onShuffleClick = { },
-        onPlayClick = { },
+        entityScreenState = EntityScreenState.Loading<String>(),
+        headerContent = { DefaultEntityScreenHeader(title = "Playlist name") },
+        mediaContent = { },
+        mediaLoadingContent = { SecondaryPlaceholderChip() },
         focusRequester = FocusRequester(),
         scalingLazyListState = rememberScalingLazyListState(),
-        downloadItemArtworkPlaceholder = rememberVectorPainter(
-            image = Icons.Default.MusicNote,
-            tintColor = Color.Blue
-        )
+        buttonsContent = { ButtonContentForStatePreview() }
     )
 }
 
 @WearPreviewDevices
 @Composable
-fun EntityScreenPreviewLoadedPartiallyDownloadedDownloading() {
+fun EntityScreenPreviewFailedState() {
     EntityScreen(
-        entityScreenState = EntityScreenState.Loaded(
-            playlistUiModel = playlistUiModel,
-            downloadList = mixedDownloads,
-            downloading = true
-        ),
-        onDownloadClick = { },
-        onDownloadItemClick = { },
-        onShuffleClick = { },
-        onPlayClick = { },
+        entityScreenState = EntityScreenState.Failed<String>(),
+        headerContent = { DefaultEntityScreenHeader(title = "Playlist name") },
+        mediaContent = { },
+        mediaLoadingContent = { },
         focusRequester = FocusRequester(),
         scalingLazyListState = rememberScalingLazyListState(),
-        downloadItemArtworkPlaceholder = rememberVectorPainter(
-            image = Icons.Default.MusicNote,
-            tintColor = Color.Blue
-        )
+        buttonsContent = { ButtonContentForStatePreview() },
+        failedContent = {
+            Column(
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Icon(
+                    imageVector = Icons.Default.CloudOff,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(24.dp)
+                        .wrapContentSize(align = Alignment.Center)
+                )
+                Text(
+                    text = "Could not retrieve the playlist.",
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
     )
 }
 
-@WearPreviewDevices
 @Composable
-fun EntityScreenPreviewLoadedFullyDownloaded() {
-    EntityScreen(
-        entityScreenState = EntityScreenState.Loaded(
-            playlistUiModel = playlistUiModel,
-            downloadList = availableDownloads,
-            downloading = false
-        ),
-        onDownloadClick = { },
-        onDownloadItemClick = { },
-        onShuffleClick = { },
-        onPlayClick = { },
-        focusRequester = FocusRequester(),
-        scalingLazyListState = rememberScalingLazyListState(),
-        downloadItemArtworkPlaceholder = rememberVectorPainter(
-            image = Icons.Default.MusicNote,
-            tintColor = Color.Blue
+private fun ButtonContentForStatePreview() {
+    Row(
+        modifier = Modifier
+            .padding(bottom = 16.dp)
+            .height(52.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        StandardButton(
+            imageVector = Icons.Default.Download,
+            contentDescription = "Download",
+            onClick = { },
+            modifier = Modifier
+                .padding(start = 6.dp)
+                .weight(weight = 0.3F, fill = false)
         )
-    )
+
+        StandardButton(
+            imageVector = Icons.Default.Shuffle,
+            contentDescription = "Shuffle",
+            onClick = { },
+            modifier = Modifier
+                .padding(start = 6.dp)
+                .weight(weight = 0.3F, fill = false)
+        )
+
+        StandardButton(
+            imageVector = Icons.Default.PlayArrow,
+            contentDescription = "Play",
+            onClick = { },
+            modifier = Modifier
+                .padding(start = 6.dp)
+                .weight(weight = 0.3F, fill = false)
+        )
+    }
 }
-
-private val unavailableDownloads = listOf(
-    DownloadMediaUiModel.Unavailable(
-        MediaUiModel(
-            id = "id",
-            title = "Song name",
-            artist = "Artist name",
-            artworkUri = "artworkUri"
-        )
-    ),
-    DownloadMediaUiModel.Unavailable(
-        MediaUiModel(
-            id = "id 2",
-            title = "Song name 2",
-            artist = "Artist name 2",
-            artworkUri = "artworkUri"
-        )
-    )
-)
-
-private val playlistUiModel = PlaylistUiModel(
-    id = "id",
-    title = "Playlist name"
-)
-
-private val mixedDownloads = listOf(
-    DownloadMediaUiModel.Available(
-        MediaUiModel(
-            id = "id",
-            title = "Song name",
-            artist = "Artist name",
-            artworkUri = "artworkUri"
-        )
-    ),
-    DownloadMediaUiModel.Unavailable(
-        MediaUiModel(
-            id = "id 2",
-            title = "Song name 2",
-            artist = "Artist name 2",
-            artworkUri = "artworkUri"
-        )
-    )
-)
-
-private val availableDownloads = listOf(
-    DownloadMediaUiModel.Available(
-        MediaUiModel(
-            id = "id",
-            title = "Song name",
-            artist = "Artist name",
-            artworkUri = "artworkUri"
-        )
-    ),
-    DownloadMediaUiModel.Available(
-        MediaUiModel(
-            id = "id 2",
-            title = "Song name 2",
-            artist = "Artist name 2",
-            artworkUri = "artworkUri"
-        )
-    )
-)

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenPreview.kt
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistMediaUiApi::class)
+
+package com.google.android.horologist.media.ui.screens.entity
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.wear.compose.material.rememberScalingLazyListState
+import com.google.android.horologist.compose.tools.WearPreviewDevices
+import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
+import com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel
+import com.google.android.horologist.media.ui.state.model.MediaUiModel
+import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
+import com.google.android.horologist.media.ui.utils.rememberVectorPainter
+
+@WearPreviewDevices
+@Composable
+fun PlaylistDownloadScreenPreviewLoading() {
+    PlaylistDownloadScreen(
+        playlistName = "Playlist name",
+        playlistDownloadScreenState = PlaylistDownloadScreenState.Loading(),
+        onDownloadClick = { },
+        onDownloadItemClick = { },
+        onShuffleClick = { },
+        onPlayClick = { },
+        focusRequester = FocusRequester(),
+        scalingLazyListState = rememberScalingLazyListState()
+    )
+}
+
+@WearPreviewDevices
+@Composable
+fun PlaylistDownloadScreenPreviewLoadedNoneDownloaded() {
+    PlaylistDownloadScreen(
+        playlistName = "Playlist name",
+        playlistDownloadScreenState = createPlaylistDownloadScreenStateLoaded(
+            playlistModel = playlistUiModel,
+            downloadMediaList = unavailableDownloads,
+            downloading = false
+        ),
+        onDownloadClick = { },
+        onDownloadItemClick = { },
+        onShuffleClick = { },
+        onPlayClick = { },
+        focusRequester = FocusRequester(),
+        scalingLazyListState = rememberScalingLazyListState(),
+        downloadItemArtworkPlaceholder = rememberVectorPainter(
+            image = Icons.Default.MusicNote,
+            tintColor = Color.Blue
+        )
+    )
+}
+
+@WearPreviewDevices
+@Composable
+fun PlaylistDownloadScreenPreviewLoadedNoneDownloadedDownloading() {
+    PlaylistDownloadScreen(
+        playlistName = "Playlist name",
+        playlistDownloadScreenState = createPlaylistDownloadScreenStateLoaded(
+            playlistModel = playlistUiModel,
+            downloadMediaList = unavailableDownloads,
+            downloading = true
+        ),
+        onDownloadClick = { },
+        onDownloadItemClick = { },
+        onShuffleClick = { },
+        onPlayClick = { },
+        focusRequester = FocusRequester(),
+        scalingLazyListState = rememberScalingLazyListState(),
+        downloadItemArtworkPlaceholder = rememberVectorPainter(
+            image = Icons.Default.MusicNote,
+            tintColor = Color.Blue
+        )
+    )
+}
+
+@WearPreviewDevices
+@Composable
+fun PlaylistDownloadScreenPreviewLoadedPartiallyDownloaded() {
+    PlaylistDownloadScreen(
+        playlistName = "Playlist name",
+        playlistDownloadScreenState = createPlaylistDownloadScreenStateLoaded(
+            playlistModel = playlistUiModel,
+            downloadMediaList = mixedDownloads,
+            downloading = false
+        ),
+        onDownloadClick = { },
+        onDownloadItemClick = { },
+        onShuffleClick = { },
+        onPlayClick = { },
+        focusRequester = FocusRequester(),
+        scalingLazyListState = rememberScalingLazyListState(),
+        downloadItemArtworkPlaceholder = rememberVectorPainter(
+            image = Icons.Default.MusicNote,
+            tintColor = Color.Blue
+        )
+    )
+}
+
+@WearPreviewDevices
+@Composable
+fun PlaylistDownloadScreenPreviewLoadedPartiallyDownloadedDownloading() {
+    PlaylistDownloadScreen(
+        playlistName = "Playlist name",
+        playlistDownloadScreenState = createPlaylistDownloadScreenStateLoaded(
+            playlistModel = playlistUiModel,
+            downloadMediaList = mixedDownloads,
+            downloading = true
+        ),
+        onDownloadClick = { },
+        onDownloadItemClick = { },
+        onShuffleClick = { },
+        onPlayClick = { },
+        focusRequester = FocusRequester(),
+        scalingLazyListState = rememberScalingLazyListState(),
+        downloadItemArtworkPlaceholder = rememberVectorPainter(
+            image = Icons.Default.MusicNote,
+            tintColor = Color.Blue
+        )
+    )
+}
+
+@WearPreviewDevices
+@Composable
+fun PlaylistDownloadScreenPreviewLoadedFullyDownloaded() {
+    PlaylistDownloadScreen(
+        playlistName = "Playlist name",
+        playlistDownloadScreenState = createPlaylistDownloadScreenStateLoaded(
+            playlistModel = playlistUiModel,
+            downloadMediaList = availableDownloads,
+            downloading = false
+        ),
+        onDownloadClick = { },
+        onDownloadItemClick = { },
+        onShuffleClick = { },
+        onPlayClick = { },
+        focusRequester = FocusRequester(),
+        scalingLazyListState = rememberScalingLazyListState(),
+        downloadItemArtworkPlaceholder = rememberVectorPainter(
+            image = Icons.Default.MusicNote,
+            tintColor = Color.Blue
+        )
+    )
+}
+
+private val unavailableDownloads = listOf(
+    DownloadMediaUiModel.Unavailable(
+        MediaUiModel(
+            id = "id",
+            title = "Song name",
+            artist = "Artist name",
+            artworkUri = "artworkUri"
+        )
+    ),
+    DownloadMediaUiModel.Unavailable(
+        MediaUiModel(
+            id = "id 2",
+            title = "Song name 2",
+            artist = "Artist name 2",
+            artworkUri = "artworkUri"
+        )
+    )
+)
+
+private val playlistUiModel = PlaylistUiModel(
+    id = "id",
+    title = "Playlist name"
+)
+
+private val mixedDownloads = listOf(
+    DownloadMediaUiModel.Available(
+        MediaUiModel(
+            id = "id",
+            title = "Song name",
+            artist = "Artist name",
+            artworkUri = "artworkUri"
+        )
+    ),
+    DownloadMediaUiModel.Unavailable(
+        MediaUiModel(
+            id = "id 2",
+            title = "Song name 2",
+            artist = "Artist name 2",
+            artworkUri = "artworkUri"
+        )
+    )
+)
+
+private val availableDownloads = listOf(
+    DownloadMediaUiModel.Available(
+        MediaUiModel(
+            id = "id",
+            title = "Song name",
+            artist = "Artist name",
+            artworkUri = "artworkUri"
+        )
+    ),
+    DownloadMediaUiModel.Available(
+        MediaUiModel(
+            id = "id 2",
+            title = "Song name 2",
+            artist = "Artist name 2",
+            artworkUri = "artworkUri"
+        )
+    )
+)

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/navigation/MediaPlayerScaffold.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/navigation/MediaPlayerScaffold.kt
@@ -62,7 +62,7 @@ public fun MediaPlayerScaffold(
     volumeViewModel: VolumeViewModel,
     playerScreen: @Composable (FocusRequester) -> Unit,
     libraryScreen: @Composable (FocusRequester, ScalingLazyListState) -> Unit,
-    categoryEntityScreen: @Composable (String, String, FocusRequester, ScalingLazyListState) -> Unit,
+    categoryEntityScreen: @Composable (id: String, name: String, FocusRequester, ScalingLazyListState) -> Unit,
     mediaEntityScreen: @Composable (FocusRequester, ScalingLazyListState) -> Unit,
     playlistsScreen: @Composable (FocusRequester, ScalingLazyListState) -> Unit,
     settingsScreen: @Composable (FocusRequester, ScalingLazyListState) -> Unit,

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/EntityScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/EntityScreen.kt
@@ -16,50 +16,31 @@
 
 package com.google.android.horologist.media.ui.screens.entity
 
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Download
-import androidx.compose.material.icons.filled.DownloadDone
-import androidx.compose.material.icons.filled.Downloading
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.ScalingLazyColumn
+import androidx.wear.compose.material.ScalingLazyListScope
 import androidx.wear.compose.material.ScalingLazyListState
 import com.google.android.horologist.compose.navscaffold.scrollableColumn
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
-import com.google.android.horologist.media.ui.R
-import com.google.android.horologist.media.ui.components.base.SecondaryPlaceholderChip
-import com.google.android.horologist.media.ui.components.base.StandardButton
-import com.google.android.horologist.media.ui.components.base.StandardButtonType
-import com.google.android.horologist.media.ui.components.base.StandardChip
-import com.google.android.horologist.media.ui.components.base.StandardChipType
 import com.google.android.horologist.media.ui.components.base.Title
-import com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel
-import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
 
+/**
+ * A screen that displays a media collection and allow actions to be taken on it.
+ */
 @ExperimentalHorologistMediaUiApi
 @Composable
 public fun EntityScreen(
-    entityScreenState: EntityScreenState,
-    onDownloadClick: (PlaylistUiModel) -> Unit,
-    onDownloadItemClick: (DownloadMediaUiModel) -> Unit,
-    onShuffleClick: (PlaylistUiModel) -> Unit,
-    onPlayClick: (PlaylistUiModel) -> Unit,
+    headerContent: @Composable () -> Unit,
     focusRequester: FocusRequester,
     scalingLazyListState: ScalingLazyListState,
     modifier: Modifier = Modifier,
-    defaultMediaTitle: String = "",
-    downloadItemArtworkPlaceholder: Painter? = null
+    buttonsContent: (@Composable () -> Unit)? = null,
+    content: (ScalingLazyListScope.() -> Unit)? = null
 ) {
     ScalingLazyColumn(
         modifier = modifier
@@ -67,205 +48,130 @@ public fun EntityScreen(
             .scrollableColumn(focusRequester, scalingLazyListState),
         state = scalingLazyListState
     ) {
-        when (entityScreenState) {
-            is EntityScreenState.Loading -> {
-                item {
-                    Title(
-                        text = entityScreenState.playlistName,
-                        modifier = Modifier.padding(bottom = 12.dp)
-                    )
-                }
+        item {
+            headerContent()
+        }
 
-                item {
-                    StandardChip(
-                        label = stringResource(id = R.string.horologist_entity_button_download),
-                        onClick = { },
-                        modifier = Modifier.padding(bottom = 16.dp),
-                        icon = Icons.Default.Download,
-                        enabled = false
-                    )
-                }
-
-                items(count = 2) {
-                    SecondaryPlaceholderChip()
-                }
+        buttonsContent?.let {
+            item {
+                buttonsContent()
             }
+        }
 
-            is EntityScreenState.Loaded -> {
-                item {
-                    Title(
-                        text = entityScreenState.playlistUiModel.title,
-                        modifier = Modifier.padding(bottom = 12.dp)
-                    )
-                }
-
-                if (entityScreenState.downloadsState == EntityScreenState.Loaded.DownloadsState.None) {
-                    if (entityScreenState.downloading) {
-                        item {
-                            StandardChip(
-                                label = stringResource(id = R.string.horologist_entity_button_downloading),
-                                onClick = { onDownloadClick(entityScreenState.playlistUiModel) },
-                                modifier = Modifier.padding(bottom = 16.dp),
-                                icon = Icons.Default.Download
-                            )
-                        }
-                    } else {
-                        item {
-                            StandardChip(
-                                label = stringResource(id = R.string.horologist_entity_button_download),
-                                onClick = { onDownloadClick(entityScreenState.playlistUiModel) },
-                                modifier = Modifier.padding(bottom = 16.dp),
-                                icon = Icons.Default.Download
-                            )
-                        }
-                    }
-                } else {
-                    item {
-                        Row(
-                            modifier = Modifier
-                                .padding(bottom = 16.dp)
-                                .height(52.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            FirstButton(
-                                downloadsState = entityScreenState.downloadsState,
-                                downloading = entityScreenState.downloading,
-                                playlistUiModel = entityScreenState.playlistUiModel,
-                                onDownloadClick = onDownloadClick,
-                                modifier = Modifier
-                                    .padding(start = 6.dp)
-                                    .weight(weight = 0.3F, fill = false)
-                            )
-
-                            StandardButton(
-                                imageVector = Icons.Default.Shuffle,
-                                contentDescription = stringResource(id = R.string.horologist_entity_button_shuffle_content_description),
-                                onClick = { onShuffleClick(entityScreenState.playlistUiModel) },
-                                modifier = Modifier
-                                    .padding(start = 6.dp)
-                                    .weight(weight = 0.3F, fill = false)
-                            )
-
-                            StandardButton(
-                                imageVector = Icons.Filled.PlayArrow,
-                                contentDescription = stringResource(id = R.string.horologist_entity_button_play_content_description),
-                                onClick = { onPlayClick(entityScreenState.playlistUiModel) },
-                                modifier = Modifier
-                                    .padding(start = 6.dp)
-                                    .weight(weight = 0.3F, fill = false)
-                            )
-                        }
-                    }
-                }
-
-                items(count = entityScreenState.downloadList.size) { index ->
-                    val downloadMediaUiModel = entityScreenState.downloadList[index]
-                    val mediaUiModel = downloadMediaUiModel.mediaUiModel
-
-                    StandardChip(
-                        label = mediaUiModel.title ?: defaultMediaTitle,
-                        onClick = { onDownloadItemClick(downloadMediaUiModel) },
-                        secondaryLabel = mediaUiModel.artist,
-                        icon = mediaUiModel.artworkUri,
-                        largeIcon = true,
-                        placeholder = downloadItemArtworkPlaceholder,
-                        chipType = StandardChipType.Secondary,
-                        enabled = downloadMediaUiModel is DownloadMediaUiModel.Available
-                    )
-                }
-            }
+        content?.let {
+            content()
         }
     }
 }
 
+/**
+ * A screen that displays a [Media] collection and allow actions to be taken on it.
+ */
 @ExperimentalHorologistMediaUiApi
 @Composable
-private fun FirstButton(
-    downloadsState: EntityScreenState.Loaded.DownloadsState,
-    downloading: Boolean,
-    playlistUiModel: PlaylistUiModel,
-    onDownloadClick: (PlaylistUiModel) -> Unit,
-    modifier: Modifier = Modifier
+public fun <Media> EntityScreen(
+    headerContent: @Composable () -> Unit,
+    mediaList: List<Media>,
+    mediaContent: @Composable (media: Media) -> Unit,
+    focusRequester: FocusRequester,
+    scalingLazyListState: ScalingLazyListState,
+    modifier: Modifier = Modifier,
+    buttonsContent: (@Composable () -> Unit)? = null
 ) {
-    val (icon, contentDescription) = when (downloadsState) {
-        EntityScreenState.Loaded.DownloadsState.Partially -> {
-            if (downloading) {
-                Pair(
-                    Icons.Default.Downloading,
-                    R.string.horologist_entity_button_downloading_content_description
-                )
-            } else {
-                Pair(
-                    Icons.Default.Download,
-                    R.string.horologist_entity_button_download_content_description
-                )
+    EntityScreen(
+        headerContent = headerContent,
+        focusRequester = focusRequester,
+        scalingLazyListState = scalingLazyListState,
+        modifier = modifier,
+        buttonsContent = buttonsContent,
+        content = {
+            items(count = mediaList.size) { index ->
+                mediaContent(mediaList[index])
             }
         }
-        EntityScreenState.Loaded.DownloadsState.Fully -> {
-            Pair(
-                Icons.Default.DownloadDone,
-                R.string.horologist_entity_button_download_done_content_description
+    )
+}
+
+/**
+ * A screen that displays a [Media] collection and allow actions to be taken on it.
+ * The content displayed is based on the screen's [state][EntityScreenState].
+ */
+@ExperimentalHorologistMediaUiApi
+@Composable
+public fun <Media> EntityScreen(
+    entityScreenState: EntityScreenState<Media>,
+    headerContent: @Composable () -> Unit,
+    mediaContent: @Composable (media: Media) -> Unit,
+    mediaLoadingContent: @Composable () -> Unit,
+    focusRequester: FocusRequester,
+    scalingLazyListState: ScalingLazyListState,
+    modifier: Modifier = Modifier,
+    buttonsContent: (@Composable () -> Unit)? = null,
+    failedContent: (@Composable () -> Unit)? = null
+) {
+    when (entityScreenState) {
+        is EntityScreenState.Loading -> {
+            EntityScreen(
+                headerContent = headerContent,
+                focusRequester = focusRequester,
+                scalingLazyListState = scalingLazyListState,
+                modifier = modifier,
+                buttonsContent = buttonsContent,
+                content = {
+                    items(count = 2) {
+                        mediaLoadingContent()
+                    }
+                }
             )
         }
-        else -> {
-            error("Invalid state to be used with this button")
+
+        is EntityScreenState.Loaded -> {
+            EntityScreen(
+                headerContent = headerContent,
+                mediaList = entityScreenState.mediaList,
+                mediaContent = mediaContent,
+                focusRequester = focusRequester,
+                scalingLazyListState = scalingLazyListState,
+                modifier = modifier,
+                buttonsContent = buttonsContent
+            )
+        }
+
+        is EntityScreenState.Failed -> {
+            EntityScreen(
+                headerContent = headerContent,
+                focusRequester = focusRequester,
+                scalingLazyListState = scalingLazyListState,
+                modifier = modifier,
+                buttonsContent = buttonsContent,
+                content = failedContent?.let {
+                    { item { failedContent() } }
+                }
+
+            )
         }
     }
-
-    StandardButton(
-        imageVector = icon,
-        contentDescription = stringResource(id = contentDescription),
-        onClick = { onDownloadClick(playlistUiModel) },
-        modifier = modifier,
-        buttonType = StandardButtonType.Secondary
-    )
 }
 
 /**
  * Represents the state of [EntityScreen].
  */
 @ExperimentalHorologistMediaUiApi
-public sealed class EntityScreenState {
+public sealed class EntityScreenState<Media> {
+    public class Loading<Media> : EntityScreenState<Media>()
 
-    public data class Loading(
-        val playlistName: String
-    ) : EntityScreenState()
+    public data class Loaded<Media>(
+        val mediaList: List<Media>
+    ) : EntityScreenState<Media>()
 
-    public data class Loaded(
-        val playlistUiModel: PlaylistUiModel,
-        val downloadList: List<DownloadMediaUiModel>,
-        val downloading: Boolean = false
-    ) : EntityScreenState() {
+    public class Failed<Media> : EntityScreenState<Media>()
+}
 
-        internal val downloadsState: DownloadsState
-
-        init {
-            downloadsState = if (downloadList.isEmpty()) {
-                DownloadsState.Fully
-            } else {
-                var none = true
-                var fully = true
-
-                downloadList.forEach {
-                    if (it is DownloadMediaUiModel.Available) none = false
-                    if (it is DownloadMediaUiModel.Unavailable) fully = false
-                }
-
-                when {
-                    !none && !fully -> DownloadsState.Partially
-                    none -> DownloadsState.None
-                    else -> DownloadsState.Fully
-                }
-            }
-        }
-
-        /**
-         * Represents the state of the downloads.
-         */
-        internal enum class DownloadsState {
-            None,
-            Partially,
-            Fully
-        }
-    }
+/**
+ * A default implementation of a header for [EntityScreen].
+ */
+@ExperimentalHorologistMediaUiApi
+@Composable
+public fun DefaultEntityScreenHeader(title: String) {
+    Title(text = title, modifier = Modifier.padding(bottom = 12.dp))
 }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.screens.entity
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.DownloadDone
+import androidx.compose.material.icons.filled.Downloading
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Shuffle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.ScalingLazyListState
+import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
+import com.google.android.horologist.media.ui.R
+import com.google.android.horologist.media.ui.components.base.SecondaryPlaceholderChip
+import com.google.android.horologist.media.ui.components.base.StandardButton
+import com.google.android.horologist.media.ui.components.base.StandardButtonType
+import com.google.android.horologist.media.ui.components.base.StandardChip
+import com.google.android.horologist.media.ui.components.base.StandardChipType
+import com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel
+import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
+
+/**
+ * An implementation of [EntityScreen] using [PlaylistUiModel] and [DownloadMediaUiModel] as
+ * models.
+ */
+@ExperimentalHorologistMediaUiApi
+@Composable
+public fun PlaylistDownloadScreen(
+    playlistName: String,
+    playlistDownloadScreenState: PlaylistDownloadScreenState<PlaylistUiModel, DownloadMediaUiModel>,
+    onDownloadClick: (PlaylistUiModel) -> Unit,
+    onDownloadItemClick: (DownloadMediaUiModel) -> Unit,
+    onShuffleClick: (PlaylistUiModel) -> Unit,
+    onPlayClick: (PlaylistUiModel) -> Unit,
+    focusRequester: FocusRequester,
+    scalingLazyListState: ScalingLazyListState,
+    modifier: Modifier = Modifier,
+    defaultMediaTitle: String = "",
+    downloadItemArtworkPlaceholder: Painter? = null
+) {
+    val entityScreenState: EntityScreenState<DownloadMediaUiModel> =
+        when (playlistDownloadScreenState) {
+            is PlaylistDownloadScreenState.Loading -> EntityScreenState.Loading()
+            is PlaylistDownloadScreenState.Loaded -> EntityScreenState.Loaded(
+                playlistDownloadScreenState.mediaList
+            )
+        }
+
+    EntityScreen(
+        entityScreenState = entityScreenState,
+        headerContent = { DefaultEntityScreenHeader(title = playlistName) },
+        mediaContent = { downloadMediaUiModel ->
+            val mediaUiModel = downloadMediaUiModel.mediaUiModel
+
+            StandardChip(
+                label = mediaUiModel.title ?: defaultMediaTitle,
+                onClick = { onDownloadItemClick(downloadMediaUiModel) },
+                secondaryLabel = mediaUiModel.artist,
+                icon = mediaUiModel.artworkUri,
+                largeIcon = true,
+                placeholder = downloadItemArtworkPlaceholder,
+                chipType = StandardChipType.Secondary,
+                enabled = downloadMediaUiModel is DownloadMediaUiModel.Available
+            )
+        },
+        mediaLoadingContent = {
+            SecondaryPlaceholderChip()
+        },
+        focusRequester = focusRequester,
+        scalingLazyListState = scalingLazyListState,
+        modifier = modifier,
+        buttonsContent = {
+            ButtonsContent(
+                state = playlistDownloadScreenState,
+                onDownloadClick = onDownloadClick,
+                onShuffleClick = onShuffleClick,
+                onPlayClick = onPlayClick
+            )
+        }
+    )
+}
+
+@ExperimentalHorologistMediaUiApi
+@Composable
+private fun ButtonsContent(
+    state: PlaylistDownloadScreenState<PlaylistUiModel, DownloadMediaUiModel>,
+    onDownloadClick: (PlaylistUiModel) -> Unit,
+    onShuffleClick: (PlaylistUiModel) -> Unit,
+    onPlayClick: (PlaylistUiModel) -> Unit
+) {
+    when (state) {
+        is PlaylistDownloadScreenState.Loading -> {
+            StandardChip(
+                label = stringResource(id = R.string.horologist_entity_button_download),
+                onClick = { },
+                modifier = Modifier.padding(bottom = 16.dp),
+                icon = Icons.Default.Download,
+                enabled = false
+            )
+        }
+
+        is PlaylistDownloadScreenState.Loaded -> {
+            if (state.downloadsState == PlaylistDownloadScreenState.Loaded.DownloadMediaListState.None) {
+                if (state.downloading) {
+                    StandardChip(
+                        label = stringResource(id = R.string.horologist_entity_button_downloading),
+                        onClick = { },
+                        modifier = Modifier.padding(bottom = 16.dp),
+                        icon = Icons.Default.Download
+                    )
+                } else {
+                    StandardChip(
+                        label = stringResource(id = R.string.horologist_entity_button_download),
+                        onClick = { onDownloadClick(state.collectionModel) },
+                        modifier = Modifier.padding(bottom = 16.dp),
+                        icon = Icons.Default.Download
+                    )
+                }
+            } else {
+                Row(
+                    modifier = Modifier
+                        .padding(bottom = 16.dp)
+                        .height(52.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    FirstButton(
+                        downloadMediaListState = state.downloadsState,
+                        downloading = state.downloading,
+                        collectionModel = state.collectionModel,
+                        onDownloadClick = onDownloadClick,
+                        modifier = Modifier
+                            .padding(start = 6.dp)
+                            .weight(weight = 0.3F, fill = false)
+                    )
+
+                    StandardButton(
+                        imageVector = Icons.Default.Shuffle,
+                        contentDescription = stringResource(id = R.string.horologist_entity_button_shuffle_content_description),
+                        onClick = { onShuffleClick(state.collectionModel) },
+                        modifier = Modifier
+                            .padding(start = 6.dp)
+                            .weight(weight = 0.3F, fill = false)
+                    )
+
+                    StandardButton(
+                        imageVector = Icons.Filled.PlayArrow,
+                        contentDescription = stringResource(id = R.string.horologist_entity_button_play_content_description),
+                        onClick = { onPlayClick(state.collectionModel) },
+                        modifier = Modifier
+                            .padding(start = 6.dp)
+                            .weight(weight = 0.3F, fill = false)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@ExperimentalHorologistMediaUiApi
+@Composable
+private fun <Collection> FirstButton(
+    downloadMediaListState: PlaylistDownloadScreenState.Loaded.DownloadMediaListState,
+    downloading: Boolean,
+    collectionModel: Collection,
+    onDownloadClick: (Collection) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val (icon, contentDescription) = when (downloadMediaListState) {
+        PlaylistDownloadScreenState.Loaded.DownloadMediaListState.Partially -> {
+            if (downloading) {
+                Pair(
+                    Icons.Default.Downloading,
+                    R.string.horologist_entity_button_downloading_content_description
+                )
+            } else {
+                Pair(
+                    Icons.Default.Download,
+                    R.string.horologist_entity_button_download_content_description
+                )
+            }
+        }
+        PlaylistDownloadScreenState.Loaded.DownloadMediaListState.Fully -> {
+            Pair(
+                Icons.Default.DownloadDone,
+                R.string.horologist_entity_button_download_done_content_description
+            )
+        }
+        else -> {
+            error("Invalid state to be used with this button")
+        }
+    }
+
+    StandardButton(
+        imageVector = icon,
+        contentDescription = stringResource(id = contentDescription),
+        onClick = { onDownloadClick(collectionModel) },
+        modifier = modifier,
+        buttonType = StandardButtonType.Secondary
+    )
+}
+
+/**
+ * Represents the state of [PlaylistDownloadScreen].
+ */
+@ExperimentalHorologistMediaUiApi
+public sealed class PlaylistDownloadScreenState<Collection, Media> {
+
+    public class Loading<Collection, Media> : PlaylistDownloadScreenState<Collection, Media>()
+
+    public data class Loaded<Collection, Media>(
+        val collectionModel: Collection,
+        val mediaList: List<Media>,
+        val downloadsState: DownloadMediaListState,
+        val downloading: Boolean = false
+    ) : PlaylistDownloadScreenState<Collection, Media>() {
+
+        /**
+         * Represents the state of the list of [Media] when [PlaylistDownloadScreenState] is [Loaded].
+         */
+        public enum class DownloadMediaListState {
+            None,
+            Partially,
+            Fully
+        }
+    }
+}
+
+/**
+ * A helper function to build a [EntityScreenState.Loaded] with [PlaylistUiModel] and
+ * [DownloadMediaUiModel], calculating the value of [PlaylistDownloadScreenState.Loaded.downloadsState].
+ */
+@ExperimentalHorologistMediaUiApi
+public fun createPlaylistDownloadScreenStateLoaded(
+    playlistModel: PlaylistUiModel,
+    downloadMediaList: List<DownloadMediaUiModel>,
+    downloading: Boolean = false
+): PlaylistDownloadScreenState.Loaded<PlaylistUiModel, DownloadMediaUiModel> {
+    val downloadsState = if (downloadMediaList.isEmpty()) {
+        PlaylistDownloadScreenState.Loaded.DownloadMediaListState.Fully
+    } else {
+        var none = true
+        var fully = true
+
+        downloadMediaList.forEach {
+            if (it is DownloadMediaUiModel.Available) none = false
+            if (it is DownloadMediaUiModel.Unavailable) fully = false
+        }
+
+        when {
+            !none && !fully -> PlaylistDownloadScreenState.Loaded.DownloadMediaListState.Partially
+            none -> PlaylistDownloadScreenState.Loaded.DownloadMediaListState.None
+            else -> PlaylistDownloadScreenState.Loaded.DownloadMediaListState.Fully
+        }
+    }
+
+    return PlaylistDownloadScreenState.Loaded(
+        collectionModel = playlistModel,
+        mediaList = downloadMediaList,
+        downloadsState = downloadsState,
+        downloading = downloading
+    )
+}

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/screens/entity/CreatePlaylistDownloadScreenStateLoadedTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/screens/entity/CreatePlaylistDownloadScreenStateLoadedTest.kt
@@ -25,7 +25,7 @@ import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
-class EntityScreenStateTest {
+class CreatePlaylistDownloadScreenStateLoadedTest {
 
     @Test
     fun givenUnavailableDownloads_thenDownloadStateIsNone() {
@@ -50,17 +50,17 @@ class EntityScreenStateTest {
         )
 
         // when
-        val result = EntityScreenState.Loaded(
-            playlistUiModel = PlaylistUiModel(
+        val result = createPlaylistDownloadScreenStateLoaded(
+            playlistModel = PlaylistUiModel(
                 id = "id",
                 title = "title"
             ),
-            downloadList = downloads,
+            downloadMediaList = downloads,
             downloading = false
         ).downloadsState
 
         // then
-        assertThat(result).isEqualTo(EntityScreenState.Loaded.DownloadsState.None)
+        assertThat(result).isEqualTo(PlaylistDownloadScreenState.Loaded.DownloadMediaListState.None)
     }
 
     @Test
@@ -86,17 +86,17 @@ class EntityScreenStateTest {
         )
 
         // when
-        val result = EntityScreenState.Loaded(
-            playlistUiModel = PlaylistUiModel(
+        val result = createPlaylistDownloadScreenStateLoaded(
+            playlistModel = PlaylistUiModel(
                 id = "id",
                 title = "title"
             ),
-            downloadList = downloads,
+            downloadMediaList = downloads,
             downloading = false
         ).downloadsState
 
         // then
-        assertThat(result).isEqualTo(EntityScreenState.Loaded.DownloadsState.Partially)
+        assertThat(result).isEqualTo(PlaylistDownloadScreenState.Loaded.DownloadMediaListState.Partially)
     }
 
     @Test
@@ -122,17 +122,17 @@ class EntityScreenStateTest {
         )
 
         // when
-        val result = EntityScreenState.Loaded(
-            playlistUiModel = PlaylistUiModel(
+        val result = createPlaylistDownloadScreenStateLoaded(
+            playlistModel = PlaylistUiModel(
                 id = "id",
                 title = "title"
             ),
-            downloadList = downloads,
+            downloadMediaList = downloads,
             downloading = false
         ).downloadsState
 
         // then
-        assertThat(result).isEqualTo(EntityScreenState.Loaded.DownloadsState.Fully)
+        assertThat(result).isEqualTo(PlaylistDownloadScreenState.Loaded.DownloadMediaListState.Fully)
     }
 
     @Test
@@ -141,16 +141,16 @@ class EntityScreenStateTest {
         val downloads = emptyList<DownloadMediaUiModel>()
 
         // when
-        val result = EntityScreenState.Loaded(
-            playlistUiModel = PlaylistUiModel(
+        val result = createPlaylistDownloadScreenStateLoaded(
+            playlistModel = PlaylistUiModel(
                 id = "id",
                 title = "title"
             ),
-            downloadList = downloads,
+            downloadMediaList = downloads,
             downloading = false
         ).downloadsState
 
         // then
-        assertThat(result).isEqualTo(EntityScreenState.Loaded.DownloadsState.Fully)
+        assertThat(result).isEqualTo(PlaylistDownloadScreenState.Loaded.DownloadMediaListState.Fully)
     }
 }


### PR DESCRIPTION
#### WHAT

Make `EntityScreen` more customizable;

![Screen Shot 2022-08-17 at 10 17 56](https://user-images.githubusercontent.com/878134/185098496-aeb16927-d35c-4aa6-8c29-3011278c45a7.png)

<details>
<summary>Small rounded devices preview</summary>

<img src="https://user-images.githubusercontent.com/878134/185099861-174ed1a4-630c-40e0-a5c1-8a8095ea696f.png" />

</details>

<details>
<summary>Square device previews</summary>

<img src="https://user-images.githubusercontent.com/878134/185099878-683276be-c6e4-44be-b182-3b99092da8c1.png" />

</details>

Add `PlaylistDownloadScreen`, a specific implementation of `EntityScreen`.

![Screen Shot 2022-08-16 at 13 28 40](https://user-images.githubusercontent.com/878134/185099409-5558861f-eb2d-4e07-a9d9-42b6144d4558.png)

#### WHY

In order to provide common screens.

#### WHAT

- Add a stateless and stateful implementation of `EntityScreen`;
- Add `PlaylistDownloadScreen`;
- Add previews in debug folder;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
