### PR TITLE
Add PlaceholderChip to composables module

### DIFF
--- a/composables/api/current.api
+++ b/composables/api/current.api
@@ -12,6 +12,10 @@ package com.google.android.horologist.composables {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public static void MarqueeText(String text, optional androidx.compose.ui.Modifier modifier, optional long color, optional androidx.compose.ui.text.TextStyle style, optional int textAlign, optional float followGap, optional float edgeGradientWidth, optional float marqueeDpPerSecond, optional long pauseTime);
   }
 
+  public final class PlaceholderChipKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public static void PlaceholderChip(optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.wear.compose.material.ChipColors colors, optional boolean enabled);
+  }
+
   public final class ProgressIndicatorSegment {
     ctor public ProgressIndicatorSegment(float weight, long indicatorColor, optional androidx.compose.ui.graphics.Color? trackColor, optional androidx.compose.ui.graphics.Color? inProgressTrackColor);
     method public float component1();

--- a/composables/src/debug/java/com/google/android/horologist/composables/PlaceholderChipPreview.kt
+++ b/composables/src/debug/java/com/google/android/horologist/composables/PlaceholderChipPreview.kt
@@ -14,13 +14,22 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.media.ui.components.base
+@file:OptIn(ExperimentalHorologistComposablesApi::class)
+
+package com.google.android.horologist.composables
 
 import androidx.compose.runtime.Composable
+import androidx.wear.compose.material.ChipDefaults
 import com.google.android.horologist.compose.tools.WearPreview
 
 @WearPreview
 @Composable
-fun SecondaryPlaceholderChipPreview() {
-    SecondaryPlaceholderChip()
+fun PlaceholderChipPreview() {
+    PlaceholderChip()
+}
+
+@WearPreview
+@Composable
+fun PlaceholderChipPreviewWithSecondaryColors() {
+    PlaceholderChip(colors = ChipDefaults.secondaryChipColors())
 }

--- a/composables/src/main/java/com/google/android/horologist/composables/PlaceholderChip.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/PlaceholderChip.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.media.ui.components.base
+package com.google.android.horologist.composables
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -33,16 +33,19 @@ import androidx.compose.ui.draw.paint
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Chip
+import androidx.wear.compose.material.ChipColors
 import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.MaterialTheme
 
 /**
- * Secondary placeholder chip.
+ * A placeholder chip to be displayed while the contents of the [Chip] is being loaded.
  */
+@ExperimentalHorologistComposablesApi
 @Composable
-internal fun SecondaryPlaceholderChip(
+public fun PlaceholderChip(
     modifier: Modifier = Modifier,
     onClick: () -> Unit = {},
+    colors: ChipColors = ChipDefaults.primaryChipColors(),
     enabled: Boolean = true
 ) {
     val backgroundColor = MaterialTheme.colors.onSurfaceVariant.copy(alpha = 0.38f)
@@ -53,8 +56,7 @@ internal fun SecondaryPlaceholderChip(
             .fillMaxWidth()
             .clip(shape = MaterialTheme.shapes.small)
             .paint(
-                painter = ChipDefaults
-                    .secondaryChipColors()
+                painter = colors
                     .background(enabled = enabled).value,
                 contentScale = ContentScale.Crop
             )
@@ -91,6 +93,6 @@ internal fun SecondaryPlaceholderChip(
                     .size(ChipDefaults.LargeIconSize)
             )
         },
-        colors = ChipDefaults.secondaryChipColors()
+        colors = colors
     )
 }

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/PlaceholderChipTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/PlaceholderChipTest.kt
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistPaparazziApi::class)
+@file:OptIn(ExperimentalHorologistPaparazziApi::class, ExperimentalHorologistComposablesApi::class)
 
-package com.google.android.horologist.media.ui.components.base
+package com.google.android.horologist.composables
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.wear.compose.material.ChipDefaults
 import app.cash.paparazzi.Paparazzi
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.GALAXY_WATCH4_CLASSIC_LARGE
@@ -31,7 +32,7 @@ import com.google.android.horologist.paparazzi.determineHandler
 import org.junit.Rule
 import org.junit.Test
 
-class SecondaryPlaceholderChipTest {
+class PlaceholderChipTest {
 
     private val maxPercentDifference = 0.1
 
@@ -47,7 +48,16 @@ class SecondaryPlaceholderChipTest {
     fun default() {
         paparazzi.snapshot {
             Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                SecondaryPlaceholderChip()
+                PlaceholderChip()
+            }
+        }
+    }
+
+    @Test
+    fun secondaryColors() {
+        paparazzi.snapshot {
+            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
+                PlaceholderChip(colors = ChipDefaults.secondaryChipColors())
             }
         }
     }

--- a/composables/src/test/snapshots/images/com.google.android.horologist.composables_PlaceholderChipTest_default.png
+++ b/composables/src/test/snapshots/images/com.google.android.horologist.composables_PlaceholderChipTest_default.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10317d988013897e8968946d85c744ca9bdd0437a88d3a64a3f9b2b9835f3250
+size 29492

--- a/composables/src/test/snapshots/images/com.google.android.horologist.composables_PlaceholderChipTest_secondaryColors.png
+++ b/composables/src/test/snapshots/images/com.google.android.horologist.composables_PlaceholderChipTest_secondaryColors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:738a861d52be9c16c475752cace5349e64915fec77ecaf8b6dca3487f4ed6453
+size 28057

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -137,9 +137,6 @@ package com.google.android.horologist.media.ui.components.background {
 
 package com.google.android.horologist.media.ui.components.base {
 
-  public final class SecondaryPlaceholderChipKt {
-  }
-
   public final class StandardButtonKt {
   }
 

--- a/media-ui/build.gradle
+++ b/media-ui/build.gradle
@@ -44,11 +44,12 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
         freeCompilerArgs += "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
+        freeCompilerArgs += "-opt-in=com.google.accompanist.pager.ExperimentalPagerApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.media.ExperimentalHorologistMediaApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.audio.ExperimentalHorologistAudioApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi"
-        freeCompilerArgs += "-opt-in=com.google.accompanist.pager.ExperimentalPagerApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi"
+        freeCompilerArgs += "-opt-in=com.google.android.horologist.composables.ExperimentalHorologistComposablesApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.tiles.ExperimentalHorologistTilesApi"
     }
 

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/list/sectioned/SectionedListPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/list/sectioned/SectionedListPreview.kt
@@ -27,12 +27,13 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.rememberScalingLazyListState
+import com.google.android.horologist.composables.PlaceholderChip
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
-import com.google.android.horologist.media.ui.components.base.SecondaryPlaceholderChip
 import com.google.android.horologist.media.ui.components.base.StandardChip
 import com.google.android.horologist.media.ui.components.base.StandardChipType
 import com.google.android.horologist.media.ui.components.base.Title
@@ -118,7 +119,7 @@ private fun DownloadsHeader() {
 
 @Composable
 private fun DownloadsLoading() {
-    SecondaryPlaceholderChip()
+    PlaceholderChip(colors = ChipDefaults.secondaryChipColors())
 }
 
 @Composable
@@ -193,7 +194,7 @@ private fun FavouritesHeader() {
 
 @Composable
 private fun FavouritesLoading() {
-    SecondaryPlaceholderChip()
+    PlaceholderChip(colors = ChipDefaults.secondaryChipColors())
 }
 
 @Composable

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/EntityScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/EntityScreenPreview.kt
@@ -43,12 +43,13 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.rememberScalingLazyListState
+import com.google.android.horologist.composables.PlaceholderChip
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
-import com.google.android.horologist.media.ui.components.base.SecondaryPlaceholderChip
 import com.google.android.horologist.media.ui.components.base.StandardButton
 import com.google.android.horologist.media.ui.components.base.StandardChip
 
@@ -129,7 +130,7 @@ fun EntityScreenPreviewLoadingState() {
     EntityScreen(
         entityScreenState = EntityScreenState.Loading<String>(),
         headerContent = { DefaultEntityScreenHeader(title = "Playlist name") },
-        loadingContent = { items(count = 2) { SecondaryPlaceholderChip() } },
+        loadingContent = { items(count = 2) { PlaceholderChip(colors = ChipDefaults.secondaryChipColors()) } },
         mediaContent = { },
         focusRequester = FocusRequester(),
         scalingLazyListState = rememberScalingLazyListState(),

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreen.kt
@@ -28,14 +28,15 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.ScalingLazyColumnDefaults
 import androidx.wear.compose.material.ScalingLazyListState
 import androidx.wear.compose.material.ScalingParams
 import androidx.wear.compose.material.Text
+import com.google.android.horologist.composables.PlaceholderChip
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.R
-import com.google.android.horologist.media.ui.components.base.SecondaryPlaceholderChip
 import com.google.android.horologist.media.ui.components.base.StandardChip
 import com.google.android.horologist.media.ui.components.base.StandardChipType
 import com.google.android.horologist.media.ui.components.base.Title
@@ -91,7 +92,7 @@ public fun BrowseScreen(
             }
 
             loading {
-                SecondaryPlaceholderChip()
+                PlaceholderChip(colors = ChipDefaults.secondaryChipColors())
             }
 
             loaded { download: PlaylistDownloadUiModel ->

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
@@ -40,13 +40,14 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Button
 import androidx.wear.compose.material.ButtonDefaults
+import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.CircularProgressIndicator
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.ScalingLazyListState
+import com.google.android.horologist.composables.PlaceholderChip
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.R
-import com.google.android.horologist.media.ui.components.base.SecondaryPlaceholderChip
 import com.google.android.horologist.media.ui.components.base.StandardButton
 import com.google.android.horologist.media.ui.components.base.StandardButtonSize
 import com.google.android.horologist.media.ui.components.base.StandardButtonType
@@ -90,7 +91,7 @@ public fun PlaylistDownloadScreen(
     EntityScreen(
         entityScreenState = entityScreenState,
         headerContent = { DefaultEntityScreenHeader(title = playlistName) },
-        loadingContent = { items(count = 2) { SecondaryPlaceholderChip() } },
+        loadingContent = { items(count = 2) { PlaceholderChip(colors = ChipDefaults.secondaryChipColors()) } },
         mediaContent = { downloadMediaUiModel ->
 
             val secondaryLabel = when (downloadMediaUiModel) {

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreen.kt
@@ -23,10 +23,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.ScalingLazyListState
+import com.google.android.horologist.composables.PlaceholderChip
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.R
-import com.google.android.horologist.media.ui.components.base.SecondaryPlaceholderChip
 import com.google.android.horologist.media.ui.components.base.StandardChip
 import com.google.android.horologist.media.ui.components.base.StandardChipType
 import com.google.android.horologist.media.ui.components.base.Title
@@ -86,10 +87,19 @@ public fun <T> PlaylistsScreen(
 
             loading {
                 Column {
-                    SecondaryPlaceholderChip()
-                    SecondaryPlaceholderChip(modifier = Modifier.padding(top = 4.dp))
-                    SecondaryPlaceholderChip(modifier = Modifier.padding(top = 4.dp))
-                    SecondaryPlaceholderChip(modifier = Modifier.padding(top = 4.dp))
+                    PlaceholderChip(colors = ChipDefaults.secondaryChipColors())
+                    PlaceholderChip(
+                        modifier = Modifier.padding(top = 4.dp),
+                        colors = ChipDefaults.secondaryChipColors()
+                    )
+                    PlaceholderChip(
+                        modifier = Modifier.padding(top = 4.dp),
+                        colors = ChipDefaults.secondaryChipColors()
+                    )
+                    PlaceholderChip(
+                        modifier = Modifier.padding(top = 4.dp),
+                        colors = ChipDefaults.secondaryChipColors()
+                    )
                 }
             }
         }

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_SecondaryPlaceholderChipTest_default.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.base_SecondaryPlaceholderChipTest_default.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:88de358235d5bab6bffd309dc775d3193457262a072852a74835e1c84ed67df9
-size 28192


### PR DESCRIPTION
#### WHAT

Add `PlaceholderChip` to composables module.

![Screen Shot 2022-09-05 at 17 08 39](https://user-images.githubusercontent.com/878134/188487085-fb2f54ec-429f-4d49-b126-64bba05ce15e.png)


#### WHY

In order to provide common components.

#### HOW

- Move and rename `SecondaryPlaceholderChip` from `media-ui` to `composables` module;
- Add experimental annotation and change from internal to public;
- Add `colors` param;
- Update code to pass appropriate value to `colors` param;
- Add snapshot tests;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
