### PR TITLE
CI builds debug only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,10 +42,10 @@ jobs:
             ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
 
-      - name: Build
+      - name: Build (Debug)
         run: |
           ./gradlew --scan --stacktrace \
-              assemble
+              assembleDebug
 
       - name: Metalava compatibility check
         run: |


### PR DESCRIPTION
#### WHAT

`./gradlew --scan --stacktrace assembleDebug`

#### WHY

CI builds were going over 30 minutes, likely due to release artifacts.

#### HOW

Run assembleDebug instead.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
