### PR TITLE
Add playlist download progress

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
@@ -63,6 +63,9 @@ fun UampEntityScreen(
         onDownloadClick = {
             uampEntityScreenViewModel.download()
         },
+        onCancelDownloadClick = {
+            /* TO BE IMPLEMENTED */
+        },
         onDownloadItemClick = {
             uampEntityScreenViewModel.play(it.id)
             onDownloadItemClick(it)

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/mapper/DownloadMediaUiModelMapper.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/mapper/DownloadMediaUiModelMapper.kt
@@ -22,6 +22,7 @@ import com.google.android.horologist.mediasample.domain.model.MediaDownload
 object DownloadMediaUiModelMapper {
 
     private const val PROGRESS_FORMAT = "%.0f"
+    private const val PROGRESS_WAITING = 0f
 
     fun map(
         mediaDownload: MediaDownload
@@ -39,7 +40,11 @@ object DownloadMediaUiModelMapper {
             DownloadMediaUiModel.Downloading(
                 id = mediaDownload.media.id,
                 title = mediaDownload.media.title,
-                progress = PROGRESS_FORMAT.format(mediaDownload.status.progress),
+                progress = if (mediaDownload.status.progress == PROGRESS_WAITING) {
+                    DownloadMediaUiModel.Progress.Waiting
+                } else {
+                    DownloadMediaUiModel.Progress.InProgress(PROGRESS_FORMAT.format(mediaDownload.status.progress))
+                },
                 size = when (mediaDownload.size) {
                     is MediaDownload.Size.Known -> DownloadMediaUiModel.Size.Known(mediaDownload.size.sizeInBytes)
                     is MediaDownload.Size.Unknown -> DownloadMediaUiModel.Size.Unknown

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -295,8 +295,9 @@ package com.google.android.horologist.media.ui.components.list.sectioned {
 
   public final class SectionedListScope {
     ctor public SectionedListScope();
-    method public <T> void section(java.util.List<? extends T> list, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.components.list.sectioned.SectionContentScope<T>,kotlin.Unit> builder);
     method public <T> void section(com.google.android.horologist.media.ui.components.list.sectioned.Section.State state, optional boolean displayFooterOnlyOnLoadedState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.components.list.sectioned.SectionContentScope<T>,kotlin.Unit> builder);
+    method public <T> void section(java.util.List<? extends T> list, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.components.list.sectioned.SectionContentScope<T>,kotlin.Unit> builder);
+    method public void section(kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.components.list.sectioned.SectionContentScope<kotlin.Unit>,kotlin.Unit> builder);
   }
 
 }
@@ -429,27 +430,31 @@ package com.google.android.horologist.media.ui.screens.entity {
   }
 
   public final class PlaylistDownloadScreenKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PlaylistDownloadScreen(String playlistName, com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState<com.google.android.horologist.media.ui.state.model.PlaylistUiModel,com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel> playlistDownloadScreenState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onDownloadClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel,kotlin.Unit> onDownloadItemClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onShuffleClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onPlayClick, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.wear.compose.material.ScalingLazyListState scalingLazyListState, optional androidx.compose.ui.Modifier modifier, optional String defaultMediaTitle, optional androidx.compose.ui.graphics.painter.Painter? downloadItemArtworkPlaceholder);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PlaylistDownloadScreen(String playlistName, com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState<com.google.android.horologist.media.ui.state.model.PlaylistUiModel,com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel> playlistDownloadScreenState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onDownloadClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onCancelDownloadClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel,kotlin.Unit> onDownloadItemClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onShuffleClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onPlayClick, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.wear.compose.material.ScalingLazyListState scalingLazyListState, optional androidx.compose.ui.Modifier modifier, optional String defaultMediaTitle, optional androidx.compose.ui.graphics.painter.Painter? downloadItemArtworkPlaceholder);
     method @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded<com.google.android.horologist.media.ui.state.model.PlaylistUiModel,com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel> createPlaylistDownloadScreenStateLoaded(com.google.android.horologist.media.ui.state.model.PlaylistUiModel playlistModel, java.util.List<? extends com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel> downloadMediaList);
   }
 
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public abstract sealed class PlaylistDownloadScreenState<Collection, Media> {
   }
 
+  public static final class PlaylistDownloadScreenState.Failed<Collection, Media> extends com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState<Collection,Media> {
+    ctor public PlaylistDownloadScreenState.Failed();
+  }
+
   public static final class PlaylistDownloadScreenState.Loaded<Collection, Media> extends com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState<Collection,Media> {
-    ctor public PlaylistDownloadScreenState.Loaded(Collection? collectionModel, java.util.List<? extends Media> mediaList, com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadMediaListState downloadsState, optional boolean downloading);
+    ctor public PlaylistDownloadScreenState.Loaded(Collection? collectionModel, java.util.List<? extends Media> mediaList, com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadMediaListState downloadMediaListState, optional com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadsProgress downloadsProgress);
     method public Collection! component1();
     method public java.util.List<Media> component2();
     method public com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadMediaListState component3();
-    method public boolean component4();
-    method public com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded<Collection,Media> copy(Collection! collectionModel, java.util.List<? extends Media> mediaList, com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadMediaListState downloadsState, boolean downloading);
+    method public com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadsProgress component4();
+    method public com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded<Collection,Media> copy(Collection! collectionModel, java.util.List<? extends Media> mediaList, com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadMediaListState downloadMediaListState, com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadsProgress downloadsProgress);
     method public Collection! getCollectionModel();
-    method public boolean getDownloading();
-    method public com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadMediaListState getDownloadsState();
+    method public com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadMediaListState getDownloadMediaListState();
+    method public com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadsProgress getDownloadsProgress();
     method public java.util.List<Media> getMediaList();
     property public final Collection! collectionModel;
-    property public final boolean downloading;
-    property public final com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadMediaListState downloadsState;
+    property public final com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadMediaListState downloadMediaListState;
+    property public final com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadsProgress downloadsProgress;
     property public final java.util.List<Media> mediaList;
   }
 
@@ -457,6 +462,21 @@ package com.google.android.horologist.media.ui.screens.entity {
     enum_constant public static final com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadMediaListState Fully;
     enum_constant public static final com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadMediaListState None;
     enum_constant public static final com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadMediaListState Partially;
+  }
+
+  public abstract static sealed class PlaylistDownloadScreenState.Loaded.DownloadsProgress {
+  }
+
+  public static final class PlaylistDownloadScreenState.Loaded.DownloadsProgress.Idle extends com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadsProgress {
+    field public static final com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadsProgress.Idle INSTANCE;
+  }
+
+  public static final class PlaylistDownloadScreenState.Loaded.DownloadsProgress.InProgress extends com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadsProgress {
+    ctor public PlaylistDownloadScreenState.Loaded.DownloadsProgress.InProgress(float progress);
+    method public float component1();
+    method public com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadsProgress.InProgress copy(float progress);
+    method public float getProgress();
+    property public final float progress;
   }
 
   public static final class PlaylistDownloadScreenState.Loading<Collection, Media> extends com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState<Collection,Media> {
@@ -681,18 +701,18 @@ package com.google.android.horologist.media.ui.state.model {
   }
 
   public static final class DownloadMediaUiModel.Downloading extends com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel {
-    ctor public DownloadMediaUiModel.Downloading(String id, optional String? title, String progress, com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Size size, optional String? artworkUri);
+    ctor public DownloadMediaUiModel.Downloading(String id, optional String? title, com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Progress progress, com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Size size, optional String? artworkUri);
     method public String component1();
     method public String? component2();
-    method public String component3();
+    method public com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Progress component3();
     method public com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Size component4();
     method public String? component5();
-    method public com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Downloading copy(String id, String? title, String progress, com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Size size, String? artworkUri);
-    method public String getProgress();
+    method public com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Downloading copy(String id, String? title, com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Progress progress, com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Size size, String? artworkUri);
+    method public com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Progress getProgress();
     method public com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Size getSize();
     property public String? artworkUri;
     property public String id;
-    property public final String progress;
+    property public final com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Progress progress;
     property public final com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Size size;
     property public String? title;
   }
@@ -709,6 +729,21 @@ package com.google.android.horologist.media.ui.state.model {
     property public String? artworkUri;
     property public String id;
     property public String? title;
+  }
+
+  public abstract static sealed class DownloadMediaUiModel.Progress {
+  }
+
+  public static final class DownloadMediaUiModel.Progress.InProgress extends com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Progress {
+    ctor public DownloadMediaUiModel.Progress.InProgress(String progress);
+    method public String component1();
+    method public com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Progress.InProgress copy(String progress);
+    method public String getProgress();
+    property public final String progress;
+  }
+
+  public static final class DownloadMediaUiModel.Progress.Waiting extends com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Progress {
+    field public static final com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel.Progress.Waiting INSTANCE;
   }
 
   public abstract static sealed class DownloadMediaUiModel.Size {
@@ -847,6 +882,13 @@ package com.google.android.horologist.media.ui.tiles {
 
   public final class ToTileColorsKt {
     method @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static androidx.wear.tiles.material.Colors toTileColors(androidx.wear.compose.material.Colors);
+  }
+
+}
+
+package com.google.android.horologist.media.ui.util {
+
+  public final class IfNanKt {
   }
 
 }

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenPreview.kt
@@ -37,6 +37,7 @@ fun PlaylistDownloadScreenPreviewLoading() {
         playlistName = "Playlist name",
         playlistDownloadScreenState = PlaylistDownloadScreenState.Loading(),
         onDownloadClick = { },
+        onCancelDownloadClick = { },
         onDownloadItemClick = { },
         onShuffleClick = { },
         onPlayClick = { },
@@ -55,6 +56,7 @@ fun PlaylistDownloadScreenPreviewLoadedNoneDownloaded() {
             downloadMediaList = notDownloaded
         ),
         onDownloadClick = { },
+        onCancelDownloadClick = { },
         onDownloadItemClick = { },
         onShuffleClick = { },
         onPlayClick = { },
@@ -77,6 +79,7 @@ fun PlaylistDownloadScreenPreviewLoadedNoneDownloadedDownloading() {
             downloadMediaList = notDownloadedAndDownloading
         ),
         onDownloadClick = { },
+        onCancelDownloadClick = { },
         onDownloadItemClick = { },
         onShuffleClick = { },
         onPlayClick = { },
@@ -99,6 +102,7 @@ fun PlaylistDownloadScreenPreviewLoadedPartiallyDownloaded() {
             downloadMediaList = downloadedNotDownloaded
         ),
         onDownloadClick = { },
+        onCancelDownloadClick = { },
         onDownloadItemClick = { },
         onShuffleClick = { },
         onPlayClick = { },
@@ -121,6 +125,30 @@ fun PlaylistDownloadScreenPreviewLoadedPartiallyDownloadedDownloadingUnknownSize
             downloadMediaList = downloadedAndDownloadingUnknown
         ),
         onDownloadClick = { },
+        onCancelDownloadClick = { },
+        onDownloadItemClick = { },
+        onShuffleClick = { },
+        onPlayClick = { },
+        focusRequester = FocusRequester(),
+        scalingLazyListState = rememberScalingLazyListState(),
+        downloadItemArtworkPlaceholder = rememberVectorPainter(
+            image = Icons.Default.MusicNote,
+            tintColor = Color.Blue
+        )
+    )
+}
+
+@WearPreviewDevices
+@Composable
+fun PlaylistDownloadScreenPreviewLoadedPartiallyDownloadedDownloadingWaiting() {
+    PlaylistDownloadScreen(
+        playlistName = "Playlist name",
+        playlistDownloadScreenState = createPlaylistDownloadScreenStateLoaded(
+            playlistModel = playlistUiModel,
+            downloadMediaList = downloadedAndDownloadingWaiting
+        ),
+        onDownloadClick = { },
+        onCancelDownloadClick = { },
         onDownloadItemClick = { },
         onShuffleClick = { },
         onPlayClick = { },
@@ -143,6 +171,7 @@ fun PlaylistDownloadScreenPreviewLoadedFullyDownloaded() {
             downloadMediaList = downloaded
         ),
         onDownloadClick = { },
+        onCancelDownloadClick = { },
         onDownloadItemClick = { },
         onShuffleClick = { },
         onPlayClick = { },
@@ -162,6 +191,7 @@ fun PlaylistDownloadScreenPreviewFailed() {
         playlistName = "Playlist name",
         playlistDownloadScreenState = PlaylistDownloadScreenState.Failed(),
         onDownloadClick = { },
+        onCancelDownloadClick = { },
         onDownloadItemClick = { },
         onShuffleClick = { },
         onPlayClick = { },
@@ -200,7 +230,7 @@ private val notDownloadedAndDownloading = listOf(
     DownloadMediaUiModel.Downloading(
         id = "id 2",
         title = "Song name 2",
-        progress = "78",
+        progress = DownloadMediaUiModel.Progress.InProgress("78"),
         size = DownloadMediaUiModel.Size.Known(sizeInBytes = 123456L),
         artworkUri = "artworkUri"
     )
@@ -216,7 +246,23 @@ private val downloadedAndDownloadingUnknown = listOf(
     DownloadMediaUiModel.Downloading(
         id = "id 2",
         title = "Song name 2",
-        progress = "78",
+        progress = DownloadMediaUiModel.Progress.InProgress("78"),
+        size = DownloadMediaUiModel.Size.Unknown,
+        artworkUri = "artworkUri"
+    )
+)
+
+private val downloadedAndDownloadingWaiting = listOf(
+    DownloadMediaUiModel.Downloaded(
+        id = "id",
+        title = "Song name",
+        artist = "Artist name",
+        artworkUri = "artworkUri"
+    ),
+    DownloadMediaUiModel.Downloading(
+        id = "id 2",
+        title = "Song name 2",
+        progress = DownloadMediaUiModel.Progress.Waiting,
         size = DownloadMediaUiModel.Size.Unknown,
         artworkUri = "artworkUri"
     )

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/PlayPauseButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/PlayPauseButton.kt
@@ -36,6 +36,7 @@ import androidx.wear.compose.material.MaterialTheme
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.components.controls.PauseButton
 import com.google.android.horologist.media.ui.components.controls.PlayButton
+import com.google.android.horologist.media.ui.util.ifNan
 
 @ExperimentalHorologistMediaUiApi
 @Composable
@@ -117,5 +118,3 @@ public fun PlayPauseProgressButton(
         }
     }
 }
-
-private fun Float.ifNan(default: Float) = if (isNaN()) default else this

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
@@ -17,33 +17,45 @@
 package com.google.android.horologist.media.ui.screens.entity
 
 import android.text.format.Formatter
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.DownloadDone
-import androidx.compose.material.icons.filled.Downloading
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.Button
+import androidx.wear.compose.material.ButtonDefaults
+import androidx.wear.compose.material.CircularProgressIndicator
+import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.ScalingLazyListState
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.R
 import com.google.android.horologist.media.ui.components.base.SecondaryPlaceholderChip
 import com.google.android.horologist.media.ui.components.base.StandardButton
+import com.google.android.horologist.media.ui.components.base.StandardButtonSize
 import com.google.android.horologist.media.ui.components.base.StandardButtonType
 import com.google.android.horologist.media.ui.components.base.StandardChip
 import com.google.android.horologist.media.ui.components.base.StandardChipType
+import com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadsProgress
 import com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
+import com.google.android.horologist.media.ui.util.ifNan
 
 /**
  * An implementation of [EntityScreen] using [PlaylistUiModel] and [DownloadMediaUiModel] as
@@ -55,6 +67,7 @@ public fun PlaylistDownloadScreen(
     playlistName: String,
     playlistDownloadScreenState: PlaylistDownloadScreenState<PlaylistUiModel, DownloadMediaUiModel>,
     onDownloadClick: (PlaylistUiModel) -> Unit,
+    onCancelDownloadClick: (PlaylistUiModel) -> Unit,
     onDownloadItemClick: (DownloadMediaUiModel) -> Unit,
     onShuffleClick: (PlaylistUiModel) -> Unit,
     onPlayClick: (PlaylistUiModel) -> Unit,
@@ -81,22 +94,27 @@ public fun PlaylistDownloadScreen(
 
             val secondaryLabel = when (downloadMediaUiModel) {
                 is DownloadMediaUiModel.Downloading -> {
-                    when (downloadMediaUiModel.size) {
-                        is DownloadMediaUiModel.Size.Known -> {
-                            val size = Formatter.formatShortFileSize(
-                                LocalContext.current,
-                                downloadMediaUiModel.size.sizeInBytes
-                            )
-                            stringResource(
-                                id = R.string.horologist_playlist_download_download_progress_known_size,
-                                downloadMediaUiModel.progress,
-                                size
+                    when (downloadMediaUiModel.progress) {
+                        is DownloadMediaUiModel.Progress.Waiting -> stringResource(
+                            id = R.string.horologist_playlist_download_download_progress_waiting
+                        )
+                        is DownloadMediaUiModel.Progress.InProgress -> when (downloadMediaUiModel.size) {
+                            is DownloadMediaUiModel.Size.Known -> {
+                                val size = Formatter.formatShortFileSize(
+                                    LocalContext.current,
+                                    downloadMediaUiModel.size.sizeInBytes
+                                )
+                                stringResource(
+                                    id = R.string.horologist_playlist_download_download_progress_known_size,
+                                    downloadMediaUiModel.progress.progress,
+                                    size
+                                )
+                            }
+                            DownloadMediaUiModel.Size.Unknown -> stringResource(
+                                id = R.string.horologist_playlist_download_download_progress_unknown_size,
+                                downloadMediaUiModel.progress
                             )
                         }
-                        DownloadMediaUiModel.Size.Unknown -> stringResource(
-                            id = R.string.horologist_playlist_download_download_progress_unknown_size,
-                            downloadMediaUiModel.progress
-                        )
                     }
                 }
                 is DownloadMediaUiModel.Downloaded -> downloadMediaUiModel.artist
@@ -121,6 +139,7 @@ public fun PlaylistDownloadScreen(
             ButtonsContent(
                 state = playlistDownloadScreenState,
                 onDownloadClick = onDownloadClick,
+                onCancelDownloadClick = onCancelDownloadClick,
                 onShuffleClick = onShuffleClick,
                 onPlayClick = onPlayClick
             )
@@ -133,6 +152,7 @@ public fun PlaylistDownloadScreen(
 private fun ButtonsContent(
     state: PlaylistDownloadScreenState<PlaylistUiModel, DownloadMediaUiModel>,
     onDownloadClick: (PlaylistUiModel) -> Unit,
+    onCancelDownloadClick: (PlaylistUiModel) -> Unit,
     onShuffleClick: (PlaylistUiModel) -> Unit,
     onPlayClick: (PlaylistUiModel) -> Unit
 ) {
@@ -141,7 +161,7 @@ private fun ButtonsContent(
         is PlaylistDownloadScreenState.Loading -> {
             StandardChip(
                 label = stringResource(id = R.string.horologist_playlist_download_button_download),
-                onClick = { },
+                onClick = { /* do nothing */ },
                 modifier = Modifier.padding(bottom = 16.dp),
                 icon = Icons.Default.Download,
                 enabled = false
@@ -149,13 +169,13 @@ private fun ButtonsContent(
         }
 
         is PlaylistDownloadScreenState.Loaded -> {
-            if (state.downloadsState == PlaylistDownloadScreenState.Loaded.DownloadMediaListState.None) {
-                if (state.downloading) {
+            if (state.downloadMediaListState == PlaylistDownloadScreenState.Loaded.DownloadMediaListState.None) {
+                if (state.downloadsProgress is DownloadsProgress.InProgress) {
                     StandardChip(
-                        label = stringResource(id = R.string.horologist_playlist_download_button_downloading),
+                        label = stringResource(id = R.string.horologist_playlist_download_button_cancel),
                         onClick = { },
                         modifier = Modifier.padding(bottom = 16.dp),
-                        icon = Icons.Default.Download
+                        icon = Icons.Default.Close
                     )
                 } else {
                     StandardChip(
@@ -173,10 +193,11 @@ private fun ButtonsContent(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     FirstButton(
-                        downloadMediaListState = state.downloadsState,
-                        downloading = state.downloading,
+                        downloadMediaListState = state.downloadMediaListState,
+                        downloadsProgress = state.downloadsProgress,
                         collectionModel = state.collectionModel,
                         onDownloadClick = onDownloadClick,
+                        onCancelDownloadClick = onCancelDownloadClick,
                         modifier = Modifier
                             .padding(start = 6.dp)
                             .weight(weight = 0.3F, fill = false)
@@ -209,43 +230,58 @@ private fun ButtonsContent(
 @Composable
 private fun <Collection> FirstButton(
     downloadMediaListState: PlaylistDownloadScreenState.Loaded.DownloadMediaListState,
-    downloading: Boolean,
+    downloadsProgress: DownloadsProgress,
     collectionModel: Collection,
     onDownloadClick: (Collection) -> Unit,
+    onCancelDownloadClick: (Collection) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val (icon, contentDescription) = when (downloadMediaListState) {
-        PlaylistDownloadScreenState.Loaded.DownloadMediaListState.Partially -> {
-            if (downloading) {
-                Pair(
-                    Icons.Default.Downloading,
-                    R.string.horologist_playlist_download_button_downloading_content_description
-                )
-            } else {
-                Pair(
-                    Icons.Default.Download,
-                    R.string.horologist_playlist_download_button_download_content_description
-                )
-            }
-        }
-        PlaylistDownloadScreenState.Loaded.DownloadMediaListState.Fully -> {
-            Pair(
-                Icons.Default.DownloadDone,
-                R.string.horologist_playlist_download_button_download_done_content_description
+    if (downloadsProgress is DownloadsProgress.InProgress) {
+        Button(
+            onClick = { onCancelDownloadClick(collectionModel) },
+            modifier = modifier.size(StandardButtonSize.Default.tapTargetSize),
+            enabled = true,
+            colors = ButtonDefaults.buttonColors(backgroundColor = Color.Transparent)
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(
+                        ButtonDefaults
+                            .secondaryButtonColors()
+                            .backgroundColor(enabled = true).value
+                    ),
+                progress = downloadsProgress.progress.ifNan(0f),
+                indicatorColor = MaterialTheme.colors.primary,
+                trackColor = MaterialTheme.colors.onSurface.copy(alpha = 0.10f)
+            )
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = stringResource(id = R.string.horologist_playlist_download_button_cancel_content_description),
+                modifier = Modifier
+                    .size(StandardButtonSize.Default.iconSize)
+                    .align(Alignment.Center)
             )
         }
-        else -> {
-            error("Invalid state to be used with this button")
-        }
+    } else if (downloadMediaListState == PlaylistDownloadScreenState.Loaded.DownloadMediaListState.Partially) {
+        StandardButton(
+            imageVector = Icons.Default.Download,
+            contentDescription = stringResource(id = R.string.horologist_playlist_download_button_download_content_description),
+            onClick = { onDownloadClick(collectionModel) },
+            modifier = modifier,
+            buttonType = StandardButtonType.Secondary
+        )
+    } else if (downloadMediaListState == PlaylistDownloadScreenState.Loaded.DownloadMediaListState.Fully) {
+        StandardButton(
+            imageVector = Icons.Default.DownloadDone,
+            contentDescription = stringResource(id = R.string.horologist_playlist_download_button_download_done_content_description),
+            onClick = { /* do nothing */ },
+            modifier = modifier,
+            buttonType = StandardButtonType.Secondary
+        )
+    } else {
+        error("Invalid state to be used with this button")
     }
-
-    StandardButton(
-        imageVector = icon,
-        contentDescription = stringResource(id = contentDescription),
-        onClick = { onDownloadClick(collectionModel) },
-        modifier = modifier,
-        buttonType = StandardButtonType.Secondary
-    )
 }
 
 /**
@@ -259,17 +295,28 @@ public sealed class PlaylistDownloadScreenState<Collection, Media> {
     public data class Loaded<Collection, Media>(
         val collectionModel: Collection,
         val mediaList: List<Media>,
-        val downloadsState: DownloadMediaListState,
-        val downloading: Boolean = false
+        val downloadMediaListState: DownloadMediaListState,
+        val downloadsProgress: DownloadsProgress = DownloadsProgress.Idle
     ) : PlaylistDownloadScreenState<Collection, Media>() {
 
         /**
-         * Represents the state of the list of [Media] when [PlaylistDownloadScreenState] is [Loaded].
+         * Represents the state of the list of [Loaded.mediaList] when [PlaylistDownloadScreenState]
+         * is [Loaded].
          */
         public enum class DownloadMediaListState {
             None,
             Partially,
             Fully
+        }
+
+        /**
+         * Represents the status of the downloads when [PlaylistDownloadScreenState] is [Loaded].
+         */
+        public sealed class DownloadsProgress {
+
+            public object Idle : DownloadsProgress()
+
+            public data class InProgress(val progress: Float) : DownloadsProgress()
         }
     }
 
@@ -278,25 +325,38 @@ public sealed class PlaylistDownloadScreenState<Collection, Media> {
 
 /**
  * A helper function to build a [EntityScreenState.Loaded] with [PlaylistUiModel] and
- * [DownloadMediaUiModel], calculating the value of [PlaylistDownloadScreenState.Loaded.downloadsState].
+ * [DownloadMediaUiModel], calculating the value of [PlaylistDownloadScreenState.Loaded.downloadMediaListState].
  */
 @ExperimentalHorologistMediaUiApi
 public fun createPlaylistDownloadScreenStateLoaded(
     playlistModel: PlaylistUiModel,
     downloadMediaList: List<DownloadMediaUiModel>
 ): PlaylistDownloadScreenState.Loaded<PlaylistUiModel, DownloadMediaUiModel> {
-    var downloading = false
+    var downloadsProgress: DownloadsProgress = DownloadsProgress.Idle
 
     val downloadsState = if (downloadMediaList.isEmpty()) {
         PlaylistDownloadScreenState.Loaded.DownloadMediaListState.Fully
     } else {
         var none = true
         var fully = true
+        var downloading = false
 
+        var downloadedCount = 0
         downloadMediaList.forEach {
-            if (it is DownloadMediaUiModel.Downloaded) none = false
+            if (it is DownloadMediaUiModel.Downloaded) {
+                downloadedCount++
+                none = false
+            }
             if (it is DownloadMediaUiModel.NotDownloaded) fully = false
-            if (it is DownloadMediaUiModel.Downloading) downloading = true
+            if (it is DownloadMediaUiModel.Downloading) {
+                fully = false
+                downloading = true
+            }
+        }
+
+        if (downloading) {
+            downloadsProgress =
+                DownloadsProgress.InProgress(downloadedCount.toFloat() / downloadMediaList.size)
         }
 
         when {
@@ -309,7 +369,7 @@ public fun createPlaylistDownloadScreenStateLoaded(
     return PlaylistDownloadScreenState.Loaded(
         collectionModel = playlistModel,
         mediaList = downloadMediaList,
-        downloadsState = downloadsState,
-        downloading = downloading
+        downloadMediaListState = downloadsState,
+        downloadsProgress = downloadsProgress
     )
 }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/DownloadMediaUiModel.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/DownloadMediaUiModel.kt
@@ -38,7 +38,7 @@ public sealed class DownloadMediaUiModel(
     public data class Downloading(
         override val id: String,
         override val title: String? = null,
-        val progress: String,
+        val progress: Progress,
         val size: Size,
         override val artworkUri: String? = null
     ) : DownloadMediaUiModel(
@@ -57,6 +57,12 @@ public sealed class DownloadMediaUiModel(
         title = title,
         artworkUri = artworkUri
     )
+
+    public sealed class Progress {
+        public object Waiting : Progress()
+
+        public data class InProgress(val progress: String) : Progress()
+    }
 
     public sealed class Size {
         public object Unknown : Size()

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/util/IfNan.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/util/IfNan.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.util
+
+internal fun Float.ifNan(default: Float) = if (isNaN()) default else this

--- a/media-ui/src/main/res/values/strings.xml
+++ b/media-ui/src/main/res/values/strings.xml
@@ -34,14 +34,15 @@
     <string name="horologist_browse_library_settings">Settings</string>
     <string name="horologist_browse_playlist_title">Playlists</string>
     <string name="horologist_playlist_download_button_download">Download to your watch</string>
-    <string name="horologist_playlist_download_button_downloading">Downloading…</string>
-    <string name="horologist_playlist_download_button_download_content_description">Download</string>
-    <string name="horologist_playlist_download_button_downloading_content_description">Downloading</string>
-    <string name="horologist_playlist_download_button_download_done_content_description">Download done</string>
+    <string name="horologist_playlist_download_button_cancel">Cancel</string>
+    <string name="horologist_playlist_download_button_download_content_description">Download available</string>
+    <string name="horologist_playlist_download_button_cancel_content_description">Cancel downloads</string>
+    <string name="horologist_playlist_download_button_download_done_content_description">Downloaded</string>
     <string name="horologist_playlist_download_button_shuffle_content_description">Shuffle</string>
     <string name="horologist_playlist_download_button_play_content_description">Play</string>
     <string name="horologist_playlist_download_download_progress_unknown_size">%1$s%%</string>
     <string name="horologist_playlist_download_download_progress_known_size">%1$s%% of %2$s</string>
+    <string name="horologist_playlist_download_download_progress_waiting">Waiting…</string>
     <string name="horologist_preview_app_name">UAMP</string>
     <string name="horologist_preview_favorites">Favorites</string>
 </resources>

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/screens/entity/CreatePlaylistDownloadScreenStateLoadedTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/screens/entity/CreatePlaylistDownloadScreenStateLoadedTest.kt
@@ -27,7 +27,7 @@ import org.junit.Test
 class CreatePlaylistDownloadScreenStateLoadedTest {
 
     @Test
-    fun givenUnavailableDownloads_thenDownloadStateIsNone() {
+    fun givenNoDownloaded_thenDownloadMediaListStateIsNone() {
         // given
         val downloads = listOf(
             DownloadMediaUiModel.NotDownloaded(
@@ -41,6 +41,13 @@ class CreatePlaylistDownloadScreenStateLoadedTest {
                 title = "Song name 2",
                 artist = "Artist name 2",
                 artworkUri = "artworkUri"
+            ),
+            DownloadMediaUiModel.Downloading(
+                id = "id 3",
+                title = "Song name 3",
+                artworkUri = "artworkUri",
+                progress = DownloadMediaUiModel.Progress.InProgress("60"),
+                size = DownloadMediaUiModel.Size.Known(sizeInBytes = 1280049)
             )
         )
 
@@ -51,14 +58,14 @@ class CreatePlaylistDownloadScreenStateLoadedTest {
                 title = "title"
             ),
             downloadMediaList = downloads
-        ).downloadsState
+        ).downloadMediaListState
 
         // then
         assertThat(result).isEqualTo(PlaylistDownloadScreenState.Loaded.DownloadMediaListState.None)
     }
 
     @Test
-    fun givenMixedDownloads_thenDownloadStateIsPartially() {
+    fun givenMixed_thenDownloadMediaListStateIsPartially() {
         // given
         val downloads = listOf(
             DownloadMediaUiModel.Downloaded(
@@ -72,6 +79,13 @@ class CreatePlaylistDownloadScreenStateLoadedTest {
                 title = "Song name 2",
                 artist = "Artist name 2",
                 artworkUri = "artworkUri"
+            ),
+            DownloadMediaUiModel.Downloading(
+                id = "id 3",
+                title = "Song name 3",
+                artworkUri = "artworkUri",
+                progress = DownloadMediaUiModel.Progress.InProgress("60"),
+                size = DownloadMediaUiModel.Size.Known(sizeInBytes = 1280049)
             )
         )
 
@@ -82,14 +96,46 @@ class CreatePlaylistDownloadScreenStateLoadedTest {
                 title = "title"
             ),
             downloadMediaList = downloads
-        ).downloadsState
+        ).downloadMediaListState
 
         // then
         assertThat(result).isEqualTo(PlaylistDownloadScreenState.Loaded.DownloadMediaListState.Partially)
     }
 
     @Test
-    fun givenAvailableDownloads_thenDownloadStateIsFully() {
+    fun givenDownloadedAndDownloading_thenDownloadMediaListStateIsPartially() {
+        // given
+        val downloads = listOf(
+            DownloadMediaUiModel.Downloaded(
+                id = "id",
+                title = "Song name",
+                artist = "Artist name",
+                artworkUri = "artworkUri"
+            ),
+            DownloadMediaUiModel.Downloading(
+                id = "id 2",
+                title = "Song name 2",
+                artworkUri = "artworkUri",
+                progress = DownloadMediaUiModel.Progress.InProgress("60"),
+                size = DownloadMediaUiModel.Size.Known(sizeInBytes = 1280049)
+            )
+        )
+
+        // when
+        val result = createPlaylistDownloadScreenStateLoaded(
+            playlistModel = PlaylistUiModel(
+                id = "id",
+                title = "title"
+            ),
+            downloadMediaList = downloads
+        ).downloadMediaListState
+
+        // then
+        assertThat(result).isEqualTo(PlaylistDownloadScreenState.Loaded.DownloadMediaListState.Partially)
+    }
+
+    @Test
+    fun givenDownloaded_thenDownloadMediaListStateIsFully() {
         // given
         val downloads = listOf(
             DownloadMediaUiModel.Downloaded(
@@ -113,14 +159,14 @@ class CreatePlaylistDownloadScreenStateLoadedTest {
                 title = "title"
             ),
             downloadMediaList = downloads
-        ).downloadsState
+        ).downloadMediaListState
 
         // then
         assertThat(result).isEqualTo(PlaylistDownloadScreenState.Loaded.DownloadMediaListState.Fully)
     }
 
     @Test
-    fun givenEmptyDownloads_thenDownloadStateIsFully() {
+    fun givenEmptyDownloads_thenDownloadMediaListStateIsFully() {
         // given
         val downloads = emptyList<DownloadMediaUiModel>()
 
@@ -131,9 +177,105 @@ class CreatePlaylistDownloadScreenStateLoadedTest {
                 title = "title"
             ),
             downloadMediaList = downloads
-        ).downloadsState
+        ).downloadMediaListState
 
         // then
         assertThat(result).isEqualTo(PlaylistDownloadScreenState.Loaded.DownloadMediaListState.Fully)
+    }
+
+    @Test
+    fun givenNoDownloading_thenDownloadsProgressIsIdle() {
+        // given
+        val downloads = listOf(
+            DownloadMediaUiModel.Downloaded(
+                id = "id",
+                title = "Song name",
+                artist = "Artist name",
+                artworkUri = "artworkUri"
+            ),
+            DownloadMediaUiModel.NotDownloaded(
+                id = "id 2",
+                title = "Song name 2",
+                artist = "Artist name 2",
+                artworkUri = "artworkUri"
+            )
+        )
+
+        // when
+        val result = createPlaylistDownloadScreenStateLoaded(
+            playlistModel = PlaylistUiModel(
+                id = "id",
+                title = "title"
+            ),
+            downloadMediaList = downloads
+        ).downloadsProgress
+
+        // then
+        assertThat(result).isEqualTo(PlaylistDownloadScreenState.Loaded.DownloadsProgress.Idle)
+    }
+
+    @Test
+    fun givenDownloading_thenDownloadsProgressIsInProgress() {
+        // given
+        val downloads = listOf(
+            DownloadMediaUiModel.Downloaded(
+                id = "id",
+                title = "Song name",
+                artist = "Artist name",
+                artworkUri = "artworkUri"
+            ),
+            DownloadMediaUiModel.NotDownloaded(
+                id = "id 2",
+                title = "Song name 2",
+                artist = "Artist name 2",
+                artworkUri = "artworkUri"
+            ),
+            DownloadMediaUiModel.Downloading(
+                id = "id 3",
+                title = "Song name 3",
+                artworkUri = "artworkUri",
+                progress = DownloadMediaUiModel.Progress.InProgress("60"),
+                size = DownloadMediaUiModel.Size.Known(sizeInBytes = 1280049)
+            ),
+            DownloadMediaUiModel.Downloading(
+                id = "id 4",
+                title = "Song name 4",
+                artworkUri = "artworkUri",
+                progress = DownloadMediaUiModel.Progress.InProgress("60"),
+                size = DownloadMediaUiModel.Size.Known(sizeInBytes = 1280049)
+            )
+        )
+
+        // when
+        val result = createPlaylistDownloadScreenStateLoaded(
+            playlistModel = PlaylistUiModel(
+                id = "id",
+                title = "title"
+            ),
+            downloadMediaList = downloads
+        ).downloadsProgress
+
+        // then
+        assertThat(result).isEqualTo(
+            PlaylistDownloadScreenState.Loaded.DownloadsProgress.InProgress(0.25F)
+        )
+    }
+
+    @Test
+    fun givenEmptyDownloads_thenDownloadsProgressIsIdle() {
+        // given
+        val downloads = emptyList<DownloadMediaUiModel>()
+
+        // when
+        val result = createPlaylistDownloadScreenStateLoaded(
+            playlistModel = PlaylistUiModel(
+                id = "id",
+                title = "title"
+            ),
+            downloadMediaList = downloads
+        ).downloadsProgress
+
+        // then
+        assertThat(result).isEqualTo(PlaylistDownloadScreenState.Loaded.DownloadsProgress.Idle)
     }
 }


### PR DESCRIPTION
#### WHAT

Implement the playlist download progress indicator.

https://user-images.githubusercontent.com/878134/186452274-5afbffb2-2fc4-4752-8d57-109fff8051b7.mp4

Also:
- improved the download / cancel buttons to have different click handlers;
- implemented the display of "waiting" status for queued downloads;
- changed button status from "downloading" to "cancel" - cancel functionality to be implemented in a separate pr;

#### WHY

In order to align with specs from Figma.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
