### PR TITLE
Change default to show browse screen

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/settings/SettingsSerializer.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/settings/SettingsSerializer.kt
@@ -32,7 +32,7 @@ object SettingsSerializer : Serializer<Settings> {
     override val defaultValue: Settings = settings {
         this.animated = true
         this.debugOffload = false
-        this.loadItemsAtStartup = true
+        this.loadItemsAtStartup = false
         this.offloadMode = SettingsProto.OffloadMode.BACKGROUND
         this.podcastControls = false
         this.showTimeTextInfo = false

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/settings/DeveloperOptionsScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/settings/DeveloperOptionsScreenViewModel.kt
@@ -68,7 +68,7 @@ class DeveloperOptionsScreenViewModel @Inject constructor(
     data class UiState(
         val showTimeTextInfo: Boolean = false,
         val podcastControls: Boolean = false,
-        val loadItemsAtStartup: Boolean = true,
+        val loadItemsAtStartup: Boolean = false,
         val animated: Boolean = true,
         val debugOffload: Boolean = false,
         val offloadMode: OffloadMode = OffloadMode.BACKGROUND,


### PR DESCRIPTION
#### WHAT

Change default to show browse screen.

#### WHY

It wasn't clear if this was a conscious decision to load items, but that's not finding items anyway, so instead show a browse screen.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
