### PR TITLE
Improve usage of SectionedList

### DIFF
--- a/composables/src/debug/java/com/google/android/horologist/composables/SectionedListPreview.kt
+++ b/composables/src/debug/java/com/google/android/horologist/composables/SectionedListPreview.kt
@@ -47,9 +47,9 @@ fun SectionedListPreviewLoadingSection() {
         focusRequester = FocusRequester(),
         scalingLazyListState = rememberScalingLazyListState()
     ) {
-        downloadsSection(scope = this, state = Section.State.Loading())
+        downloadsSection(state = Section.State.Loading())
 
-        favouritesSection(scope = this, state = Section.State.Empty())
+        favouritesSection(state = Section.State.Empty())
     }
 }
 
@@ -60,9 +60,9 @@ fun SectionedListPreviewLoadedSection() {
         focusRequester = FocusRequester(),
         scalingLazyListState = rememberScalingLazyListState()
     ) {
-        downloadsSection(scope = this, state = Section.State.Loaded(downloads))
+        downloadsSection(state = Section.State.Loaded(downloads))
 
-        favouritesSection(scope = this, state = Section.State.Failed())
+        favouritesSection(state = Section.State.Failed())
     }
 }
 
@@ -73,9 +73,9 @@ fun SectionedListPreviewFailedSection() {
         focusRequester = FocusRequester(),
         scalingLazyListState = rememberScalingLazyListState()
     ) {
-        downloadsSection(scope = this, state = Section.State.Failed())
+        downloadsSection(state = Section.State.Failed())
 
-        favouritesSection(scope = this, state = Section.State.Loaded(favourites))
+        favouritesSection(state = Section.State.Loaded(favourites))
     }
 }
 
@@ -86,16 +86,16 @@ fun SectionedListPreviewEmptySection() {
         focusRequester = FocusRequester(),
         scalingLazyListState = rememberScalingLazyListState()
     ) {
-        downloadsSection(scope = this, state = Section.State.Empty())
+        downloadsSection(state = Section.State.Empty())
 
-        favouritesSection(scope = this, state = Section.State.Loading())
+        favouritesSection(state = Section.State.Loading())
     }
 }
 
 private val downloads = listOf("Nu Metal Essentials", "00s Rock")
 
-private fun downloadsSection(scope: SectionedListScope, state: Section.State<String>) {
-    scope.section(state = state) {
+private fun SectionedListScope.downloadsSection(state: Section.State<String>) {
+    section(state = state) {
         header { DownloadsHeader() }
 
         loading { DownloadsLoading() }
@@ -194,8 +194,8 @@ private fun DownloadsFooter() {
 
 private val favourites = listOf("Dance Anthems", "Indie Jukebox")
 
-private fun favouritesSection(scope: SectionedListScope, state: Section.State<String>) {
-    scope.section(state = state) {
+private fun SectionedListScope.favouritesSection(state: Section.State<String>) {
+    section(state = state) {
         header { FavouritesHeader() }
 
         loading { FavouritesLoading() }

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/expandable/SectionedListExpandableScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/expandable/SectionedListExpandableScreen.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.horologist.sectionedlist.expandable
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
@@ -41,7 +42,9 @@ import androidx.wear.compose.material.ScalingLazyListState
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.rememberScalingLazyListState
 import com.google.android.horologist.composables.Section
+import com.google.android.horologist.composables.SectionContentScope
 import com.google.android.horologist.composables.SectionedList
+import com.google.android.horologist.composables.SectionedListScope
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 import com.google.android.horologist.sample.R
 import com.google.android.horologist.sectionedlist.component.SingleLineChip
@@ -88,66 +91,32 @@ fun SectionedListExpandableScreen(
             loaded { Title(stringResource(R.string.sectionedlist_my_tasks)) }
         }
 
-        section(state = todaySectionState) {
-            header {
-                SectionHeader(
-                    text = stringResource(R.string.sectionedlist_today),
-                    expanded = todaySectionExpanded,
-                    onClick = { todaySectionExpanded = !todaySectionExpanded }
-                )
-            }
+        taskSection(
+            titleId = R.string.sectionedlist_today,
+            state = todaySectionState,
+            expanded = todaySectionExpanded,
+            onHeaderClick = { todaySectionExpanded = !todaySectionExpanded }
+        )
 
-            loaded { (text, iconTint) ->
-                SingleLineChip(
-                    text = text,
-                    imageVector = Icons.Outlined.Circle,
-                    iconTint = iconTint
-                )
-            }
-        }
+        taskSection(
+            titleId = R.string.sectionedlist_tomorrow,
+            state = tomorrowSectionState,
+            expanded = tomorrowSectionExpanded,
+            onHeaderClick = { tomorrowSectionExpanded = !tomorrowSectionExpanded }
+        )
 
-        section(state = tomorrowSectionState) {
-            header {
-                SectionHeader(
-                    text = stringResource(R.string.sectionedlist_tomorrow),
-                    expanded = tomorrowSectionExpanded,
-                    onClick = { tomorrowSectionExpanded = !tomorrowSectionExpanded }
-                )
-            }
-
-            loaded { (text, iconTint) ->
-                SingleLineChip(
-                    text = text,
-                    imageVector = Icons.Outlined.Circle,
-                    iconTint = iconTint
-                )
-            }
-        }
-
-        section(state = laterSectionState) {
-            header {
-                SectionHeader(
-                    text = stringResource(R.string.sectionedlist_later_week),
-                    expanded = laterSectionExpanded,
-                    onClick = { laterSectionExpanded = !laterSectionExpanded }
-                )
-            }
-
-            loaded { (text, iconTint) ->
-                SingleLineChip(
-                    text = text,
-                    imageVector = Icons.Outlined.Circle,
-                    iconTint = iconTint
-                )
-            }
-
-            footer {
+        taskSection(
+            titleId = R.string.sectionedlist_later_week,
+            state = laterSectionState,
+            expanded = laterSectionExpanded,
+            onHeaderClick = { laterSectionExpanded = !laterSectionExpanded },
+            footerContent = {
                 SingleLineNoIconChip(
                     text = stringResource(R.string.sectionedlist_more_tasks),
                     colors = ChipDefaults.primaryChipColors()
                 )
             }
-        }
+        )
     }
 
     LaunchedEffect(Unit) {
@@ -159,6 +128,38 @@ private fun getState(expanded: Boolean, list: List<Pair<String, Color>>) = if (e
     Section.State.Loaded(list)
 } else {
     Section.State.Loaded(emptyList())
+}
+
+private fun SectionedListScope.taskSection(
+    @StringRes titleId: Int,
+    state: Section.State<Pair<String, Color>>,
+    expanded: Boolean,
+    onHeaderClick: () -> Unit,
+    footerContent: @Composable (SectionContentScope.() -> Unit)? = null
+) {
+    section(state = state) {
+        header {
+            SectionHeader(
+                text = stringResource(titleId),
+                expanded = expanded,
+                onClick = onHeaderClick
+            )
+        }
+
+        loaded { (text, iconTint) ->
+            SingleLineChip(
+                text = text,
+                imageVector = Icons.Outlined.Circle,
+                iconTint = iconTint
+            )
+        }
+
+        footerContent?.let {
+            footer {
+                footerContent()
+            }
+        }
+    }
 }
 
 @Composable

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/stateful/SectionedListStatefulScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/stateful/SectionedListStatefulScreen.kt
@@ -51,6 +51,7 @@ import androidx.wear.compose.material.rememberScalingLazyListState
 import com.google.android.horologist.composables.PlaceholderChip
 import com.google.android.horologist.composables.Section
 import com.google.android.horologist.composables.SectionedList
+import com.google.android.horologist.composables.SectionedListScope
 import com.google.android.horologist.compose.layout.StateUtils.rememberStateWithLifecycle
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 import com.google.android.horologist.sample.R
@@ -77,110 +78,134 @@ fun SectionedListStatefulScreen(
         scalingLazyListState = scalingLazyListState,
         modifier = modifier
     ) {
-        section(
-            listOf(
-                Pair(R.string.sectionedlist_downloads_button, Icons.Default.DownloadDone),
-                Pair(R.string.sectionedlist_your_library_button, Icons.Default.LibraryMusic)
-            )
-        ) {
-            loaded { item ->
-                SingleLineChip(text = stringResource(item.first), imageVector = item.second)
-            }
-        }
+        topMenuSection()
 
-        val recommendationsState: Section.State<Recommendation> =
-            when (val recommendationSectionState = state.recommendationSectionState) {
-                RecommendationSectionState.Loading -> Section.State.Loading()
-                is RecommendationSectionState.Loaded -> Section.State.Loaded(
-                    recommendationSectionState.list
-                )
-                RecommendationSectionState.Failed -> Section.State.Failed()
-            }
+        recommendationsSection(state = state, viewModel = viewModel)
 
-        section(recommendationsState) {
-            header {
-                Title(stringResource(id = R.string.sectionedlist_recommendations_title))
-            }
+        trendingSection(state = state, viewModel = viewModel)
 
-            loaded { recommendation: Recommendation ->
-                SingleLineChip(
-                    text = recommendation.playlistName,
-                    imageVector = recommendation.icon
-                )
-            }
-
-            loading {
-                Column {
-                    PlaceholderChip(colors = ChipDefaults.secondaryChipColors())
-                    PlaceholderChip(
-                        modifier = Modifier.padding(top = 4.dp),
-                        colors = ChipDefaults.secondaryChipColors()
-                    )
-                }
-            }
-
-            failed {
-                FailedView(onClick = { viewModel.loadRecommendations() })
-            }
-
-            footer {
-                SingleLineNoIconChip(stringResource(id = R.string.sectionedlist_see_more_button))
-            }
-        }
-
-        val trendingState: Section.State<Trending> =
-            when (val recommendationSectionState = state.trendingSectionState) {
-                TrendingSectionState.Loading -> Section.State.Loading()
-                is TrendingSectionState.Loaded -> Section.State.Loaded(
-                    recommendationSectionState.list
-                )
-                TrendingSectionState.Failed -> Section.State.Failed()
-            }
-
-        section(trendingState) {
-            header {
-                Title(stringResource(id = R.string.sectionedlist_trending_title))
-            }
-
-            loaded { trending: Trending ->
-                TwoLinesChip(
-                    primaryLabel = trending.name,
-                    secondaryLabel = trending.artist,
-                    imageVector = Icons.Default.MusicNote
-                )
-            }
-
-            loading {
-                Column {
-                    PlaceholderChip(colors = ChipDefaults.secondaryChipColors())
-                    PlaceholderChip(
-                        modifier = Modifier.padding(top = 4.dp),
-                        colors = ChipDefaults.secondaryChipColors()
-                    )
-                }
-            }
-
-            failed {
-                FailedView(onClick = { viewModel.loadTrending() })
-            }
-
-            footer {
-                SingleLineNoIconChip(stringResource(id = R.string.sectionedlist_see_more_button))
-            }
-        }
-
-        section {
-            loaded {
-                SingleLineChip(
-                    text = stringResource(R.string.sectionedlist_settings_button),
-                    imageVector = Icons.Default.Settings
-                )
-            }
-        }
+        bottomMenuSection()
     }
 
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
+    }
+}
+
+private fun SectionedListScope.topMenuSection() {
+    section(
+        listOf(
+            Pair(R.string.sectionedlist_downloads_button, Icons.Default.DownloadDone),
+            Pair(R.string.sectionedlist_your_library_button, Icons.Default.LibraryMusic)
+        )
+    ) {
+        loaded { item ->
+            SingleLineChip(text = stringResource(item.first), imageVector = item.second)
+        }
+    }
+}
+
+private fun SectionedListScope.recommendationsSection(
+    state: SectionedListStatefulScreenViewModel.UiState,
+    viewModel: SectionedListStatefulScreenViewModel
+) {
+    val recommendationsState: Section.State<Recommendation> =
+        when (val recommendationSectionState = state.recommendationSectionState) {
+            RecommendationSectionState.Loading -> Section.State.Loading()
+            is RecommendationSectionState.Loaded -> Section.State.Loaded(
+                recommendationSectionState.list
+            )
+
+            RecommendationSectionState.Failed -> Section.State.Failed()
+        }
+
+    section(recommendationsState) {
+        header {
+            Title(stringResource(id = R.string.sectionedlist_recommendations_title))
+        }
+
+        loaded { recommendation: Recommendation ->
+            SingleLineChip(
+                text = recommendation.playlistName,
+                imageVector = recommendation.icon
+            )
+        }
+
+        loading {
+            Column {
+                PlaceholderChip(colors = ChipDefaults.secondaryChipColors())
+                PlaceholderChip(
+                    modifier = Modifier.padding(top = 4.dp),
+                    colors = ChipDefaults.secondaryChipColors()
+                )
+            }
+        }
+
+        failed {
+            FailedView(onClick = { viewModel.loadRecommendations() })
+        }
+
+        footer {
+            SingleLineNoIconChip(stringResource(id = R.string.sectionedlist_see_more_button))
+        }
+    }
+}
+
+private fun SectionedListScope.trendingSection(
+    state: SectionedListStatefulScreenViewModel.UiState,
+    viewModel: SectionedListStatefulScreenViewModel
+) {
+    val trendingState: Section.State<Trending> =
+        when (val recommendationSectionState = state.trendingSectionState) {
+            TrendingSectionState.Loading -> Section.State.Loading()
+            is TrendingSectionState.Loaded -> Section.State.Loaded(
+                recommendationSectionState.list
+            )
+
+            TrendingSectionState.Failed -> Section.State.Failed()
+        }
+
+    section(trendingState) {
+        header {
+            Title(stringResource(id = R.string.sectionedlist_trending_title))
+        }
+
+        loaded { trending: Trending ->
+            TwoLinesChip(
+                primaryLabel = trending.name,
+                secondaryLabel = trending.artist,
+                imageVector = Icons.Default.MusicNote
+            )
+        }
+
+        loading {
+            Column {
+                PlaceholderChip(colors = ChipDefaults.secondaryChipColors())
+                PlaceholderChip(
+                    modifier = Modifier.padding(top = 4.dp),
+                    colors = ChipDefaults.secondaryChipColors()
+                )
+            }
+        }
+
+        failed {
+            FailedView(onClick = { viewModel.loadTrending() })
+        }
+
+        footer {
+            SingleLineNoIconChip(stringResource(id = R.string.sectionedlist_see_more_button))
+        }
+    }
+}
+
+private fun SectionedListScope.bottomMenuSection() {
+    section {
+        loaded {
+            SingleLineChip(
+                text = stringResource(R.string.sectionedlist_settings_button),
+                imageVector = Icons.Default.Settings
+            )
+        }
     }
 }
 

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/stateless/SectionedListStatelessScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/stateless/SectionedListStatelessScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.wear.compose.material.ScalingLazyListState
 import androidx.wear.compose.material.rememberScalingLazyListState
 import com.google.android.horologist.composables.SectionedList
+import com.google.android.horologist.composables.SectionedListScope
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 import com.google.android.horologist.sample.R
 import com.google.android.horologist.sectionedlist.component.SingleLineChip
@@ -51,77 +52,93 @@ fun SectionedListStatelessScreen(
         scalingLazyListState = scalingLazyListState,
         modifier = modifier
     ) {
-        // Section without header and without footer
-        section(
-            listOf(
-                Pair(R.string.sectionedlist_downloads_button, Icons.Default.DownloadDone),
-                Pair(R.string.sectionedlist_your_library_button, Icons.Default.LibraryMusic)
-            )
-        ) {
-            loaded { item ->
-                SingleLineChip(text = stringResource(item.first), imageVector = item.second)
-            }
-        }
+        topMenuSection()
 
-        // Section with header and footer
-        section(
-            listOf(
-                Pair("Running playlist", Icons.Default.DirectionsRun),
-                Pair("Focus", Icons.Default.SelfImprovement),
-                Pair("Summer hits", Icons.Default.LightMode)
-            )
-        ) {
-            header {
-                Title(stringResource(id = R.string.sectionedlist_recommendations_title))
-            }
+        recommendationsSection()
 
-            loaded { item ->
-                SingleLineChip(item.first, item.second)
-            }
+        trendingSection()
 
-            footer {
-                SingleLineNoIconChip(stringResource(id = R.string.sectionedlist_see_more_button))
-            }
-        }
-
-        // Section with header and footer
-        section(
-            listOf(
-                Pair("Bad Habits", "Ed Sheeran"),
-                Pair("There'd Better Be A Mirrorball", "Arctic Monkeys"),
-                Pair("180 Hours", "Dudu Kanegae")
-            )
-        ) {
-            header {
-                Title(stringResource(id = R.string.sectionedlist_trending_title))
-            }
-
-            loaded { item ->
-                TwoLinesChip(
-                    primaryLabel = item.first,
-                    secondaryLabel = item.second,
-                    imageVector = Icons.Default.MusicNote
-                )
-            }
-
-            footer {
-                SingleLineNoIconChip(stringResource(id = R.string.sectionedlist_see_more_button))
-            }
-        }
-
-        // Section with single item
-        section {
-            loaded {
-                SingleLineChip(
-                    text = stringResource(R.string.sectionedlist_settings_button),
-                    imageVector = Icons.Default.Settings
-                )
-            }
-        }
+        bottomMenuSection()
     }
 
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
+    }
+}
+
+private fun SectionedListScope.topMenuSection() {
+    // Section without header and without footer
+    section(
+        listOf(
+            Pair(R.string.sectionedlist_downloads_button, Icons.Default.DownloadDone),
+            Pair(R.string.sectionedlist_your_library_button, Icons.Default.LibraryMusic)
+        )
+    ) {
+        loaded { item ->
+            SingleLineChip(text = stringResource(item.first), imageVector = item.second)
+        }
+    }
+}
+
+private fun SectionedListScope.recommendationsSection() {
+    // Section with header and footer
+    section(
+        listOf(
+            Pair("Running playlist", Icons.Default.DirectionsRun),
+            Pair("Focus", Icons.Default.SelfImprovement),
+            Pair("Summer hits", Icons.Default.LightMode)
+        )
+    ) {
+        header {
+            Title(stringResource(id = R.string.sectionedlist_recommendations_title))
+        }
+
+        loaded { item ->
+            SingleLineChip(item.first, item.second)
+        }
+
+        footer {
+            SingleLineNoIconChip(stringResource(id = R.string.sectionedlist_see_more_button))
+        }
+    }
+}
+
+private fun SectionedListScope.trendingSection() {
+    // Section with header and footer
+    section(
+        listOf(
+            Pair("Bad Habits", "Ed Sheeran"),
+            Pair("There'd Better Be A Mirrorball", "Arctic Monkeys"),
+            Pair("180 Hours", "Dudu Kanegae")
+        )
+    ) {
+        header {
+            Title(stringResource(id = R.string.sectionedlist_trending_title))
+        }
+
+        loaded { item ->
+            TwoLinesChip(
+                primaryLabel = item.first,
+                secondaryLabel = item.second,
+                imageVector = Icons.Default.MusicNote
+            )
+        }
+
+        footer {
+            SingleLineNoIconChip(stringResource(id = R.string.sectionedlist_see_more_button))
+        }
+    }
+}
+
+private fun SectionedListScope.bottomMenuSection() {
+    // Section with single item
+    section {
+        loaded {
+            SingleLineChip(
+                text = stringResource(R.string.sectionedlist_settings_button),
+                imageVector = Icons.Default.Settings
+            )
+        }
     }
 }
 


### PR DESCRIPTION
#### WHAT

Improve usage of `SectionedList` in our previews and samples to split out section definitions in separate functions.

#### WHY

Address https://github.com/google/horologist/pull/635#discussion_r981428617

#### HOW

Add section functions as extension functions of `SectionedListScope`.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
