### PR TITLE
 Avoid NPE in WearNavScaffold

### DIFF
--- a/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/WearNavScaffold.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/WearNavScaffold.kt
@@ -101,8 +101,8 @@ public fun WearNavScaffold(
 
                                 timeText(
                                     Modifier.fadeAwayScalingLazyList(
-                                        viewModel.initialIndex!!,
-                                        viewModel.initialOffset!!
+                                        viewModel.initialIndex ?: 1,
+                                        viewModel.initialOffset ?: 0
                                     ) {
                                         scalingLazyListState
                                     }

--- a/sample/src/main/java/com/google/android/horologist/navsample/NavWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/navsample/NavWearApp.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -53,7 +54,8 @@ fun NavWearApp(
     navController: NavHostController
 ) {
     val snackbarViewModel = viewModel<SnackbarViewModel>(factory = SnackbarViewModel.Factory)
-    val networkStatusViewModel = viewModel<NetworkStatusViewModel>(factory = NetworkStatusViewModel.Factory)
+    val networkStatusViewModel =
+        viewModel<NetworkStatusViewModel>(factory = NetworkStatusViewModel.Factory)
 
     val swipeDismissState = rememberSwipeToDismissBoxState()
     val navState = rememberSwipeDismissableNavHostState(swipeDismissState)
@@ -81,7 +83,12 @@ fun NavWearApp(
     ) {
         scalingLazyColumnComposable(
             NavScreen.Menu.route,
-            scrollStateBuilder = { ScalingLazyListState(initialCenterItemIndex = 0) }
+            scrollStateBuilder = {
+                ScalingLazyListState(
+                    initialCenterItemIndex = 0,
+                    initialCenterItemScrollOffset = 50
+                )
+            }
         ) {
             NavMenuScreen(
                 navigateToRoute = { route -> navController.navigate(route) },
@@ -108,7 +115,7 @@ fun NavWearApp(
 
         scrollStateComposable(
             NavScreen.Column.route,
-            scrollStateBuilder = { ScrollState(0) }
+            scrollStateBuilder = { ScrollState(initial = 0) }
         ) {
             BigColumn(
                 scrollState = it.scrollableState,

--- a/sample/src/main/java/com/google/android/horologist/navsample/NavWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/navsample/NavWearApp.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier


### PR DESCRIPTION
#### WHAT

Avoid NPE in WearNavScaffold. Turn NPE into a layout glitch.

Not clear how to reproduce, but just in case we get into this state.

#### WHY

A hopeful fix for https://github.com/google/horologist/issues/602

```
Exception java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.Integer.intValue()' on a null object reference
  at com.google.android.horologist.compose.navscaffold.WearNavScaffoldKt$WearNavScaffold$3.invoke (WearNavScaffold.kt:86)
  at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke (ComposableLambda.jvm.kt:34)
  at androidx.compose.runtime.ComposerImpl.recomposeToGroupEnd (Composer.kt:2304)
  at androidx.compose.runtime.ComposerImpl.skipToGroupEnd (Composer.kt:2634)
  at androidx.wear.compose.material.ScaffoldKt.Scaffold (Scaffold.kt:63)
```


#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
