### PR TITLE
Set default networking rules to Lenient

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/AppConfig.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/AppConfig.kt
@@ -25,7 +25,7 @@ import java.io.File
 
 data class AppConfig(
     val offloadEnabled: Boolean = Build.VERSION.SDK_INT >= 30,
-    val strictNetworking: NetworkingRules? = NetworkingRules.Conservative,
+    val strictNetworking: NetworkingRules? = NetworkingRules.Lenient,
     val deeplinkUriPrefix: String = "uamp${if (BuildConfig.DEBUG) "-debug" else ""}://uamp",
     val cacheItems: Boolean = true,
     val cacheWriteBack: Boolean = true,

--- a/network-awareness/src/main/java/com/google/android/horologist/networks/rules/NetworkingRulesEngine.kt
+++ b/network-awareness/src/main/java/com/google/android/horologist/networks/rules/NetworkingRulesEngine.kt
@@ -32,7 +32,7 @@ import java.net.InetSocketAddress
 public class NetworkingRulesEngine(
     internal val networkRepository: NetworkRepository,
     internal val logger: NetworkStatusLogger = NetworkStatusLogger.Logging,
-    private val networkingRules: NetworkingRules = NetworkingRules.Conservative
+    private val networkingRules: NetworkingRules = NetworkingRules.Lenient
 ) {
     public fun preferredNetwork(requestType: RequestType): NetworkStatus? {
         val networks = networkRepository.networkStatus.value


### PR DESCRIPTION
#### WHAT

Set default networking rules to `Lenient`.

#### WHY

Let users decide when to apply more strict rules.

#### HOW

- Set default `NetworkingRules` in `NetworkingRulesEngine` to `Lenient`.
- Change sample app to also use `Lenient` for now;

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
