### PR TITLE
Simplify construction of PlayerRepositoryImpl

### DIFF
--- a/media-data/api/current.api
+++ b/media-data/api/current.api
@@ -299,7 +299,7 @@ package com.google.android.horologist.media.data.mapper {
 package com.google.android.horologist.media.data.repository {
 
   @com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi public final class PlayerRepositoryImpl implements java.io.Closeable com.google.android.horologist.media.repository.PlayerRepository {
-    ctor public PlayerRepositoryImpl(com.google.android.horologist.media.data.mapper.MediaMapper mediaMapper, com.google.android.horologist.media.data.mapper.MediaItemMapper mediaItemMapper);
+    ctor public PlayerRepositoryImpl(optional com.google.android.horologist.media.data.mapper.MediaMapper mediaMapper, optional com.google.android.horologist.media.data.mapper.MediaItemMapper mediaItemMapper);
     method public void addMedia(com.google.android.horologist.media.model.Media media);
     method public void addMedia(int index, com.google.android.horologist.media.model.Media media);
     method public void clearMediaList();

--- a/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImpl.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImpl.kt
@@ -21,6 +21,8 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
 import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi
+import com.google.android.horologist.media.data.mapper.MediaExtrasMapperNoopImpl
+import com.google.android.horologist.media.data.mapper.MediaItemExtrasMapperNoopImpl
 import com.google.android.horologist.media.data.mapper.MediaItemMapper
 import com.google.android.horologist.media.data.mapper.MediaMapper
 import com.google.android.horologist.media.data.mapper.MediaPositionMapper
@@ -47,8 +49,8 @@ import kotlin.time.toDuration
  */
 @ExperimentalHorologistMediaDataApi
 public class PlayerRepositoryImpl(
-    private val mediaMapper: MediaMapper,
-    private val mediaItemMapper: MediaItemMapper
+    private val mediaMapper: MediaMapper = MediaMapper(MediaExtrasMapperNoopImpl),
+    private val mediaItemMapper: MediaItemMapper = MediaItemMapper(MediaItemExtrasMapperNoopImpl)
 ) : PlayerRepository, Closeable {
 
     private var onClose: (() -> Unit)? = null

--- a/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplCloseTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplCloseTest.kt
@@ -23,10 +23,6 @@ import android.os.Looper.getMainLooper
 import androidx.media3.test.utils.TestExoPlayerBuilder
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi
-import com.google.android.horologist.media.data.mapper.MediaExtrasMapperNoopImpl
-import com.google.android.horologist.media.data.mapper.MediaItemExtrasMapperNoopImpl
-import com.google.android.horologist.media.data.mapper.MediaItemMapper
-import com.google.android.horologist.media.data.mapper.MediaMapper
 import com.google.android.horologist.media.model.Media
 import org.junit.Assert.assertThrows
 import org.junit.Before
@@ -54,10 +50,7 @@ class PlayerRepositoryImplCloseTest(
         shadowOf(getMainLooper()).idle()
 
         context = ApplicationProvider.getApplicationContext()
-        sut = PlayerRepositoryImpl(
-            mediaMapper = MediaMapper(MediaExtrasMapperNoopImpl),
-            mediaItemMapper = MediaItemMapper(MediaItemExtrasMapperNoopImpl)
-        )
+        sut = PlayerRepositoryImpl()
     }
 
     @Test

--- a/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplNotConnectedTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplNotConnectedTest.kt
@@ -22,10 +22,6 @@ import android.content.Context
 import android.os.Looper.getMainLooper
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi
-import com.google.android.horologist.media.data.mapper.MediaExtrasMapperNoopImpl
-import com.google.android.horologist.media.data.mapper.MediaItemExtrasMapperNoopImpl
-import com.google.android.horologist.media.data.mapper.MediaItemMapper
-import com.google.android.horologist.media.data.mapper.MediaMapper
 import com.google.android.horologist.media.model.Media
 import com.google.android.horologist.media.model.PlayerState
 import com.google.common.truth.Truth.assertThat
@@ -54,10 +50,7 @@ class PlayerRepositoryImplNotConnectedTest(
         shadowOf(getMainLooper()).idle()
 
         context = ApplicationProvider.getApplicationContext()
-        sut = PlayerRepositoryImpl(
-            mediaMapper = MediaMapper(MediaExtrasMapperNoopImpl),
-            mediaItemMapper = MediaItemMapper(MediaItemExtrasMapperNoopImpl)
-        )
+        sut = PlayerRepositoryImpl()
     }
 
     @Test

--- a/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplTest.kt
@@ -27,10 +27,8 @@ import androidx.media3.test.utils.robolectric.TestPlayerRunHelper.runUntilPendin
 import androidx.media3.test.utils.robolectric.TestPlayerRunHelper.runUntilPlaybackState
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi
-import com.google.android.horologist.media.data.mapper.MediaExtrasMapperNoopImpl
 import com.google.android.horologist.media.data.mapper.MediaItemExtrasMapperNoopImpl
 import com.google.android.horologist.media.data.mapper.MediaItemMapper
-import com.google.android.horologist.media.data.mapper.MediaMapper
 import com.google.android.horologist.media.model.Command
 import com.google.android.horologist.media.model.Media
 import com.google.android.horologist.media.model.MediaPosition
@@ -67,10 +65,7 @@ class PlayerRepositoryImplTest {
         mediaItemMapper = MediaItemMapper(MediaItemExtrasMapperNoopImpl)
 
         context = ApplicationProvider.getApplicationContext()
-        sut = PlayerRepositoryImpl(
-            mediaMapper = MediaMapper(MediaExtrasMapperNoopImpl),
-            mediaItemMapper = mediaItemMapper
-        )
+        sut = PlayerRepositoryImpl()
     }
 
     @Test


### PR DESCRIPTION
#### WHAT

Simplify construction of `PlayerRepositoryImpl`.

#### WHY

In order to make it easier to create a new instance of `PlayerRepositoryImpl`.

#### HOW

Provide default noop values for `mediaMapper` and `mediaItemMapper` parameters.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
