### PR TITLE
Extend the isEmulator check to work with more emulators

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/ConfigModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/ConfigModule.kt
@@ -39,7 +39,7 @@ object ConfigModule {
     @Singleton
     @Provides
     @IsEmulator
-    fun isEmulator() = Build.PRODUCT.startsWith("sdk_gwear")
+    fun isEmulator() = listOf(Build.PRODUCT, Build.MODEL).any { it.startsWith("sdk_gwear") }
 
     @Singleton
     @Provides


### PR DESCRIPTION
#### WHAT
Also check the MODEL instead of just thecking the PRODUCT when determining whether the device is an emulator.

#### WHY
Some emulators use realistic MODEL names, but PRODUCT names that start with sdk_gwear.

#### HOW


#### Checklist :clipboard:
- [n/a] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
