### PR TITLE
Set correct gradle task for generating metalava signature in contribution readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ When submitting a PR, please check API compatibility and lint rules first.
 A good first step is 
 
 ```
-$ ./gradlew spotlessApply spotlessCheck compileDebugSources compileReleaseSources metalavaGenerateSignature lintDebug
+$ ./gradlew spotlessApply spotlessCheck compileDebugSources compileReleaseSources metalavaGenerateSignatureDebug lintDebug
 ```
 
 Also make sure you have [Git LFS]([url](https://git-lfs.github.com/)) installed.


### PR DESCRIPTION
#### WHAT
After this https://github.com/google/horologist/pull/483/files  `./gradlew metalavaGenerateSignature` does not work. However,  `./gradlew metalavaGenerateSignatureDebug` works fine, so in this PR I have edited the contribution readme to include the command that worked for generating the metalava signature. 

#### WHY
This solves #568 

#### HOW
Adding the command that works to the good first step :) 

To be honest, I am unsure if this is the best solution. Would like some feedback on this if possible :) 

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
