### PR TITLE
Display progress of media downloads

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/database/dao/MediaDownloadDao.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/database/dao/MediaDownloadDao.kt
@@ -20,6 +20,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Update
 import com.google.android.horologist.mediasample.data.database.model.MediaDownloadEntity
 import com.google.android.horologist.mediasample.data.database.model.MediaDownloadEntityStatus
 import kotlinx.coroutines.flow.Flow
@@ -35,6 +36,16 @@ interface MediaDownloadDao {
     )
     fun getList(mediaIds: List<String>): Flow<List<MediaDownloadEntity>>
 
+    @Query(
+        value = """
+        SELECT * FROM MediaDownloadEntity
+        WHERE status = :status
+    """
+    )
+    suspend fun getAllByStatus(
+        status: MediaDownloadEntityStatus
+    ): List<MediaDownloadEntity>
+
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insert(mediaDownloadEntity: MediaDownloadEntity): Long
 
@@ -46,6 +57,19 @@ interface MediaDownloadDao {
     """
     )
     suspend fun updateStatus(mediaId: String, status: MediaDownloadEntityStatus)
+
+    @Query(
+        """
+        UPDATE MediaDownloadEntity
+        SET progress = :progress,
+        size = :size
+        WHERE mediaId = :mediaId
+    """
+    )
+    suspend fun updateProgress(mediaId: String, progress: Float, size: Long)
+
+    @Update(entity = MediaDownloadEntity::class)
+    suspend fun updateStatusAndProgress(statusAndProgress: StatusAndProgress)
 
     @Query(
         """
@@ -62,4 +86,16 @@ interface MediaDownloadDao {
     """
     )
     suspend fun delete(mediaIds: List<String>)
+
+    data class StatusAndProgress(
+        val mediaId: String,
+        val status: MediaDownloadEntityStatus,
+        val progress: Float
+    )
+
+    companion object {
+        internal const val DOWNLOAD_PROGRESS_START = 0f
+        internal const val DOWNLOAD_PROGRESS_END = 100f
+        internal const val SIZE_UNKNOWN = -1L
+    }
 }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/database/model/MediaDownloadEntity.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/database/model/MediaDownloadEntity.kt
@@ -22,7 +22,9 @@ import androidx.room.PrimaryKey
 @Entity
 data class MediaDownloadEntity(
     @PrimaryKey val mediaId: String,
-    val status: MediaDownloadEntityStatus
+    val status: MediaDownloadEntityStatus,
+    val progress: Float,
+    val size: Long
 )
 
 enum class MediaDownloadEntityStatus {

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/datasource/Media3DownloadDataSource.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/datasource/Media3DownloadDataSource.kt
@@ -18,15 +18,12 @@ package com.google.android.horologist.mediasample.data.datasource
 
 import android.content.Context
 import android.net.Uri
-import androidx.media3.exoplayer.offline.Download
-import androidx.media3.exoplayer.offline.DownloadIndex
 import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
 
 class Media3DownloadDataSource(
     private val context: Context,
-    private val downloadService: Class<out DownloadService>,
-    private val downloadIndex: DownloadIndex
+    private val downloadService: Class<out DownloadService>
 ) {
 
     fun download(id: String, uri: Uri) {
@@ -48,6 +45,4 @@ class Media3DownloadDataSource(
             false
         )
     }
-
-    fun getDownload(id: String): Download? = downloadIndex.getDownload(id)
 }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/datasource/PlaylistRemoteDataSource.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/datasource/PlaylistRemoteDataSource.kt
@@ -18,13 +18,15 @@ package com.google.android.horologist.mediasample.data.datasource
 
 import com.google.android.horologist.mediasample.data.api.UampService
 import com.google.android.horologist.mediasample.data.api.model.CatalogApiModel
+import com.google.android.horologist.mediasample.di.annotation.Dispatcher
+import com.google.android.horologist.mediasample.di.annotation.UampDispatchers.IO
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 
 class PlaylistRemoteDataSource(
-    private val ioDispatcher: CoroutineDispatcher,
+    @Dispatcher(IO) private val ioDispatcher: CoroutineDispatcher,
     private val uampService: UampService
 ) {
 

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/mapper/MediaDownloadMapper.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/mapper/MediaDownloadMapper.kt
@@ -17,6 +17,7 @@
 package com.google.android.horologist.mediasample.data.mapper
 
 import com.google.android.horologist.media.model.Media
+import com.google.android.horologist.mediasample.data.database.dao.MediaDownloadDao.Companion.SIZE_UNKNOWN
 import com.google.android.horologist.mediasample.data.database.model.MediaDownloadEntity
 import com.google.android.horologist.mediasample.domain.model.MediaDownload
 import com.google.android.horologist.mediasample.domain.model.Playlist
@@ -25,7 +26,12 @@ object MediaDownloadMapper {
 
     fun map(media: Media, mediaDownloadEntity: MediaDownloadEntity): MediaDownload = MediaDownload(
         media = media,
-        status = MediaDownloadStatusMapper.map(mediaDownloadEntity.status)
+        status = MediaDownloadStatusMapper.map(mediaDownloadEntity),
+        size = if (mediaDownloadEntity.size == SIZE_UNKNOWN) {
+            MediaDownload.Size.Unknown
+        } else {
+            MediaDownload.Size.Known(mediaDownloadEntity.size)
+        }
     )
 
     fun map(
@@ -37,7 +43,8 @@ object MediaDownloadMapper {
                 map(media = media, mediaDownloadEntity = mediaDownloadEntity)
             } ?: MediaDownload(
                 media = media,
-                status = MediaDownload.Status.Idle
+                status = MediaDownload.Status.Idle,
+                size = MediaDownload.Size.Unknown
             )
         }
 }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/mapper/MediaDownloadStatusMapper.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/mapper/MediaDownloadStatusMapper.kt
@@ -16,14 +16,15 @@
 
 package com.google.android.horologist.mediasample.data.mapper
 
+import com.google.android.horologist.mediasample.data.database.model.MediaDownloadEntity
 import com.google.android.horologist.mediasample.data.database.model.MediaDownloadEntityStatus
 import com.google.android.horologist.mediasample.domain.model.MediaDownload
 
 object MediaDownloadStatusMapper {
 
-    fun map(mediaDownloadEntityStatus: MediaDownloadEntityStatus): MediaDownload.Status = when (mediaDownloadEntityStatus) {
+    fun map(mediaDownloadEntity: MediaDownloadEntity): MediaDownload.Status = when (mediaDownloadEntity.status) {
         MediaDownloadEntityStatus.NotDownloaded -> MediaDownload.Status.Idle
-        MediaDownloadEntityStatus.Downloading -> MediaDownload.Status.InProgress
+        MediaDownloadEntityStatus.Downloading -> MediaDownload.Status.InProgress(mediaDownloadEntity.progress)
         MediaDownloadEntityStatus.Downloaded -> MediaDownload.Status.Completed
         MediaDownloadEntityStatus.Failed -> MediaDownload.Status.Idle
     }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/service/download/DownloadProgressMonitor.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/service/download/DownloadProgressMonitor.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.data.service.download
+
+import android.os.Handler
+import android.os.Looper
+import androidx.media3.exoplayer.offline.DownloadManager
+import com.google.android.horologist.mediasample.data.datasource.MediaDownloadLocalDataSource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class DownloadProgressMonitor(
+    private val coroutineScope: CoroutineScope,
+    private val mediaDownloadLocalDataSource: MediaDownloadLocalDataSource
+) {
+
+    private val handler = Handler(Looper.getMainLooper())
+    private var running = false
+
+    fun start(downloadManager: DownloadManager) {
+        Dispatchers.Main
+        running = true
+        update(downloadManager)
+    }
+
+    fun stop() {
+        running = false
+        handler.removeCallbacksAndMessages(null)
+    }
+
+    private fun update(downloadManager: DownloadManager) {
+        coroutineScope.launch {
+            val downloads = mediaDownloadLocalDataSource.getAllDownloading()
+
+            if (downloads.isNotEmpty()) {
+                downloads.forEach {
+                    downloadManager.downloadIndex.getDownload(it.mediaId)?.let { download ->
+                        mediaDownloadLocalDataSource.updateProgress(
+                            mediaId = download.request.id,
+                            progress = download.percentDownloaded,
+                            size = download.contentLength
+                        )
+                    }
+                }
+            } else {
+                stop()
+            }
+        }
+
+        if (running) {
+            handler.removeCallbacksAndMessages(null)
+            handler.postDelayed({ update(downloadManager) }, UPDATE_INTERVAL_MILLIS)
+        }
+    }
+
+    companion object {
+        private const val UPDATE_INTERVAL_MILLIS = 1000L
+    }
+}

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/service/download/MediaDownloadService.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/service/download/MediaDownloadService.kt
@@ -48,6 +48,21 @@ class MediaDownloadService : DownloadService(
     @Inject
     lateinit var intentBuilder: IntentBuilder
 
+    @Inject
+    lateinit var downloadManagerListener: DownloadManagerListener
+
+    override fun onCreate() {
+        super.onCreate()
+
+        downloadManagerListener.onServiceCreated(downloadManagerParam)
+    }
+
+    override fun onDestroy() {
+        downloadManagerListener.onServiceDestroyed()
+
+        super.onDestroy()
+    }
+
     override fun getDownloadManager(): DownloadManager = downloadManagerParam
 
     override fun getScheduler(): Scheduler = workManagerScheduler

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/DataModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/DataModule.kt
@@ -18,7 +18,6 @@ package com.google.android.horologist.mediasample.di
 
 import android.content.Context
 import androidx.datastore.core.DataStore
-import androidx.media3.exoplayer.offline.DownloadIndex
 import com.google.android.horologist.mediasample.data.api.NetworkChangeListService
 import com.google.android.horologist.mediasample.data.api.UampService
 import com.google.android.horologist.mediasample.data.database.MediaDatabase
@@ -100,12 +99,10 @@ class DataModule {
     @Singleton
     @Provides
     fun media3DownloadDataSource(
-        @ApplicationContext applicationContext: Context,
-        downloadIndex: DownloadIndex
+        @ApplicationContext applicationContext: Context
     ) = Media3DownloadDataSource(
         applicationContext,
-        MediaDownloadService::class.java,
-        downloadIndex
+        MediaDownloadService::class.java
     )
 
     @Provides

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/DownloadModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/DownloadModule.kt
@@ -22,6 +22,7 @@ import androidx.media3.database.StandaloneDatabaseProvider
 import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.cache.Cache
 import androidx.media3.datasource.okhttp.OkHttpDataSource
+import androidx.media3.exoplayer.offline.DownloadIndex
 import androidx.media3.exoplayer.offline.DownloadManager
 import androidx.media3.exoplayer.offline.DownloadNotificationHelper
 import androidx.media3.exoplayer.workmanager.WorkManagerScheduler
@@ -30,6 +31,7 @@ import com.google.android.horologist.media3.logging.TransferListener
 import com.google.android.horologist.media3.service.NetworkAwareDownloadListener
 import com.google.android.horologist.mediasample.data.datasource.MediaDownloadLocalDataSource
 import com.google.android.horologist.mediasample.data.service.download.DownloadManagerListener
+import com.google.android.horologist.mediasample.data.service.download.DownloadProgressMonitor
 import com.google.android.horologist.mediasample.data.service.download.MediaDownloadService
 import com.google.android.horologist.mediasample.di.annotation.Dispatcher
 import com.google.android.horologist.mediasample.di.annotation.DownloadFeature
@@ -118,7 +120,7 @@ object DownloadModule {
     }
 
     @Provides
-    fun downloadIndex(downloadManager: DownloadManager) = downloadManager.downloadIndex
+    fun downloadIndex(downloadManager: DownloadManager): DownloadIndex = downloadManager.downloadIndex
 
     @Singleton
     @Provides
@@ -137,10 +139,22 @@ object DownloadModule {
     @Singleton
     fun downloadManagerListener(
         @DownloadFeature coroutineScope: CoroutineScope,
-        mediaDownloadLocalDataSource: MediaDownloadLocalDataSource
+        mediaDownloadLocalDataSource: MediaDownloadLocalDataSource,
+        downloadProgressMonitor: DownloadProgressMonitor
     ): DownloadManagerListener = DownloadManagerListener(
-        coroutineScope,
-        mediaDownloadLocalDataSource
+        coroutineScope = coroutineScope,
+        mediaDownloadLocalDataSource = mediaDownloadLocalDataSource,
+        downloadProgressMonitor = downloadProgressMonitor
+    )
+
+    @Provides
+    @Singleton
+    fun downloadProgressMonitor(
+        @DownloadFeature coroutineScope: CoroutineScope,
+        mediaDownloadLocalDataSource: MediaDownloadLocalDataSource
+    ): DownloadProgressMonitor = DownloadProgressMonitor(
+        coroutineScope = coroutineScope,
+        mediaDownloadLocalDataSource = mediaDownloadLocalDataSource
     )
 
     @Provides

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/model/MediaDownload.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/model/MediaDownload.kt
@@ -20,12 +20,22 @@ import com.google.android.horologist.media.model.Media
 
 data class MediaDownload(
     val media: Media,
-    val status: Status
+    val status: Status,
+    val size: Size
 ) {
 
-    enum class Status {
-        Idle,
-        InProgress,
-        Completed
+    sealed class Status {
+
+        object Idle : Status()
+
+        data class InProgress(val progress: Float) : Status()
+
+        object Completed : Status()
+    }
+
+    public sealed class Size {
+        public object Unknown : Size()
+
+        public data class Known(val sizeInBytes: Long) : Size()
     }
 }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
@@ -44,7 +44,7 @@ fun UampEntityScreen(
             uampEntityScreenViewModel.download()
         },
         onDownloadItemClick = {
-            uampEntityScreenViewModel.play(it.mediaUiModel.id)
+            uampEntityScreenViewModel.play(it.id)
             onDownloadItemClick(it)
         },
         onShuffleClick = {

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreenViewModel.kt
@@ -55,7 +55,7 @@ class UampEntityScreenViewModel @Inject constructor(
                 createPlaylistDownloadScreenStateLoaded(
                     playlistModel = PlaylistUiModelMapper.map(playlistDownload.playlist),
                     downloadMediaList = playlistDownload.mediaList.map(DownloadMediaUiModelMapper::map),
-                    downloading = playlistDownload.mediaList.any { (_, status) -> status == MediaDownload.Status.InProgress }
+                    downloading = playlistDownload.mediaList.any { (_, status) -> status is MediaDownload.Status.InProgress }
                 )
             } else {
                 PlaylistDownloadScreenState.Loading()

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/mapper/DownloadMediaUiModelMapper.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/mapper/DownloadMediaUiModelMapper.kt
@@ -16,21 +16,45 @@
 
 package com.google.android.horologist.mediasample.ui.mapper
 
-import com.google.android.horologist.media.ui.state.mapper.MediaUiModelMapper
 import com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel
 import com.google.android.horologist.mediasample.domain.model.MediaDownload
 
 object DownloadMediaUiModelMapper {
 
+    private const val PROGRESS_FORMAT = "%.0f"
+    private const val SIZE_FORMAT = "%.0f"
+
     fun map(
         mediaDownload: MediaDownload
     ): DownloadMediaUiModel = when (mediaDownload.status) {
-        MediaDownload.Status.Idle,
-        MediaDownload.Status.InProgress -> {
-            DownloadMediaUiModel.Unavailable(MediaUiModelMapper.map(mediaDownload.media))
+        MediaDownload.Status.Idle -> {
+            DownloadMediaUiModel.NotDownloaded(
+                id = mediaDownload.media.id,
+                title = mediaDownload.media.title,
+                artist = mediaDownload.media.artist,
+                artworkUri = mediaDownload.media.artworkUri
+            )
+        }
+
+        is MediaDownload.Status.InProgress -> {
+            DownloadMediaUiModel.Downloading(
+                id = mediaDownload.media.id,
+                title = mediaDownload.media.title,
+                progress = PROGRESS_FORMAT.format(mediaDownload.status.progress),
+                size = when (mediaDownload.size) {
+                    is MediaDownload.Size.Known -> DownloadMediaUiModel.Size.Known(mediaDownload.size.sizeInBytes)
+                    is MediaDownload.Size.Unknown -> DownloadMediaUiModel.Size.Unknown
+                },
+                artworkUri = mediaDownload.media.artworkUri
+            )
         }
         MediaDownload.Status.Completed -> {
-            DownloadMediaUiModel.Available(MediaUiModelMapper.map(mediaDownload.media))
+            DownloadMediaUiModel.Downloaded(
+                id = mediaDownload.media.id,
+                title = mediaDownload.media.title,
+                artist = mediaDownload.media.artist,
+                artworkUri = mediaDownload.media.artworkUri
+            )
         }
     }
 }

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -583,22 +583,72 @@ package com.google.android.horologist.media.ui.state.mapper {
 package com.google.android.horologist.media.ui.state.model {
 
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public abstract sealed class DownloadMediaUiModel {
-    method public com.google.android.horologist.media.ui.state.model.MediaUiModel getMediaUiModel();
-    property public com.google.android.horologist.media.ui.state.model.MediaUiModel mediaUiModel;
+    method public String? getArtworkUri();
+    method public String getId();
+    method public String? getTitle();
+    property public String? artworkUri;
+    property public String id;
+    property public String? title;
   }
 
-  public static final class DownloadMediaUiModel.Available extends com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel {
-    ctor public DownloadMediaUiModel.Available(com.google.android.horologist.media.ui.state.model.MediaUiModel mediaUiModel);
-    method public com.google.android.horologist.media.ui.state.model.MediaUiModel component1();
-    method public com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Available copy(com.google.android.horologist.media.ui.state.model.MediaUiModel mediaUiModel);
-    property public com.google.android.horologist.media.ui.state.model.MediaUiModel mediaUiModel;
+  public static final class DownloadMediaUiModel.Downloaded extends com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel {
+    ctor public DownloadMediaUiModel.Downloaded(String id, optional String? title, optional String? artist, optional String? artworkUri);
+    method public String component1();
+    method public String? component2();
+    method public String? component3();
+    method public String? component4();
+    method public com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Downloaded copy(String id, String? title, String? artist, String? artworkUri);
+    method public String? getArtist();
+    property public final String? artist;
+    property public String? artworkUri;
+    property public String id;
+    property public String? title;
   }
 
-  public static final class DownloadMediaUiModel.Unavailable extends com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel {
-    ctor public DownloadMediaUiModel.Unavailable(com.google.android.horologist.media.ui.state.model.MediaUiModel mediaUiModel);
-    method public com.google.android.horologist.media.ui.state.model.MediaUiModel component1();
-    method public com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Unavailable copy(com.google.android.horologist.media.ui.state.model.MediaUiModel mediaUiModel);
-    property public com.google.android.horologist.media.ui.state.model.MediaUiModel mediaUiModel;
+  public static final class DownloadMediaUiModel.Downloading extends com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel {
+    ctor public DownloadMediaUiModel.Downloading(String id, optional String? title, String progress, com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Size size, optional String? artworkUri);
+    method public String component1();
+    method public String? component2();
+    method public String component3();
+    method public com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Size component4();
+    method public String? component5();
+    method public com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Downloading copy(String id, String? title, String progress, com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Size size, String? artworkUri);
+    method public String getProgress();
+    method public com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Size getSize();
+    property public String? artworkUri;
+    property public String id;
+    property public final String progress;
+    property public final com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Size size;
+    property public String? title;
+  }
+
+  public static final class DownloadMediaUiModel.NotDownloaded extends com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel {
+    ctor public DownloadMediaUiModel.NotDownloaded(String id, optional String? title, optional String? artist, optional String? artworkUri);
+    method public String component1();
+    method public String? component2();
+    method public String? component3();
+    method public String? component4();
+    method public com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.NotDownloaded copy(String id, String? title, String? artist, String? artworkUri);
+    method public String? getArtist();
+    property public final String? artist;
+    property public String? artworkUri;
+    property public String id;
+    property public String? title;
+  }
+
+  public abstract static sealed class DownloadMediaUiModel.Size {
+  }
+
+  public static final class DownloadMediaUiModel.Size.Known extends com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Size {
+    ctor public DownloadMediaUiModel.Size.Known(long sizeInBytes);
+    method public long component1();
+    method public com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Size.Known copy(long sizeInBytes);
+    method public long getSizeInBytes();
+    property public final long sizeInBytes;
+  }
+
+  public static final class DownloadMediaUiModel.Size.Unknown extends com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Size {
+    field public static final com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Size.Unknown INSTANCE;
   }
 
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public final class MediaUiModel {

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenPreview.kt
@@ -27,7 +27,6 @@ import androidx.wear.compose.material.rememberScalingLazyListState
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel
-import com.google.android.horologist.media.ui.state.model.MediaUiModel
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
 import com.google.android.horologist.media.ui.utils.rememberVectorPainter
 
@@ -162,21 +161,17 @@ fun PlaylistDownloadScreenPreviewLoadedFullyDownloaded() {
 }
 
 private val unavailableDownloads = listOf(
-    DownloadMediaUiModel.Unavailable(
-        MediaUiModel(
-            id = "id",
-            title = "Song name",
-            artist = "Artist name",
-            artworkUri = "artworkUri"
-        )
+    DownloadMediaUiModel.NotDownloaded(
+        id = "id",
+        title = "Song name",
+        artist = "Artist name",
+        artworkUri = "artworkUri"
     ),
-    DownloadMediaUiModel.Unavailable(
-        MediaUiModel(
-            id = "id 2",
-            title = "Song name 2",
-            artist = "Artist name 2",
-            artworkUri = "artworkUri"
-        )
+    DownloadMediaUiModel.NotDownloaded(
+        id = "id 2",
+        title = "Song name 2",
+        artist = "Artist name 2",
+        artworkUri = "artworkUri"
     )
 )
 
@@ -186,39 +181,31 @@ private val playlistUiModel = PlaylistUiModel(
 )
 
 private val mixedDownloads = listOf(
-    DownloadMediaUiModel.Available(
-        MediaUiModel(
-            id = "id",
-            title = "Song name",
-            artist = "Artist name",
-            artworkUri = "artworkUri"
-        )
+    DownloadMediaUiModel.Downloaded(
+        id = "id",
+        title = "Song name",
+        artist = "Artist name",
+        artworkUri = "artworkUri"
     ),
-    DownloadMediaUiModel.Unavailable(
-        MediaUiModel(
-            id = "id 2",
-            title = "Song name 2",
-            artist = "Artist name 2",
-            artworkUri = "artworkUri"
-        )
+    DownloadMediaUiModel.NotDownloaded(
+        id = "id 2",
+        title = "Song name 2",
+        artist = "Artist name 2",
+        artworkUri = "artworkUri"
     )
 )
 
 private val availableDownloads = listOf(
-    DownloadMediaUiModel.Available(
-        MediaUiModel(
-            id = "id",
-            title = "Song name",
-            artist = "Artist name",
-            artworkUri = "artworkUri"
-        )
+    DownloadMediaUiModel.Downloaded(
+        id = "id",
+        title = "Song name",
+        artist = "Artist name",
+        artworkUri = "artworkUri"
     ),
-    DownloadMediaUiModel.Available(
-        MediaUiModel(
-            id = "id 2",
-            title = "Song name 2",
-            artist = "Artist name 2",
-            artworkUri = "artworkUri"
-        )
+    DownloadMediaUiModel.Downloaded(
+        id = "id 2",
+        title = "Song name 2",
+        artist = "Artist name 2",
+        artworkUri = "artworkUri"
     )
 )

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/DownloadMediaUiModel.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/DownloadMediaUiModel.kt
@@ -20,13 +20,47 @@ import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 
 @ExperimentalHorologistMediaUiApi
 public sealed class DownloadMediaUiModel(
-    public open val mediaUiModel: MediaUiModel
+    public open val id: String,
+    public open val title: String? = null,
+    public open val artworkUri: String? = null
 ) {
-    public data class Available(
-        override val mediaUiModel: MediaUiModel
-    ) : DownloadMediaUiModel(mediaUiModel = mediaUiModel)
+    public data class Downloaded(
+        override val id: String,
+        override val title: String? = null,
+        val artist: String? = null,
+        override val artworkUri: String? = null
+    ) : DownloadMediaUiModel(
+        id = id,
+        title = title,
+        artworkUri = artworkUri
+    )
 
-    public data class Unavailable(
-        override val mediaUiModel: MediaUiModel
-    ) : DownloadMediaUiModel(mediaUiModel = mediaUiModel)
+    public data class Downloading(
+        override val id: String,
+        override val title: String? = null,
+        val progress: String,
+        val size: Size,
+        override val artworkUri: String? = null
+    ) : DownloadMediaUiModel(
+        id = id,
+        title = title,
+        artworkUri = artworkUri
+    )
+
+    public data class NotDownloaded(
+        override val id: String,
+        override val title: String? = null,
+        val artist: String? = null,
+        override val artworkUri: String? = null
+    ) : DownloadMediaUiModel(
+        id = id,
+        title = title,
+        artworkUri = artworkUri
+    )
+
+    public sealed class Size {
+        public object Unknown : Size()
+
+        public data class Known(val sizeInBytes: Long) : Size()
+    }
 }

--- a/media-ui/src/main/res/values/strings.xml
+++ b/media-ui/src/main/res/values/strings.xml
@@ -40,6 +40,8 @@
     <string name="horologist_entity_button_download_done_content_description">Download done</string>
     <string name="horologist_entity_button_shuffle_content_description">Shuffle</string>
     <string name="horologist_entity_button_play_content_description">Play</string>
+    <string name="horologist_playlist_download_download_progress_unknown_size">%1$s%%</string>
+    <string name="horologist_playlist_download_download_progress_known_size">%1$s%% of %2$s</string>
     <string name="horologist_preview_app_name">UAMP</string>
     <string name="horologist_preview_favorites">Favorites</string>
 </resources>

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/screens/entity/CreatePlaylistDownloadScreenStateLoadedTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/screens/entity/CreatePlaylistDownloadScreenStateLoadedTest.kt
@@ -20,7 +20,6 @@ package com.google.android.horologist.media.ui.screens.entity
 
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel
-import com.google.android.horologist.media.ui.state.model.MediaUiModel
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
@@ -31,21 +30,17 @@ class CreatePlaylistDownloadScreenStateLoadedTest {
     fun givenUnavailableDownloads_thenDownloadStateIsNone() {
         // given
         val downloads = listOf(
-            DownloadMediaUiModel.Unavailable(
-                MediaUiModel(
-                    id = "id",
-                    title = "Song name",
-                    artist = "Artist name",
-                    artworkUri = "artworkUri"
-                )
+            DownloadMediaUiModel.NotDownloaded(
+                id = "id",
+                title = "Song name",
+                artist = "Artist name",
+                artworkUri = "artworkUri"
             ),
-            DownloadMediaUiModel.Unavailable(
-                MediaUiModel(
-                    id = "id 2",
-                    title = "Song name 2",
-                    artist = "Artist name 2",
-                    artworkUri = "artworkUri"
-                )
+            DownloadMediaUiModel.NotDownloaded(
+                id = "id 2",
+                title = "Song name 2",
+                artist = "Artist name 2",
+                artworkUri = "artworkUri"
             )
         )
 
@@ -67,21 +62,17 @@ class CreatePlaylistDownloadScreenStateLoadedTest {
     fun givenMixedDownloads_thenDownloadStateIsPartially() {
         // given
         val downloads = listOf(
-            DownloadMediaUiModel.Available(
-                MediaUiModel(
-                    id = "id",
-                    title = "Song name",
-                    artist = "Artist name",
-                    artworkUri = "artworkUri"
-                )
+            DownloadMediaUiModel.Downloaded(
+                id = "id",
+                title = "Song name",
+                artist = "Artist name",
+                artworkUri = "artworkUri"
             ),
-            DownloadMediaUiModel.Unavailable(
-                MediaUiModel(
-                    id = "id 2",
-                    title = "Song name 2",
-                    artist = "Artist name 2",
-                    artworkUri = "artworkUri"
-                )
+            DownloadMediaUiModel.NotDownloaded(
+                id = "id 2",
+                title = "Song name 2",
+                artist = "Artist name 2",
+                artworkUri = "artworkUri"
             )
         )
 
@@ -103,21 +94,17 @@ class CreatePlaylistDownloadScreenStateLoadedTest {
     fun givenAvailableDownloads_thenDownloadStateIsFully() {
         // given
         val downloads = listOf(
-            DownloadMediaUiModel.Available(
-                MediaUiModel(
-                    id = "id",
-                    title = "Song name",
-                    artist = "Artist name",
-                    artworkUri = "artworkUri"
-                )
+            DownloadMediaUiModel.Downloaded(
+                id = "id",
+                title = "Song name",
+                artist = "Artist name",
+                artworkUri = "artworkUri"
             ),
-            DownloadMediaUiModel.Available(
-                MediaUiModel(
-                    id = "id 2",
-                    title = "Song name 2",
-                    artist = "Artist name 2",
-                    artworkUri = "artworkUri"
-                )
+            DownloadMediaUiModel.Downloaded(
+                id = "id 2",
+                title = "Song name 2",
+                artist = "Artist name 2",
+                artworkUri = "artworkUri"
             )
         )
 


### PR DESCRIPTION
#### WHAT

Display progress of media downloads in `PlaylistDownloadScreen`.

https://user-images.githubusercontent.com/878134/185630854-0d641585-6f69-4a32-a215-4fd4d5dc6344.mp4


#### WHY

In order to align with Figma specs.

#### HOW

- Add `progress` and `size` to `MediaDownloadEntity`;
- Add `DownloadProgressMonitor` to query `DownloadManager` every specified interval and update the download progress with `MediaDownloadLocalDataSource`;
- Improve `DownloadManagerListener` to start and stop `DownloadProgressMonitor`;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
