### PR TITLE
Fix data race in DataClient.dataItemFlow

### DIFF
--- a/datalayer/src/main/java/com/google/android/horologist/data/store/impl/DataItemFlow.kt
+++ b/datalayer/src/main/java/com/google/android/horologist/data/store/impl/DataItemFlow.kt
@@ -50,11 +50,11 @@ public fun <T> DataClient.dataItemFlow(
         .authority(nodeId)
         .build()
 
-    val item: DataItem? = this@dataItemFlow.getDataItem(uri).await()
+    addListener(listener, uri, DataClient.FILTER_LITERAL).await() // Ensure we are subscribed to updates first,
+
+    val item: DataItem? = this@dataItemFlow.getDataItem(uri).await() // then get the current value.
 
     trySend(item?.data)
-
-    addListener(listener, uri, DataClient.FILTER_LITERAL)
 
     awaitClose {
         removeListener(listener)


### PR DESCRIPTION
#### WHAT

Fixes #593

#### WHY

Because data races are bad.

#### HOW

By ensuring we are subscribed to changes before getting the current value.

#### Checklist :clipboard:
- [ ] ~~Add explicit visibility modifier and explicit return types for public declarations~~
- [ ] ~~Run spotless check~~
- [ ] ~~Run tests~~
- [ ] ~~Update metalava's signature text files~~