### PR TITLE
Hold highbandwidth network for 3 seconds more

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/NetworkModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/NetworkModule.kt
@@ -59,6 +59,7 @@ import retrofit2.converter.moshi.MoshiConverterFactory
 import java.io.File
 import javax.inject.Provider
 import javax.inject.Singleton
+import kotlin.time.Duration.Companion.seconds
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -142,10 +143,13 @@ object NetworkModule {
     @Provides
     fun aggregatingHighBandwidthRequester(
         networkLogger: NetworkStatusLogger,
-        networkRequester: NetworkRequester
+        networkRequester: NetworkRequester,
+        @ForApplicationScope coroutineScope: CoroutineScope
     ) = StandardHighBandwidthNetworkMediator(
         networkLogger,
-        networkRequester
+        networkRequester,
+        coroutineScope,
+        3.seconds
     )
 
     @Singleton

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/config/UampNetworkingRules.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/config/UampNetworkingRules.kt
@@ -37,7 +37,7 @@ object UampNetworkingRules : NetworkingRules {
         // For testing purposes fail if we get unknown requests
         check(requestType != UnknownRequest)
 
-        return requestType is RequestType.MediaRequest
+        return requestType is RequestType.MediaRequest || requestType is RequestType.ImageRequest
     }
 
     override fun checkValidRequest(

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/config/UampNetworkingRules.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/config/UampNetworkingRules.kt
@@ -37,6 +37,7 @@ object UampNetworkingRules : NetworkingRules {
         // For testing purposes fail if we get unknown requests
         check(requestType != UnknownRequest)
 
+        // For testing purposes use high bandwidth for images
         return requestType is RequestType.MediaRequest || requestType is RequestType.ImageRequest
     }
 

--- a/network-awareness/api/current.api
+++ b/network-awareness/api/current.api
@@ -321,7 +321,7 @@ package com.google.android.horologist.networks.highbandwidth {
   }
 
   @com.google.android.horologist.networks.ExperimentalHorologistNetworksApi public final class StandardHighBandwidthNetworkMediator implements com.google.android.horologist.networks.highbandwidth.HighBandwidthNetworkMediator {
-    ctor public StandardHighBandwidthNetworkMediator(com.google.android.horologist.networks.logging.NetworkStatusLogger logger, com.google.android.horologist.networks.request.NetworkRequester networkRequester);
+    ctor public StandardHighBandwidthNetworkMediator(com.google.android.horologist.networks.logging.NetworkStatusLogger logger, com.google.android.horologist.networks.request.NetworkRequester networkRequester, kotlinx.coroutines.CoroutineScope coroutineScope, long delayToRelease);
     method public kotlinx.coroutines.flow.Flow<java.util.Set<com.google.android.horologist.networks.data.NetworkType>> getPinned();
     method public com.google.android.horologist.networks.highbandwidth.HighBandwidthConnectionLease requestHighBandwidthNetwork(com.google.android.horologist.networks.request.HighBandwidthRequest request);
     property public kotlinx.coroutines.flow.Flow<java.util.Set<com.google.android.horologist.networks.data.NetworkType>> pinned;

--- a/network-awareness/src/main/java/com/google/android/horologist/networks/highbandwidth/StandardHighBandwidthNetworkMediator.kt
+++ b/network-awareness/src/main/java/com/google/android/horologist/networks/highbandwidth/StandardHighBandwidthNetworkMediator.kt
@@ -160,7 +160,7 @@ public class StandardHighBandwidthNetworkMediator(
             }
         }
 
-        countAndLease.updateCount(delta = - 1)
+        countAndLease.updateCount(delta = -1)
     }
 
     private suspend fun processCancel(

--- a/network-awareness/src/main/java/com/google/android/horologist/networks/highbandwidth/StandardHighBandwidthNetworkMediator.kt
+++ b/network-awareness/src/main/java/com/google/android/horologist/networks/highbandwidth/StandardHighBandwidthNetworkMediator.kt
@@ -161,7 +161,7 @@ public class StandardHighBandwidthNetworkMediator(
             }
 
             countAndLease.copy(
-                count = countAndLease.count - 1,
+                count = countAndLease.count - 1
             )
         }
     }

--- a/network-awareness/src/main/java/com/google/android/horologist/networks/request/NetworkRequesterImpl.kt
+++ b/network-awareness/src/main/java/com/google/android/horologist/networks/request/NetworkRequesterImpl.kt
@@ -41,6 +41,10 @@ public class NetworkRequesterImpl(
     private inner class NetworkLeaseImpl : NetworkCallback(), NetworkLease {
         override val acquiredAt: Instant = Instant.now()
 
+        init {
+            println("acquired")
+        }
+
         override val grantedNetwork: MutableStateFlow<NetworkReference?> =
             MutableStateFlow(null)
 
@@ -54,6 +58,7 @@ public class NetworkRequesterImpl(
         }
 
         override fun close() {
+            println("release")
             connectivityManager.unregisterNetworkCallback(this)
             grantedNetwork.value = null
         }

--- a/network-awareness/src/main/java/com/google/android/horologist/networks/request/NetworkRequesterImpl.kt
+++ b/network-awareness/src/main/java/com/google/android/horologist/networks/request/NetworkRequesterImpl.kt
@@ -41,10 +41,6 @@ public class NetworkRequesterImpl(
     private inner class NetworkLeaseImpl : NetworkCallback(), NetworkLease {
         override val acquiredAt: Instant = Instant.now()
 
-        init {
-            println("acquired")
-        }
-
         override val grantedNetwork: MutableStateFlow<NetworkReference?> =
             MutableStateFlow(null)
 
@@ -58,7 +54,6 @@ public class NetworkRequesterImpl(
         }
 
         override fun close() {
-            println("release")
             connectivityManager.unregisterNetworkCallback(this)
             grantedNetwork.value = null
         }

--- a/network-awareness/src/test/java/com/google/android/horologist/networks/rules/NetworkSelectingCallFactoryTest.kt
+++ b/network-awareness/src/test/java/com/google/android/horologist/networks/rules/NetworkSelectingCallFactoryTest.kt
@@ -48,6 +48,7 @@ import java.io.IOException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
 
 class NetworkSelectingCallFactoryTest {
     private val testScope = TestScope()
@@ -57,7 +58,9 @@ class NetworkSelectingCallFactoryTest {
     private val networkRequester = FakeNetworkRequester(networkRepository)
     private val highBandwidthRequester = StandardHighBandwidthNetworkMediator(
         logger,
-        networkRequester
+        networkRequester,
+        testScope,
+        3.seconds
     )
     private val dataRequestRepository = InMemoryDataRequestRepository()
 

--- a/sample/src/main/java/com/google/android/horologist/sample/di/SampleAppDI.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/di/SampleAppDI.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import okhttp3.Call
 import okhttp3.OkHttpClient
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Simple DI implementation - to be replaced by hilt.
@@ -80,7 +81,9 @@ object SampleAppDI {
 
         val highBandwidthRequester = StandardHighBandwidthNetworkMediator(
             networkRequester = networkRequester,
-            logger = networkLogger
+            logger = networkLogger,
+            coroutineScope = coroutineScope,
+            delayToRelease = 3.seconds
         )
 
         val networkingRulesEngine = NetworkingRulesEngine(


### PR DESCRIPTION
#### WHAT

Hold highbandwidth network for 3 seconds more.

#### WHY

#fixes https://github.com/google/horologist/issues/623

If we request a high bandwidth network for downloads, streaming or images, there is a high likelyhood that a completed request is followed by another, so delay releasing.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
