### PR TITLE
Update segmented progress indicator to use canvas api directly

### DIFF
--- a/composables/src/main/java/com/google/android/horologist/composables/SegmentedProgressIndicator.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/SegmentedProgressIndicator.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.onSizeChanged
@@ -121,7 +122,7 @@ public fun SegmentedProgressIndicator(
         var remainingProgress = progress.coerceIn(0.0f, 1.0f) * segmentableAngle
 
         val stroke = with(localDensity) {
-            Stroke(width = strokeWidth.toPx(), cap = androidx.compose.ui.graphics.StrokeCap.Round)
+            Stroke(width = strokeWidth.toPx(), cap = StrokeCap.Round)
         }
 
         Canvas(

--- a/composables/src/main/java/com/google/android/horologist/composables/SegmentedProgressIndicator.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/SegmentedProgressIndicator.kt
@@ -17,14 +17,11 @@
 package com.google.android.horologist.composables
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.progressSemantics
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -33,7 +30,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.wear.compose.material.MaterialTheme
@@ -89,16 +85,13 @@ public fun SegmentedProgressIndicator(
     paddingAngle: Float = 0.0f,
     trackColor: Color = MaterialTheme.colors.onBackground.copy(alpha = 0.1f)
 ) {
-    var boxMinDimension by remember { mutableStateOf(0) }
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = Modifier.onSizeChanged { boxMinDimension = min(it.width, it.height) }
+    BoxWithConstraints(
+        contentAlignment = Alignment.Center
     ) {
         val localDensity = LocalDensity.current
 
-        val boxMinDimensionDp = with(localDensity) {
-            boxMinDimension.toDp()
-        }
+        val boxMinDimensionDp = minOf(minWidth, minHeight)
+
         // The progress bar uses rounded ends. The small delta requires calculation to take account
         // for the rounded end to ensure that neighbouring segments meet correctly.
         val endDelta = remember(strokeWidth, boxMinDimensionDp) {

--- a/composables/src/main/java/com/google/android/horologist/composables/SegmentedProgressIndicator.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/SegmentedProgressIndicator.kt
@@ -16,8 +16,10 @@
 
 package com.google.android.horologist.composables
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.progressSemantics
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -25,11 +27,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
-import androidx.wear.compose.material.CircularProgressIndicator
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.ProgressIndicatorDefaults
 import kotlin.math.asin
@@ -88,7 +93,9 @@ public fun SegmentedProgressIndicator(
         contentAlignment = Alignment.Center,
         modifier = Modifier.onSizeChanged { boxMinDimension = min(it.width, it.height) }
     ) {
-        val boxMinDimensionDp = with(LocalDensity.current) {
+        val localDensity = LocalDensity.current
+
+        val boxMinDimensionDp = with(localDensity) {
             boxMinDimension.toDp()
         }
         // The progress bar uses rounded ends. The small delta requires calculation to take account
@@ -112,19 +119,87 @@ public fun SegmentedProgressIndicator(
         var currentStartAngle = startAngle + paddingAngle / 2
 
         var remainingProgress = progress.coerceIn(0.0f, 1.0f) * segmentableAngle
-        trackSegments.forEach { segment ->
-            val segmentAngle = (segment.weight * segmentableAngle) / totalWeight
-            CircularProgressIndicator(
-                modifier = modifier.fillMaxSize(),
-                progress = remainingProgress / segmentAngle,
-                startAngle = currentStartAngle + endDelta,
-                endAngle = currentStartAngle + segmentAngle - endDelta,
-                indicatorColor = segment.indicatorColor,
-                trackColor = segment.trackColor ?: trackColor,
-                strokeWidth = strokeWidth
-            )
-            currentStartAngle += segmentAngle + paddingAngle
-            remainingProgress -= segmentAngle
+
+        val stroke = with(localDensity) {
+            Stroke(width = strokeWidth.toPx(), cap = androidx.compose.ui.graphics.StrokeCap.Round)
+        }
+
+        Canvas(
+            modifier = modifier
+                .fillMaxSize()
+                .progressSemantics(progress)
+        ) {
+            trackSegments.forEach { segment ->
+                val segmentAngle = (segment.weight * segmentableAngle) / totalWeight
+
+                val currentEndAngle = currentStartAngle + segmentAngle - endDelta
+                val startAngleWithDelta = currentStartAngle + endDelta
+                val backgroundSweep =
+                    360f - ((startAngleWithDelta - currentEndAngle) % 360 + 360) % 360
+                val sectionProgress = remainingProgress / segmentAngle
+                val progressSweep = backgroundSweep * sectionProgress.coerceIn(0f..1f)
+
+                val diameter = min(size.width, size.height)
+                val diameterOffset = stroke.width / 2
+                val arcDimen = diameter - 2 * diameterOffset
+
+                drawCircularProgressIndicator(
+                    segment = segment,
+                    currentStartAngle = currentStartAngle,
+                    endDelta = endDelta,
+                    backgroundSweep = backgroundSweep,
+                    diameterOffset = diameterOffset,
+                    diameter = diameter,
+                    arcDimen = arcDimen,
+                    stroke = stroke,
+                    progressSweep = progressSweep,
+                    trackColor = trackColor
+                )
+
+                currentStartAngle += segmentAngle + paddingAngle
+                remainingProgress -= segmentAngle
+            }
         }
     }
+}
+
+private fun DrawScope.drawCircularProgressIndicator(
+    segment: ProgressIndicatorSegment,
+    currentStartAngle: Float,
+    endDelta: Float,
+    backgroundSweep: Float,
+    diameterOffset: Float,
+    diameter: Float,
+    arcDimen: Float,
+    stroke: Stroke,
+    progressSweep: Float,
+    trackColor: Color
+) {
+    // Draw Track
+    drawArc(
+        color = segment.trackColor ?: trackColor,
+        startAngle = currentStartAngle + endDelta,
+        sweepAngle = backgroundSweep,
+        useCenter = false,
+        topLeft = Offset(
+            diameterOffset + (size.width - diameter) / 2,
+            diameterOffset + (size.height - diameter) / 2
+        ),
+        size = Size(arcDimen, arcDimen),
+        style = stroke
+    )
+
+    // Draw Progress
+    drawArc(
+        color = segment.indicatorColor,
+        startAngle = currentStartAngle + endDelta,
+        sweepAngle = progressSweep,
+        useCenter = false,
+        topLeft = Offset(
+            diameterOffset + (size.width - diameter) / 2,
+            diameterOffset + (size.height - diameter) / 2
+        ),
+        size = Size(arcDimen, arcDimen),
+        style = stroke
+    )
 }

--- a/composables/src/main/java/com/google/android/horologist/composables/SegmentedProgressIndicator.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/SegmentedProgressIndicator.kt
@@ -114,6 +114,8 @@ public fun SegmentedProgressIndicator(
 
         var remainingProgress = progress.coerceIn(0.0f, 1.0f) * segmentableAngle
 
+        // This code is heavily inspired from the implementation of CircularProgressIndicator
+        // Please see https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:wear/compose/compose-material/src/commonMain/kotlin/androidx/wear/compose/material/ProgressIndicator.kt?q=CircularProgressIndicator
         val stroke = with(localDensity) {
             Stroke(width = strokeWidth.toPx(), cap = StrokeCap.Round)
         }

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/SegmentedProgressIndicatorTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/SegmentedProgressIndicatorTest.kt
@@ -1,0 +1,4 @@
+package com.google.android.horologist.composables
+
+class SegmentedProgressIndicatorTest {
+}

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/SegmentedProgressIndicatorTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/SegmentedProgressIndicatorTest.kt
@@ -1,4 +1,62 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.android.horologist.composables
 
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import app.cash.paparazzi.Paparazzi
+import com.google.android.horologist.paparazzi.GALAXY_WATCH4_CLASSIC_LARGE
+import com.google.android.horologist.paparazzi.WearSnapshotHandler
+import org.junit.Rule
+import org.junit.Test
+
 class SegmentedProgressIndicatorTest {
+    private val maxPercentDifference = 0.1
+
+    @get:Rule
+    val paparazzi = Paparazzi(
+        deviceConfig = GALAXY_WATCH4_CLASSIC_LARGE,
+        theme = "android:ThemeOverlay.Material.Dark",
+        maxPercentDifference = maxPercentDifference,
+        snapshotHandler = WearSnapshotHandler(determineHandler(maxPercentDifference))
+    )
+
+    @OptIn(ExperimentalHorologistComposablesApi::class)
+    @Test
+    fun segmentedPicker() {
+        paparazzi.snapshot {
+            val segments = listOf(
+                ProgressIndicatorSegment(1f, Color.Green),
+                ProgressIndicatorSegment(1f, Color.Cyan),
+                ProgressIndicatorSegment(1f, Color.Magenta),
+                ProgressIndicatorSegment(1f, Color.Yellow),
+                ProgressIndicatorSegment(2f, Color.Red)
+            )
+
+            SegmentedProgressIndicator(
+                modifier = Modifier.fillMaxSize(),
+                trackSegments = segments,
+                progress = 0.5833f,
+                strokeWidth = 10.dp,
+                trackColor = Color.Gray,
+                paddingAngle = 2f
+            )
+        }
+    }
 }

--- a/composables/src/test/snapshots/images/com.google.android.horologist.composables_SegmentedProgressIndicatorTest_segmentedPicker.png
+++ b/composables/src/test/snapshots/images/com.google.android.horologist.composables_SegmentedProgressIndicatorTest_segmentedPicker.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d90c762e377a98eb7de012a68896f45e3bb66df49cc97840e2413f5482843b7
+size 92840


### PR DESCRIPTION
#### WHAT
In this PR I have update the SegmentedProgressIndicator to use the Canvas APIs directly.

#### WHY
The reasoning behind this is that we don't want to draw multiple canvases on top of each other.


#### Screenshots

Here the total weight is 6
<img width="418" alt="Screenshot 2022-08-21 at 17 42 38" src="https://user-images.githubusercontent.com/54936943/185801461-a717550f-0122-4416-b902-7740ac8977d6.png">


Here the total weight is 3
<img width="351" alt="Screenshot 2022-08-21 at 17 44 08" src="https://user-images.githubusercontent.com/54936943/185801443-e2c5be2d-7462-49ec-90ae-a8409bde161a.png">



#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
