### PR TITLE
Add contentalpha to placeholder icon in standard chip

### DIFF
--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/base/StandardChip.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/base/StandardChip.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.LocalContentAlpha
 import androidx.wear.compose.material.Text
 import coil.compose.rememberAsyncImagePainter
 
@@ -110,7 +111,8 @@ internal fun StandardChip(
                             modifier = Modifier
                                 .size(iconSize)
                                 .clip(CircleShape),
-                            contentScale = ContentScale.Crop
+                            contentScale = ContentScale.Crop,
+                            alpha = LocalContentAlpha.current
                         )
                     }
                 }

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_disabledWithIconPlaceholder.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_PrimaryChipTest_disabledWithIconPlaceholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:97c15db3114ab6ab0d47472b7755b346b85a8cd31a5ecfb4c02e3f80743c8cd9
-size 43907
+oid sha256:5c38feb76a3836701b9285b6b4b8c872d1426eb83ca559119f48f2aeb0503f58
+size 43460

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_SecondaryChipTest_disabledWithIconPlaceholder.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_SecondaryChipTest_disabledWithIconPlaceholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:947231dd01ac619cd165c2fe9521900ce30e3c573980594dcf180e8a19cfcb3f
-size 45918
+oid sha256:f174254aae581f418cbe9c1591eabbef7b9921d5527dde848ecc008167f3c6c0
+size 46982


### PR DESCRIPTION
#### WHAT
In this PR I have added content alpha to the placeholder icon for the `StandardChip`.  If I understand the task correctly, it is now just that the placeholder Icons have the wrong alpha when disabled. From the previews, setting the LocalContentAlpha as the alpha seems to fix it if Im not mistaken. 

#### WHY
This fixes #329 

#### HOW
Added `LocalContentAlpha.current` to the placeholder Image.

#### How it looks

##### Now
<img width="429" alt="Screenshot 2022-08-30 at 11 15 35" src="https://user-images.githubusercontent.com/54936943/187399112-aa035637-e441-4607-9013-f38ea36224c4.png">


##### Before
<img width="444" alt="Screenshot 2022-08-30 at 11 14 04" src="https://user-images.githubusercontent.com/54936943/187398669-1be400ab-80b5-447d-9489-f7bcebf043c4.png">


#### Checklist :clipboard:
- [x] Run spotless check
- [x] Run tests
