### PR TITLE
Fix request type for streaming

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/PlaybackServiceModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/PlaybackServiceModule.kt
@@ -57,7 +57,6 @@ import com.google.android.horologist.mediasample.data.service.playback.UampMedia
 import com.google.android.horologist.mediasample.domain.SettingsRepository
 import com.google.android.horologist.mediasample.domain.strategy
 import com.google.android.horologist.mediasample.ui.AppConfig
-import com.google.android.horologist.networks.data.RequestType
 import com.google.android.horologist.networks.data.RequestType.MediaRequest.Companion.StreamRequest
 import com.google.android.horologist.networks.okhttp.NetworkAwareCallFactory
 import dagger.Module

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/PlaybackServiceModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/PlaybackServiceModule.kt
@@ -58,6 +58,7 @@ import com.google.android.horologist.mediasample.domain.SettingsRepository
 import com.google.android.horologist.mediasample.domain.strategy
 import com.google.android.horologist.mediasample.ui.AppConfig
 import com.google.android.horologist.networks.data.RequestType
+import com.google.android.horologist.networks.data.RequestType.MediaRequest.Companion.StreamRequest
 import com.google.android.horologist.networks.okhttp.NetworkAwareCallFactory
 import dagger.Module
 import dagger.Provides
@@ -133,7 +134,7 @@ object PlaybackServiceModule {
         OkHttpDataSource.Factory(
             NetworkAwareCallFactory(
                 callFactory,
-                defaultRequestType = RequestType.UnknownRequest
+                defaultRequestType = StreamRequest
             )
         )
             .setTransferListener(transferListener)


### PR DESCRIPTION
#### WHAT

Set the request type correctly for streaming media downloads.

#### WHY

Didn't notice before because we are Download first.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
