### PR TITLE
Add basic animation for download progress indicators

### DIFF
--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/base/StandardChipIconWithProgressPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/base/StandardChipIconWithProgressPreview.kt
@@ -54,8 +54,8 @@ fun StandardChipIconWithProgressInProgressPreview() {
 fun StandardChipIconWithProgressInProgressLargeIconPreview() {
     StandardChipIconWithProgress(
         progress = 75f,
-        largeIcon = true,
-        icon = Icon48dp
+        icon = Icon48dp,
+        largeIcon = true
     )
 }
 

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/base/StandardChip.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/base/StandardChip.kt
@@ -58,31 +58,6 @@ internal fun StandardChip(
     chipType: StandardChipType = StandardChipType.Primary,
     enabled: Boolean = true
 ) {
-    val hasSecondaryLabel = secondaryLabel != null
-    val hasIcon = icon != null
-
-    val labelParam: (@Composable RowScope.() -> Unit) =
-        {
-            Text(
-                text = label,
-                modifier = Modifier.fillMaxWidth(),
-                textAlign = if (hasSecondaryLabel || hasIcon) TextAlign.Left else TextAlign.Center,
-                overflow = TextOverflow.Ellipsis,
-                maxLines = if (hasSecondaryLabel) 1 else 2
-            )
-        }
-
-    val secondaryLabelParam: (@Composable RowScope.() -> Unit)? =
-        secondaryLabel?.let {
-            {
-                Text(
-                    text = secondaryLabel,
-                    overflow = TextOverflow.Ellipsis,
-                    maxLines = 1
-                )
-            }
-        }
-
     val iconParam: (@Composable BoxScope.() -> Unit)? =
         icon?.let {
             {
@@ -119,26 +94,15 @@ internal fun StandardChip(
             }
         }
 
-    val contentPadding = if (largeIcon) {
-        val horizontalPadding = 10.dp
-        val verticalPadding = 6.dp // same as Chip.ChipVerticalPadding
-        PaddingValues(horizontal = horizontalPadding, vertical = verticalPadding)
-    } else {
-        ChipDefaults.ContentPadding
-    }
-
-    Chip(
-        label = labelParam,
+    StandardChip(
+        label = label,
         onClick = onClick,
-        modifier = modifier.fillMaxWidth(),
-        secondaryLabel = secondaryLabelParam,
+        modifier = modifier,
+        secondaryLabel = secondaryLabel,
         icon = iconParam,
-        colors = when (chipType) {
-            StandardChipType.Primary -> ChipDefaults.primaryChipColors()
-            StandardChipType.Secondary -> ChipDefaults.secondaryChipColors()
-        },
-        enabled = enabled,
-        contentPadding = contentPadding
+        largeIcon = largeIcon,
+        chipType = chipType,
+        enabled = enabled
     )
 }
 
@@ -151,19 +115,20 @@ internal fun StandardChip(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     secondaryLabel: String? = null,
-    icon: @Composable BoxScope.() -> Unit,
+    icon: (@Composable BoxScope.() -> Unit)?,
     largeIcon: Boolean = false,
     chipType: StandardChipType = StandardChipType.Primary,
     enabled: Boolean = true
 ) {
     val hasSecondaryLabel = secondaryLabel != null
+    val hasIcon = icon != null
 
     val labelParam: (@Composable RowScope.() -> Unit) =
         {
             Text(
                 text = label,
                 modifier = Modifier.fillMaxWidth(),
-                textAlign = TextAlign.Left,
+                textAlign = if (hasSecondaryLabel || hasIcon) TextAlign.Left else TextAlign.Center,
                 overflow = TextOverflow.Ellipsis,
                 maxLines = if (hasSecondaryLabel) 1 else 2
             )

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/base/StandardChipIconWithProgress.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/base/StandardChipIconWithProgress.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.CircularProgressIndicator
@@ -46,68 +45,30 @@ private val progressBarStrokeWidth = 2.dp
  * The progress indicator is in an indeterminate state and spins indefinitely.
  *
  * @param modifier [Modifier] to apply to this layout node.
- * @param icon image or icon to be displayed in the center of this view.
- * @param largeIcon true if it should display the icon with in a large size.
- * @param progressIndicatorColor the color of the progress indicator that is around the icon.
- * @param progressTrackColor the color of the background for the progress indicator.
- * @param placeholder A [Painter] that is displayed while the image is loading.
+ * @param icon Image or icon to be displayed in the center of this view.
+ * @param largeIcon True if it should display the icon with in a large size.
+ * @param placeholder A [Painter] that is displayed while the icon image is loading.
+ * @param progressIndicatorColor The color of the progress indicator that is around the icon.
+ * @param progressTrackColor The color of the background for the progress indicator.
  */
 @Composable
 internal fun StandardChipIconWithProgress(
     modifier: Modifier = Modifier,
-    largeIcon: Boolean = false,
     icon: Any? = null,
+    largeIcon: Boolean = false,
     placeholder: Painter? = null,
     progressIndicatorColor: Color = MaterialTheme.colors.primary,
     progressTrackColor: Color = MaterialTheme.colors.onSurface.copy(alpha = 0.10f)
 ) {
-    val iconSize = if (largeIcon) {
-        ChipDefaults.LargeIconSize
-    } else {
-        ChipDefaults.IconSize
-    }
-
-    Box(
+    StandardChipIconWithProgressInternal(
+        progress = null,
+        icon = icon,
+        largeIcon = largeIcon,
+        placeholder = placeholder,
+        progressIndicatorColor = progressIndicatorColor,
+        progressTrackColor = progressTrackColor,
         modifier = modifier
-            .size(iconSize)
-            .clip(CircleShape)
-    ) {
-        CircularProgressBar(
-            modifier = Modifier.align(Alignment.Center),
-            progress = null,
-            size = iconSize - progressBarStrokeWidth,
-            indicatorPadding = indicatorPadding,
-            iconProgressIndicatorColor = progressIndicatorColor,
-            iconProgressTrackColor = progressTrackColor
-        )
-        when (icon) {
-            is ImageVector -> {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = null, // hidden from talkback
-                    modifier = Modifier
-                        .align(Alignment.Center)
-                        .size(iconSize - indicatorPadding)
-                        .clip(CircleShape)
-                )
-            }
-            else -> {
-                Image(
-                    painter = rememberAsyncImagePainter(
-                        model = icon,
-                        placeholder = placeholder
-                    ),
-                    contentDescription = null, // hidden from talkback
-                    modifier = Modifier
-                        .align(Alignment.Center)
-                        .size(iconSize - indicatorPadding)
-                        .clip(CircleShape),
-                    contentScale = ContentScale.Crop,
-                    alpha = LocalContentAlpha.current
-                )
-            }
-        }
-    }
+    )
 }
 
 /**
@@ -115,24 +76,45 @@ internal fun StandardChipIconWithProgress(
  * This implementation displays an icon with a circular progress indicator around it.
  * The progress indicator express the proportion of completion of an ongoing task.
  *
- * @param modifier [Modifier] to apply to this layout node.
- * @param icon image or icon to be displayed in the center of this view.
- * @param largeIcon true if it should display the icon with in a large size.
- * @param progressIndicatorColor the color of the progress indicator that is around the icon.
- * @param progressTrackColor the color of the background for the progress indicator.
- * @param placeholder A [Painter] that is displayed while the image is loading.
  * @param progress The progress of this progress indicator where 0.0 represents no progress and 1.0
  * represents completion. Values outside of this range are coerced into the range 0..1.
+ * @param modifier [Modifier] to apply to this layout node.
+ * @param icon Image or icon to be displayed in the center of this view.
+ * @param largeIcon True if it should display the icon with in a large size.
+ * @param placeholder A [Painter] that is displayed while the icon image is loading.
+ * @param progressIndicatorColor The color of the progress indicator that is around the icon.
+ * @param progressTrackColor The color of the background for the progress indicator.
  */
 @Composable
 internal fun StandardChipIconWithProgress(
     progress: Float,
     modifier: Modifier = Modifier,
-    largeIcon: Boolean = false,
     icon: Any? = null,
+    largeIcon: Boolean = false,
     placeholder: Painter? = null,
     progressIndicatorColor: Color = MaterialTheme.colors.primary,
     progressTrackColor: Color = MaterialTheme.colors.onSurface.copy(alpha = 0.10f)
+) {
+    StandardChipIconWithProgressInternal(
+        progress = progress,
+        icon = icon,
+        largeIcon = largeIcon,
+        placeholder = placeholder,
+        progressIndicatorColor = progressIndicatorColor,
+        progressTrackColor = progressTrackColor,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun StandardChipIconWithProgressInternal(
+    progress: Float?,
+    icon: Any?,
+    largeIcon: Boolean,
+    placeholder: Painter?,
+    progressIndicatorColor: Color,
+    progressTrackColor: Color,
+    modifier: Modifier = Modifier
 ) {
     val iconSize = if (largeIcon) {
         ChipDefaults.LargeIconSize
@@ -145,14 +127,24 @@ internal fun StandardChipIconWithProgress(
             .size(iconSize)
             .clip(CircleShape)
     ) {
-        CircularProgressBar(
-            modifier = Modifier.align(Alignment.Center),
-            progress = progress,
-            size = iconSize - progressBarStrokeWidth,
-            indicatorPadding = indicatorPadding,
-            iconProgressIndicatorColor = progressIndicatorColor,
-            iconProgressTrackColor = progressTrackColor
-        )
+        if (progress != null) {
+            CircularProgressIndicator(
+                modifier = modifier
+                    .size(iconSize - progressBarStrokeWidth + indicatorPadding),
+                indicatorColor = progressIndicatorColor,
+                trackColor = progressTrackColor,
+                progress = progress / 100,
+                strokeWidth = progressBarStrokeWidth
+            )
+        } else {
+            CircularProgressIndicator(
+                modifier = modifier
+                    .size(iconSize - progressBarStrokeWidth + indicatorPadding),
+                indicatorColor = progressIndicatorColor,
+                trackColor = progressTrackColor,
+                strokeWidth = progressBarStrokeWidth
+            )
+        }
 
         when (icon) {
             is ImageVector -> {
@@ -181,34 +173,5 @@ internal fun StandardChipIconWithProgress(
                 )
             }
         }
-    }
-}
-
-@Composable
-private fun CircularProgressBar(
-    modifier: Modifier = Modifier,
-    progress: Float?,
-    size: Dp,
-    indicatorPadding: Dp,
-    iconProgressIndicatorColor: Color,
-    iconProgressTrackColor: Color
-) {
-    if (progress != null) {
-        CircularProgressIndicator(
-            modifier = modifier
-                .size(size + indicatorPadding),
-            indicatorColor = iconProgressIndicatorColor,
-            trackColor = iconProgressTrackColor,
-            progress = progress / 100,
-            strokeWidth = 2.dp
-        )
-    } else {
-        CircularProgressIndicator(
-            modifier = modifier
-                .size(size + indicatorPadding),
-            indicatorColor = iconProgressIndicatorColor,
-            trackColor = iconProgressTrackColor,
-            strokeWidth = 2.dp
-        )
     }
 }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistComposablesApi::class)
+@file:OptIn(ExperimentalHorologistMediaUiApi::class, ExperimentalHorologistComposablesApi::class)
 
 package com.google.android.horologist.media.ui.screens.entity
 
 import android.text.format.Formatter
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Row
@@ -33,6 +34,7 @@ import androidx.compose.material.icons.filled.DownloadDone
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -47,6 +49,7 @@ import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.CircularProgressIndicator
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.ProgressIndicatorDefaults
 import androidx.wear.compose.material.ScalingLazyListState
 import com.google.android.horologist.composables.ExperimentalHorologistComposablesApi
 import com.google.android.horologist.composables.PlaceholderChip
@@ -98,85 +101,12 @@ public fun PlaylistDownloadScreen(
         headerContent = { DefaultEntityScreenHeader(title = playlistName) },
         loadingContent = { items(count = 2) { PlaceholderChip(colors = ChipDefaults.secondaryChipColors()) } },
         mediaContent = { downloadMediaUiModel ->
-
-            val secondaryLabel = when (downloadMediaUiModel) {
-                is DownloadMediaUiModel.Downloading -> {
-                    when (downloadMediaUiModel.progress) {
-                        is DownloadMediaUiModel.Progress.Waiting -> stringResource(
-                            id = R.string.horologist_playlist_download_download_progress_waiting
-                        )
-                        is DownloadMediaUiModel.Progress.InProgress -> when (downloadMediaUiModel.size) {
-                            is DownloadMediaUiModel.Size.Known -> {
-                                val size = Formatter.formatShortFileSize(
-                                    LocalContext.current,
-                                    downloadMediaUiModel.size.sizeInBytes
-                                )
-                                stringResource(
-                                    id = R.string.horologist_playlist_download_download_progress_known_size,
-                                    downloadMediaUiModel.progress.progress,
-                                    size
-                                )
-                            }
-                            DownloadMediaUiModel.Size.Unknown -> stringResource(
-                                id = R.string.horologist_playlist_download_download_progress_unknown_size,
-                                downloadMediaUiModel.progress.progress
-                            )
-                        }
-                    }
-                }
-                is DownloadMediaUiModel.Downloaded -> downloadMediaUiModel.artist
-                is DownloadMediaUiModel.NotDownloaded -> downloadMediaUiModel.artist
-            }
-
-            when (downloadMediaUiModel) {
-                is DownloadMediaUiModel.Downloaded,
-                is DownloadMediaUiModel.NotDownloaded -> {
-                    StandardChip(
-                        label = downloadMediaUiModel.title ?: defaultMediaTitle,
-                        onClick = { onDownloadItemClick(downloadMediaUiModel) },
-                        secondaryLabel = secondaryLabel,
-                        icon = downloadMediaUiModel.artworkUri,
-                        largeIcon = true,
-                        placeholder = downloadItemArtworkPlaceholder,
-                        chipType = StandardChipType.Secondary,
-                        enabled = downloadMediaUiModel !is DownloadMediaUiModel.NotDownloaded
-                    )
-                }
-                is DownloadMediaUiModel.Downloading -> {
-                    val icon: @Composable BoxScope.() -> Unit =
-                        when (downloadMediaUiModel.progress) {
-                            is DownloadMediaUiModel.Progress.InProgress -> {
-                                {
-                                    StandardChipIconWithProgress(
-                                        progress = downloadMediaUiModel.progress.progress,
-                                        icon = downloadMediaUiModel.artworkUri,
-                                        largeIcon = true,
-                                        placeholder = downloadItemArtworkPlaceholder
-                                    )
-                                }
-                            }
-                            is DownloadMediaUiModel.Progress.Waiting -> {
-                                {
-                                    StandardChipIconWithProgress(
-                                        icon = downloadMediaUiModel.artworkUri,
-                                        largeIcon = true,
-                                        placeholder = downloadItemArtworkPlaceholder
-                                    )
-                                }
-                            }
-                        }
-
-                    StandardChip(
-                        label = downloadMediaUiModel.title ?: defaultMediaTitle,
-                        onClick = { onDownloadItemClick(downloadMediaUiModel) },
-                        secondaryLabel = secondaryLabel,
-                        icon = icon,
-                        largeIcon = true,
-                        chipType = StandardChipType.Secondary,
-                        enabled = true
-                    )
-                }
-            }
+            MediaContent(
+                downloadMediaUiModel = downloadMediaUiModel,
+                onDownloadItemClick = onDownloadItemClick,
+                defaultMediaTitle = defaultMediaTitle,
+                downloadItemArtworkPlaceholder = downloadItemArtworkPlaceholder
+            )
         },
         focusRequester = focusRequester,
         scalingLazyListState = scalingLazyListState,
@@ -195,7 +125,98 @@ public fun PlaylistDownloadScreen(
     )
 }
 
-@ExperimentalHorologistMediaUiApi
+@Composable
+private fun MediaContent(
+    downloadMediaUiModel: DownloadMediaUiModel,
+    onDownloadItemClick: (DownloadMediaUiModel) -> Unit,
+    defaultMediaTitle: String = "",
+    downloadItemArtworkPlaceholder: Painter? = null
+) {
+    val secondaryLabel = when (downloadMediaUiModel) {
+        is DownloadMediaUiModel.Downloading -> {
+            when (downloadMediaUiModel.progress) {
+                is DownloadMediaUiModel.Progress.Waiting -> stringResource(
+                    id = R.string.horologist_playlist_download_download_progress_waiting
+                )
+                is DownloadMediaUiModel.Progress.InProgress -> when (downloadMediaUiModel.size) {
+                    is DownloadMediaUiModel.Size.Known -> {
+                        val size = Formatter.formatShortFileSize(
+                            LocalContext.current,
+                            downloadMediaUiModel.size.sizeInBytes
+                        )
+                        stringResource(
+                            id = R.string.horologist_playlist_download_download_progress_known_size,
+                            downloadMediaUiModel.progress.progress,
+                            size
+                        )
+                    }
+                    DownloadMediaUiModel.Size.Unknown -> stringResource(
+                        id = R.string.horologist_playlist_download_download_progress_unknown_size,
+                        downloadMediaUiModel.progress.progress
+                    )
+                }
+            }
+        }
+        is DownloadMediaUiModel.Downloaded -> downloadMediaUiModel.artist
+        is DownloadMediaUiModel.NotDownloaded -> downloadMediaUiModel.artist
+    }
+
+    when (downloadMediaUiModel) {
+        is DownloadMediaUiModel.Downloaded,
+        is DownloadMediaUiModel.NotDownloaded -> {
+            StandardChip(
+                label = downloadMediaUiModel.title ?: defaultMediaTitle,
+                onClick = { onDownloadItemClick(downloadMediaUiModel) },
+                secondaryLabel = secondaryLabel,
+                icon = downloadMediaUiModel.artworkUri,
+                largeIcon = true,
+                placeholder = downloadItemArtworkPlaceholder,
+                chipType = StandardChipType.Secondary,
+                enabled = downloadMediaUiModel !is DownloadMediaUiModel.NotDownloaded
+            )
+        }
+        is DownloadMediaUiModel.Downloading -> {
+            val icon: @Composable BoxScope.() -> Unit =
+                when (downloadMediaUiModel.progress) {
+                    is DownloadMediaUiModel.Progress.InProgress -> {
+                        {
+                            val progress by animateFloatAsState(
+                                targetValue = downloadMediaUiModel.progress.progress,
+                                animationSpec = ProgressIndicatorDefaults.ProgressAnimationSpec
+                            )
+
+                            StandardChipIconWithProgress(
+                                progress = progress,
+                                icon = downloadMediaUiModel.artworkUri,
+                                largeIcon = true,
+                                placeholder = downloadItemArtworkPlaceholder
+                            )
+                        }
+                    }
+                    is DownloadMediaUiModel.Progress.Waiting -> {
+                        {
+                            StandardChipIconWithProgress(
+                                icon = downloadMediaUiModel.artworkUri,
+                                largeIcon = true,
+                                placeholder = downloadItemArtworkPlaceholder
+                            )
+                        }
+                    }
+                }
+
+            StandardChip(
+                label = downloadMediaUiModel.title ?: defaultMediaTitle,
+                onClick = { onDownloadItemClick(downloadMediaUiModel) },
+                secondaryLabel = secondaryLabel,
+                icon = icon,
+                largeIcon = true,
+                chipType = StandardChipType.Secondary,
+                enabled = true
+            )
+        }
+    }
+}
+
 @Composable
 private fun ButtonsContent(
     state: PlaylistDownloadScreenState<PlaylistUiModel, DownloadMediaUiModel>,
@@ -276,7 +297,6 @@ private fun ButtonsContent(
     }
 }
 
-@ExperimentalHorologistMediaUiApi
 @Composable
 private fun <Collection> FirstButton(
     downloadMediaListState: PlaylistDownloadScreenState.Loaded.DownloadMediaListState,
@@ -288,6 +308,11 @@ private fun <Collection> FirstButton(
     modifier: Modifier = Modifier
 ) {
     if (downloadsProgress is DownloadsProgress.InProgress) {
+        val progress by animateFloatAsState(
+            targetValue = downloadsProgress.progress.ifNan(0f),
+            animationSpec = ProgressIndicatorDefaults.ProgressAnimationSpec
+        )
+
         Button(
             onClick = { onCancelDownloadButtonClick(collectionModel) },
             modifier = modifier.size(StandardButtonSize.Default.tapTargetSize),
@@ -302,7 +327,7 @@ private fun <Collection> FirstButton(
                             .secondaryButtonColors()
                             .backgroundColor(enabled = true).value
                     ),
-                progress = downloadsProgress.progress.ifNan(0f),
+                progress = progress,
                 indicatorColor = MaterialTheme.colors.primary,
                 trackColor = MaterialTheme.colors.onSurface.copy(alpha = 0.10f)
             )

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
@@ -20,6 +20,7 @@ package com.google.android.horologist.media.ui.screens.entity
 
 import android.text.format.Formatter
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -142,31 +143,34 @@ public fun PlaylistDownloadScreen(
                     )
                 }
                 is DownloadMediaUiModel.Downloading -> {
+                    val icon: @Composable BoxScope.() -> Unit =
+                        when (downloadMediaUiModel.progress) {
+                            is DownloadMediaUiModel.Progress.InProgress -> {
+                                {
+                                    StandardChipIconWithProgress(
+                                        progress = downloadMediaUiModel.progress.progress,
+                                        icon = downloadMediaUiModel.artworkUri,
+                                        largeIcon = true,
+                                        placeholder = downloadItemArtworkPlaceholder
+                                    )
+                                }
+                            }
+                            is DownloadMediaUiModel.Progress.Waiting -> {
+                                {
+                                    StandardChipIconWithProgress(
+                                        icon = downloadMediaUiModel.artworkUri,
+                                        largeIcon = true,
+                                        placeholder = downloadItemArtworkPlaceholder
+                                    )
+                                }
+                            }
+                        }
+
                     StandardChip(
                         label = downloadMediaUiModel.title ?: defaultMediaTitle,
                         onClick = { onDownloadItemClick(downloadMediaUiModel) },
                         secondaryLabel = secondaryLabel,
-                        icon = {
-                            when (downloadMediaUiModel.progress) {
-                                is DownloadMediaUiModel.Progress.InProgress -> {
-                                    StandardChipIconWithProgress(
-                                        modifier = modifier,
-                                        placeholder = downloadItemArtworkPlaceholder,
-                                        progress = downloadMediaUiModel.progress.progress,
-                                        largeIcon = true,
-                                        icon = downloadMediaUiModel.artworkUri
-                                    )
-                                }
-                                is DownloadMediaUiModel.Progress.Waiting -> {
-                                    StandardChipIconWithProgress(
-                                        modifier = modifier,
-                                        placeholder = downloadItemArtworkPlaceholder,
-                                        largeIcon = true,
-                                        icon = downloadMediaUiModel.artworkUri
-                                    )
-                                }
-                            }
-                        },
+                        icon = icon,
                         largeIcon = true,
                         chipType = StandardChipType.Secondary,
                         enabled = true

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/base/StandardChipIconWithProgressTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/base/StandardChipIconWithProgressTest.kt
@@ -78,8 +78,8 @@ class StandardChipIconWithProgressTest {
             Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
                 StandardChipIconWithProgress(
                     progress = 75f,
-                    largeIcon = true,
-                    icon = Icon48dp
+                    icon = Icon48dp,
+                    largeIcon = true
                 )
             }
         }


### PR DESCRIPTION
#### WHAT

Add basic animation for download progress indicators.

Playlist download progress indicator:

https://user-images.githubusercontent.com/878134/191355057-755091ab-0e53-4b68-842b-7d9d8c722863.mp4

Individual media download progress indicator:

https://user-images.githubusercontent.com/878134/191355045-ba4e6f55-b279-4286-a0ac-0f150cdc43de.mp4

#### HOW

- Add calls to `animateFloatAsState` for progress values;

Some other refactoring:
- Extract `MediaContent` composable function from `PlaylistDownloadScreen`;
- Remove duplicated code from `StandardChip`;
- Remove duplicated code from `StandardChipIconWithProgress`;

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
