### PR TITLE
Add a11y tests

### DIFF
--- a/compose-tools/api/current.api
+++ b/compose-tools/api/current.api
@@ -114,6 +114,7 @@ package com.google.android.horologist.compose.tools.coil {
     property public coil.disk.DiskCache? diskCache;
     property public coil.memory.MemoryCache? memoryCache;
     field public static final com.google.android.horologist.compose.tools.coil.FakeImageLoader.Companion Companion;
+    field public static final String TestUriPrefix = "android.resource://com.google.android.horologist.compose.tools/";
   }
 
   public static final class FakeImageLoader.Companion {
@@ -124,7 +125,6 @@ package com.google.android.horologist.compose.tools.coil {
     method public com.google.android.horologist.compose.tools.coil.FakeImageLoader getResources();
     method public int getTestIconResource();
     method public String getTestIconResourceUri();
-    method public String getTestUriPrefix();
     method public coil.request.ImageResult loadErrorBitmap(coil.request.ImageRequest request);
     method public coil.request.ImageResult loadSuccessBitmap(android.content.Context context, coil.request.ImageRequest request, @DrawableRes int id);
     property public final com.google.android.horologist.compose.tools.coil.FakeImageLoader Never;
@@ -132,7 +132,6 @@ package com.google.android.horologist.compose.tools.coil {
     property public final com.google.android.horologist.compose.tools.coil.FakeImageLoader Resources;
     property public final int TestIconResource;
     property public final String TestIconResourceUri;
-    property public final String TestUriPrefix;
   }
 
 }

--- a/compose-tools/src/main/java/com/google/android/horologist/compose/tools/coil/FakeImageLoader.kt
+++ b/compose-tools/src/main/java/com/google/android/horologist/compose/tools/coil/FakeImageLoader.kt
@@ -124,7 +124,7 @@ public class FakeImageLoader(private val imageFn: suspend (ImageRequest) -> Imag
         }
 
         @DrawableRes public val TestIconResource: Int = R.drawable.ic_uamp
-        public val TestUriPrefix: String = "android.resource://com.google.android.horologist.compose.tools/"
+        public const val TestUriPrefix: String = "android.resource://com.google.android.horologist.compose.tools/"
         public val TestIconResourceUri: String = TestUriPrefix + TestIconResource
     }
 }

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/MediaArtworkA11yTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/MediaArtworkA11yTest.kt
@@ -36,6 +36,7 @@ import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.state.model.MediaUiModel
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
+import com.google.android.horologist.paparazzi.RoundNonFullScreenDevice
 import com.google.android.horologist.paparazzi.WearPaparazzi
 import com.google.android.horologist.paparazzi.a11y.A11ySnapshotHandler
 import com.google.android.horologist.paparazzi.determineHandler
@@ -49,6 +50,7 @@ class MediaArtworkA11yTest {
 
     @get:Rule
     val paparazzi = WearPaparazzi(
+        deviceConfig = RoundNonFullScreenDevice,
         maxPercentDifference = maxPercentDifference,
         renderExtensions = setOf(composeA11yExtension),
         snapshotHandler = A11ySnapshotHandler(

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/MediaArtworkA11yTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/MediaArtworkA11yTest.kt
@@ -24,30 +24,31 @@ package com.google.android.horologist.media.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Album
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.a11y.ComposeA11yExtension
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.state.model.MediaUiModel
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
-import com.google.android.horologist.paparazzi.RoundNonFullScreenDevice
 import com.google.android.horologist.paparazzi.WearPaparazzi
 import com.google.android.horologist.paparazzi.a11y.A11ySnapshotHandler
 import com.google.android.horologist.paparazzi.determineHandler
 import org.junit.Rule
 import org.junit.Test
 
-class MediaChipA11yTest {
+class MediaArtworkA11yTest {
     private val maxPercentDifference = 1.0
 
     private val composeA11yExtension = ComposeA11yExtension()
 
     @get:Rule
     val paparazzi = WearPaparazzi(
-        deviceConfig = RoundNonFullScreenDevice,
         maxPercentDifference = maxPercentDifference,
         renderExtensions = setOf(composeA11yExtension),
         snapshotHandler = A11ySnapshotHandler(
@@ -66,13 +67,13 @@ class MediaChipA11yTest {
                     modifier = Modifier.background(Color.Black),
                     contentAlignment = Alignment.Center
                 ) {
-                    MediaChip(
+                    MediaArtwork(
                         media = MediaUiModel(
                             id = "id",
-                            title = "Red Hot Chilli Peppers",
+                            title = "title",
                             artworkUri = FakeImageLoader.TestIconResourceUri
                         ),
-                        onClick = {}
+                        placeholder = rememberVectorPainter(image = Icons.Default.Album)
                     )
                 }
             }

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChipA11yTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChipA11yTest.kt
@@ -20,7 +20,7 @@
     ExperimentalHorologistMediaUiApi::class
 )
 
-package com.google.android.horologist.media.ui.components
+package com.google.android.horologist.media.ui.components.actions
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -31,23 +31,21 @@ import com.google.android.horologist.compose.tools.ExperimentalHorologistCompose
 import com.google.android.horologist.compose.tools.a11y.ComposeA11yExtension
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
-import com.google.android.horologist.media.ui.state.model.MediaUiModel
+import com.google.android.horologist.media.ui.R
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
-import com.google.android.horologist.paparazzi.RoundNonFullScreenDevice
 import com.google.android.horologist.paparazzi.WearPaparazzi
 import com.google.android.horologist.paparazzi.a11y.A11ySnapshotHandler
 import com.google.android.horologist.paparazzi.determineHandler
 import org.junit.Rule
 import org.junit.Test
 
-class MediaChipA11yTest {
+class ShowPlaylistChipA11yTest {
     private val maxPercentDifference = 1.0
 
     private val composeA11yExtension = ComposeA11yExtension()
 
     @get:Rule
     val paparazzi = WearPaparazzi(
-        deviceConfig = RoundNonFullScreenDevice,
         maxPercentDifference = maxPercentDifference,
         renderExtensions = setOf(composeA11yExtension),
         snapshotHandler = A11ySnapshotHandler(
@@ -66,12 +64,9 @@ class MediaChipA11yTest {
                     modifier = Modifier.background(Color.Black),
                     contentAlignment = Alignment.Center
                 ) {
-                    MediaChip(
-                        media = MediaUiModel(
-                            id = "id",
-                            title = "Red Hot Chilli Peppers",
-                            artworkUri = FakeImageLoader.TestIconResourceUri
-                        ),
+                    ShowPlaylistChip(
+                        artworkUri = R.drawable.ic_uamp,
+                        name = "Playlists",
                         onClick = {}
                     )
                 }

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChipA11yTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChipA11yTest.kt
@@ -33,6 +33,7 @@ import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.R
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
+import com.google.android.horologist.paparazzi.RoundNonFullScreenDevice
 import com.google.android.horologist.paparazzi.WearPaparazzi
 import com.google.android.horologist.paparazzi.a11y.A11ySnapshotHandler
 import com.google.android.horologist.paparazzi.determineHandler
@@ -46,6 +47,7 @@ class ShowPlaylistChipA11yTest {
 
     @get:Rule
     val paparazzi = WearPaparazzi(
+        deviceConfig = RoundNonFullScreenDevice,
         maxPercentDifference = maxPercentDifference,
         renderExtensions = setOf(composeA11yExtension),
         snapshotHandler = A11ySnapshotHandler(

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.actions_ShowPlaylistChipA11yTest_a11y.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.actions_ShowPlaylistChipA11yTest_a11y.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4944f202cbc267bc502f8076f0e4fc8f0ec2df60e380900b221e031073a3a71c
-size 51134
+oid sha256:bd4f6c184a3232cde025fe542eda58d4f53f1e33c3797a48ad2656fcc3af53d9
+size 47122

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.actions_ShowPlaylistChipA11yTest_a11y.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components.actions_ShowPlaylistChipA11yTest_a11y.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4944f202cbc267bc502f8076f0e4fc8f0ec2df60e380900b221e031073a3a71c
+size 51134

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components_MediaArtworkA11yTest_a11y.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components_MediaArtworkA11yTest_a11y.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6ac13a1b30755c714055442e022b96b2730aa846c258253a241296f1b6bacae9
-size 37119
+oid sha256:de13b0993d7b8e4ddbc2ee9b716f8a324eb73be6d3fa4aa7466d6f586df83c87
+size 33918

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components_MediaArtworkA11yTest_a11y.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components_MediaArtworkA11yTest_a11y.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ac13a1b30755c714055442e022b96b2730aa846c258253a241296f1b6bacae9
+size 37119

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components_MediaChipA11yTest_a11y.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.components_MediaChipA11yTest_a11y.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:99c5411ff1535dbeb12167525866ffcd941e5a78e7d9215bc18e0e353e9362d1
-size 48536
+oid sha256:ab3ce3c64b6a36eeb5f905079b2b0372344a2a7a03c193b658db8f412c8805d8
+size 59971


### PR DESCRIPTION
#### WHAT

Add a11y snapshot tests for `MediaArtwork` and `ShowPlaylistChip`. 
Also changed test for `MediaChip` to display image. 

#### WHY

Apart from the benefit of having the tests, I wanted to check if this [line](https://github.com/google/horologist/blob/e51902e114b14a2466a53c3aaf96af2f58e45945/media-ui/src/main/java/com/google/android/horologist/media/ui/components/MediaArtwork.kt#L37) was not causing duplicated feedback on talkback (manual tests did not indicate it).

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
