### PR TITLE
Add failed state to Entity screen

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/database/dao/PlaylistDao.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/database/dao/PlaylistDao.kt
@@ -53,7 +53,7 @@ interface PlaylistDao {
         WHERE playlistId = :playlistId
     """
     )
-    fun getPopulatedStream(playlistId: String): Flow<PopulatedPlaylist>
+    fun getPopulatedStream(playlistId: String): Flow<PopulatedPlaylist?>
 
     @Transaction
     @Query(

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/datasource/PlaylistLocalDataSource.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/datasource/PlaylistLocalDataSource.kt
@@ -46,7 +46,7 @@ class PlaylistLocalDataSource(
     suspend fun getPopulated(playlistId: String): PopulatedPlaylist? =
         playlistDao.getPopulated(playlistId)
 
-    fun getPopulatedStream(playlistId: String): Flow<PopulatedPlaylist> =
+    fun getPopulatedStream(playlistId: String): Flow<PopulatedPlaylist?> =
         playlistDao.getPopulatedStream(playlistId)
 
     fun getAllPopulated(): Flow<List<PopulatedPlaylist>> =

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/datasource/PlaylistRemoteDataSource.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/datasource/PlaylistRemoteDataSource.kt
@@ -18,15 +18,13 @@ package com.google.android.horologist.mediasample.data.datasource
 
 import com.google.android.horologist.mediasample.data.api.UampService
 import com.google.android.horologist.mediasample.data.api.model.CatalogApiModel
-import com.google.android.horologist.mediasample.di.annotation.Dispatcher
-import com.google.android.horologist.mediasample.di.annotation.UampDispatchers.IO
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 
 class PlaylistRemoteDataSource(
-    @Dispatcher(IO) private val ioDispatcher: CoroutineDispatcher,
+    private val ioDispatcher: CoroutineDispatcher,
     private val uampService: UampService
 ) {
 

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/repository/PlaylistDownloadRepositoryImpl.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/repository/PlaylistDownloadRepositoryImpl.kt
@@ -40,16 +40,20 @@ class PlaylistDownloadRepositoryImpl(
 ) : PlaylistDownloadRepository {
 
     @OptIn(FlowPreview::class)
-    override fun get(playlistId: String): Flow<PlaylistDownload> =
+    override fun get(playlistId: String): Flow<PlaylistDownload?> =
         playlistLocalDataSource.getPopulatedStream(playlistId).flatMapMerge { populatedPlaylist ->
-            combine(
-                flowOf(populatedPlaylist),
-                mediaDownloadLocalDataSource.get(
-                    populatedPlaylist.mediaList
-                        .map { it.mediaId }.toList()
-                )
-            ) { _, mediaDownloadList ->
-                PlaylistDownloadMapper.map(populatedPlaylist, mediaDownloadList)
+            if (populatedPlaylist != null) {
+                combine(
+                    flowOf(populatedPlaylist),
+                    mediaDownloadLocalDataSource.get(
+                        populatedPlaylist.mediaList
+                            .map { it.mediaId }.toList()
+                    )
+                ) { _, mediaDownloadList ->
+                    PlaylistDownloadMapper.map(populatedPlaylist, mediaDownloadList)
+                }
+            } else {
+                flowOf(null)
             }
         }
 

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/service/download/DownloadProgressMonitor.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/service/download/DownloadProgressMonitor.kt
@@ -21,7 +21,6 @@ import android.os.Looper
 import androidx.media3.exoplayer.offline.DownloadManager
 import com.google.android.horologist.mediasample.data.datasource.MediaDownloadLocalDataSource
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class DownloadProgressMonitor(
@@ -33,7 +32,6 @@ class DownloadProgressMonitor(
     private var running = false
 
     fun start(downloadManager: DownloadManager) {
-        Dispatchers.Main
         running = true
         update(downloadManager)
     }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/PlaylistDownloadRepository.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/domain/PlaylistDownloadRepository.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.flow.Flow
  */
 interface PlaylistDownloadRepository {
 
-    fun get(playlistId: String): Flow<PlaylistDownload>
+    fun get(playlistId: String): Flow<PlaylistDownload?>
 
     fun download(playlist: Playlist)
 }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
@@ -114,6 +114,7 @@ fun UampWearApp(
                     },
                     onShuffleClick = { navController.navigateToPlayer() },
                     onPlayClick = { navController.navigateToPlayer() },
+                    onErrorDialogCancelClick = { navController.popBackStack() },
                     focusRequester = focusRequester,
                     scalingLazyListState = scalingLazyListState
                 )

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
@@ -16,14 +16,33 @@
 
 package com.google.android.horologist.mediasample.ui.entity
 
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.Button
+import androidx.wear.compose.material.ButtonDefaults
+import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.ScalingLazyListState
+import androidx.wear.compose.material.Text
+import androidx.wear.compose.material.dialog.Alert
+import androidx.wear.compose.material.dialog.Dialog
 import com.google.android.horologist.compose.layout.StateUtils
 import com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreen
+import com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState
 import com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
+import com.google.android.horologist.mediasample.R
 
 @Composable
 fun UampEntityScreen(
@@ -32,6 +51,7 @@ fun UampEntityScreen(
     onDownloadItemClick: (DownloadMediaUiModel) -> Unit,
     onShuffleClick: (PlaylistUiModel) -> Unit,
     onPlayClick: (PlaylistUiModel) -> Unit,
+    onErrorDialogCancelClick: () -> Unit,
     focusRequester: FocusRequester,
     scalingLazyListState: ScalingLazyListState
 ) {
@@ -58,4 +78,43 @@ fun UampEntityScreen(
         focusRequester = focusRequester,
         scalingLazyListState = scalingLazyListState
     )
+
+    // b/243381431 - it should stop listening to uiState emissions while dialog is presented
+    if (uiState is PlaylistDownloadScreenState.Failed) {
+        Dialog(
+            showDialog = true,
+            onDismissRequest = onErrorDialogCancelClick,
+            scrollState = scalingLazyListState
+        ) {
+            Alert(
+                title = {
+                    Text(
+                        text = stringResource(R.string.entity_no_playlists),
+                        color = MaterialTheme.colors.onBackground,
+                        textAlign = TextAlign.Center,
+                        style = MaterialTheme.typography.title3
+                    )
+                }
+            ) {
+                item {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Button(
+                            onClick = onErrorDialogCancelClick,
+                            colors = ButtonDefaults.secondaryButtonColors()
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Close,
+                                contentDescription = stringResource(id = R.string.entity_failed_dialog_cancel_button_content_description),
+                                modifier = Modifier
+                                    .size(24.dp)
+                                    .wrapContentSize(align = Alignment.Center)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreenViewModel.kt
@@ -32,6 +32,7 @@ import com.google.android.horologist.mediasample.ui.mapper.PlaylistUiModelMapper
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
@@ -56,8 +57,10 @@ class UampEntityScreenViewModel @Inject constructor(
                     downloadMediaList = playlistDownload.mediaList.map(DownloadMediaUiModelMapper::map)
                 )
             } else {
-                PlaylistDownloadScreenState.Loading()
+                PlaylistDownloadScreenState.Failed()
             }
+        }.catch {
+            emit(PlaylistDownloadScreenState.Failed())
         }.stateIn(
             viewModelScope,
             SharingStarted.WhileSubscribed(5000),

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/UampPlaylistsScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/UampPlaylistsScreen.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.horologist.mediasample.ui.playlists
 
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.icons.Icons
@@ -48,8 +49,7 @@ fun UampPlaylistsScreen(
     onPlaylistItemClick: (PlaylistUiModel) -> Unit,
     onErrorDialogCancelClick: () -> Unit,
     focusRequester: FocusRequester,
-    scalingLazyListState: ScalingLazyListState,
-    modifier: Modifier = Modifier
+    scalingLazyListState: ScalingLazyListState
 ) {
     val uiState by rememberStateWithLifecycle(uampPlaylistsScreenViewModel.uiState)
 
@@ -72,8 +72,7 @@ fun UampPlaylistsScreen(
             onPlaylistItemClick(it)
         },
         focusRequester = focusRequester,
-        scalingLazyListState = scalingLazyListState,
-        modifier = modifier
+        scalingLazyListState = scalingLazyListState
     )
 
     // b/242302037 - it should stop listening to uiState emissions while dialog is presented
@@ -91,25 +90,27 @@ fun UampPlaylistsScreen(
                         textAlign = TextAlign.Center,
                         style = MaterialTheme.typography.title3
                     )
-                },
-                negativeButton = {
-                    Button(
-                        onClick = onErrorDialogCancelClick,
-                        colors = ButtonDefaults.secondaryButtonColors()
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Close,
-                            contentDescription = stringResource(id = R.string.playlists_failed_dialog_cancel_button_content_description),
-                            modifier = modifier
-                                .size(24.dp)
-                                .wrapContentSize(align = Alignment.Center)
-                        )
-                    }
-                },
-                positiveButton = {
-                    // b/242302037 - retry functionality to be defined
                 }
-            )
+            ) {
+                item {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Button(
+                            onClick = onErrorDialogCancelClick,
+                            colors = ButtonDefaults.secondaryButtonColors()
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Close,
+                                contentDescription = stringResource(id = R.string.playlists_failed_dialog_cancel_button_content_description),
+                                modifier = Modifier
+                                    .size(24.dp)
+                                    .wrapContentSize(align = Alignment.Center)
+                            )
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/media-sample/src/main/res/values/strings.xml
+++ b/media-sample/src/main/res/values/strings.xml
@@ -55,4 +55,6 @@
     <string name="sync_notification_channel_description">Background tasks for UAMP</string>
     <string name="playlists_no_playlists">No playlists available at the moment</string>
     <string name="playlists_failed_dialog_cancel_button_content_description">Cancel</string>
+    <string name="entity_no_playlists">Can’t find any songs in playlist</string>
+    <string name="entity_failed_dialog_cancel_button_content_description">Cancel</string>
 </resources>

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenPreview.kt
@@ -155,6 +155,21 @@ fun PlaylistDownloadScreenPreviewLoadedFullyDownloaded() {
     )
 }
 
+@WearPreviewDevices
+@Composable
+fun PlaylistDownloadScreenPreviewFailed() {
+    PlaylistDownloadScreen(
+        playlistName = "Playlist name",
+        playlistDownloadScreenState = PlaylistDownloadScreenState.Failed(),
+        onDownloadClick = { },
+        onDownloadItemClick = { },
+        onShuffleClick = { },
+        onPlayClick = { },
+        focusRequester = FocusRequester(),
+        scalingLazyListState = rememberScalingLazyListState()
+    )
+}
+
 private val playlistUiModel = PlaylistUiModel(
     id = "id",
     title = "Playlist name"

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreenPreview.kt
@@ -76,6 +76,17 @@ fun PlaylistsScreenPreviewLoading() {
 
 @WearPreviewDevices
 @Composable
+fun PlaylistsScreenPreviewFailed() {
+    PlaylistsScreen(
+        playlistsScreenState = PlaylistsScreenState.Failed(),
+        onPlaylistItemClick = { },
+        focusRequester = FocusRequester(),
+        scalingLazyListState = rememberScalingLazyListState()
+    )
+}
+
+@WearPreviewDevices
+@Composable
 fun PlaylistsScreenPreviewCustomLayout() {
     PlaylistsScreen(
         playlists = listOf(

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
@@ -70,6 +70,7 @@ public fun PlaylistDownloadScreen(
             is PlaylistDownloadScreenState.Loaded -> EntityScreenState.Loaded(
                 playlistDownloadScreenState.mediaList
             )
+            is PlaylistDownloadScreenState.Failed -> EntityScreenState.Failed()
         }
 
     EntityScreen(
@@ -136,6 +137,7 @@ private fun ButtonsContent(
     onPlayClick: (PlaylistUiModel) -> Unit
 ) {
     when (state) {
+        is PlaylistDownloadScreenState.Failed,
         is PlaylistDownloadScreenState.Loading -> {
             StandardChip(
                 label = stringResource(id = R.string.horologist_playlist_download_button_download),
@@ -270,6 +272,8 @@ public sealed class PlaylistDownloadScreenState<Collection, Media> {
             Fully
         }
     }
+
+    public class Failed<Collection, Media> : PlaylistDownloadScreenState<Collection, Media>()
 }
 
 /**

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreen.kt
@@ -75,17 +75,14 @@ public fun <T> PlaylistsScreen(
         }
 
         when (playlistsScreenState) {
-            is PlaylistsScreenState.Loaded<*> -> {
+            is PlaylistsScreenState.Loaded<T> -> {
                 items(count = playlistsScreenState.playlistList.size) { index ->
-
-                    @Suppress("UNCHECKED_CAST")
-                    // Suppress reason: PlaylistsScreen and PlaylistsScreenState share same T type.
                     playlistContent(
-                        playlist = playlistsScreenState.playlistList[index] as T
+                        playlist = playlistsScreenState.playlistList[index]
                     )
                 }
             }
-            is PlaylistsScreenState.Loading<*> -> {
+            is PlaylistsScreenState.Loading<T> -> {
                 items(count = 4) {
                     SecondaryPlaceholderChip()
                 }


### PR DESCRIPTION
#### WHAT

Add failed state to `EntityScreen`.

![Screenshot_20220822_175048](https://user-images.githubusercontent.com/878134/185977011-b5cbc02e-cd7e-4c16-98ee-4ca9e8cd845a.png)

Also fix layout of dialog of `UampPlaylistsScreen`, as the button wasn't centred as per preview in https://github.com/google/horologist/pull/490.

![Screenshot_20220822_175409](https://user-images.githubusercontent.com/878134/185977173-827e3d89-c5f1-421f-982c-4cd114b9e972.png)

#### WHY

In order to have design closer to Figma specs.
In order to have user journey aligned with Figma specs.

#### HOW

- Change ViewModel to emit a "failed" state for any exception;
- Change screen to display a dialog on Failed state;
- Add onErrorDialogCancelClick param to screen so it can navigate back when the dialog is dismissed;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
