### PR TITLE
Add twitter compose rules ktlint check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,8 @@ jobs:
         run: |
           ./gradlew --scan --stacktrace \
               spotlessCheck \
-              lintDebug
+              lintDebug \
+              lintKotlin
 
       - name: Unit Tests
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ buildscript {
         classpath libs.paparazziPlugin
 
         classpath libs.dagger.hiltandroidplugin
+
+        classpath libs.twitter.compose.rules.ktlint
     }
 }
 
@@ -47,6 +49,7 @@ plugins {
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.kapt) apply false
     alias(libs.plugins.protobuf) apply false
+    alias(libs.plugins.kolinter) apply false
 }
 
 apply plugin: 'org.jetbrains.dokka'
@@ -104,6 +107,7 @@ allprojects {
 
 subprojects {
     apply plugin: 'com.diffplug.spotless'
+    apply plugin: 'org.jmailen.kotlinter'
 
     spotless {
         kotlin {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ googledagger = "2.43.2"
 gradlePlugin = "7.2.2"
 io-coil-kt = "2.1.0"
 junit = "4.13.2"
+kolinter = "3.12.0"
 kotlin = "1.7.0"
 kotlinxCoroutine = "1.6.4"
 ksp = "1.7.0-1.0.6"
@@ -39,6 +40,7 @@ moshi = "1.13.0"
 room = "2.4.3"
 spotless = "6.9.0"
 truth = "1.1.3"
+twitterComposeRulesKtlint = "0.0.13"
 versionCatalogUpdate = "0.5.3"
 wearcompose = "1.0.0"
 
@@ -143,6 +145,7 @@ room-common = { module = "androidx.room:room-common", version.ref = "room" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
+twitter-compose-rules-ktlint = { module = "com.twitter.compose.rules:ktlint", version.ref = "twitterComposeRulesKtlint" }
 wearcompose-foundation = { module = "androidx.wear.compose:compose-foundation", version.ref = "wearcompose" }
 wearcompose-material = { module = "androidx.wear.compose:compose-material", version.ref = "wearcompose" }
 wearcompose-navigation = { module = "androidx.wear.compose:compose-navigation", version.ref = "wearcompose" }
@@ -150,6 +153,7 @@ wearcompose-navigation = { module = "androidx.wear.compose:compose-navigation", 
 [plugins]
 benManes = { id = "com.github.ben-manes.versions", version.ref = "benManes" }
 kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+kolinter = { id = "org.jmailen.kotlinter", version.ref = "kolinter" }
 kotlinGradle = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
#### WHAT

Run [Twitter's Jetpack Compose Rules](https://github.com/twitter/compose-rules) in CI.

#### WHY

In order to improve quality of project's composables.

#### HOW

Add plugin via [kolinter](https://twitter.github.io/compose-rules/ktlint/#using-with-kotlinter) given it's not currently working with [spotless](https://twitter.github.io/compose-rules/ktlint/#using-with-spotless). Given it might be potentially  doing duplicated work and increasing build time, we might decide to only add it to the project once it's supported by spotless.

#### RESULTS

- A lot of findings in composables functions in preview files, test files, and sample apps, which we should filter out for those rules.

- `modifier-missing-check` in many functions.
```
Lint error > [twitter-compose:modifier-missing-check] This @Composable function emits content but doesn't have a modifier parameter.

See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information.
```

- `param-order-check` in `WearNavScaffold`, `SegmentedProgressIndicator`, `FillerScreen`, `BigScalingLazyColumn`, `BigColumn`, `MediaPlayerScaffold`, `StandardChip` and other internal functions.
```
Lint error > [twitter-compose:param-order-check]         Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.

See https://twitter.github.io/compose-rules/rules/#ordering-composable-parameters-properly for more information.
```

- `modifier-reused-check` in `PlayPauseButton` (seems to be intended?).
```
[twitter-compose:modifier-reused-check] Modifiers should only be used once and by the root level layout of a Composable. This is true even if
appended to or with other modifiers e.g. 'modifier.fillMaxWith()'.

Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other Composables.

See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information.
```

- `twitter-compose:multiple-emitters-check` in `TimePicker`.
```
Lint error > [twitter-compose:multiple-emitters-check] Composable functions should only be emitting content into the composition from one source at their top level.
```

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
