### PR TITLE
Fix download progress label for downloads of unknown size

### DIFF
--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
@@ -113,7 +113,7 @@ public fun PlaylistDownloadScreen(
                             }
                             DownloadMediaUiModel.Size.Unknown -> stringResource(
                                 id = R.string.horologist_playlist_download_download_progress_unknown_size,
-                                downloadMediaUiModel.progress
+                                downloadMediaUiModel.progress.progress
                             )
                         }
                     }


### PR DESCRIPTION
#### WHAT

Fix download progress label for downloads of unknown size.

![Screen Shot 2022-08-31 at 11 13 40](https://user-images.githubusercontent.com/878134/187655810-57522a3a-475f-4631-b464-ee1e28fc268b.png)

#### WHY

It was displaying the class "toString":

![Screen Shot 2022-08-31 at 11 13 20](https://user-images.githubusercontent.com/878134/187655858-754f1fc9-33c4-428d-809f-713877e65ed3.png)

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
