### PR TITLE
Use rememberSaveable

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -61,8 +61,8 @@ fun UampEntityScreen(
 ) {
     val uiState by StateUtils.rememberStateWithLifecycle(flow = uampEntityScreenViewModel.uiState)
 
-    var showCancelDownloadsDialog by remember { mutableStateOf(false) }
-    var showRemoveDownloadsDialog by remember { mutableStateOf(false) }
+    var showCancelDownloadsDialog by rememberSaveable { mutableStateOf(false) }
+    var showRemoveDownloadsDialog by rememberSaveable { mutableStateOf(false) }
 
     PlaylistDownloadScreen(
         playlistName = playlistName,

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/expandable/SectionedListExpandableScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/expandable/SectionedListExpandableScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -74,9 +75,9 @@ fun SectionedListExpandableScreen(
     scalingLazyListState: ScalingLazyListState = rememberScalingLazyListState(),
     focusRequester: FocusRequester = remember { FocusRequester() }
 ) {
-    var todaySectionExpanded by remember { mutableStateOf(true) }
-    var tomorrowSectionExpanded by remember { mutableStateOf(true) }
-    var laterSectionExpanded by remember { mutableStateOf(false) }
+    var todaySectionExpanded by rememberSaveable { mutableStateOf(true) }
+    var tomorrowSectionExpanded by rememberSaveable { mutableStateOf(true) }
+    var laterSectionExpanded by rememberSaveable { mutableStateOf(false) }
 
     val todaySectionState = getState(todaySectionExpanded, todayTasks)
     val tomorrowSectionState = getState(tomorrowSectionExpanded, tomorrowTasks)


### PR DESCRIPTION
#### WHAT

Use rememberSaveable in `UampEntityScreen` and `SectionedListExpandableScreen`.

#### WHY

In order to values to survive configuration changes.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
