### PR TITLE
Display failed dialog if no playlists are available

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/UampPlaylistsScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/UampPlaylistsScreenViewModel.kt
@@ -37,8 +37,12 @@ class UampPlaylistsScreenViewModel @Inject constructor(
 
     val uiState: StateFlow<PlaylistsScreenState<PlaylistUiModel>> =
         playlistRepository.getAll().map {
-            PlaylistsScreenState.Loaded(it.map(PlaylistUiModelMapper::map))
-        }.catch<PlaylistsScreenState<PlaylistUiModel>> {
+            if (it.isNotEmpty()) {
+                PlaylistsScreenState.Loaded(it.map(PlaylistUiModelMapper::map))
+            } else {
+                PlaylistsScreenState.Failed()
+            }
+        }.catch {
             emit(PlaylistsScreenState.Failed())
         }.stateIn(
             viewModelScope,


### PR DESCRIPTION
#### WHAT

Display failed dialog if no playlists are available.

Same dialog as implemented in #490 - no retry functionality implemented yet.

#### WHY

In order to align with Figma specs.

#### HOW

Emit failed state if data returned from repository is empty.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
