### PR TITLE
Set download progress to zero when it's unset in media3

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/service/download/DownloadProgressMonitor.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/service/download/DownloadProgressMonitor.kt
@@ -19,6 +19,7 @@ package com.google.android.horologist.mediasample.data.service.download
 import android.os.Handler
 import android.os.Looper
 import androidx.media3.exoplayer.offline.DownloadManager
+import com.google.android.horologist.media.data.database.dao.MediaDownloadDao.Companion.DOWNLOAD_PROGRESS_START
 import com.google.android.horologist.media.data.datasource.MediaDownloadLocalDataSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -50,7 +51,9 @@ class DownloadProgressMonitor(
                     downloadManager.downloadIndex.getDownload(it.mediaId)?.let { download ->
                         mediaDownloadLocalDataSource.updateProgress(
                             mediaId = download.request.id,
-                            progress = download.percentDownloaded,
+                            progress = download.percentDownloaded
+                                // it can return -1 (C.PERCENTAGE_UNSET)
+                                .coerceAtLeast(DOWNLOAD_PROGRESS_START),
                             size = download.contentLength
                         )
                     }


### PR DESCRIPTION
#### WHAT

Set download progress to zero when it's unset in media3.

#### WHY

The app was displaying a negative progress before starting downloading:
![Screenshot_20220831_144216](https://user-images.githubusercontent.com/878134/188116136-a0eb04ed-0fc9-4f55-be8a-21338528a1d0.png)

#### HOW

Store value zero in our database for all negative values coming from media3.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
