### PR TITLE
[RFC] Streaming UI mode

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
@@ -53,8 +53,8 @@ fun UampEntityScreen(
     playlistName: String,
     uampEntityScreenViewModel: UampEntityScreenViewModel,
     onDownloadItemClick: (DownloadMediaUiModel) -> Unit,
-    onShuffleClick: (PlaylistUiModel) -> Unit,
-    onPlayClick: (PlaylistUiModel) -> Unit,
+    onShuffleClick: (PlaylistUiModel?) -> Unit,
+    onPlayClick: (PlaylistUiModel?) -> Unit,
     onErrorDialogCancelClick: () -> Unit,
     focusRequester: FocusRequester,
     scalingLazyListState: ScalingLazyListState

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
@@ -76,18 +76,19 @@ import com.google.android.horologist.media.ui.util.ifNan
 public fun PlaylistDownloadScreen(
     playlistName: String,
     playlistDownloadScreenState: PlaylistDownloadScreenState<PlaylistUiModel, DownloadMediaUiModel>,
-    onDownloadButtonClick: (PlaylistUiModel) -> Unit,
-    onCancelDownloadButtonClick: (PlaylistUiModel) -> Unit,
+    onDownloadButtonClick: (PlaylistUiModel?) -> Unit,
+    onCancelDownloadButtonClick: (PlaylistUiModel?) -> Unit,
     onDownloadItemClick: (DownloadMediaUiModel) -> Unit,
-    onShuffleButtonClick: (PlaylistUiModel) -> Unit,
-    onPlayButtonClick: (PlaylistUiModel) -> Unit,
+    onShuffleButtonClick: (PlaylistUiModel?) -> Unit,
+    onPlayButtonClick: (PlaylistUiModel?) -> Unit,
     focusRequester: FocusRequester,
     scalingLazyListState: ScalingLazyListState,
     modifier: Modifier = Modifier,
     autoCentering: AutoCenteringParams? = AutoCenteringParams(),
-    onDownloadCompletedButtonClick: ((PlaylistUiModel) -> Unit)? = null,
+    onDownloadCompletedButtonClick: ((PlaylistUiModel?) -> Unit)? = null,
     defaultMediaTitle: String = "",
-    downloadItemArtworkPlaceholder: Painter? = null
+    downloadItemArtworkPlaceholder: Painter? = null,
+    streamingOnly: Boolean = true
 ) {
     val entityScreenState: EntityScreenState<DownloadMediaUiModel> =
         when (playlistDownloadScreenState) {
@@ -115,15 +116,42 @@ public fun PlaylistDownloadScreen(
         modifier = modifier,
         autoCentering = autoCentering,
         buttonsContent = {
-            ButtonsContent(
-                state = playlistDownloadScreenState,
-                onDownloadButtonClick = onDownloadButtonClick,
-                onCancelDownloadButtonClick = onCancelDownloadButtonClick,
-                onDownloadCompletedButtonClick = onDownloadCompletedButtonClick
-                    ?: { /* do nothing */ },
-                onShuffleButtonClick = onShuffleButtonClick,
-                onPlayButtonClick = onPlayButtonClick
-            )
+            if (streamingOnly) {
+                Row(
+                    modifier = Modifier
+                        .padding(bottom = 16.dp)
+                        .height(52.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    StandardButton(
+                        imageVector = Icons.Default.Shuffle,
+                        contentDescription = stringResource(id = R.string.horologist_playlist_download_button_shuffle_content_description),
+                        onClick = { onShuffleButtonClick(null) },
+                        modifier = Modifier
+                            .padding(start = 6.dp)
+                            .weight(weight = 0.3F, fill = false)
+                    )
+
+                    StandardButton(
+                        imageVector = Icons.Filled.PlayArrow,
+                        contentDescription = stringResource(id = R.string.horologist_playlist_download_button_play_content_description),
+                        onClick = { onPlayButtonClick(null) },
+                        modifier = Modifier
+                            .padding(start = 6.dp)
+                            .weight(weight = 0.3F, fill = false)
+                    )
+                }
+            } else {
+                ButtonsContent(
+                    state = playlistDownloadScreenState,
+                    onDownloadButtonClick = onDownloadButtonClick,
+                    onCancelDownloadButtonClick = onCancelDownloadButtonClick,
+                    onDownloadCompletedButtonClick = onDownloadCompletedButtonClick
+                        ?: { /* do nothing */ },
+                    onShuffleButtonClick = onShuffleButtonClick,
+                    onPlayButtonClick = onPlayButtonClick
+                )
+            }
         }
     )
 }


### PR DESCRIPTION
#### WHAT

Streaming UI mode - consider what code paths would be needed for testing streaming instead of download only.

#### WHY

Things like prefetch only make sense with streaming, and so the reference app isn't useful for testing.

#### HOW

TODO add a settings for download/streaming and then make the UI reasonably usable in both modes.

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
