### PR TITLE
Use Service's lifecycleScope

### DIFF
--- a/media-data/api/current.api
+++ b/media-data/api/current.api
@@ -374,12 +374,13 @@ package com.google.android.horologist.media.data.service.download {
     field public static final long UPDATE_INTERVAL_MILLIS = 1000L; // 0x3e8L
   }
 
-  @com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi public abstract class MediaDownloadService extends androidx.media3.exoplayer.offline.DownloadService {
+  @com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi public abstract class MediaDownloadService extends androidx.media3.exoplayer.offline.DownloadService implements androidx.lifecycle.LifecycleOwner {
     ctor public MediaDownloadService(int foregroundNotificationId, long foregroundNotificationUpdateInterval, String? channelId, @StringRes int channelNameResourceId, @StringRes int channelDescriptionResourceId, @DrawableRes int notificationIcon);
     method protected abstract android.app.PendingIntent getDownloadIntent();
     method protected abstract com.google.android.horologist.media.data.service.download.DownloadManagerListener getDownloadManagerListener();
     method protected abstract androidx.media3.exoplayer.offline.DownloadNotificationHelper getDownloadNotificationHelper();
     method protected android.app.Notification getForegroundNotification(java.util.List<androidx.media3.exoplayer.offline.Download> downloads, int notMetRequirements);
+    method public androidx.lifecycle.Lifecycle getLifecycle();
     method protected androidx.media3.exoplayer.scheduler.Scheduler getScheduler();
     method protected abstract androidx.media3.exoplayer.workmanager.WorkManagerScheduler getWorkManagerScheduler();
     property protected abstract android.app.PendingIntent downloadIntent;

--- a/media-data/build.gradle
+++ b/media-data/build.gradle
@@ -92,6 +92,7 @@ dependencies {
     implementation libs.room.common
     implementation libs.room.ktx
     ksp libs.room.compiler
+    implementation libs.androidx.lifecycle.service
 
     testImplementation libs.junit
     testImplementation libs.truth

--- a/media-data/src/main/java/com/google/android/horologist/media/data/service/download/MediaDownloadService.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/service/download/MediaDownloadService.kt
@@ -19,8 +19,12 @@ package com.google.android.horologist.media.data.service.download
 import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.PendingIntent
+import android.content.Intent
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ServiceLifecycleDispatcher
 import androidx.media3.exoplayer.offline.Download
 import androidx.media3.exoplayer.offline.DownloadNotificationHelper
 import androidx.media3.exoplayer.offline.DownloadService
@@ -56,16 +60,30 @@ public abstract class MediaDownloadService(
     channelId,
     channelNameResourceId,
     channelDescriptionResourceId
-) {
+), LifecycleOwner {
+    private val dispatcher = ServiceLifecycleDispatcher(this)
 
     override fun onCreate() {
+        dispatcher.onServicePreSuperOnCreate()
+
         super.onCreate()
 
         downloadManagerListener.onDownloadServiceCreated(downloadManager)
     }
 
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        dispatcher.onServicePreSuperOnStart()
+        return super.onStartCommand(intent, flags, startId)
+    }
+
+    override fun getLifecycle(): Lifecycle {
+        return dispatcher.lifecycle
+    }
+
     override fun onDestroy() {
         downloadManagerListener.onDownloadServiceDestroyed()
+
+        dispatcher.onServicePreSuperOnDestroy()
 
         super.onDestroy()
     }

--- a/media-data/src/main/java/com/google/android/horologist/media/data/service/download/MediaDownloadService.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/service/download/MediaDownloadService.kt
@@ -60,7 +60,8 @@ public abstract class MediaDownloadService(
     channelId,
     channelNameResourceId,
     channelDescriptionResourceId
-), LifecycleOwner {
+),
+    LifecycleOwner {
     private val dispatcher = ServiceLifecycleDispatcher(this)
 
     override fun onCreate() {

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/PlaybackServiceModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/PlaybackServiceModule.kt
@@ -21,6 +21,7 @@ import android.app.Service
 import android.os.Build
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.Player
@@ -68,8 +69,6 @@ import dagger.hilt.android.components.ServiceComponent
 import dagger.hilt.android.scopes.ServiceScoped
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -205,13 +204,7 @@ object PlaybackServiceModule {
     fun serviceCoroutineScope(
         service: Service
     ): CoroutineScope {
-        return CoroutineScope(SupervisorJob() + Dispatchers.Default).also {
-            (service as LifecycleOwner).lifecycle.addObserver(object : DefaultLifecycleObserver {
-                override fun onStop(owner: LifecycleOwner) {
-                    it.cancel()
-                }
-            })
-        }
+        return (service as LifecycleOwner).lifecycleScope
     }
 
     @ServiceScoped


### PR DESCRIPTION
#### WHAT

Assume LifecycleService or LifecycleOwner for all services. Use lifecycleScope for the CoroutineScope.

#### WHY

No point creating an additional CoroutineScope and managing it's lifecycle.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
