### PR TITLE
Add screen samples using SectionedList

### DIFF
--- a/composables/src/debug/java/com/google/android/horologist/composables/SectionedListPreview.kt
+++ b/composables/src/debug/java/com/google/android/horologist/composables/SectionedListPreview.kt
@@ -143,7 +143,7 @@ private fun DownloadsLoaded(text: String) {
         icon = {
             Icon(
                 imageVector = Icons.Default.FeaturedPlayList,
-                contentDescription = null, // hidden from talkback
+                contentDescription = null,
                 modifier = Modifier
                     .size(ChipDefaults.LargeIconSize)
                     .clip(CircleShape),
@@ -243,7 +243,7 @@ private fun FavouritesLoaded(text: String) {
         icon = {
             Icon(
                 imageVector = Icons.Default.FeaturedPlayList,
-                contentDescription = null, // hidden from talkback
+                contentDescription = null,
                 modifier = Modifier
                     .size(ChipDefaults.LargeIconSize)
                     .clip(CircleShape),

--- a/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -89,6 +90,16 @@ fun MenuScreen(
         }
         item {
             TimeWithoutSecondsPickerChip(time) { navigateToRoute(Screen.TimeWithoutSecondsPicker.route) }
+        }
+        item {
+            Chip(
+                label = {
+                    Text(text = stringResource(id = R.string.sectionedlist_samples_menu))
+                },
+                modifier = modifier.fillMaxWidth(),
+                onClick = { navigateToRoute(Screen.SectionedListMenuScreen.route) },
+                colors = ChipDefaults.primaryChipColors()
+            )
         }
     }
 

--- a/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
@@ -37,6 +37,9 @@ import com.google.android.horologist.composables.TimePickerWith12HourClock
 import com.google.android.horologist.datalayer.DataLayerNodesScreen
 import com.google.android.horologist.datalayer.DataLayerNodesViewModel
 import com.google.android.horologist.networks.NetworkScreen
+import com.google.android.horologist.sectionedlist.SectionedListMenuScreen
+import com.google.android.horologist.sectionedlist.stateful.SectionedListStatefulScreen
+import com.google.android.horologist.sectionedlist.stateless.SectionedListStatelessScreen
 import java.time.LocalDateTime
 
 @Composable
@@ -124,6 +127,18 @@ fun SampleWearApp() {
                     },
                     showSeconds = false
                 )
+            }
+            composable(route = Screen.SectionedListMenuScreen.route) {
+                SectionedListMenuScreen(
+                    modifier = Modifier.fillMaxSize(),
+                    navigateToRoute = { route -> navController.navigate(route) }
+                )
+            }
+            composable(Screen.SectionedListStatelessScreen.route) {
+                SectionedListStatelessScreen()
+            }
+            composable(Screen.SectionedListStatefulScreen.route) {
+                SectionedListStatefulScreen()
             }
         }
     }

--- a/sample/src/main/java/com/google/android/horologist/sample/Screen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/Screen.kt
@@ -32,4 +32,8 @@ sealed class Screen(
     object Network : Screen("network")
 
     object DataLayerNodes : Screen("nodes")
+
+    object SectionedListMenuScreen : Screen("sectionedListMenuScreen")
+    object SectionedListStatelessScreen : Screen("sectionedListStatelessScreen")
+    object SectionedListStatefulScreen : Screen("sectionedListStatefulScreen")
 }

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/SectionedListMenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/SectionedListMenuScreen.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.sectionedlist
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.res.stringResource
+import androidx.wear.compose.material.Chip
+import androidx.wear.compose.material.ChipDefaults
+import androidx.wear.compose.material.ScalingLazyListState
+import androidx.wear.compose.material.Text
+import androidx.wear.compose.material.rememberScalingLazyListState
+import com.google.android.horologist.composables.SectionedList
+import com.google.android.horologist.sample.R
+import com.google.android.horologist.sample.Screen
+import com.google.android.horologist.sectionedlist.component.Title
+
+@Composable
+fun SectionedListMenuScreen(
+    modifier: Modifier = Modifier,
+    navigateToRoute: (String) -> Unit,
+    scalingLazyListState: ScalingLazyListState = rememberScalingLazyListState(),
+    focusRequester: FocusRequester = remember { FocusRequester() }
+) {
+    SectionedList(
+        focusRequester = focusRequester,
+        scalingLazyListState = scalingLazyListState,
+        modifier = modifier
+    ) {
+        section(
+            listOf(
+                Pair(
+                    R.string.sectionedlist_stateless_sections_menu,
+                    Screen.SectionedListStatelessScreen.route
+                ),
+                Pair(
+                    R.string.sectionedlist_stateful_sections_menu,
+                    Screen.SectionedListStatefulScreen.route
+                )
+            )
+        ) {
+            header {
+                Title(stringResource(R.string.sectionedlist_samples_title))
+            }
+
+            loaded { item ->
+                Chip(
+                    label = {
+                        Text(text = stringResource(id = item.first))
+                    },
+                    modifier = modifier.fillMaxWidth(),
+                    onClick = { navigateToRoute(item.second) },
+                    colors = ChipDefaults.primaryChipColors()
+                )
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+}

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/component/SingleLineChip.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/component/SingleLineChip.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.sectionedlist.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.wear.compose.material.Chip
+import androidx.wear.compose.material.ChipDefaults
+import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.Text
+
+@Composable
+fun SingleLineChip(text: String, imageVector: ImageVector) {
+    Chip(
+        label = {
+            Text(
+                text = text,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Left,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 2
+            )
+        },
+        onClick = { },
+        modifier = Modifier.fillMaxWidth(),
+        icon = {
+            Icon(
+                imageVector = imageVector,
+                contentDescription = null, // hidden from talkback
+                modifier = Modifier
+                    .size(ChipDefaults.LargeIconSize)
+                    .clip(CircleShape),
+                tint = Color.Gray
+            )
+        },
+        colors = ChipDefaults.secondaryChipColors()
+    )
+}

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/component/SingleLineNoIconChip.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/component/SingleLineNoIconChip.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.sectionedlist.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.wear.compose.material.Chip
+import androidx.wear.compose.material.ChipDefaults
+import androidx.wear.compose.material.Text
+
+@Composable
+fun SingleLineNoIconChip(text: String) {
+    Chip(
+        label = {
+            Text(
+                text = text,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 2
+            )
+        },
+        onClick = { },
+        modifier = Modifier.fillMaxWidth(),
+        colors = ChipDefaults.secondaryChipColors()
+    )
+}

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/component/Title.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/component/Title.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.sectionedlist.component
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
+
+@Composable
+fun Title(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = text,
+        modifier = modifier.padding(vertical = 8.dp),
+        overflow = TextOverflow.Ellipsis,
+        maxLines = 3,
+        style = MaterialTheme.typography.title3
+    )
+}

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/component/TwoLinesChip.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/component/TwoLinesChip.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.sectionedlist.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.wear.compose.material.Chip
+import androidx.wear.compose.material.ChipDefaults
+import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.Text
+
+@Composable
+fun TwoLinesChip(
+    primaryLabel: String,
+    secondaryLabel: String,
+    imageVector: ImageVector
+) {
+    Chip(
+        label = {
+            Text(
+                text = primaryLabel,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Left,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1
+            )
+        },
+        onClick = { },
+        modifier = Modifier.fillMaxWidth(),
+        secondaryLabel = {
+            Text(
+                text = secondaryLabel,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1
+            )
+        },
+        icon = {
+            Icon(
+                imageVector = imageVector,
+                contentDescription = null, // hidden from talkback
+                modifier = Modifier
+                    .size(ChipDefaults.LargeIconSize)
+                    .clip(CircleShape),
+                tint = Color.Gray
+            )
+        },
+        colors = ChipDefaults.secondaryChipColors()
+    )
+}

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/stateful/SectionedListStatefulScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/stateful/SectionedListStatefulScreen.kt
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.sectionedlist.stateful
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material.icons.filled.DownloadDone
+import androidx.compose.material.icons.filled.LibraryMusic
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.wear.compose.material.ChipDefaults
+import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.ScalingLazyListState
+import androidx.wear.compose.material.Text
+import androidx.wear.compose.material.rememberScalingLazyListState
+import com.google.android.horologist.composables.PlaceholderChip
+import com.google.android.horologist.composables.Section
+import com.google.android.horologist.composables.SectionedList
+import com.google.android.horologist.compose.layout.StateUtils.rememberStateWithLifecycle
+import com.google.android.horologist.compose.tools.WearPreviewDevices
+import com.google.android.horologist.sample.R
+import com.google.android.horologist.sectionedlist.component.SingleLineChip
+import com.google.android.horologist.sectionedlist.component.SingleLineNoIconChip
+import com.google.android.horologist.sectionedlist.component.Title
+import com.google.android.horologist.sectionedlist.component.TwoLinesChip
+import com.google.android.horologist.sectionedlist.stateful.SectionedListStatefulScreenViewModel.Recommendation
+import com.google.android.horologist.sectionedlist.stateful.SectionedListStatefulScreenViewModel.RecommendationSectionState
+import com.google.android.horologist.sectionedlist.stateful.SectionedListStatefulScreenViewModel.Trending
+import com.google.android.horologist.sectionedlist.stateful.SectionedListStatefulScreenViewModel.TrendingSectionState
+
+@Composable
+fun SectionedListStatefulScreen(
+    modifier: Modifier = Modifier,
+    viewModel: SectionedListStatefulScreenViewModel = viewModel(),
+    scalingLazyListState: ScalingLazyListState = rememberScalingLazyListState(),
+    focusRequester: FocusRequester = remember { FocusRequester() }
+) {
+    val state by rememberStateWithLifecycle(viewModel.uiState)
+
+    SectionedList(
+        focusRequester = focusRequester,
+        scalingLazyListState = scalingLazyListState,
+        modifier = modifier
+    ) {
+        section(
+            listOf(
+                Pair(R.string.sectionedlist_downloads_button, Icons.Default.DownloadDone),
+                Pair(R.string.sectionedlist_your_library_button, Icons.Default.LibraryMusic)
+            )
+        ) {
+            loaded { item ->
+                SingleLineChip(text = stringResource(item.first), imageVector = item.second)
+            }
+        }
+
+        val recommendationsState: Section.State =
+            when (val recommendationSectionState = state.recommendationSectionState) {
+                RecommendationSectionState.Loading -> Section.State.Loading
+                is RecommendationSectionState.Loaded -> Section.State.Loaded(
+                    recommendationSectionState.list
+                )
+                RecommendationSectionState.Failed -> Section.State.Failed
+            }
+
+        section(recommendationsState) {
+            header {
+                Title(stringResource(id = R.string.sectionedlist_recommendations_title))
+            }
+
+            loaded { recommendation: Recommendation ->
+                SingleLineChip(
+                    text = recommendation.playlistName,
+                    imageVector = recommendation.icon
+                )
+            }
+
+            loading {
+                Column {
+                    PlaceholderChip(colors = ChipDefaults.secondaryChipColors())
+                    PlaceholderChip(
+                        modifier = Modifier.padding(top = 4.dp),
+                        colors = ChipDefaults.secondaryChipColors()
+                    )
+                }
+            }
+
+            failed {
+                FailedView(onClick = { viewModel.loadRecommendations() })
+            }
+
+            footer {
+                SingleLineNoIconChip(stringResource(id = R.string.sectionedlist_see_more_button))
+            }
+        }
+
+        val trendingState: Section.State =
+            when (val recommendationSectionState = state.trendingSectionState) {
+                TrendingSectionState.Loading -> Section.State.Loading
+                is TrendingSectionState.Loaded -> Section.State.Loaded(
+                    recommendationSectionState.list
+                )
+                TrendingSectionState.Failed -> Section.State.Failed
+            }
+
+        section(trendingState) {
+            header {
+                Title(stringResource(id = R.string.sectionedlist_trending_title))
+            }
+
+            loaded { trending: Trending ->
+                TwoLinesChip(
+                    primaryLabel = trending.name,
+                    secondaryLabel = trending.artist,
+                    imageVector = Icons.Default.MusicNote
+                )
+            }
+
+            loading {
+                Column {
+                    PlaceholderChip(colors = ChipDefaults.secondaryChipColors())
+                    PlaceholderChip(
+                        modifier = Modifier.padding(top = 4.dp),
+                        colors = ChipDefaults.secondaryChipColors()
+                    )
+                }
+            }
+
+            failed {
+                FailedView(onClick = { viewModel.loadTrending() })
+            }
+
+            footer {
+                SingleLineNoIconChip(stringResource(id = R.string.sectionedlist_see_more_button))
+            }
+        }
+
+        section {
+            loaded {
+                SingleLineChip(
+                    text = stringResource(R.string.sectionedlist_settings_button),
+                    imageVector = Icons.Default.Settings
+                )
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+}
+
+@Composable
+private fun FailedView(onClick: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .height(108.dp)
+            .clickable { onClick() },
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            imageVector = Icons.Default.CloudOff,
+            contentDescription = null, // hidden from talkback
+            modifier = Modifier
+                .size(ChipDefaults.LargeIconSize)
+                .clip(CircleShape),
+            tint = Color.Gray
+        )
+
+        Text(
+            text = stringResource(R.string.sectionedlist_failed_to_load),
+            modifier = Modifier.padding(top = 8.dp, bottom = 8.dp),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.body2
+        )
+    }
+}
+
+@WearPreviewDevices
+@Composable
+fun SectionedListStatefulScreenPreview() {
+    SectionedListStatefulScreen()
+}

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/stateful/SectionedListStatefulScreenViewModel.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/stateful/SectionedListStatefulScreenViewModel.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.sectionedlist.stateful
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DirectionsRun
+import androidx.compose.material.icons.filled.SelfImprovement
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlin.random.Random
+
+class SectionedListStatefulScreenViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(
+        UiState(
+            recommendationSectionState = RecommendationSectionState.Loading,
+            trendingSectionState = TrendingSectionState.Loading
+        )
+    )
+    val uiState: StateFlow<UiState> = _uiState
+
+    init {
+        loadRecommendations()
+        loadTrending()
+    }
+
+    data class UiState(
+        val recommendationSectionState: RecommendationSectionState,
+        val trendingSectionState: TrendingSectionState
+    )
+
+    sealed class RecommendationSectionState {
+        object Loading : RecommendationSectionState()
+        data class Loaded(val list: List<Recommendation>) : RecommendationSectionState()
+        object Failed : RecommendationSectionState()
+    }
+
+    data class Recommendation(
+        val playlistName: String,
+        val icon: ImageVector
+    )
+
+    sealed class TrendingSectionState {
+        object Loading : TrendingSectionState()
+        data class Loaded(val list: List<Trending>) : TrendingSectionState()
+        object Failed : TrendingSectionState()
+    }
+
+    data class Trending(
+        val name: String,
+        val artist: String
+    )
+
+    fun loadRecommendations() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(
+                recommendationSectionState = RecommendationSectionState.Loading
+            )
+
+            // pretend it is fetching date over remote
+            delay(getRandomTimeInMillis())
+
+            _uiState.value = _uiState.value.copy(
+                recommendationSectionState = if (shouldFailToLoad()) {
+                    RecommendationSectionState.Failed
+                } else {
+                    RecommendationSectionState.Loaded(
+                        list = listOf(
+                            Recommendation("Running playlist", Icons.Default.DirectionsRun),
+                            Recommendation("Focus", Icons.Default.SelfImprovement)
+                        )
+                    )
+                }
+            )
+        }
+    }
+
+    fun loadTrending() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(
+                trendingSectionState = TrendingSectionState.Loading
+            )
+
+            // pretend it is fetching date over remote
+            delay(getRandomTimeInMillis())
+
+            _uiState.value = _uiState.value.copy(
+                trendingSectionState = if (shouldFailToLoad()) {
+                    TrendingSectionState.Failed
+                } else {
+                    TrendingSectionState.Loaded(
+                        list = listOf(
+                            Trending("There'd Better Be A Mirrorball", "Arctic Monkeys"),
+                            Trending("180 Hours", "Dudu Kanegae")
+                        )
+                    )
+                }
+            )
+        }
+    }
+
+    private fun shouldFailToLoad(): Boolean {
+        return Random.nextInt(1, 3) == 1
+    }
+
+    private fun getRandomTimeInMillis(): Long {
+        return Random.nextLong(3000, 7000)
+    }
+}

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/stateless/SectionedListStatelessScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/stateless/SectionedListStatelessScreen.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.sectionedlist.stateless
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DirectionsRun
+import androidx.compose.material.icons.filled.DownloadDone
+import androidx.compose.material.icons.filled.LibraryMusic
+import androidx.compose.material.icons.filled.LightMode
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.SelfImprovement
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.res.stringResource
+import androidx.wear.compose.material.ScalingLazyListState
+import androidx.wear.compose.material.rememberScalingLazyListState
+import com.google.android.horologist.composables.SectionedList
+import com.google.android.horologist.compose.tools.WearPreviewDevices
+import com.google.android.horologist.sample.R
+import com.google.android.horologist.sectionedlist.component.SingleLineChip
+import com.google.android.horologist.sectionedlist.component.SingleLineNoIconChip
+import com.google.android.horologist.sectionedlist.component.Title
+import com.google.android.horologist.sectionedlist.component.TwoLinesChip
+
+@Composable
+fun SectionedListStatelessScreen(
+    modifier: Modifier = Modifier,
+    scalingLazyListState: ScalingLazyListState = rememberScalingLazyListState(),
+    focusRequester: FocusRequester = remember { FocusRequester() }
+) {
+    SectionedList(
+        focusRequester = focusRequester,
+        scalingLazyListState = scalingLazyListState,
+        modifier = modifier
+    ) {
+        // Section without header and without footer
+        section(
+            listOf(
+                Pair(R.string.sectionedlist_downloads_button, Icons.Default.DownloadDone),
+                Pair(R.string.sectionedlist_your_library_button, Icons.Default.LibraryMusic)
+            )
+        ) {
+            loaded { item ->
+                SingleLineChip(text = stringResource(item.first), imageVector = item.second)
+            }
+        }
+
+        // Section with header and footer
+        section(
+            listOf(
+                Pair("Running playlist", Icons.Default.DirectionsRun),
+                Pair("Focus", Icons.Default.SelfImprovement),
+                Pair("Summer hits", Icons.Default.LightMode)
+            )
+        ) {
+            header {
+                Title(stringResource(id = R.string.sectionedlist_recommendations_title))
+            }
+
+            loaded { item ->
+                SingleLineChip(item.first, item.second)
+            }
+
+            footer {
+                SingleLineNoIconChip(stringResource(id = R.string.sectionedlist_see_more_button))
+            }
+        }
+
+        // Section with header and footer
+        section(
+            listOf(
+                Pair("Bad Habits", "Ed Sheeran"),
+                Pair("There'd Better Be A Mirrorball", "Arctic Monkeys"),
+                Pair("180 Hours", "Dudu Kanegae")
+            )
+        ) {
+            header {
+                Title(stringResource(id = R.string.sectionedlist_trending_title))
+            }
+
+            loaded { item ->
+                TwoLinesChip(
+                    primaryLabel = item.first,
+                    secondaryLabel = item.second,
+                    imageVector = Icons.Default.MusicNote
+                )
+            }
+
+            footer {
+                SingleLineNoIconChip(stringResource(id = R.string.sectionedlist_see_more_button))
+            }
+        }
+
+        // Section with single item
+        section {
+            loaded {
+                SingleLineChip(
+                    text = stringResource(R.string.sectionedlist_settings_button),
+                    imageVector = Icons.Default.Settings
+                )
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+}
+
+@WearPreviewDevices
+@Composable
+fun SectionedListStatelessScreenPreview() {
+    SectionedListStatelessScreen()
+}

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -23,4 +23,15 @@
     <string name="tile_text">Hello world</string>
     <string name="tile_sample_label">Sample Tile</string>
     <string name="sample_tile_description">Sample tile description</string>
+    <string name="sectionedlist_samples_menu">SectionedList Samples</string>
+    <string name="sectionedlist_stateless_sections_menu">Stateless sections</string>
+    <string name="sectionedlist_stateful_sections_menu">Stateful sections</string>
+    <string name="sectionedlist_samples_title">SectionedList samples</string>
+    <string name="sectionedlist_recommendations_title">Recommendations</string>
+    <string name="sectionedlist_trending_title">Trending</string>
+    <string name="sectionedlist_downloads_button">Downloads</string>
+    <string name="sectionedlist_your_library_button">Your library</string>
+    <string name="sectionedlist_settings_button">Settings</string>
+    <string name="sectionedlist_see_more_button">See more</string>
+    <string name="sectionedlist_failed_to_load">Failed to load, tap to try again.</string>
 </resources>


### PR DESCRIPTION
#### WHAT

Add screen samples using `SectionedList`.


https://user-images.githubusercontent.com/878134/188883704-f13f2c22-77d2-46b9-a378-6af5aaae2e15.mp4



#### WHY

In order to have different samples of how the component can be used.

#### HOW

- Add "SectionedList Samples" menu item to `sample` app with two sub-items:
  - Stateless sections
  - Stateful sections

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
