### PR TITLE
Fail fast in UampNetworkingRules

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/config/UampNetworkingRules.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/config/UampNetworkingRules.kt
@@ -23,6 +23,7 @@ import com.google.android.horologist.networks.data.Networks
 import com.google.android.horologist.networks.data.RequestType
 import com.google.android.horologist.networks.data.RequestType.MediaRequest.Companion.DownloadRequest
 import com.google.android.horologist.networks.data.RequestType.MediaRequest.Companion.LiveRequest
+import com.google.android.horologist.networks.data.RequestType.UnknownRequest
 import com.google.android.horologist.networks.rules.Allow
 import com.google.android.horologist.networks.rules.Fail
 import com.google.android.horologist.networks.rules.NetworkingRules
@@ -33,6 +34,9 @@ import com.google.android.horologist.networks.rules.RequestCheck
  */
 object UampNetworkingRules : NetworkingRules {
     override fun isHighBandwidthRequest(requestType: RequestType): Boolean {
+        // For testing purposes fail if we get unknown requests
+        check(requestType != UnknownRequest)
+
         return requestType is RequestType.MediaRequest
     }
 


### PR DESCRIPTION
#### WHAT

Fail fast in UampNetworkingRules

#### WHY

We had a bug where we were using Unknown, want to avoid that and use correct network choices.

#### HOW

Extracted from https://github.com/google/horologist/pull/585

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
