### PR TITLE
Add release-0.1.x to list of branches that will trigger build on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release-0.1.x
     paths-ignore:
       - '**.md'
   pull_request:


### PR DESCRIPTION
#### WHAT

Add `release-0.1.x` to list of branches that will trigger build on push

#### WHY

So it can be checked that `release-0.1.x` is green after merging a PR.

