### PR TITLE
Add tracing for ExoPlayer status

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/PlaybackServiceModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/PlaybackServiceModule.kt
@@ -52,6 +52,7 @@ import com.google.android.horologist.media3.navigation.IntentBuilder
 import com.google.android.horologist.media3.offload.AudioOffloadManager
 import com.google.android.horologist.media3.offload.AudioOffloadStrategy
 import com.google.android.horologist.media3.rules.PlaybackRules
+import com.google.android.horologist.media3.tracing.TracingListener
 import com.google.android.horologist.mediasample.data.service.complication.DataUpdates
 import com.google.android.horologist.mediasample.data.service.playback.UampMediaLibrarySessionCallback
 import com.google.android.horologist.mediasample.domain.SettingsRepository
@@ -231,6 +232,8 @@ object PlaybackServiceModule {
             errorReporter = logger,
             coroutineScope = serviceCoroutineScope
         ).also { wearConfiguredPlayer ->
+            exoPlayer.addListener(TracingListener())
+
             serviceCoroutineScope.launch {
                 wearConfiguredPlayer.startNoiseDetection()
             }

--- a/media3-backend/src/main/java/com/google/android/horologist/media3/tracing/TracingListener.kt
+++ b/media3-backend/src/main/java/com/google/android/horologist/media3/tracing/TracingListener.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media3.tracing
+
+import androidx.media3.common.Player
+import androidx.tracing.Trace
+
+public class TracingListener : Player.Listener {
+    private var isPlaying: Boolean = false
+    private var isLoading: Boolean = false
+
+    override fun onIsPlayingChanged(newIsPlaying: Boolean) {
+        if (newIsPlaying != isPlaying) {
+            if (newIsPlaying) {
+                Trace.beginAsyncSection("Player.isPlaying", 0)
+            } else {
+                Trace.endAsyncSection("Player.isPlaying", 0)
+            }
+        }
+
+        this.isPlaying = newIsPlaying
+    }
+
+    override fun onIsLoadingChanged(newIsLoading: Boolean) {
+        if (newIsLoading != isLoading) {
+            if (newIsLoading) {
+                Trace.beginAsyncSection("Player.isLoading", 0)
+            } else {
+                Trace.endAsyncSection("Player.isLoading", 0)
+            }
+        }
+
+        this.isLoading = newIsLoading
+    }
+}


### PR DESCRIPTION
#### WHAT

Add tracing for ExoPlayer status

#### WHY

Perfetto traces showing playback status is useful

#### HOW

Extracted from https://github.com/google/horologist/pull/585

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
