### PR TITLE
Fix pause not on main thread

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/PlaybackServiceModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/PlaybackServiceModule.kt
@@ -234,7 +234,7 @@ object PlaybackServiceModule {
         ).also { wearConfiguredPlayer ->
             exoPlayer.addListener(TracingListener())
 
-            serviceCoroutineScope.launch {
+            serviceCoroutineScope.launch(Dispatchers.Main) {
                 wearConfiguredPlayer.startNoiseDetection()
             }
 


### PR DESCRIPTION
#### WHAT

```
Expected thread: 'main'
See https://exoplayer.dev/issues/player-accessed-on-wrong-thread
       at androidx.media3.exoplayer.ExoPlayerImpl.verifyApplicationThread(ExoPlayerImpl.java:4)
       at androidx.media3.exoplayer.ExoPlayerImpl.setPlayWhenReady(ExoPlayerImpl.java)
       at androidx.media3.common.BasePlayer.pause(BasePlayer.java:4)
       at com.google.android.horologist.media3.WearConfiguredPlayer.pause(WearConfiguredPlayer.java:3)
       at com.google.android.horologist.media3.WearConfiguredPlayer$startNoiseDetection$4.emit(WearConfiguredPlayer.java:11)
       at com.google.android.horologist.media3.WearConfiguredPlayer$startNoiseDetection$$inlined$filter$1$2.emit(WearConfiguredPlayer.java:6)
       at 
```       

#### WHY

Interacting with ExoPlayer must be on main thread.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
