### PR TITLE
Disable HighBandwidthCall.execute

### DIFF
--- a/network-awareness/src/main/java/com/google/android/horologist/networks/okhttp/impl/HighBandwidthCall.kt
+++ b/network-awareness/src/main/java/com/google/android/horologist/networks/okhttp/impl/HighBandwidthCall.kt
@@ -26,7 +26,6 @@ import com.google.android.horologist.networks.okhttp.impl.RequestTypeHolder.Comp
 import com.google.android.horologist.networks.okhttp.requestType
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import okhttp3.Call
 import okhttp3.Callback
@@ -94,15 +93,7 @@ internal class HighBandwidthCall(
     }
 
     override fun execute(): Response {
-        val token = requestNetwork()
-
-        runBlocking {
-            withTimeoutOrNull(callFactory.timeout) {
-                token.awaitGranted()
-            }
-        }
-
-        return callFactory.newDirectCall(request).execute()
+        throw IOException("High Bandwidth Requests are not supported with execute")
     }
 
     private fun requestNetwork(): HighBandwithConnectionLease {

--- a/network-awareness/src/main/java/com/google/android/horologist/networks/okhttp/impl/HighBandwidthCall.kt
+++ b/network-awareness/src/main/java/com/google/android/horologist/networks/okhttp/impl/HighBandwidthCall.kt
@@ -26,7 +26,6 @@ import com.google.android.horologist.networks.okhttp.impl.RequestTypeHolder.Comp
 import com.google.android.horologist.networks.okhttp.requestType
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withTimeoutOrNull
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.Request

--- a/network-awareness/src/test/java/com/google/android/horologist/networks/rules/NetworkSelectingCallFactoryTest.kt
+++ b/network-awareness/src/test/java/com/google/android/horologist/networks/rules/NetworkSelectingCallFactoryTest.kt
@@ -97,45 +97,17 @@ class NetworkSelectingCallFactoryTest {
     }
 
     @Test
-    fun requestHighBandwidthForDownloads() {
-        networkingRules.preferredNetworks[RequestType.MediaRequest(Download)] = NetworkType.Wifi
+    fun executeFailsOnHighBandwidthCalls() {
         networkingRules.highBandwidthTypes[RequestType.MediaRequest(Download)] = true
-        networkRequester.supportedNetworks = listOf(NetworkType.Wifi)
 
         val request = Request.Builder()
             .url("https://example.org/music.mp3")
             .requestType(RequestType.MediaRequest(Download))
             .build()
 
-        val response = callFactory.newCall(request).execute()
-        response.close()
-
-        val networkType = request.networkInfo
-
-        assertThat(networkType?.type).isEqualTo(NetworkType.Wifi)
-
-        assertThat(highBandwidthRequester.pinned.value).isNull()
-    }
-
-    @Test
-    fun requestHighBandwidthForDownloadsButFails() {
-        networkingRules.preferredNetworks[DownloadRequest] = NetworkType.Wifi
-        networkingRules.highBandwidthTypes[DownloadRequest] = true
-        networkingRules.validRequests[Pair(DownloadRequest, BT)] = false
-        networkRequester.supportedNetworks = listOf()
-
-        val request = Request.Builder()
-            .url("https://example.org/music.mp3")
-            .requestType(RequestType.MediaRequest(Download))
-            .build()
-
-        val thrown = assertThrows(IOException::class.java) {
+        assertThrows("High Bandwidth Requests are not supported with execute", IOException::class.java) {
             callFactory.newCall(request).execute()
         }
-
-        assertThat(thrown).hasMessageThat().isEqualTo("Unable to use BT for media-download")
-
-        assertThat(highBandwidthRequester.pinned.value).isNull()
     }
 
     @Test


### PR DESCRIPTION
#### WHAT

Disable HighBandwidthCall.execute.

#### WHY

runBlocking is problematic, and better to ask clients to use enqueue here.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
