### PR TITLE
Set Media3 MediaItem title.

### DIFF
--- a/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaItemMapper.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaItemMapper.kt
@@ -44,6 +44,7 @@ public class MediaItemMapper(
             .setUri(parsedUri)
 
         mediaMetadataBuilder
+            .setTitle(mediaItem.title)
             .setDisplayTitle(mediaItem.title)
             .setArtist(mediaItem.artist)
             .setArtworkUri(artworkUri)

--- a/media-data/src/test/java/com/google/android/horologist/media/data/mapper/MediaItemMapperTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/mapper/MediaItemMapperTest.kt
@@ -67,6 +67,7 @@ class MediaItemMapperTest {
         assertThat(result.localConfiguration!!.uri).isEqualTo((Uri.parse(uri)))
         assertThat(result.requestMetadata.mediaUri).isEqualTo((Uri.parse(uri)))
         assertThat(result.mediaMetadata.displayTitle).isEqualTo(title)
+        assertThat(result.mediaMetadata.title).isEqualTo(title)
         assertThat(result.mediaMetadata.artist).isEqualTo(artist)
         assertThat(result.mediaMetadata.artworkUri).isEqualTo(Uri.parse(artworkUri))
     }
@@ -94,6 +95,7 @@ class MediaItemMapperTest {
         assertThat(result.localConfiguration!!.uri).isEqualTo((Uri.parse(uri)))
         assertThat(result.requestMetadata.mediaUri).isEqualTo((Uri.parse(uri)))
         assertThat(result.mediaMetadata.displayTitle).isEqualTo(title)
+        assertThat(result.mediaMetadata.title).isEqualTo(title)
         assertThat(result.mediaMetadata.artist).isEqualTo(artist)
         assertThat(result.mediaMetadata.artworkUri).isNull()
     }


### PR DESCRIPTION
#### WHAT

Set Media3 MediaItem title.

#### WHY

DefaultMediaNotificationProvider uses metadata.title and metadata.artist specifically.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
