### PR TITLE
Increase tolerance of A11y test

### DIFF
--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenA11yScreenshotTest.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenA11yScreenshotTest.kt
@@ -29,12 +29,11 @@ import com.google.android.horologist.paparazzi.GALAXY_WATCH4_CLASSIC_LARGE
 import com.google.android.horologist.paparazzi.WearSnapshotHandler
 import com.google.android.horologist.paparazzi.a11y.A11ySnapshotHandler
 import com.google.android.horologist.paparazzi.determineHandler
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
 class VolumeScreenA11yScreenshotTest {
-    private val maxPercentDifference = 0.1
+    private val maxPercentDifference = 1.0
 
     val composeA11yExtension = ComposeA11yExtension()
 
@@ -54,7 +53,6 @@ class VolumeScreenA11yScreenshotTest {
         )
     )
 
-    @Ignore("https://github.com/google/horologist/issues/535")
     @Test
     fun volumeScreenAtMinimums() {
         val volumeState = VolumeState(

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/BrowseScreenA11yScreenshotTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/BrowseScreenA11yScreenshotTest.kt
@@ -37,12 +37,11 @@ import com.google.android.horologist.paparazzi.GALAXY_WATCH4_CLASSIC_LARGE
 import com.google.android.horologist.paparazzi.WearSnapshotHandler
 import com.google.android.horologist.paparazzi.a11y.A11ySnapshotHandler
 import com.google.android.horologist.paparazzi.determineHandler
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
 class BrowseScreenA11yScreenshotTest {
-    private val maxPercentDifference = 0.1
+    private val maxPercentDifference = 1.0
 
     val composeA11yExtension = ComposeA11yExtension()
 
@@ -62,7 +61,6 @@ class BrowseScreenA11yScreenshotTest {
         )
     )
 
-    @Ignore("https://github.com/google/horologist/issues/535")
     @Test
     fun browseScreen() {
         val scrollState = ScalingLazyListState()

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/BrowseScreenA11yScreenshotTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/BrowseScreenA11yScreenshotTest.kt
@@ -82,7 +82,6 @@ class BrowseScreenA11yScreenshotTest {
         }
     }
 
-    @Ignore("https://github.com/google/horologist/issues/535")
     @Test
     fun secondPage() {
         val scrollState = ScalingLazyListState()

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/BrowseScreenA11yTallScreenshotTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/BrowseScreenA11yTallScreenshotTest.kt
@@ -36,12 +36,11 @@ import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziAp
 import com.google.android.horologist.paparazzi.GALAXY_WATCH4_CLASSIC_LARGE
 import com.google.android.horologist.paparazzi.a11y.A11ySnapshotHandler
 import com.google.android.horologist.paparazzi.determineHandler
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
 class BrowseScreenA11yTallScreenshotTest {
-    private val maxPercentDifference = 0.1
+    private val maxPercentDifference = 1.0
 
     val composeA11yExtension = ComposeA11yExtension()
 
@@ -60,7 +59,6 @@ class BrowseScreenA11yTallScreenshotTest {
         )
     )
 
-    @Ignore("https://github.com/google/horologist/issues/535")
     @Test
     fun browseScreen() {
         val scrollState = ScalingLazyListState()

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerA11yScreenshotTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerA11yScreenshotTest.kt
@@ -34,12 +34,11 @@ import com.google.android.horologist.paparazzi.GALAXY_WATCH4_CLASSIC_LARGE
 import com.google.android.horologist.paparazzi.WearSnapshotHandler
 import com.google.android.horologist.paparazzi.a11y.A11ySnapshotHandler
 import com.google.android.horologist.paparazzi.determineHandler
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
 class MediaPlayerA11yScreenshotTest {
-    private val maxPercentDifference = 0.1
+    private val maxPercentDifference = 1.0
 
     val composeA11yExtension = ComposeA11yExtension()
 
@@ -59,7 +58,6 @@ class MediaPlayerA11yScreenshotTest {
         )
     )
 
-    @Ignore("https://github.com/google/horologist/issues/535")
     @Test
     fun mediaPlayer() {
         val playerUiState = PlayerUiState(


### PR DESCRIPTION
#### WHAT

Bump to 1%, since the BufferedImage code is probably less deterministic then existing logic across platform.

#### WHY

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
