### PR TITLE
Fix TimeText behavior in ScalingLazyList according to scrollState

### DIFF
--- a/compose-layout/src/androidTest/java/com/google/android/horologist/compose/navscaffold/NavScaffoldTest.kt
+++ b/compose-layout/src/androidTest/java/com/google/android/horologist/compose/navscaffold/NavScaffoldTest.kt
@@ -70,6 +70,7 @@ class NavScaffoldTest {
 
         lateinit var aScrollState: ScalingLazyListState
         lateinit var bScrollState: ScalingLazyListState
+        lateinit var cScrollState: ScalingLazyListState
         lateinit var navController: NavHostController
 
         fun NavGraphBuilder.scrollingList(
@@ -101,6 +102,7 @@ class NavScaffoldTest {
             navController = rememberSwipeDismissableNavController()
             aScrollState = rememberScalingLazyListState(initialCenterItemIndex = 0)
             bScrollState = rememberScalingLazyListState(initialCenterItemIndex = 10)
+            cScrollState = rememberScalingLazyListState(initialCenterItemScrollOffset = 50)
 
             WearNavScaffold(
                 startDestination = "a",
@@ -108,6 +110,7 @@ class NavScaffoldTest {
             ) {
                 scrollingList("a", aScrollState)
                 scrollingList("b", bScrollState)
+                scrollingList("c", cScrollState)
             }
         }
 
@@ -126,6 +129,16 @@ class NavScaffoldTest {
         val bViewModel =
             ViewModelProvider(navController.currentBackStackEntry!!).get<NavScaffoldViewModel>()
         assertSame(bScrollState, bViewModel.scrollableState)
+
+        withContext(Dispatchers.Main) {
+            navController.navigate("c")
+        }
+
+        composeTestRule.awaitIdle()
+
+        val cViewModel =
+            ViewModelProvider(navController.currentBackStackEntry!!).get<NavScaffoldViewModel>()
+        assertSame(cScrollState, cViewModel.scrollableState)
     }
 
     @Test

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/NavScaffoldViewModel.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/NavScaffoldViewModel.kt
@@ -50,6 +50,7 @@ public open class NavScaffoldViewModel(
     private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
     internal var initialIndex: Int? = null
+    internal var initialOffset: Int? = null
     internal var scrollType by mutableStateOf<ScrollType?>(null)
 
     private lateinit var _scrollableState: ScrollableState
@@ -127,6 +128,7 @@ public open class NavScaffoldViewModel(
             ) {
                 scrollableStateBuilder().also {
                     initialIndex = it.centerItemIndex
+                    initialOffset = it.centerItemScrollOffset
                 }
             }
         }

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/WearNavScaffold.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/WearNavScaffold.kt
@@ -100,7 +100,10 @@ public fun WearNavScaffold(
                                     viewModel.scrollableState as ScalingLazyListState
 
                                 timeText(
-                                    Modifier.fadeAwayScalingLazyList(viewModel.initialIndex!!) {
+                                    Modifier.fadeAwayScalingLazyList(
+                                        viewModel.initialIndex!!,
+                                        viewModel.initialOffset!!
+                                    ) {
                                         scalingLazyListState
                                     }
                                 )


### PR DESCRIPTION
#### WHAT

I tried to customize the `ScalingLazyColumn` offset but the `TimeText` disappeared and was scrolled away. 

the expected behavior is that the time text remain and consider the added offset.

#### WHY

Changing the `initialCenterItemScrollOffset` in `ScalingLazyListState` and also the `itemOffset` in the `AutoCenteringParams` does not reflect in the `fadeAway` behavior of the TimeText. 

Currently, we are only handling the `itemIndex` customization and that's why if we try to move the centered item with the offset will make the TimeText scrolled away.


#### HOW

I added a second property in the [NavScaffoldViewModel.kt](https://github.com/moncefguettat/horologist/blob/main/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/NavScaffoldViewModel.kt) to handle to the offset changes, which is used by the `TimeText` `fadeAway` behavior to react to any changes to the centered Item `Index` or `Offset`.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
