### PR TITLE
Add fixed version of rememberPickerState

### DIFF
--- a/composables/api/current.api
+++ b/composables/api/current.api
@@ -33,6 +33,9 @@ package com.google.android.horologist.composables {
     property public final float weight;
   }
 
+  public final class RememberPickerStateKt {
+  }
+
   @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public final class Section<T> {
     ctor public Section(com.google.android.horologist.composables.Section.State<T> state, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? headerContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? loadingContent, optional int loadingContentCount, kotlin.jvm.functions.Function2<? super com.google.android.horologist.composables.SectionContentScope,? super T,kotlin.Unit> loadedContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? failedContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? emptyContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? footerContent, optional boolean displayFooterOnlyOnLoadedState);
     method public com.google.android.horologist.composables.Section.State<T> component1();

--- a/composables/src/main/java/com/google/android/horologist/composables/DatePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/DatePicker.kt
@@ -49,7 +49,6 @@ import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.PickerState
 import androidx.wear.compose.material.Text
-import androidx.wear.compose.material.rememberPickerState
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.temporal.TemporalAdjusters

--- a/composables/src/main/java/com/google/android/horologist/composables/RememberPickerState.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/RememberPickerState.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.composables
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.wear.compose.material.PickerState
+
+/**
+ * A version of [androidx.wear.compose.material.rememberPickerState] with a fix for issue:
+ * https://issuetracker.google.com/issues/255323197
+ */
+@Composable
+internal fun rememberPickerState(
+    initialNumberOfOptions: Int,
+    initiallySelectedOption: Int = 0,
+    repeatItems: Boolean = true
+): PickerState = rememberSaveable(
+    initialNumberOfOptions,
+    initiallySelectedOption,
+    repeatItems,
+    saver = PickerState.Saver
+) {
+    PickerState(initialNumberOfOptions, initiallySelectedOption, repeatItems)
+}

--- a/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
@@ -63,7 +63,6 @@ import androidx.wear.compose.material.PickerDefaults
 import androidx.wear.compose.material.PickerScope
 import androidx.wear.compose.material.PickerState
 import androidx.wear.compose.material.Text
-import androidx.wear.compose.material.rememberPickerState
 import com.google.android.horologist.compose.rotaryinput.onRotaryInputAccumulated
 import kotlinx.coroutines.launch
 import java.time.LocalTime


### PR DESCRIPTION
#### WHAT

Add fixed version of `rememberPickerState` and change `DatePicker` and `TimePicker` to use it.

#### WHY

https://issuetracker.google.com/issues/255323197

#### HOW

Add a `rememberPickerState` function that calls `rememberSaveable` passing all its input parameters.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
