### PR TITLE
Fix download progress displayed on PlaylistDownloadScreen

### DIFF
--- a/media-ui/src/main/res/values/strings.xml
+++ b/media-ui/src/main/res/values/strings.xml
@@ -41,7 +41,7 @@
     <string name="horologist_playlist_download_button_shuffle_content_description">Shuffle</string>
     <string name="horologist_playlist_download_button_play_content_description">Play</string>
     <string name="horologist_playlist_download_download_progress_unknown_size">%1$s%%</string>
-    <string name="horologist_playlist_download_download_progress_known_size">%1$s%% of %2$s</string>
+    <string name="horologist_playlist_download_download_progress_known_size">%1$.0f%% of %2$s</string>
     <string name="horologist_playlist_download_download_progress_waiting">Waiting…</string>
     <string name="horologist_preview_app_name">UAMP</string>
     <string name="horologist_preview_favorites">Favorites</string>


### PR DESCRIPTION
#### WHAT

Fix download progress displayed on `PlaylistDownloadScreen`.

![Screenshot_20220915_174720](https://user-images.githubusercontent.com/878134/190462402-18e7c967-1c4f-4356-95ea-b962be53b28f.png)

#### WHY

It was displaying with many decimal places:
![Screenshot_20220915_170952](https://user-images.githubusercontent.com/878134/190462454-0febaa2f-3037-43d3-8fc5-110c3f651f83.png)


#### HOW
Change format in the string resource.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
