### PR TITLE
Improve naming and docs of content description for decorative elements

### DIFF
--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -892,10 +892,10 @@ package com.google.android.horologist.media.ui.tiles {
 
 package com.google.android.horologist.media.ui.util {
 
-  public final class IfNanKt {
+  public final class A11yKt {
   }
 
-  public final class TalkbackKt {
+  public final class IfNanKt {
   }
 
 }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/base/StandardChip.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/base/StandardChip.kt
@@ -41,7 +41,7 @@ import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.LocalContentAlpha
 import androidx.wear.compose.material.Text
 import coil.compose.rememberAsyncImagePainter
-import com.google.android.horologist.media.ui.util.CONTENT_DESCRIPTION_HIDDEN_FROM_TALKBACK
+import com.google.android.horologist.media.ui.util.DECORATIVE_ELEMENT_CONTENT_DESCRIPTION
 
 /**
  * This composable fulfils the redlines of the following components:
@@ -74,7 +74,7 @@ internal fun StandardChip(
                     if (icon is ImageVector) {
                         Icon(
                             imageVector = icon,
-                            contentDescription = CONTENT_DESCRIPTION_HIDDEN_FROM_TALKBACK,
+                            contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
                             modifier = Modifier
                                 .size(iconSize)
                                 .clip(CircleShape)
@@ -85,7 +85,7 @@ internal fun StandardChip(
                                 model = icon,
                                 placeholder = placeholder
                             ),
-                            contentDescription = CONTENT_DESCRIPTION_HIDDEN_FROM_TALKBACK,
+                            contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
                             modifier = Modifier
                                 .size(iconSize)
                                 .clip(CircleShape),

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/base/StandardChipIconWithProgress.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/base/StandardChipIconWithProgress.kt
@@ -35,7 +35,7 @@ import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.LocalContentAlpha
 import androidx.wear.compose.material.MaterialTheme
 import coil.compose.rememberAsyncImagePainter
-import com.google.android.horologist.media.ui.util.CONTENT_DESCRIPTION_HIDDEN_FROM_TALKBACK
+import com.google.android.horologist.media.ui.util.DECORATIVE_ELEMENT_CONTENT_DESCRIPTION
 
 private val indicatorPadding = 8.dp
 private val progressBarStrokeWidth = 2.dp
@@ -151,7 +151,7 @@ private fun StandardChipIconWithProgressInternal(
             is ImageVector -> {
                 Icon(
                     imageVector = icon,
-                    contentDescription = CONTENT_DESCRIPTION_HIDDEN_FROM_TALKBACK,
+                    contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
                     modifier = Modifier
                         .align(Alignment.Center)
                         .size(iconSize - indicatorPadding)
@@ -164,7 +164,7 @@ private fun StandardChipIconWithProgressInternal(
                         model = icon,
                         placeholder = placeholder
                     ),
-                    contentDescription = CONTENT_DESCRIPTION_HIDDEN_FROM_TALKBACK,
+                    contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
                     modifier = Modifier
                         .align(Alignment.Center)
                         .size(iconSize - indicatorPadding)

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/util/A11y.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/util/A11y.kt
@@ -17,6 +17,9 @@
 package com.google.android.horologist.media.ui.util
 
 /**
- * Make explicit that a conscious decision was made to hide the content description from talkback.
+ * Make explicit that a conscious decision was made to mark an element as decorative, so it does not
+ * have associated actions or state.
+ *
+ * https://developer.android.com/jetpack/compose/accessibility#describe-visual
  */
-internal val CONTENT_DESCRIPTION_HIDDEN_FROM_TALKBACK: String? = null
+internal val DECORATIVE_ELEMENT_CONTENT_DESCRIPTION: String? = null

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/component/SingleLineChip.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/component/SingleLineChip.kt
@@ -52,7 +52,7 @@ fun SingleLineChip(
         icon = {
             Icon(
                 imageVector = imageVector,
-                contentDescription = null, // hidden from talkback
+                contentDescription = null, // decorative element
                 modifier = Modifier
                     .size(ChipDefaults.LargeIconSize)
                     .clip(CircleShape),

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/component/TwoLinesChip.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/component/TwoLinesChip.kt
@@ -59,7 +59,7 @@ fun TwoLinesChip(
         icon = {
             Icon(
                 imageVector = imageVector,
-                contentDescription = null, // hidden from talkback
+                contentDescription = null, // decorative element
                 modifier = Modifier
                     .size(ChipDefaults.LargeIconSize)
                     .clip(CircleShape),

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/stateful/SectionedListStatefulScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/stateful/SectionedListStatefulScreen.kt
@@ -212,7 +212,7 @@ private fun FailedView(onClick: () -> Unit) {
     ) {
         Icon(
             imageVector = Icons.Default.CloudOff,
-            contentDescription = null, // hidden from talkback
+            contentDescription = null, // decorative element
             modifier = Modifier
                 .size(ChipDefaults.LargeIconSize)
                 .clip(CircleShape),


### PR DESCRIPTION
#### WHAT

Improve naming and docs of content description for decorative elements.

#### WHY

In order to avoid giving the impression that accessibility is limited to talkback.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
