### PR TITLE
#535 Ignore broken test

### DIFF
--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenA11yScreenshotTest.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenA11yScreenshotTest.kt
@@ -29,6 +29,7 @@ import com.google.android.horologist.paparazzi.GALAXY_WATCH4_CLASSIC_LARGE
 import com.google.android.horologist.paparazzi.WearSnapshotHandler
 import com.google.android.horologist.paparazzi.a11y.A11ySnapshotHandler
 import com.google.android.horologist.paparazzi.determineHandler
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -53,6 +54,7 @@ class VolumeScreenA11yScreenshotTest {
         )
     )
 
+    @Ignore("https://github.com/google/horologist/issues/535")
     @Test
     fun volumeScreenAtMinimums() {
         val volumeState = VolumeState(


### PR DESCRIPTION
#### WHAT

Ignore broken test `VolumeScreenA11yScreenshotTest.volumeScreenAtMinimums`

#### WHY

https://github.com/google/horologist/issues/535

#### HOW

Add ignore annotation.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
