### PR TITLE
Decouple PlayerViewModel

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/player/UampMediaPlayerScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/player/UampMediaPlayerScreen.kt
@@ -33,8 +33,8 @@ import com.google.android.horologist.media.ui.components.background.ArtworkColor
 import com.google.android.horologist.media.ui.screens.player.DefaultPlayerScreenControlButtons
 import com.google.android.horologist.media.ui.screens.player.DefaultPlayerScreenMediaDisplay
 import com.google.android.horologist.media.ui.screens.player.PlayerScreen
+import com.google.android.horologist.media.ui.state.PlayerUiController
 import com.google.android.horologist.media.ui.state.PlayerUiState
-import com.google.android.horologist.media.ui.state.PlayerViewModel
 import com.google.android.horologist.mediasample.ui.components.AnimatedPlayerScreenMediaDisplay
 import com.google.android.horologist.mediasample.ui.util.ReportFullyDrawn
 
@@ -74,24 +74,24 @@ fun UampMediaPlayerScreen(
                     enabled = it.connected
                 )
             },
-            controlButtons = {
+            controlButtons = { playerUiController, playerUiState ->
                 if (settingsState.podcastControls) {
-                    PlayerScreenPodcastControlButtons(mediaPlayerScreenViewModel, it)
+                    PlayerScreenPodcastControlButtons(playerUiController, playerUiState)
                 } else {
                     if (settingsState.animated) {
                         AnimatedMediaControlButtons(
-                            onPlayButtonClick = { mediaPlayerScreenViewModel.play() },
-                            onPauseButtonClick = { mediaPlayerScreenViewModel.pause() },
-                            playPauseButtonEnabled = it.playPauseEnabled,
-                            playing = it.playing,
-                            onSeekToPreviousButtonClick = { mediaPlayerScreenViewModel.skipToPreviousMedia() },
-                            seekToPreviousButtonEnabled = it.seekToPreviousEnabled,
-                            onSeekToNextButtonClick = { mediaPlayerScreenViewModel.skipToNextMedia() },
-                            seekToNextButtonEnabled = it.seekToNextEnabled,
-                            percent = it.trackPosition?.percent ?: 0f
+                            onPlayButtonClick = { playerUiController.play() },
+                            onPauseButtonClick = { playerUiController.pause() },
+                            playPauseButtonEnabled = playerUiState.playPauseEnabled,
+                            playing = playerUiState.playing,
+                            onSeekToPreviousButtonClick = { playerUiController.skipToPreviousMedia() },
+                            seekToPreviousButtonEnabled = playerUiState.seekToPreviousEnabled,
+                            onSeekToNextButtonClick = { playerUiController.skipToNextMedia() },
+                            seekToNextButtonEnabled = playerUiState.seekToNextEnabled,
+                            percent = playerUiState.trackPosition?.percent ?: 0f
                         )
                     } else {
-                        DefaultPlayerScreenControlButtons(mediaPlayerScreenViewModel, it)
+                        DefaultPlayerScreenControlButtons(playerUiController, playerUiState)
                     }
                 }
             },
@@ -113,18 +113,18 @@ fun UampMediaPlayerScreen(
 
 @Composable
 public fun PlayerScreenPodcastControlButtons(
-    playerViewModel: PlayerViewModel,
+    playerUiController: PlayerUiController,
     playerUiState: PlayerUiState
 ) {
     PodcastControlButtons(
-        onPlayButtonClick = { playerViewModel.play() },
-        onPauseButtonClick = { playerViewModel.pause() },
+        onPlayButtonClick = { playerUiController.play() },
+        onPauseButtonClick = { playerUiController.pause() },
         playPauseButtonEnabled = playerUiState.playPauseEnabled,
         playing = playerUiState.playing,
         percent = playerUiState.trackPosition?.percent ?: 0f,
-        onSeekBackButtonClick = { playerViewModel.seekBack() },
+        onSeekBackButtonClick = { playerUiController.seekBack() },
         seekBackButtonEnabled = playerUiState.seekBackEnabled,
-        onSeekForwardButtonClick = { playerViewModel.seekForward() },
+        onSeekForwardButtonClick = { playerUiController.seekForward() },
         seekForwardButtonEnabled = playerUiState.seekForwardEnabled,
         seekBackButtonIncrement = playerUiState.seekBackButtonIncrement,
         seekForwardButtonIncrement = playerUiState.seekForwardButtonIncrement

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -84,7 +84,7 @@ package com.google.android.horologist.media.ui.components {
   }
 
   public final class PodcastControlButtonsKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PodcastControlButtons(com.google.android.horologist.media.ui.state.PlayerViewModel playerViewModel, com.google.android.horologist.media.ui.state.PlayerUiState playerUiState, optional androidx.compose.ui.Modifier modifier, optional boolean showProgress, optional androidx.wear.compose.material.ButtonColors colors);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PodcastControlButtons(com.google.android.horologist.media.ui.state.PlayerUiController playerController, com.google.android.horologist.media.ui.state.PlayerUiState playerUiState, optional androidx.compose.ui.Modifier modifier, optional boolean showProgress, optional androidx.wear.compose.material.ButtonColors colors);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PodcastControlButtons(kotlin.jvm.functions.Function0<kotlin.Unit> onPlayButtonClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPauseButtonClick, boolean playPauseButtonEnabled, boolean playing, float percent, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekBackButtonClick, boolean seekBackButtonEnabled, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekForwardButtonClick, boolean seekForwardButtonEnabled, optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement seekBackButtonIncrement, optional com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement seekForwardButtonIncrement, optional androidx.wear.compose.material.ButtonColors colors);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PodcastControlButtons(kotlin.jvm.functions.Function0<kotlin.Unit> onPlayButtonClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPauseButtonClick, boolean playPauseButtonEnabled, boolean playing, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekBackButtonClick, boolean seekBackButtonEnabled, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekForwardButtonClick, boolean seekForwardButtonEnabled, optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement seekBackButtonIncrement, optional com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement seekForwardButtonIncrement, optional androidx.wear.compose.material.ButtonColors colors);
   }
@@ -450,9 +450,9 @@ package com.google.android.horologist.media.ui.screens.entity {
 package com.google.android.horologist.media.ui.screens.player {
 
   public final class PlayerScreenKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void DefaultPlayerScreenControlButtons(com.google.android.horologist.media.ui.state.PlayerViewModel playerViewModel, com.google.android.horologist.media.ui.state.PlayerUiState playerUiState, optional boolean showProgress);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void DefaultPlayerScreenControlButtons(com.google.android.horologist.media.ui.state.PlayerUiController playerController, com.google.android.horologist.media.ui.state.PlayerUiState playerUiState, optional boolean showProgress);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void DefaultPlayerScreenMediaDisplay(com.google.android.horologist.media.ui.state.PlayerUiState playerUiState, optional androidx.compose.ui.Modifier modifier);
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PlayerScreen(com.google.android.horologist.media.ui.state.PlayerViewModel playerViewModel, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function2<? super androidx.compose.foundation.layout.ColumnScope,? super com.google.android.horologist.media.ui.state.PlayerUiState,kotlin.Unit> mediaDisplay, optional kotlin.jvm.functions.Function2<? super androidx.compose.foundation.layout.RowScope,? super com.google.android.horologist.media.ui.state.PlayerUiState,kotlin.Unit> controlButtons, optional kotlin.jvm.functions.Function2<? super androidx.compose.foundation.layout.RowScope,? super com.google.android.horologist.media.ui.state.PlayerUiState,kotlin.Unit> buttons, optional kotlin.jvm.functions.Function2<? super androidx.compose.foundation.layout.BoxScope,? super com.google.android.horologist.media.ui.state.PlayerUiState,kotlin.Unit> background);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PlayerScreen(com.google.android.horologist.media.ui.state.PlayerViewModel playerViewModel, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function2<? super androidx.compose.foundation.layout.ColumnScope,? super com.google.android.horologist.media.ui.state.PlayerUiState,kotlin.Unit> mediaDisplay, optional kotlin.jvm.functions.Function3<? super androidx.compose.foundation.layout.RowScope,? super com.google.android.horologist.media.ui.state.PlayerUiController,? super com.google.android.horologist.media.ui.state.PlayerUiState,kotlin.Unit> controlButtons, optional kotlin.jvm.functions.Function2<? super androidx.compose.foundation.layout.RowScope,? super com.google.android.horologist.media.ui.state.PlayerUiState,kotlin.Unit> buttons, optional kotlin.jvm.functions.Function2<? super androidx.compose.foundation.layout.BoxScope,? super com.google.android.horologist.media.ui.state.PlayerUiState,kotlin.Unit> background);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PlayerScreen(kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.ColumnScope,kotlin.Unit> mediaDisplay, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.RowScope,kotlin.Unit> controlButtons, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.RowScope,kotlin.Unit> buttons, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.BoxScope,kotlin.Unit> background);
   }
 
@@ -550,6 +550,16 @@ package com.google.android.horologist.media.ui.snackbar {
 
 package com.google.android.horologist.media.ui.state {
 
+  public final class PlayerUiController {
+    ctor public PlayerUiController(com.google.android.horologist.media.repository.PlayerRepository playerRepository);
+    method public void pause();
+    method public void play();
+    method public void seekBack();
+    method public void seekForward();
+    method public void skipToNextMedia();
+    method public void skipToPreviousMedia();
+  }
+
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public final class PlayerUiState {
     ctor public PlayerUiState(boolean playEnabled, boolean pauseEnabled, boolean seekBackEnabled, boolean seekForwardEnabled, boolean seekToPreviousEnabled, boolean seekToNextEnabled, boolean shuffleEnabled, boolean shuffleOn, boolean playPauseEnabled, boolean playing, com.google.android.horologist.media.ui.state.model.MediaUiModel? media, com.google.android.horologist.media.ui.state.model.TrackPositionUiModel? trackPosition, optional com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement seekBackButtonIncrement, optional com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement seekForwardButtonIncrement, boolean connected);
     method public boolean component1();
@@ -600,15 +610,17 @@ package com.google.android.horologist.media.ui.state {
     property public final com.google.android.horologist.media.ui.state.model.TrackPositionUiModel? trackPosition;
   }
 
+  @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public final class PlayerUiStateProducer {
+    ctor public PlayerUiStateProducer(com.google.android.horologist.media.repository.PlayerRepository playerRepository);
+    method public kotlinx.coroutines.flow.Flow<com.google.android.horologist.media.ui.state.PlayerUiState> getPlayerUiStateFlow();
+    property public final kotlinx.coroutines.flow.Flow<com.google.android.horologist.media.ui.state.PlayerUiState> playerUiStateFlow;
+  }
+
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public class PlayerViewModel extends androidx.lifecycle.ViewModel {
     ctor public PlayerViewModel(com.google.android.horologist.media.repository.PlayerRepository playerRepository);
+    method public final com.google.android.horologist.media.ui.state.PlayerUiController getPlayerUiController();
     method public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.media.ui.state.PlayerUiState> getPlayerUiState();
-    method public final void pause();
-    method public final void play();
-    method public final void seekBack();
-    method public final void seekForward();
-    method public final void skipToNextMedia();
-    method public final void skipToPreviousMedia();
+    property public final com.google.android.horologist.media.ui.state.PlayerUiController playerUiController;
     property public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.media.ui.state.PlayerUiState> playerUiState;
     field public static final com.google.android.horologist.media.ui.state.PlayerViewModel.Companion Companion;
   }

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenTest.kt
@@ -72,9 +72,9 @@ class PlayerScreenTest {
         composeTestRule.setContent {
             PlayerScreen(
                 playerViewModel = playerViewModel,
-                controlButtons = { playerUiState ->
+                controlButtons = { playerUiController, playerUiState ->
                     DefaultPlayerScreenControlButtons(
-                        playerViewModel = playerViewModel,
+                        playerController = playerUiController,
                         playerUiState = playerUiState,
                         showProgress = showProgress
                     )
@@ -322,7 +322,7 @@ class PlayerScreenTest {
         composeTestRule.setContent {
             PlayerScreen(
                 playerViewModel = PlayerViewModel(FakePlayerRepository()),
-                controlButtons = { Text("Custom") }
+                controlButtons = { _, _ -> Text("Custom") }
             )
         }
 

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/PodcastControlButtons.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/PodcastControlButtons.kt
@@ -24,18 +24,18 @@ import com.google.android.horologist.media.ui.components.controls.MediaButtonDef
 import com.google.android.horologist.media.ui.components.controls.SeekBackButton
 import com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement
 import com.google.android.horologist.media.ui.components.controls.SeekForwardButton
+import com.google.android.horologist.media.ui.state.PlayerUiController
 import com.google.android.horologist.media.ui.state.PlayerUiState
-import com.google.android.horologist.media.ui.state.PlayerViewModel
 
 /**
- * Stateful version of [PodcastControlButtons].
+ * Convenience wrapper of [PodcastControlButtons].
  *
- * This version listens to [PlayerUiState]s emitted from [PlayerViewModel] to update the controls.
+ * This version passes events to the provided [PlayerUiController].
  */
 @ExperimentalHorologistMediaUiApi
 @Composable
 public fun PodcastControlButtons(
-    playerViewModel: PlayerViewModel,
+    playerController: PlayerUiController,
     playerUiState: PlayerUiState,
     modifier: Modifier = Modifier,
     showProgress: Boolean = true,
@@ -48,14 +48,14 @@ public fun PodcastControlButtons(
     }
 
     PodcastControlButtons(
-        onPlayButtonClick = { playerViewModel.play() },
-        onPauseButtonClick = { playerViewModel.pause() },
+        onPlayButtonClick = { playerController.play() },
+        onPauseButtonClick = { playerController.pause() },
         playPauseButtonEnabled = playerUiState.playPauseEnabled,
         playing = playerUiState.playing,
-        onSeekBackButtonClick = { playerViewModel.skipToPreviousMedia() },
+        onSeekBackButtonClick = { playerController.skipToPreviousMedia() },
         seekBackButtonIncrement = playerUiState.seekBackButtonIncrement,
         seekBackButtonEnabled = playerUiState.seekBackEnabled,
-        onSeekForwardButtonClick = { playerViewModel.skipToNextMedia() },
+        onSeekForwardButtonClick = { playerController.skipToNextMedia() },
         seekForwardButtonIncrement = playerUiState.seekForwardButtonIncrement,
         seekForwardButtonEnabled = playerUiState.seekForwardEnabled,
         showProgress = showProgress,

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/player/PlayerScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/player/PlayerScreen.kt
@@ -43,6 +43,7 @@ import com.google.android.horologist.media.ui.components.DefaultMediaDisplay
 import com.google.android.horologist.media.ui.components.InfoMediaDisplay
 import com.google.android.horologist.media.ui.components.LoadingMediaDisplay
 import com.google.android.horologist.media.ui.components.MediaControlButtons
+import com.google.android.horologist.media.ui.state.PlayerUiController
 import com.google.android.horologist.media.ui.state.PlayerUiState
 import com.google.android.horologist.media.ui.state.PlayerViewModel
 
@@ -50,7 +51,7 @@ import com.google.android.horologist.media.ui.state.PlayerViewModel
 public typealias MediaDisplay = @Composable ColumnScope.(playerUiState: PlayerUiState) -> Unit
 
 @OptIn(ExperimentalHorologistMediaUiApi::class)
-public typealias ControlButtons = @Composable RowScope.(playerUiState: PlayerUiState) -> Unit
+public typealias ControlButtons = @Composable RowScope.(playerUiController: PlayerUiController, playerUiState: PlayerUiState) -> Unit
 
 @OptIn(ExperimentalHorologistMediaUiApi::class)
 public typealias SettingsButtons = @Composable RowScope.(playerUiState: PlayerUiState) -> Unit
@@ -71,8 +72,8 @@ public fun PlayerScreen(
     mediaDisplay: MediaDisplay = { playerUiState ->
         DefaultPlayerScreenMediaDisplay(playerUiState)
     },
-    controlButtons: ControlButtons = { playerUiState ->
-        DefaultPlayerScreenControlButtons(playerViewModel, playerUiState)
+    controlButtons: ControlButtons = { playerUiController, playerUiState ->
+        DefaultPlayerScreenControlButtons(playerUiController, playerUiState)
     },
     buttons: SettingsButtons = {},
     background: PlayerBackground = {}
@@ -81,7 +82,7 @@ public fun PlayerScreen(
 
     PlayerScreen(
         mediaDisplay = { mediaDisplay(playerUiState) },
-        controlButtons = { controlButtons(playerUiState) },
+        controlButtons = { controlButtons(playerViewModel.playerUiController, playerUiState) },
         buttons = {
             buttons(playerUiState)
         },
@@ -121,18 +122,18 @@ public fun DefaultPlayerScreenMediaDisplay(
 @ExperimentalHorologistMediaUiApi
 @Composable
 public fun DefaultPlayerScreenControlButtons(
-    playerViewModel: PlayerViewModel,
+    playerController: PlayerUiController,
     playerUiState: PlayerUiState,
     showProgress: Boolean = true
 ) {
     MediaControlButtons(
-        onPlayButtonClick = { playerViewModel.play() },
-        onPauseButtonClick = { playerViewModel.pause() },
+        onPlayButtonClick = { playerController.play() },
+        onPauseButtonClick = { playerController.pause() },
         playPauseButtonEnabled = playerUiState.playPauseEnabled,
         playing = playerUiState.playing,
-        onSeekToPreviousButtonClick = { playerViewModel.skipToPreviousMedia() },
+        onSeekToPreviousButtonClick = { playerController.skipToPreviousMedia() },
         seekToPreviousButtonEnabled = playerUiState.seekToPreviousEnabled,
-        onSeekToNextButtonClick = { playerViewModel.skipToNextMedia() },
+        onSeekToNextButtonClick = { playerController.skipToNextMedia() },
         seekToNextButtonEnabled = playerUiState.seekToNextEnabled,
         showProgress = showProgress,
         percent = playerUiState.trackPosition?.percent ?: 0f

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/PlayerUiController.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/PlayerUiController.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.state
+
+import com.google.android.horologist.media.repository.PlayerRepository
+
+/**
+ * Represents a mapping between media UI controls and a [PlayerRepository].
+ *
+ * This class should generally always be hosted inside a ViewModel to ensure it's tied to a
+ * lifecycle that survives configuration changes.
+ */
+public class PlayerUiController(private val playerRepository: PlayerRepository) {
+    public fun play() {
+        // Prepare is needed to ensure playback
+        playerRepository.prepare()
+        playerRepository.play()
+    }
+
+    public fun pause() {
+        playerRepository.pause()
+    }
+
+    public fun skipToPreviousMedia() {
+        playerRepository.skipToPreviousMedia()
+    }
+
+    public fun skipToNextMedia() {
+        playerRepository.skipToNextMedia()
+    }
+
+    public fun seekBack() {
+        playerRepository.seekBack()
+    }
+
+    public fun seekForward() {
+        playerRepository.seekForward()
+    }
+}

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/PlayerUiStateProducer.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/PlayerUiStateProducer.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistMediaApi::class)
+
+package com.google.android.horologist.media.ui.state
+
+import com.google.android.horologist.media.ExperimentalHorologistMediaApi
+import com.google.android.horologist.media.repository.PlayerRepository
+import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
+import com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement
+import com.google.android.horologist.media.ui.state.mapper.PlayerUiStateMapper
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+
+/**
+ * Produces a flow of [PlayerUiState] based on events produced by a [PlayerRepository].
+ *
+ * This class should generally always be hosted inside a ViewModel to ensure it's tied to a
+ * lifecycle that survives configuration changes.
+ */
+@ExperimentalHorologistMediaUiApi
+public class PlayerUiStateProducer(
+    private val playerRepository: PlayerRepository
+) {
+    private data class StaticState(
+        val connected: Boolean,
+        val shuffleModeEnabled: Boolean,
+        val seekBackButtonIncrement: SeekButtonIncrement,
+        val seekForwardButtonIncrement: SeekButtonIncrement
+    )
+
+    private val staticFlow = combine(
+        playerRepository.connected,
+        playerRepository.shuffleModeEnabled
+    ) { connected, shuffleModeEnabled ->
+        val seekBackSeconds = playerRepository.getSeekBackIncrement().inWholeSeconds.toInt()
+        val seekForwardSeconds = playerRepository.getSeekForwardIncrement().inWholeSeconds.toInt()
+
+        StaticState(
+            connected = connected,
+            shuffleModeEnabled = shuffleModeEnabled,
+            seekBackButtonIncrement = SeekButtonIncrement.ofSeconds(seekBackSeconds),
+            seekForwardButtonIncrement = SeekButtonIncrement.ofSeconds(seekForwardSeconds)
+        )
+    }
+
+    public val playerUiStateFlow: Flow<PlayerUiState> = combine(
+        playerRepository.currentState,
+        playerRepository.availableCommands,
+        playerRepository.currentMedia,
+        playerRepository.mediaPosition,
+        staticFlow
+    ) { currentState, availableCommands, media, mediaPosition, staticData ->
+        PlayerUiStateMapper.map(
+            currentState = currentState,
+            availableCommands = availableCommands,
+            media = media,
+            mediaPosition = mediaPosition,
+            shuffleModeEnabled = staticData.shuffleModeEnabled,
+            connected = playerRepository.connected.value,
+            seekBackButtonIncrement = staticData.seekBackButtonIncrement,
+            seekForwardButtonIncrement = staticData.seekForwardButtonIncrement
+        )
+    }
+}

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/PlayerUiStateProducerTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/PlayerUiStateProducerTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistMediaUiApi::class)
+
+package com.google.android.horologist.media.ui.state
+
+import com.google.android.horologist.media.model.Command
+import com.google.android.horologist.media.model.Media
+import com.google.android.horologist.media.model.MediaPosition
+import com.google.android.horologist.media.model.PlayerState
+import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
+import com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement
+import com.google.android.horologist.media.ui.state.model.MediaUiModel
+import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
+import com.google.android.horologist.test.toolbox.testdoubles.MockPlayerRepository
+import com.google.common.truth.Truth
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+
+class PlayerUiStateProducerTest {
+    @Test
+    fun `given a PlayerRepository produces correct PlayerUiState`() = runTest {
+        // when
+        val sut = PlayerUiStateProducer(
+            MockPlayerRepository(
+                connectedValue = true,
+                availableCommandsValue = setOf(Command.PlayPause, Command.SeekBack),
+                currentStateValue = PlayerState.Playing,
+                currentMediaValue = Media(
+                    id = "id",
+                    uri = "http://uri",
+                    title = "title",
+                    artist = "artist"
+                ),
+                mediaPositionValue = MediaPosition.create(
+                    current = 2.toDuration(DurationUnit.SECONDS),
+                    duration = 20.toDuration(DurationUnit.SECONDS)
+                )
+            )
+        )
+
+        // then
+        Truth.assertThat(sut.playerUiStateFlow.first()).isEqualTo(
+            PlayerUiState(
+                playEnabled = true,
+                pauseEnabled = true,
+                seekBackEnabled = true,
+                seekForwardEnabled = false,
+                seekToPreviousEnabled = false,
+                seekToNextEnabled = false,
+                shuffleEnabled = false,
+                shuffleOn = false,
+                playPauseEnabled = true,
+                playing = true,
+                media = MediaUiModel(id = "id", title = "title", artist = "artist"),
+                trackPosition = TrackPositionUiModel(current = 2000, duration = 20000, percent = 0.1f),
+                seekBackButtonIncrement = SeekButtonIncrement.Other(0),
+                seekForwardButtonIncrement = SeekButtonIncrement.Other(0),
+                connected = true
+            )
+        )
+    }
+}

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/PlayerViewModelTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/PlayerViewModelTest.kt
@@ -21,7 +21,7 @@ package com.google.android.horologist.media.ui.state
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.state.model.MediaUiModel
 import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
-import com.google.android.horologist.test.toolbox.testdoubles.StubPlayerRepository
+import com.google.android.horologist.test.toolbox.testdoubles.MockPlayerRepository
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
@@ -34,7 +34,7 @@ class PlayerViewModelTest {
 
     @Before
     fun setUp() {
-        sut = PlayerViewModel(StubPlayerRepository())
+        sut = PlayerViewModel(MockPlayerRepository())
     }
 
     @Test

--- a/media-ui/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/MockPlayerRepository.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/MockPlayerRepository.kt
@@ -28,25 +28,32 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalHorologistMediaApi::class)
-class StubPlayerRepository : PlayerRepository {
+class MockPlayerRepository(
+    private val connectedValue: Boolean = false,
+    private val availableCommandsValue: Set<Command> = emptySet(),
+    private val currentStateValue: PlayerState = PlayerState.Idle,
+    private val currentMediaValue: Media? = null,
+    private val mediaPositionValue: MediaPosition? = null,
+    private val shuffleModeEnabledValue: Boolean = false
+) : PlayerRepository {
 
     override val connected: StateFlow<Boolean>
-        get() = MutableStateFlow(false)
+        get() = MutableStateFlow(connectedValue)
 
     override val availableCommands: StateFlow<Set<Command>>
-        get() = MutableStateFlow(emptySet())
+        get() = MutableStateFlow(availableCommandsValue)
 
     override val currentState: StateFlow<PlayerState>
-        get() = MutableStateFlow(PlayerState.Idle)
+        get() = MutableStateFlow(currentStateValue)
 
     override val currentMedia: StateFlow<Media?>
-        get() = MutableStateFlow(null)
+        get() = MutableStateFlow(currentMediaValue)
 
     override val mediaPosition: StateFlow<MediaPosition?>
-        get() = MutableStateFlow(null)
+        get() = MutableStateFlow(mediaPositionValue)
 
     override val shuffleModeEnabled: StateFlow<Boolean>
-        get() = MutableStateFlow(false)
+        get() = MutableStateFlow(shuffleModeEnabledValue)
 
     override fun prepare() {
         // do nothing


### PR DESCRIPTION
#### WHAT
Separates most `PlayerViewModel` logic into a plain class.

#### WHY
This makes it easier to implement a `PlayerViewModel` without having a subclass a `ViewModel` for niche use-cases, e.g. multiple players in a single `ViewModel`. Also makes testing slightly easier.

#### HOW
Moves most logic that doesn't require a lifecycle from `PlayerViewModel` into `PlayerUiStateProducer` and adds a `PlayerUiController` interface (which `PlayerViewModel` implements) so that composables like `DefaultPlayerScreenControlButtons` wouldn't need to receive a `PlayerViewModel` (but still can).

#### Checklist :clipboard:
- [X] Add explicit visibility modifier and explicit return types for public declarations
- [X] Run spotless check
- [X] Run tests
- [X] Update metalava's signature text files
