### PR TITLE
Clean-up unused method ToggleSetting from UampSettingsSecreen class.

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/settings/UampSettingsScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/settings/UampSettingsScreen.kt
@@ -189,32 +189,6 @@ fun ActionSetting(
 }
 
 @Composable
-fun ToggleSetting(
-    value: Boolean,
-    text: String,
-    enabled: Boolean = true,
-    onCheckedChange: (Boolean) -> Unit
-) {
-    ToggleChip(
-        checked = value,
-        toggleControl = {
-            Icon(
-                imageVector = ToggleChipDefaults.radioIcon(checked = value),
-                contentDescription = if (value) stringResource(id = R.string.on) else stringResource(
-                    id = R.string.off
-                )
-            )
-        },
-        enabled = enabled,
-        onCheckedChange = onCheckedChange,
-        label = {
-            Text(text)
-        },
-        modifier = Modifier.fillMaxWidth()
-    )
-}
-
-@Composable
 fun CheckedSetting(
     value: Boolean,
     text: String,


### PR DESCRIPTION
#### WHAT
Clean-up unused method ToggleSetting from UampSettingsSecreen class.

#### WHY


#### HOW


#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [X] Run spotless check
- [X] Run tests
- [N/A] Update metalava's signature text files
