### PR TITLE
Move UI mappers to media-ui

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/browse/UampBrowseScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/browse/UampBrowseScreenViewModel.kt
@@ -21,7 +21,7 @@ import androidx.lifecycle.viewModelScope
 import com.google.android.horologist.media.model.Playlist
 import com.google.android.horologist.media.repository.PlaylistRepository
 import com.google.android.horologist.media.ui.screens.browse.BrowseScreenState
-import com.google.android.horologist.mediasample.ui.mapper.PlaylistDownloadUiModelMapper
+import com.google.android.horologist.media.ui.state.mapper.PlaylistDownloadUiModelMapper
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreenViewModel.kt
@@ -25,10 +25,10 @@ import com.google.android.horologist.media.repository.PlaylistDownloadRepository
 import com.google.android.horologist.media.ui.navigation.NavigationScreens
 import com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState
 import com.google.android.horologist.media.ui.screens.entity.createPlaylistDownloadScreenStateLoaded
+import com.google.android.horologist.media.ui.state.mapper.DownloadMediaUiModelMapper
+import com.google.android.horologist.media.ui.state.mapper.PlaylistUiModelMapper
 import com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
-import com.google.android.horologist.mediasample.ui.mapper.DownloadMediaUiModelMapper
-import com.google.android.horologist.mediasample.ui.mapper.PlaylistUiModelMapper
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/UampPlaylistsScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/UampPlaylistsScreenViewModel.kt
@@ -20,8 +20,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.android.horologist.media.repository.PlaylistRepository
 import com.google.android.horologist.media.ui.screens.playlists.PlaylistsScreenState
+import com.google.android.horologist.media.ui.state.mapper.PlaylistUiModelMapper
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
-import com.google.android.horologist.mediasample.ui.mapper.PlaylistUiModelMapper
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -662,6 +662,11 @@ package com.google.android.horologist.media.ui.state {
 
 package com.google.android.horologist.media.ui.state.mapper {
 
+  @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public final class DownloadMediaUiModelMapper {
+    method public com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel map(com.google.android.horologist.media.model.MediaDownload mediaDownload);
+    field public static final com.google.android.horologist.media.ui.state.mapper.DownloadMediaUiModelMapper INSTANCE;
+  }
+
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public final class MediaUiModelMapper {
     method public com.google.android.horologist.media.ui.state.model.MediaUiModel map(com.google.android.horologist.media.model.Media media);
     field public static final com.google.android.horologist.media.ui.state.mapper.MediaUiModelMapper INSTANCE;
@@ -670,6 +675,16 @@ package com.google.android.horologist.media.ui.state.mapper {
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public final class PlayerUiStateMapper {
     method public com.google.android.horologist.media.ui.state.PlayerUiState map(com.google.android.horologist.media.model.PlayerState currentState, java.util.Set<? extends com.google.android.horologist.media.model.Command> availableCommands, com.google.android.horologist.media.model.Media? media, com.google.android.horologist.media.model.MediaPosition? mediaPosition, boolean shuffleModeEnabled, boolean connected, optional com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement seekBackButtonIncrement, optional com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement seekForwardButtonIncrement);
     field public static final com.google.android.horologist.media.ui.state.mapper.PlayerUiStateMapper INSTANCE;
+  }
+
+  @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public final class PlaylistDownloadUiModelMapper {
+    method public com.google.android.horologist.media.ui.state.model.PlaylistDownloadUiModel.Completed map(com.google.android.horologist.media.model.Playlist playlist);
+    field public static final com.google.android.horologist.media.ui.state.mapper.PlaylistDownloadUiModelMapper INSTANCE;
+  }
+
+  @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public final class PlaylistUiModelMapper {
+    method public com.google.android.horologist.media.ui.state.model.PlaylistUiModel map(com.google.android.horologist.media.model.Playlist playlist);
+    field public static final com.google.android.horologist.media.ui.state.mapper.PlaylistUiModelMapper INSTANCE;
   }
 
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public final class TrackPositionUiModelMapper {

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/DownloadMediaUiModelMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/DownloadMediaUiModelMapper.kt
@@ -14,17 +14,25 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.mediasample.ui.mapper
+package com.google.android.horologist.media.ui.state.mapper
 
 import com.google.android.horologist.media.model.MediaDownload
+import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel
 
-object DownloadMediaUiModelMapper {
+/**
+ * Functions to map models from other layers and / or packages into a [DownloadMediaUiModel].
+ */
+@ExperimentalHorologistMediaUiApi
+public object DownloadMediaUiModelMapper {
 
     private const val PROGRESS_FORMAT = "%.0f"
     private const val PROGRESS_WAITING = 0f
 
-    fun map(
+    /**
+     * Maps from [MediaDownload].
+     */
+    public fun map(
         mediaDownload: MediaDownload
     ): DownloadMediaUiModel = when (mediaDownload.status) {
         MediaDownload.Status.Idle -> {
@@ -56,6 +64,7 @@ object DownloadMediaUiModelMapper {
                 artworkUri = mediaDownload.media.artworkUri
             )
         }
+
         MediaDownload.Status.Completed -> {
             DownloadMediaUiModel.Downloaded(
                 id = mediaDownload.media.id,

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/PlaylistDownloadUiModelMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/PlaylistDownloadUiModelMapper.kt
@@ -14,16 +14,21 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.mediasample.ui.mapper
+package com.google.android.horologist.media.ui.state.mapper
 
 import com.google.android.horologist.media.model.Playlist
+import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.state.model.PlaylistDownloadUiModel
 
 /**
- * Maps a [Playlist] into a [PlaylistDownloadUiModel].
+ * Functions to map models from other layers and / or packages into a [PlaylistDownloadUiModel].
  */
-object PlaylistDownloadUiModelMapper {
+@ExperimentalHorologistMediaUiApi
+public object PlaylistDownloadUiModelMapper {
 
-    fun map(playlist: Playlist): PlaylistDownloadUiModel =
+    /**
+     * Maps from [Playlist].
+     */
+    public fun map(playlist: Playlist): PlaylistDownloadUiModel.Completed =
         PlaylistDownloadUiModel.Completed(PlaylistUiModelMapper.map(playlist))
 }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/PlaylistUiModelMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/PlaylistUiModelMapper.kt
@@ -14,17 +14,22 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.mediasample.ui.mapper
+package com.google.android.horologist.media.ui.state.mapper
 
 import com.google.android.horologist.media.model.Playlist
+import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
 
 /**
- * Maps a [Playlist] into a [PlaylistUiModel].
+ * Functions to map models from other layers and / or packages into a [PlaylistUiModel].
  */
-object PlaylistUiModelMapper {
+@ExperimentalHorologistMediaUiApi
+public object PlaylistUiModelMapper {
 
-    fun map(
+    /**
+     * Maps from [Playlist].
+     */
+    public fun map(
         playlist: Playlist
     ): PlaylistUiModel = PlaylistUiModel(
         id = playlist.id,

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/DownloadMediaUiModelMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/DownloadMediaUiModelMapperTest.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistMediaUiApi::class)
+
+package com.google.android.horologist.media.ui.state.mapper
+
+import com.google.android.horologist.media.model.Media
+import com.google.android.horologist.media.model.MediaDownload
+import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
+import com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class DownloadMediaUiModelMapperTest {
+
+    @Test
+    fun givenStatusIdle_thenMapsCorrectly() {
+        // given
+        val id = "id"
+        val title = "title"
+        val artist = "artist"
+        val artworkUri = "artworkUri"
+        val mediaDownload = MediaDownload(
+            media = Media(
+                id = id,
+                uri = "",
+                title = title,
+                artist = artist,
+                artworkUri = artworkUri
+            ),
+            status = MediaDownload.Status.Idle,
+            size = MediaDownload.Size.Unknown
+        )
+
+        // when
+        val result = DownloadMediaUiModelMapper.map(mediaDownload)
+
+        // then
+        assertThat(result).isEqualTo(
+            DownloadMediaUiModel.NotDownloaded(
+                id = id,
+                title = title,
+                artist = artist,
+                artworkUri = artworkUri
+            )
+        )
+    }
+
+    @Test
+    fun givenStatusInProgressZeroSizeUnknown_thenMapsCorrectly() {
+        // given
+        val id = "id"
+        val title = "title"
+        val artist = "artist"
+        val artworkUri = "artworkUri"
+        val mediaDownload = MediaDownload(
+            media = Media(
+                id = id,
+                uri = "",
+                title = title,
+                artist = artist,
+                artworkUri = artworkUri
+            ),
+            status = MediaDownload.Status.InProgress(progress = 0F),
+            size = MediaDownload.Size.Unknown
+        )
+
+        // when
+        val result = DownloadMediaUiModelMapper.map(mediaDownload)
+
+        // then
+        assertThat(result).isEqualTo(
+            DownloadMediaUiModel.Downloading(
+                id = id,
+                title = title,
+                artworkUri = artworkUri,
+                progress = DownloadMediaUiModel.Progress.Waiting,
+                size = DownloadMediaUiModel.Size.Unknown
+            )
+        )
+    }
+
+    @Test
+    fun givenStatusInProgressNonZeroSizeKnown_thenMapsCorrectly() {
+        // given
+        val id = "id"
+        val title = "title"
+        val artist = "artist"
+        val artworkUri = "artworkUri"
+        val sizeInBytes = 12345L
+        val mediaDownload = MediaDownload(
+            media = Media(
+                id = id,
+                uri = "",
+                title = title,
+                artist = artist,
+                artworkUri = artworkUri
+            ),
+            status = MediaDownload.Status.InProgress(progress = 25.9F),
+            size = MediaDownload.Size.Known(sizeInBytes = sizeInBytes)
+        )
+
+        // when
+        val result = DownloadMediaUiModelMapper.map(mediaDownload)
+
+        // then
+        assertThat(result).isEqualTo(
+            DownloadMediaUiModel.Downloading(
+                id = id,
+                title = title,
+                artworkUri = artworkUri,
+                progress = DownloadMediaUiModel.Progress.InProgress(progress = "26"),
+                size = DownloadMediaUiModel.Size.Known(sizeInBytes)
+            )
+        )
+    }
+
+    @Test
+    fun givenStatusCompleted_thenMapsCorrectly() {
+        // given
+        val id = "id"
+        val title = "title"
+        val artist = "artist"
+        val artworkUri = "artworkUri"
+        val mediaDownload = MediaDownload(
+            media = Media(
+                id = id,
+                uri = "",
+                title = title,
+                artist = artist,
+                artworkUri = artworkUri
+            ),
+            status = MediaDownload.Status.Completed,
+            size = MediaDownload.Size.Unknown
+        )
+
+        // when
+        val result = DownloadMediaUiModelMapper.map(mediaDownload)
+
+        // then
+        assertThat(result).isEqualTo(
+            DownloadMediaUiModel.Downloaded(
+                id = id,
+                title = title,
+                artist = artist,
+                artworkUri = artworkUri
+            )
+        )
+    }
+}

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/PlaylistDownloadUiModelMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/PlaylistDownloadUiModelMapperTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistMediaUiApi::class)
+
+package com.google.android.horologist.media.ui.state.mapper
+
+import com.google.android.horologist.media.model.Playlist
+import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
+import com.google.android.horologist.media.ui.state.model.PlaylistDownloadUiModel
+import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class PlaylistDownloadUiModelMapperTest {
+
+    @Test
+    fun givenPlaylist_thenMapsCorrectly() {
+        // given
+        val id = "id"
+        val name = "name"
+        val artworkUri = "artworkUri"
+        val playlist = Playlist(
+            id = id,
+            name = name,
+            artworkUri = artworkUri,
+            mediaList = emptyList()
+        )
+
+        // when
+        val result = PlaylistDownloadUiModelMapper.map(playlist)
+
+        // then
+        assertThat(result).isEqualTo(
+            PlaylistDownloadUiModel.Completed(
+                PlaylistUiModel(
+                    id = id,
+                    title = name,
+                    artworkUri = artworkUri
+                )
+            )
+        )
+    }
+}

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/PlaylistUiModelMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/PlaylistUiModelMapperTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistMediaUiApi::class)
+
+package com.google.android.horologist.media.ui.state.mapper
+
+import com.google.android.horologist.media.model.Playlist
+import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
+import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class PlaylistUiModelMapperTest {
+
+    @Test
+    fun givenPlaylist_thenMapsCorrectly() {
+        // given
+        val id = "id"
+        val name = "name"
+        val artworkUri = "artworkUri"
+        val playlist = Playlist(
+            id = id,
+            name = name,
+            artworkUri = artworkUri,
+            mediaList = emptyList()
+        )
+
+        // when
+        val result = PlaylistUiModelMapper.map(playlist)
+
+        // then
+        assertThat(result).isEqualTo(
+            PlaylistUiModel(
+                id = id,
+                title = name,
+                artworkUri = artworkUri
+            )
+        )
+    }
+}


### PR DESCRIPTION
#### WHAT

Move UI mappers to `media-ui` module.

#### WHY

In order to make them available in the library.

#### HOW

- Move files, add experimental annotation, improve kdoc.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
