### PR TITLE
Improve Section.State to require a type parameter

### DIFF
--- a/composables/api/current.api
+++ b/composables/api/current.api
@@ -34,8 +34,8 @@ package com.google.android.horologist.composables {
   }
 
   @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public final class Section<T> {
-    ctor public Section(com.google.android.horologist.composables.Section.State state, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? headerContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? loadingContent, kotlin.jvm.functions.Function2<? super com.google.android.horologist.composables.SectionContentScope,? super T,kotlin.Unit> loadedContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? failedContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? emptyContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? footerContent, optional boolean displayFooterOnlyOnLoadedState);
-    method public com.google.android.horologist.composables.Section.State component1();
+    ctor public Section(com.google.android.horologist.composables.Section.State<T> state, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? headerContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? loadingContent, kotlin.jvm.functions.Function2<? super com.google.android.horologist.composables.SectionContentScope,? super T,kotlin.Unit> loadedContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? failedContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? emptyContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? footerContent, optional boolean displayFooterOnlyOnLoadedState);
+    method public com.google.android.horologist.composables.Section.State<T> component1();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? component2();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? component3();
     method public kotlin.jvm.functions.Function2<com.google.android.horologist.composables.SectionContentScope,T,kotlin.Unit> component4();
@@ -43,7 +43,7 @@ package com.google.android.horologist.composables {
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? component6();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? component7();
     method public boolean component8();
-    method public com.google.android.horologist.composables.Section<T> copy(com.google.android.horologist.composables.Section.State state, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? headerContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? loadingContent, kotlin.jvm.functions.Function2<? super com.google.android.horologist.composables.SectionContentScope,? super T,kotlin.Unit> loadedContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? failedContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? emptyContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? footerContent, boolean displayFooterOnlyOnLoadedState);
+    method public com.google.android.horologist.composables.Section<T> copy(com.google.android.horologist.composables.Section.State<T> state, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? headerContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? loadingContent, kotlin.jvm.functions.Function2<? super com.google.android.horologist.composables.SectionContentScope,? super T,kotlin.Unit> loadedContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? failedContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? emptyContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? footerContent, boolean displayFooterOnlyOnLoadedState);
     method public boolean getDisplayFooterOnlyOnLoadedState();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? getEmptyContent();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? getFailedContent();
@@ -51,7 +51,7 @@ package com.google.android.horologist.composables {
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? getHeaderContent();
     method public kotlin.jvm.functions.Function2<com.google.android.horologist.composables.SectionContentScope,T,kotlin.Unit> getLoadedContent();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? getLoadingContent();
-    method public com.google.android.horologist.composables.Section.State getState();
+    method public com.google.android.horologist.composables.Section.State<T> getState();
     property public final boolean displayFooterOnlyOnLoadedState;
     property public final kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? emptyContent;
     property public final kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? failedContent;
@@ -59,21 +59,21 @@ package com.google.android.horologist.composables {
     property public final kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? headerContent;
     property public final kotlin.jvm.functions.Function2<com.google.android.horologist.composables.SectionContentScope,T,kotlin.Unit> loadedContent;
     property public final kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? loadingContent;
-    property public final com.google.android.horologist.composables.Section.State state;
+    property public final com.google.android.horologist.composables.Section.State<T> state;
   }
 
-  public abstract static sealed class Section.State {
+  public abstract static sealed class Section.State<T> {
   }
 
-  public static final class Section.State.Empty extends com.google.android.horologist.composables.Section.State {
-    field public static final com.google.android.horologist.composables.Section.State.Empty INSTANCE;
+  public static final class Section.State.Empty<T> extends com.google.android.horologist.composables.Section.State<T> {
+    ctor public Section.State.Empty();
   }
 
-  public static final class Section.State.Failed extends com.google.android.horologist.composables.Section.State {
-    field public static final com.google.android.horologist.composables.Section.State.Failed INSTANCE;
+  public static final class Section.State.Failed<T> extends com.google.android.horologist.composables.Section.State<T> {
+    ctor public Section.State.Failed();
   }
 
-  public static final class Section.State.Loaded<T> extends com.google.android.horologist.composables.Section.State {
+  public static final class Section.State.Loaded<T> extends com.google.android.horologist.composables.Section.State<T> {
     ctor public Section.State.Loaded(java.util.List<? extends T> list);
     method public java.util.List<T> component1();
     method public com.google.android.horologist.composables.Section.State.Loaded<T> copy(java.util.List<? extends T> list);
@@ -81,8 +81,8 @@ package com.google.android.horologist.composables {
     property public final java.util.List<T> list;
   }
 
-  public static final class Section.State.Loading extends com.google.android.horologist.composables.Section.State {
-    field public static final com.google.android.horologist.composables.Section.State.Loading INSTANCE;
+  public static final class Section.State.Loading<T> extends com.google.android.horologist.composables.Section.State<T> {
+    ctor public Section.State.Loading();
   }
 
   @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public final class SectionContentScope {
@@ -106,7 +106,7 @@ package com.google.android.horologist.composables {
 
   @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public final class SectionedListScope {
     ctor public SectionedListScope();
-    method public <T> void section(com.google.android.horologist.composables.Section.State state, optional boolean displayFooterOnlyOnLoadedState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionScope<T>,kotlin.Unit> content);
+    method public <T> void section(com.google.android.horologist.composables.Section.State<T> state, optional boolean displayFooterOnlyOnLoadedState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionScope<T>,kotlin.Unit> content);
     method public <T> void section(java.util.List<? extends T> list, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionScope<T>,kotlin.Unit> content);
     method public void section(kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionScope<kotlin.Unit>,kotlin.Unit> content);
   }

--- a/composables/src/debug/java/com/google/android/horologist/composables/SectionedListPreview.kt
+++ b/composables/src/debug/java/com/google/android/horologist/composables/SectionedListPreview.kt
@@ -47,9 +47,9 @@ fun SectionedListPreviewLoadingSection() {
         focusRequester = FocusRequester(),
         scalingLazyListState = rememberScalingLazyListState()
     ) {
-        downloadsSection(scope = this, state = Section.State.Loading)
+        downloadsSection(scope = this, state = Section.State.Loading())
 
-        favouritesSection(scope = this, state = Section.State.Empty)
+        favouritesSection(scope = this, state = Section.State.Empty())
     }
 }
 
@@ -62,7 +62,7 @@ fun SectionedListPreviewLoadedSection() {
     ) {
         downloadsSection(scope = this, state = Section.State.Loaded(downloads))
 
-        favouritesSection(scope = this, state = Section.State.Failed)
+        favouritesSection(scope = this, state = Section.State.Failed())
     }
 }
 
@@ -73,7 +73,7 @@ fun SectionedListPreviewFailedSection() {
         focusRequester = FocusRequester(),
         scalingLazyListState = rememberScalingLazyListState()
     ) {
-        downloadsSection(scope = this, state = Section.State.Failed)
+        downloadsSection(scope = this, state = Section.State.Failed())
 
         favouritesSection(scope = this, state = Section.State.Loaded(favourites))
     }
@@ -86,15 +86,15 @@ fun SectionedListPreviewEmptySection() {
         focusRequester = FocusRequester(),
         scalingLazyListState = rememberScalingLazyListState()
     ) {
-        downloadsSection(scope = this, state = Section.State.Empty)
+        downloadsSection(scope = this, state = Section.State.Empty())
 
-        favouritesSection(scope = this, state = Section.State.Loading)
+        favouritesSection(scope = this, state = Section.State.Loading())
     }
 }
 
 private val downloads = listOf("Nu Metal Essentials", "00s Rock")
 
-private fun downloadsSection(scope: SectionedListScope, state: Section.State) {
+private fun downloadsSection(scope: SectionedListScope, state: Section.State<String>) {
     scope.section(state = state) {
         header { DownloadsHeader() }
 
@@ -194,7 +194,7 @@ private fun DownloadsFooter() {
 
 private val favourites = listOf("Dance Anthems", "Indie Jukebox")
 
-private fun favouritesSection(scope: SectionedListScope, state: Section.State) {
+private fun favouritesSection(scope: SectionedListScope, state: Section.State<String>) {
     scope.section(state = state) {
         header { FavouritesHeader() }
 

--- a/composables/src/main/java/com/google/android/horologist/composables/SectionedList.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/SectionedList.kt
@@ -89,24 +89,26 @@ internal fun <T> Section<T>.display(scope: ScalingLazyListScope) {
     }
 
     when (section.state) {
-        Section.State.Loading -> {
+        is Section.State.Loading -> {
             section.loadingContent?.let { content ->
                 scope.item { SectionContentScope.content() }
             }
         }
-        is Section.State.Loaded<*> -> {
+
+        is Section.State.Loaded -> {
             val list = section.state.list
             scope.items(list.size) { index ->
-                @Suppress("UNCHECKED_CAST")
-                section.loadedContent(SectionContentScope, list[index] as T)
+                section.loadedContent(SectionContentScope, list[index])
             }
         }
-        Section.State.Failed -> {
+
+        is Section.State.Failed -> {
             section.failedContent?.let { content ->
                 scope.item { SectionContentScope.content() }
             }
         }
-        Section.State.Empty -> {
+
+        is Section.State.Empty -> {
             section.emptyContent?.let { content ->
                 scope.item { SectionContentScope.content() }
             }
@@ -125,7 +127,7 @@ internal fun <T> Section<T>.display(scope: ScalingLazyListScope) {
  */
 @ExperimentalHorologistComposablesApi
 public data class Section<T> constructor(
-    val state: State,
+    val state: State<T>,
     val headerContent: (@Composable SectionContentScope.() -> Unit)? = null,
     val loadingContent: (@Composable SectionContentScope.() -> Unit)? = null,
     val loadedContent: @Composable SectionContentScope.(T) -> Unit,
@@ -137,16 +139,16 @@ public data class Section<T> constructor(
     /**
      * A state of a [Section].
      */
-    public sealed class State {
-        public object Loading : State()
+    public sealed class State<T> {
+        public class Loading<T> : State<T>()
 
         public data class Loaded<T>(
             val list: List<T>
-        ) : State()
+        ) : State<T>()
 
-        public object Failed : State()
+        public class Failed<T> : State<T>()
 
-        public object Empty : State()
+        public class Empty<T> : State<T>()
     }
 }
 
@@ -167,7 +169,7 @@ public class SectionedListScope {
 
     @SectionScopeMarker
     public fun <T> section(
-        state: Section.State,
+        state: Section.State<T>,
         displayFooterOnlyOnLoadedState: Boolean = true,
         content: SectionScope<T>.() -> Unit
     ) {

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/SectionedListTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/SectionedListTest.kt
@@ -78,9 +78,9 @@ class SectionedListTest {
                     focusRequester = FocusRequester(),
                     scalingLazyListState = scrollState
                 ) {
-                    downloadsSection(scope = this, state = Section.State.Loading)
+                    downloadsSection(scope = this, state = Section.State.Loading())
 
-                    favouritesSection(scope = this, state = Section.State.Empty)
+                    favouritesSection(scope = this, state = Section.State.Empty())
                 }
             }
         }
@@ -99,7 +99,7 @@ class SectionedListTest {
                 ) {
                     downloadsSection(scope = this, state = Section.State.Loaded(downloads))
 
-                    favouritesSection(scope = this, state = Section.State.Failed)
+                    favouritesSection(scope = this, state = Section.State.Failed())
                 }
             }
         }
@@ -118,7 +118,7 @@ class SectionedListTest {
                 ) {
                     downloadsSection(scope = this, state = Section.State.Loaded(downloads))
 
-                    favouritesSection(scope = this, state = Section.State.Failed)
+                    favouritesSection(scope = this, state = Section.State.Failed())
                 }
             }
         }
@@ -135,7 +135,7 @@ class SectionedListTest {
                     focusRequester = FocusRequester(),
                     scalingLazyListState = scrollState
                 ) {
-                    downloadsSection(scope = this, state = Section.State.Failed)
+                    downloadsSection(scope = this, state = Section.State.Failed())
 
                     favouritesSection(scope = this, state = Section.State.Loaded(favourites))
                 }
@@ -154,7 +154,7 @@ class SectionedListTest {
                     focusRequester = FocusRequester(),
                     scalingLazyListState = scrollState
                 ) {
-                    downloadsSection(scope = this, state = Section.State.Failed)
+                    downloadsSection(scope = this, state = Section.State.Failed())
 
                     favouritesSection(scope = this, state = Section.State.Loaded(favourites))
                 }
@@ -173,9 +173,9 @@ class SectionedListTest {
                     focusRequester = FocusRequester(),
                     scalingLazyListState = scrollState
                 ) {
-                    downloadsSection(scope = this, state = Section.State.Empty)
+                    downloadsSection(scope = this, state = Section.State.Empty())
 
-                    favouritesSection(scope = this, state = Section.State.Loading)
+                    favouritesSection(scope = this, state = Section.State.Loading())
                 }
             }
         }
@@ -202,7 +202,7 @@ class SectionedListTest {
 
     private val downloads = listOf("Nu Metal Essentials", "00s Rock")
 
-    private fun downloadsSection(scope: SectionedListScope, state: Section.State) {
+    private fun downloadsSection(scope: SectionedListScope, state: Section.State<String>) {
         scope.section(state = state) {
             header { DownloadsHeader() }
 
@@ -302,7 +302,7 @@ class SectionedListTest {
 
     private val favourites = listOf("Dance Anthems", "Indie Jukebox")
 
-    private fun favouritesSection(scope: SectionedListScope, state: Section.State) {
+    private fun favouritesSection(scope: SectionedListScope, state: Section.State<String>) {
         scope.section(state = state) {
             header { FavouritesHeader() }
 

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -326,9 +326,9 @@ package com.google.android.horologist.media.ui.screens.browse {
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public final class BrowseScreenScope {
     ctor public BrowseScreenScope();
     method public void button(com.google.android.horologist.media.ui.screens.browse.BrowseScreenPlaylistsSectionButton button);
-    method public <T> void downloadsSection(com.google.android.horologist.composables.Section.State state, optional boolean displayFooterOnlyOnLoadedState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.screens.browse.BrowseScreenSectionScope<T>,kotlin.Unit> content);
+    method public <T> void downloadsSection(com.google.android.horologist.composables.Section.State<T> state, optional boolean displayFooterOnlyOnLoadedState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.screens.browse.BrowseScreenSectionScope<T>,kotlin.Unit> content);
     method public void playlistsSection(java.util.List<com.google.android.horologist.media.ui.screens.browse.BrowseScreenPlaylistsSectionButton> buttons);
-    method public <T> void section(com.google.android.horologist.composables.Section.State state, @StringRes int titleId, @StringRes int emptyMessageId, optional @StringRes Integer? failedMessageId, optional boolean displayFooterOnlyOnLoadedState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.screens.browse.BrowseScreenSectionScope<T>,kotlin.Unit> content);
+    method public <T> void section(com.google.android.horologist.composables.Section.State<T> state, @StringRes int titleId, @StringRes int emptyMessageId, optional @StringRes Integer? failedMessageId, optional boolean displayFooterOnlyOnLoadedState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.screens.browse.BrowseScreenSectionScope<T>,kotlin.Unit> content);
   }
 
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public final class BrowseScreenSectionScope<T> {

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreenPreview.kt
@@ -57,8 +57,8 @@ fun BrowseScreenPreview() {
 @Composable
 fun BrowseScreenPreviewLoading() {
     BrowseScreenPreviewSample(
-        trendingSectionState = Section.State.Loading,
-        downloadsSectionState = Section.State.Loading
+        trendingSectionState = Section.State.Loading(),
+        downloadsSectionState = Section.State.Loading()
     )
 }
 
@@ -66,15 +66,15 @@ fun BrowseScreenPreviewLoading() {
 @Composable
 fun BrowseScreenPreviewFailed() {
     BrowseScreenPreviewSample(
-        trendingSectionState = Section.State.Failed,
-        downloadsSectionState = Section.State.Failed
+        trendingSectionState = Section.State.Failed(),
+        downloadsSectionState = Section.State.Failed()
     )
 }
 
 @Composable
 private fun BrowseScreenPreviewSample(
-    trendingSectionState: Section.State,
-    downloadsSectionState: Section.State
+    trendingSectionState: Section.State<String>,
+    downloadsSectionState: Section.State<Pair<String, String>>
 ) {
     BrowseScreen(
         focusRequester = FocusRequester(),

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreen.kt
@@ -86,7 +86,7 @@ public class BrowseScreenScope {
 
     @BrowseScreenScopeMarker
     public fun <T> section(
-        state: Section.State,
+        state: Section.State<T>,
         @StringRes titleId: Int,
         @StringRes emptyMessageId: Int,
         @StringRes failedMessageId: Int? = null,
@@ -136,7 +136,7 @@ public class BrowseScreenScope {
 
     @BrowseScreenScopeMarker
     public fun <T> downloadsSection(
-        state: Section.State,
+        state: Section.State<T>,
         displayFooterOnlyOnLoadedState: Boolean = true,
         content: BrowseScreenSectionScope<T>.() -> Unit
     ) {

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/browse/PlaylistDownloadBrowseScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/browse/PlaylistDownloadBrowseScreen.kt
@@ -63,17 +63,17 @@ public fun PlaylistDownloadBrowseScreen(
         autoCentering = autoCentering
     ) {
         val downloadsSectionState = when (browseScreenState) {
-            is BrowseScreenState.Loading -> Section.State.Loading
+            is BrowseScreenState.Loading -> Section.State.Loading()
             is BrowseScreenState.Loaded -> {
                 if (browseScreenState.downloadList.isEmpty()) {
-                    Section.State.Empty
+                    Section.State.Empty()
                 } else {
                     Section.State.Loaded(browseScreenState.downloadList)
                 }
             }
             is BrowseScreenState.Failed ->
                 // display empty state
-                Section.State.Empty
+                Section.State.Empty()
         }
 
         downloadsSection(state = downloadsSectionState) {

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreen.kt
@@ -77,8 +77,8 @@ public fun <T> PlaylistsScreen(
             is PlaylistsScreenState.Loaded<T> -> {
                 Section.State.Loaded(playlistsScreenState.playlistList)
             }
-            is PlaylistsScreenState.Failed -> Section.State.Failed
-            is PlaylistsScreenState.Loading -> Section.State.Loading
+            is PlaylistsScreenState.Failed -> Section.State.Failed()
+            is PlaylistsScreenState.Loading -> Section.State.Loading()
         }
 
         section(state = sectionState) {

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/stateful/SectionedListStatefulScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/stateful/SectionedListStatefulScreen.kt
@@ -88,13 +88,13 @@ fun SectionedListStatefulScreen(
             }
         }
 
-        val recommendationsState: Section.State =
+        val recommendationsState: Section.State<Recommendation> =
             when (val recommendationSectionState = state.recommendationSectionState) {
-                RecommendationSectionState.Loading -> Section.State.Loading
+                RecommendationSectionState.Loading -> Section.State.Loading()
                 is RecommendationSectionState.Loaded -> Section.State.Loaded(
                     recommendationSectionState.list
                 )
-                RecommendationSectionState.Failed -> Section.State.Failed
+                RecommendationSectionState.Failed -> Section.State.Failed()
             }
 
         section(recommendationsState) {
@@ -128,13 +128,13 @@ fun SectionedListStatefulScreen(
             }
         }
 
-        val trendingState: Section.State =
+        val trendingState: Section.State<Trending> =
             when (val recommendationSectionState = state.trendingSectionState) {
-                TrendingSectionState.Loading -> Section.State.Loading
+                TrendingSectionState.Loading -> Section.State.Loading()
                 is TrendingSectionState.Loaded -> Section.State.Loaded(
                     recommendationSectionState.list
                 )
-                TrendingSectionState.Failed -> Section.State.Failed
+                TrendingSectionState.Failed -> Section.State.Failed()
             }
 
         section(trendingState) {


### PR DESCRIPTION
#### WHAT

Improve `Section.State` to require a type parameter.

#### WHY

In order to prevent at compile time a `State` with an invalid type to be passed to a `Section`, which would cause a cast exception at runtime. 

For example, in the samples below with the current code where the `Section` has type `String` and `State` has type `Int`:

![Screen Shot 2022-09-26 at 14 26 26](https://user-images.githubusercontent.com/878134/192298516-a65989e3-0e01-45ce-9325-f721806da01a.png)

![Screen Shot 2022-09-26 at 15 03 55](https://user-images.githubusercontent.com/878134/192298557-e8fa2534-ce81-4efb-bc51-758cf33ee818.png)


Same code after these changes showing issues at compile time:

![Screen Shot 2022-09-26 at 14 25 41](https://user-images.githubusercontent.com/878134/192297946-da07b37f-ce33-4eb2-9828-6c4462f4dc0b.png)

![Screen Shot 2022-09-26 at 15 02 21](https://user-images.githubusercontent.com/878134/192298633-0fc1dc9e-ed34-4b02-a23e-cc02d9a2a4f7.png)




#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
