### PR TITLE
Update Uamp download rules.

### DIFF
--- a/network-awareness/api/current.api
+++ b/network-awareness/api/current.api
@@ -212,8 +212,10 @@ package com.google.android.horologist.networks.data {
 
   public static final class RequestType.MediaRequest.Companion {
     method public com.google.android.horologist.networks.data.RequestType.MediaRequest getDownloadRequest();
+    method public com.google.android.horologist.networks.data.RequestType.MediaRequest getLiveRequest();
     method public com.google.android.horologist.networks.data.RequestType.MediaRequest getStreamRequest();
     property public final com.google.android.horologist.networks.data.RequestType.MediaRequest DownloadRequest;
+    property public final com.google.android.horologist.networks.data.RequestType.MediaRequest LiveRequest;
     property public final com.google.android.horologist.networks.data.RequestType.MediaRequest StreamRequest;
   }
 

--- a/network-awareness/src/main/java/com/google/android/horologist/networks/data/RequestType.kt
+++ b/network-awareness/src/main/java/com/google/android/horologist/networks/data/RequestType.kt
@@ -24,6 +24,9 @@ import com.google.android.horologist.networks.ExperimentalHorologistNetworksApi
  */
 @ExperimentalHorologistNetworksApi
 public interface RequestType {
+    /**
+     * A request for image, say via Coil.
+     */
     @ExperimentalHorologistNetworksApi
     public object ImageRequest : RequestType {
         override fun toString(): String {
@@ -31,6 +34,9 @@ public interface RequestType {
         }
     }
 
+    /**
+     * A request for media, likely via Media3.
+     */
     @ExperimentalHorologistNetworksApi
     public data class MediaRequest(public val type: MediaRequestType) : RequestType {
         public val name: String = "media-${type.toString().lowercase()}"
@@ -42,9 +48,13 @@ public interface RequestType {
         public companion object {
             public val DownloadRequest: MediaRequest = MediaRequest(MediaRequestType.Download)
             public val StreamRequest: MediaRequest = MediaRequest(MediaRequestType.Stream)
+            public val LiveRequest: MediaRequest = MediaRequest(MediaRequestType.Download)
         }
     }
 
+    /**
+     * An API request such as fetching playslists or login.
+     */
     @ExperimentalHorologistNetworksApi
     public object ApiRequest : RequestType {
         override fun toString(): String {
@@ -52,6 +62,9 @@ public interface RequestType {
         }
     }
 
+    /**
+     * A request to ship app logs to the server.
+     */
     @ExperimentalHorologistNetworksApi
     public object LogsRequest : RequestType {
         override fun toString(): String {
@@ -59,6 +72,9 @@ public interface RequestType {
         }
     }
 
+    /**
+     * A request not tagged by the caller.
+     */
     @ExperimentalHorologistNetworksApi
     public object UnknownRequest : RequestType {
         override fun toString(): String {

--- a/network-awareness/src/main/java/com/google/android/horologist/networks/okhttp/NetworkSelectingCallFactory.kt
+++ b/network-awareness/src/main/java/com/google/android/horologist/networks/okhttp/NetworkSelectingCallFactory.kt
@@ -25,6 +25,7 @@ import com.google.android.horologist.networks.okhttp.impl.FailedCall
 import com.google.android.horologist.networks.okhttp.impl.HighBandwidthCall
 import com.google.android.horologist.networks.okhttp.impl.NetworkAwareEventListenerFactory
 import com.google.android.horologist.networks.okhttp.impl.NetworkSpecificSocketFactory
+import com.google.android.horologist.networks.okhttp.impl.RequestTypeHolder.Companion.requestType
 import com.google.android.horologist.networks.okhttp.impl.RequestTypeHolder.Companion.withDefaultRequestType
 import com.google.android.horologist.networks.okhttp.impl.RequestVerifyingInterceptor
 import com.google.android.horologist.networks.okhttp.impl.StandardCall
@@ -106,6 +107,9 @@ public class NetworkSelectingCallFactory(
 
         val client = clientForNetwork(networkStatus)
 
+        // Set the network so we don't have to guess later, which
+        // can be problematic
+        request.networkInfo = networkStatus.networkInfo
         val call = client.newCall(request)
 
         return StandardCall(this, call)

--- a/network-awareness/src/test/java/com/google/android/horologist/networks/rules/NetworkSelectingCallFactoryTest.kt
+++ b/network-awareness/src/test/java/com/google/android/horologist/networks/rules/NetworkSelectingCallFactoryTest.kt
@@ -67,7 +67,7 @@ class NetworkSelectingCallFactoryTest {
         networkingRules = networkingRules
     )
 
-    private val deadEndInterceptor = DeadEndInterceptor(networkRepository, networkingRulesEngine)
+    private val deadEndInterceptor = DeadEndInterceptor
 
     private val rootClient = OkHttpClient.Builder()
         .addInterceptor(deadEndInterceptor)
@@ -114,7 +114,6 @@ class NetworkSelectingCallFactoryTest {
 
         assertThat(networkType?.type).isEqualTo(NetworkType.Wifi)
 
-        println("Checking")
         assertThat(highBandwidthRequester.pinned.value).isNull()
     }
 

--- a/network-awareness/src/test/java/com/google/android/horologist/networks/rules/helpers/DeadEndInterceptor.kt
+++ b/network-awareness/src/test/java/com/google/android/horologist/networks/rules/helpers/DeadEndInterceptor.kt
@@ -17,24 +17,15 @@
 package com.google.android.horologist.networks.rules.helpers
 
 import com.google.android.horologist.networks.ExperimentalHorologistNetworksApi
-import com.google.android.horologist.networks.okhttp.impl.RequestTypeHolder.Companion.requestType
-import com.google.android.horologist.networks.okhttp.networkInfo
-import com.google.android.horologist.networks.okhttp.requestType
-import com.google.android.horologist.networks.rules.NetworkingRulesEngine
 import okhttp3.Interceptor
 import okhttp3.Protocol
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 
 @ExperimentalHorologistNetworksApi
-class DeadEndInterceptor(
-    private val networkRepository: FakeNetworkRepository,
-    private val networkingRulesEngine: NetworkingRulesEngine
-) : Interceptor {
+object DeadEndInterceptor : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
-        val networkInfo = networkingRulesEngine.preferredNetwork(request.requestType)
-        request.networkInfo = networkInfo?.networkInfo
         return Response.Builder()
             .request(request)
             .code(200)


### PR DESCRIPTION
#### WHAT

Update Uamp download rules. Images prefer BT, downloads never over BT.
Also fixes the BT logging, by setting the networkInfo proactively.

#fixes https://github.com/google/horologist/issues/563

#### WHY

Better demonstration of the approach.

#### HOW

Update UampNetworkingRules.  

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
