### PR TITLE
Improve loading API of SectionedList

### DIFF
--- a/composables/api/current.api
+++ b/composables/api/current.api
@@ -34,16 +34,17 @@ package com.google.android.horologist.composables {
   }
 
   @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public final class Section<T> {
-    ctor public Section(com.google.android.horologist.composables.Section.State<T> state, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? headerContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? loadingContent, kotlin.jvm.functions.Function2<? super com.google.android.horologist.composables.SectionContentScope,? super T,kotlin.Unit> loadedContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? failedContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? emptyContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? footerContent, optional boolean displayFooterOnlyOnLoadedState);
+    ctor public Section(com.google.android.horologist.composables.Section.State<T> state, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? headerContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? loadingContent, optional int loadingContentCount, kotlin.jvm.functions.Function2<? super com.google.android.horologist.composables.SectionContentScope,? super T,kotlin.Unit> loadedContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? failedContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? emptyContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? footerContent, optional boolean displayFooterOnlyOnLoadedState);
     method public com.google.android.horologist.composables.Section.State<T> component1();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? component2();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? component3();
-    method public kotlin.jvm.functions.Function2<com.google.android.horologist.composables.SectionContentScope,T,kotlin.Unit> component4();
-    method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? component5();
+    method public int component4();
+    method public kotlin.jvm.functions.Function2<com.google.android.horologist.composables.SectionContentScope,T,kotlin.Unit> component5();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? component6();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? component7();
-    method public boolean component8();
-    method public com.google.android.horologist.composables.Section<T> copy(com.google.android.horologist.composables.Section.State<T> state, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? headerContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? loadingContent, kotlin.jvm.functions.Function2<? super com.google.android.horologist.composables.SectionContentScope,? super T,kotlin.Unit> loadedContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? failedContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? emptyContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? footerContent, boolean displayFooterOnlyOnLoadedState);
+    method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? component8();
+    method public boolean component9();
+    method public com.google.android.horologist.composables.Section<T> copy(com.google.android.horologist.composables.Section.State<T> state, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? headerContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? loadingContent, int loadingContentCount, kotlin.jvm.functions.Function2<? super com.google.android.horologist.composables.SectionContentScope,? super T,kotlin.Unit> loadedContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? failedContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? emptyContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? footerContent, boolean displayFooterOnlyOnLoadedState);
     method public boolean getDisplayFooterOnlyOnLoadedState();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? getEmptyContent();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? getFailedContent();
@@ -51,6 +52,7 @@ package com.google.android.horologist.composables {
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? getHeaderContent();
     method public kotlin.jvm.functions.Function2<com.google.android.horologist.composables.SectionContentScope,T,kotlin.Unit> getLoadedContent();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? getLoadingContent();
+    method public int getLoadingContentCount();
     method public com.google.android.horologist.composables.Section.State<T> getState();
     property public final boolean displayFooterOnlyOnLoadedState;
     property public final kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? emptyContent;
@@ -59,7 +61,9 @@ package com.google.android.horologist.composables {
     property public final kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? headerContent;
     property public final kotlin.jvm.functions.Function2<com.google.android.horologist.composables.SectionContentScope,T,kotlin.Unit> loadedContent;
     property public final kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? loadingContent;
+    property public final int loadingContentCount;
     property public final com.google.android.horologist.composables.Section.State<T> state;
+    field public static final int DEFAULT_LOADING_CONTENT_COUNT = 1; // 0x1
   }
 
   public abstract static sealed class Section.State<T> {
@@ -96,7 +100,7 @@ package com.google.android.horologist.composables {
     method public void footer(kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit> content);
     method public void header(kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit> content);
     method public void loaded(kotlin.jvm.functions.Function2<? super com.google.android.horologist.composables.SectionContentScope,? super T,kotlin.Unit> content);
-    method public void loading(kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit> content);
+    method public void loading(optional int count, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit> content);
   }
 
   public final class SectionedListKt {

--- a/composables/src/main/java/com/google/android/horologist/composables/SectionedList.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/SectionedList.kt
@@ -28,6 +28,7 @@ import androidx.wear.compose.material.ScalingLazyColumnDefaults
 import androidx.wear.compose.material.ScalingLazyListScope
 import androidx.wear.compose.material.ScalingLazyListState
 import androidx.wear.compose.material.ScalingParams
+import com.google.android.horologist.composables.Section.Companion.DEFAULT_LOADING_CONTENT_COUNT
 import com.google.android.horologist.compose.navscaffold.scrollableColumn
 
 /**
@@ -91,7 +92,7 @@ internal fun <T> Section<T>.display(scope: ScalingLazyListScope) {
     when (section.state) {
         is Section.State.Loading -> {
             section.loadingContent?.let { content ->
-                scope.item { SectionContentScope.content() }
+                scope.items(section.loadingContentCount) { SectionContentScope.content() }
             }
         }
 
@@ -130,6 +131,7 @@ public data class Section<T> constructor(
     val state: State<T>,
     val headerContent: (@Composable SectionContentScope.() -> Unit)? = null,
     val loadingContent: (@Composable SectionContentScope.() -> Unit)? = null,
+    val loadingContentCount: Int = DEFAULT_LOADING_CONTENT_COUNT,
     val loadedContent: @Composable SectionContentScope.(T) -> Unit,
     val failedContent: (@Composable SectionContentScope.() -> Unit)? = null,
     val emptyContent: (@Composable SectionContentScope.() -> Unit)? = null,
@@ -149,6 +151,10 @@ public data class Section<T> constructor(
         public class Failed<T> : State<T>()
 
         public class Empty<T> : State<T>()
+    }
+
+    internal companion object {
+        const val DEFAULT_LOADING_CONTENT_COUNT = 1
     }
 }
 
@@ -179,6 +185,7 @@ public class SectionedListScope {
                     state = state,
                     headerContent = scope.headerContent,
                     loadingContent = scope.loadingContent,
+                    loadingContentCount = scope.loadingContentCount,
                     loadedContent = scope.loadedContent,
                     failedContent = scope.failedContent,
                     emptyContent = scope.emptyContent,
@@ -228,6 +235,9 @@ public class SectionScope<T> {
     internal var loadingContent: @Composable SectionContentScope.() -> Unit = { }
         private set
 
+    internal var loadingContentCount: Int = DEFAULT_LOADING_CONTENT_COUNT
+        private set
+
     internal var loadedContent: @Composable SectionContentScope.(T) -> Unit = { }
         private set
 
@@ -246,7 +256,12 @@ public class SectionScope<T> {
     }
 
     @SectionScopeMarker
-    public fun loading(content: @Composable SectionContentScope.() -> Unit) {
+    public fun loading(
+        count: Int = DEFAULT_LOADING_CONTENT_COUNT,
+        content: @Composable SectionContentScope.() -> Unit
+    ) {
+        check(count > 0) { "count has to be greater than zero." }
+        loadingContentCount = count
         loadingContent = content
     }
 

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/SectionedListTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/SectionedListTest.kt
@@ -78,9 +78,9 @@ class SectionedListTest {
                     focusRequester = FocusRequester(),
                     scalingLazyListState = scrollState
                 ) {
-                    downloadsSection(scope = this, state = Section.State.Loading())
+                    downloadsSection(state = Section.State.Loading())
 
-                    favouritesSection(scope = this, state = Section.State.Empty())
+                    favouritesSection(state = Section.State.Empty())
                 }
             }
         }
@@ -97,9 +97,9 @@ class SectionedListTest {
                     focusRequester = FocusRequester(),
                     scalingLazyListState = scrollState
                 ) {
-                    downloadsSection(scope = this, state = Section.State.Loaded(downloads))
+                    downloadsSection(state = Section.State.Loaded(downloads))
 
-                    favouritesSection(scope = this, state = Section.State.Failed())
+                    favouritesSection(state = Section.State.Failed())
                 }
             }
         }
@@ -116,9 +116,9 @@ class SectionedListTest {
                     focusRequester = FocusRequester(),
                     scalingLazyListState = scrollState
                 ) {
-                    downloadsSection(scope = this, state = Section.State.Loaded(downloads))
+                    downloadsSection(state = Section.State.Loaded(downloads))
 
-                    favouritesSection(scope = this, state = Section.State.Failed())
+                    favouritesSection(state = Section.State.Failed())
                 }
             }
         }
@@ -135,9 +135,9 @@ class SectionedListTest {
                     focusRequester = FocusRequester(),
                     scalingLazyListState = scrollState
                 ) {
-                    downloadsSection(scope = this, state = Section.State.Failed())
+                    downloadsSection(state = Section.State.Failed())
 
-                    favouritesSection(scope = this, state = Section.State.Loaded(favourites))
+                    favouritesSection(state = Section.State.Loaded(favourites))
                 }
             }
         }
@@ -154,9 +154,9 @@ class SectionedListTest {
                     focusRequester = FocusRequester(),
                     scalingLazyListState = scrollState
                 ) {
-                    downloadsSection(scope = this, state = Section.State.Failed())
+                    downloadsSection(state = Section.State.Failed())
 
-                    favouritesSection(scope = this, state = Section.State.Loaded(favourites))
+                    favouritesSection(state = Section.State.Loaded(favourites))
                 }
             }
         }
@@ -173,9 +173,9 @@ class SectionedListTest {
                     focusRequester = FocusRequester(),
                     scalingLazyListState = scrollState
                 ) {
-                    downloadsSection(scope = this, state = Section.State.Empty())
+                    downloadsSection(state = Section.State.Empty())
 
-                    favouritesSection(scope = this, state = Section.State.Loading())
+                    favouritesSection(state = Section.State.Loading())
                 }
             }
         }
@@ -202,8 +202,8 @@ class SectionedListTest {
 
     private val downloads = listOf("Nu Metal Essentials", "00s Rock")
 
-    private fun downloadsSection(scope: SectionedListScope, state: Section.State<String>) {
-        scope.section(state = state) {
+    private fun SectionedListScope.downloadsSection(state: Section.State<String>) {
+        section(state = state) {
             header { DownloadsHeader() }
 
             loading { DownloadsLoading() }
@@ -302,8 +302,8 @@ class SectionedListTest {
 
     private val favourites = listOf("Dance Anthems", "Indie Jukebox")
 
-    private fun favouritesSection(scope: SectionedListScope, state: Section.State<String>) {
-        scope.section(state = state) {
+    private fun SectionedListScope.favouritesSection(state: Section.State<String>) {
+        section(state = state) {
             header { FavouritesHeader() }
 
             loading { FavouritesLoading() }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreen.kt
@@ -77,6 +77,7 @@ public fun <T> PlaylistsScreen(
             is PlaylistsScreenState.Loaded<T> -> {
                 Section.State.Loaded(playlistsScreenState.playlistList)
             }
+
             is PlaylistsScreenState.Failed -> Section.State.Failed()
             is PlaylistsScreenState.Loading -> Section.State.Loading()
         }
@@ -91,21 +92,9 @@ public fun <T> PlaylistsScreen(
 
             loaded { playlistContent(it) }
 
-            loading {
+            loading(count = 4) {
                 Column {
                     PlaceholderChip(colors = ChipDefaults.secondaryChipColors())
-                    PlaceholderChip(
-                        modifier = Modifier.padding(top = 4.dp),
-                        colors = ChipDefaults.secondaryChipColors()
-                    )
-                    PlaceholderChip(
-                        modifier = Modifier.padding(top = 4.dp),
-                        colors = ChipDefaults.secondaryChipColors()
-                    )
-                    PlaceholderChip(
-                        modifier = Modifier.padding(top = 4.dp),
-                        colors = ChipDefaults.secondaryChipColors()
-                    )
                 }
             }
         }

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/stateful/SectionedListStatefulScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/stateful/SectionedListStatefulScreen.kt
@@ -131,13 +131,9 @@ private fun SectionedListScope.recommendationsSection(
             )
         }
 
-        loading {
+        loading(count = 2) {
             Column {
                 PlaceholderChip(colors = ChipDefaults.secondaryChipColors())
-                PlaceholderChip(
-                    modifier = Modifier.padding(top = 4.dp),
-                    colors = ChipDefaults.secondaryChipColors()
-                )
             }
         }
 
@@ -178,13 +174,9 @@ private fun SectionedListScope.trendingSection(
             )
         }
 
-        loading {
+        loading(count = 2) {
             Column {
                 PlaceholderChip(colors = ChipDefaults.secondaryChipColors())
-                PlaceholderChip(
-                    modifier = Modifier.padding(top = 4.dp),
-                    colors = ChipDefaults.secondaryChipColors()
-                )
             }
         }
 


### PR DESCRIPTION
#### WHAT

Improve "loading" API of `SectionedList`.

#### WHY

In order to allow multiple items to be displayed for loading state.

#### HOW

Add optional parameter `count` to `loading` function.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
