### PR TITLE
Fix issue with protobuf in release build

### DIFF
--- a/media-sample/proguard-rules.pro
+++ b/media-sample/proguard-rules.pro
@@ -1,0 +1,2 @@
+# https://b.corp.google.com/issues/144631039
+-keepclassmembers class * extends com.google.protobuf.GeneratedMessageLite { <fields>; }


### PR DESCRIPTION
#### WHAT

Fix issue with protobuf in release build

#### WHY

Release builds were crashing with:

```
Caused by: java.lang.RuntimeException: Field showTimeTextInfo_ for bc.b not found. Known fields are [public boolean bc.b.m, public boolean bc.b.n, public boolean bc.b.o, public boolean bc.b.p, public boolean bc.b.q, public int bc.b.r, public static final bc.b bc.b.s, public static volatile he.v$b bc.b.t]
```

#### HOW

Add proguard rules as per https://b.corp.google.com/issues/144631039

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
