### PR TITLE
Updates SegmentedProgressIndicator to fix re-composition issues

### DIFF
--- a/composables/src/main/java/com/google/android/horologist/composables/SegmentedProgressIndicator.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/SegmentedProgressIndicator.kt
@@ -17,12 +17,10 @@
 package com.google.android.horologist.composables
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.progressSemantics
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -35,7 +33,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.ProgressIndicatorDefaults
 import kotlin.math.asin
-import kotlin.math.min
 
 /**
  * Represents a segment of the track in a [SegmentedProgressIndicator].
@@ -85,76 +82,66 @@ public fun SegmentedProgressIndicator(
     paddingAngle: Float = 0.0f,
     trackColor: Color = MaterialTheme.colors.onBackground.copy(alpha = 0.1f)
 ) {
-    BoxWithConstraints(
-        contentAlignment = Alignment.Center
+    val localDensity = LocalDensity.current
+
+    val totalWeight = remember(trackSegments) {
+        trackSegments.sumOf { it.weight.toDouble() }.toFloat()
+    }
+    // The degrees of the circle that are available for progress indication, once any padding
+    // between segments is accounted for. This will be shared by weighting across the segments.
+    val segmentableAngle = (endAngle - startAngle) - trackSegments.size * paddingAngle
+
+    // This code is heavily inspired from the implementation of CircularProgressIndicator
+    // Please see https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:wear/compose/compose-material/src/commonMain/kotlin/androidx/wear/compose/material/ProgressIndicator.kt?q=CircularProgressIndicator
+    val stroke = with(localDensity) {
+        Stroke(width = strokeWidth.toPx(), cap = StrokeCap.Round)
+    }
+
+    Canvas(
+        modifier = modifier
+            .fillMaxSize()
+            .progressSemantics(progress)
     ) {
-        val localDensity = LocalDensity.current
-
-        val boxMinDimensionDp = minOf(minWidth, minHeight)
-
         // The progress bar uses rounded ends. The small delta requires calculation to take account
         // for the rounded end to ensure that neighbouring segments meet correctly.
-        val endDelta = remember(strokeWidth, boxMinDimensionDp) {
+        val endDelta =
             (
                 asin(
-                    strokeWidth.value /
-                        (boxMinDimensionDp.value - strokeWidth.value)
+                    strokeWidth.toPx() /
+                        (size.minDimension - strokeWidth.toPx())
                 ) * 180 / Math.PI
                 ).toFloat()
-        }
-        val totalWeight = remember(trackSegments) {
-            trackSegments.sumOf { it.weight.toDouble() }.toFloat()
-        }
-        // The degrees of the circle that are available for progress indication, once any padding
-        // between segments is accounted for. This will be shared by weighting across the segments.
-        val segmentableAngle = (endAngle - startAngle) - trackSegments.size * paddingAngle
-
         // The first segment needs half a padding between it and the start point.
         var currentStartAngle = startAngle + paddingAngle / 2
-
         var remainingProgress = progress.coerceIn(0.0f, 1.0f) * segmentableAngle
 
-        // This code is heavily inspired from the implementation of CircularProgressIndicator
-        // Please see https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:wear/compose/compose-material/src/commonMain/kotlin/androidx/wear/compose/material/ProgressIndicator.kt?q=CircularProgressIndicator
-        val stroke = with(localDensity) {
-            Stroke(width = strokeWidth.toPx(), cap = StrokeCap.Round)
-        }
+        trackSegments.forEach { segment ->
+            val segmentAngle = (segment.weight * segmentableAngle) / totalWeight
+            val currentEndAngle = currentStartAngle + segmentAngle - endDelta
+            val startAngleWithDelta = currentStartAngle + endDelta
+            val backgroundSweep =
+                360f - ((startAngleWithDelta - currentEndAngle) % 360 + 360) % 360
+            val sectionProgress = remainingProgress / segmentAngle
+            val progressSweep = backgroundSweep * sectionProgress.coerceIn(0f..1f)
 
-        Canvas(
-            modifier = modifier
-                .fillMaxSize()
-                .progressSemantics(progress)
-        ) {
-            trackSegments.forEach { segment ->
-                val segmentAngle = (segment.weight * segmentableAngle) / totalWeight
+            val diameterOffset = stroke.width / 2
+            val arcDimen = size.minDimension - 2 * diameterOffset
 
-                val currentEndAngle = currentStartAngle + segmentAngle - endDelta
-                val startAngleWithDelta = currentStartAngle + endDelta
-                val backgroundSweep =
-                    360f - ((startAngleWithDelta - currentEndAngle) % 360 + 360) % 360
-                val sectionProgress = remainingProgress / segmentAngle
-                val progressSweep = backgroundSweep * sectionProgress.coerceIn(0f..1f)
+            drawCircularProgressIndicator(
+                segment = segment,
+                currentStartAngle = currentStartAngle,
+                endDelta = endDelta,
+                backgroundSweep = backgroundSweep,
+                diameterOffset = diameterOffset,
+                diameter = size.minDimension,
+                arcDimen = arcDimen,
+                stroke = stroke,
+                progressSweep = progressSweep,
+                trackColor = trackColor
+            )
 
-                val diameter = min(size.width, size.height)
-                val diameterOffset = stroke.width / 2
-                val arcDimen = diameter - 2 * diameterOffset
-
-                drawCircularProgressIndicator(
-                    segment = segment,
-                    currentStartAngle = currentStartAngle,
-                    endDelta = endDelta,
-                    backgroundSweep = backgroundSweep,
-                    diameterOffset = diameterOffset,
-                    diameter = diameter,
-                    arcDimen = arcDimen,
-                    stroke = stroke,
-                    progressSweep = progressSweep,
-                    trackColor = trackColor
-                )
-
-                currentStartAngle += segmentAngle + paddingAngle
-                remainingProgress -= segmentAngle
-            }
+            currentStartAngle += segmentAngle + paddingAngle
+            remainingProgress -= segmentAngle
         }
     }
 }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
@@ -113,7 +113,7 @@ public fun PlaylistDownloadScreen(
                             }
                             DownloadMediaUiModel.Size.Unknown -> stringResource(
                                 id = R.string.horologist_playlist_download_download_progress_unknown_size,
-                                downloadMediaUiModel.progress
+                                downloadMediaUiModel.progress.progress
                             )
                         }
                     }


### PR DESCRIPTION
Issues in rendering could be seen on emulator or device in some cases where the Canvas was being recomposed, but the starting calculations of initial angles not recalculated.

Tested on device and emulator

#### WHAT

SegmentedProgressIndicator could in some cases render incorrectly if the Canvas was recomposed but the outer SegmentedProgressIndicator was not

#### WHY

Values used in the rendering of each segment were initialized outside of the Canvas call, and updated as each segment was drawn. Subsequent recomposition did not reinitialize these.

Moved the initialization into the Canvas call, to ensure that calls to it have no side effects.

#### HOW


#### Checklist :clipboard:
- [ n/a] Add explicit visibility modifier and explicit return types for public declarations
- [ x] Run spotless check
- [ x] Run tests
- [ n/a] Update metalava's signature text files
