### PR TITLE
Fix sample app navigation

### DIFF
--- a/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
@@ -63,67 +63,67 @@ fun SampleWearApp() {
                 DataLayerNodesScreen(
                     viewModel = viewModel(factory = DataLayerNodesViewModel.Factory)
                 )
-                composable(Screen.Network.route) {
-                    NetworkScreen()
-                }
-                composable(Screen.FillMaxRectangle.route) {
-                    FillMaxRectangleScreen()
-                }
-                composable(Screen.Volume.route) {
-                    val focusRequester = remember { FocusRequester() }
+            }
+            composable(Screen.Network.route) {
+                NetworkScreen()
+            }
+            composable(Screen.FillMaxRectangle.route) {
+                FillMaxRectangleScreen()
+            }
+            composable(Screen.Volume.route) {
+                val focusRequester = remember { FocusRequester() }
 
-                    VolumeScreen(focusRequester = focusRequester)
+                VolumeScreen(focusRequester = focusRequester)
 
-                    LaunchedEffect(Unit) {
-                        focusRequester.requestFocus()
+                LaunchedEffect(Unit) {
+                    focusRequester.requestFocus()
+                }
+            }
+            composable(Screen.FadeAway.route) {
+                FadeAwayScreenLazyColumn()
+            }
+            composable(Screen.FadeAwaySLC.route) {
+                FadeAwayScreenScalingLazyColumn()
+            }
+            composable(Screen.FadeAwayColumn.route) {
+                FadeAwayScreenColumn()
+            }
+            composable(Screen.DatePicker.route) {
+                DatePicker(
+                    date = time.toLocalDate(),
+                    onDateConfirm = {
+                        time = time.toLocalTime().atDate(it)
+                        navController.popBackStack()
                     }
-                }
-                composable(Screen.FadeAway.route) {
-                    FadeAwayScreenLazyColumn()
-                }
-                composable(Screen.FadeAwaySLC.route) {
-                    FadeAwayScreenScalingLazyColumn()
-                }
-                composable(Screen.FadeAwayColumn.route) {
-                    FadeAwayScreenColumn()
-                }
-                composable(Screen.DatePicker.route) {
-                    DatePicker(
-                        date = time.toLocalDate(),
-                        onDateConfirm = {
-                            time = time.toLocalTime().atDate(it)
-                            navController.popBackStack()
-                        }
-                    )
-                }
-                composable(Screen.TimePicker.route) {
-                    TimePickerWith12HourClock(
-                        time = time.toLocalTime(),
-                        onTimeConfirm = {
-                            time = time.toLocalDate().atTime(it)
-                            navController.popBackStack()
-                        }
-                    )
-                }
-                composable(Screen.TimeWithSecondsPicker.route) {
-                    TimePicker(
-                        time = time.toLocalTime(),
-                        onTimeConfirm = {
-                            time = time.toLocalDate().atTime(it)
-                            navController.popBackStack()
-                        }
-                    )
-                }
-                composable(Screen.TimeWithoutSecondsPicker.route) {
-                    TimePicker(
-                        time = time.toLocalTime(),
-                        onTimeConfirm = {
-                            time = time.toLocalDate().atTime(it)
-                            navController.popBackStack()
-                        },
-                        showSeconds = false
-                    )
-                }
+                )
+            }
+            composable(Screen.TimePicker.route) {
+                TimePickerWith12HourClock(
+                    time = time.toLocalTime(),
+                    onTimeConfirm = {
+                        time = time.toLocalDate().atTime(it)
+                        navController.popBackStack()
+                    }
+                )
+            }
+            composable(Screen.TimeWithSecondsPicker.route) {
+                TimePicker(
+                    time = time.toLocalTime(),
+                    onTimeConfirm = {
+                        time = time.toLocalDate().atTime(it)
+                        navController.popBackStack()
+                    }
+                )
+            }
+            composable(Screen.TimeWithoutSecondsPicker.route) {
+                TimePicker(
+                    time = time.toLocalTime(),
+                    onTimeConfirm = {
+                        time = time.toLocalDate().atTime(it)
+                        navController.popBackStack()
+                    },
+                    showSeconds = false
+                )
             }
         }
     }


### PR DESCRIPTION
#### WHAT

Fix sample app navigation.

#### WHY

App is crashing when navigating to all screens:

```
2022-09-07 15:21:00.311  5930-5930  AndroidRuntime          com...droid.horologist.sample.debug  E  FATAL EXCEPTION: main
                                                                                                    Process: com.google.android.horologist.sample.debug, PID: 5930
                                                                                                    java.lang.IllegalArgumentException: Navigation destination that matches request NavDeepLinkRequest{ uri=android-app://androidx.navigation/network } cannot be found in the navigation graph NavGraph(0x0) startDestination={Destination(0x78da666c) route=menu}
                                                                                                    	at androidx.navigation.NavController.navigate(NavController.kt:1664)
```

#### HOW

Fix calls to `composable` in `SampleWearApp`.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
