### PR TITLE
Change PlaceholderChip to have shimmer effect

### DIFF
--- a/composables/src/main/java/com/google/android/horologist/composables/PlaceholderChip.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/PlaceholderChip.kt
@@ -16,7 +16,6 @@
 
 package com.google.android.horologist.composables
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -27,6 +26,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.paint
@@ -38,11 +38,17 @@ import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipColors
 import androidx.wear.compose.material.ChipDefaults
+import androidx.wear.compose.material.ExperimentalWearMaterialApi
 import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.PlaceholderDefaults
+import androidx.wear.compose.material.placeholder
+import androidx.wear.compose.material.placeholderShimmer
+import androidx.wear.compose.material.rememberPlaceholderState
 
 /**
  * A placeholder chip to be displayed while the contents of the [Chip] is being loaded.
  */
+@OptIn(ExperimentalWearMaterialApi::class)
 @ExperimentalHorologistComposablesApi
 @Composable
 public fun PlaceholderChip(
@@ -52,7 +58,7 @@ public fun PlaceholderChip(
     enabled: Boolean = false,
     contentDescription: String = stringResource(id = R.string.horologist_placeholderchip_content_description)
 ) {
-    val backgroundColor = MaterialTheme.colors.onSurfaceVariant.copy(alpha = 0.38f)
+    val chipPlaceholderState = rememberPlaceholderState { false }
 
     Chip(
         modifier = modifier
@@ -60,10 +66,10 @@ public fun PlaceholderChip(
             .fillMaxWidth()
             .clip(shape = MaterialTheme.shapes.small)
             .paint(
-                painter = colors
-                    .background(enabled = enabled).value,
+                painter = colors.background(enabled = enabled).value,
                 contentScale = ContentScale.Crop
             )
+            .placeholderShimmer(chipPlaceholderState)
             .semantics {
                 this.contentDescription = contentDescription
             },
@@ -75,9 +81,9 @@ public fun PlaceholderChip(
                     modifier = Modifier
                         .padding(end = 10.dp)
                         .clip(RoundedCornerShape(12.dp))
-                        .background(backgroundColor)
                         .fillMaxWidth()
                         .height(12.dp)
+                        .placeholder(chipPlaceholderState)
                 )
                 Spacer(Modifier.size(8.dp))
             }
@@ -88,18 +94,27 @@ public fun PlaceholderChip(
                     .fillMaxWidth()
                     .padding(end = 30.dp)
                     .clip(RoundedCornerShape(12.dp))
-                    .background(backgroundColor)
                     .height(12.dp)
+                    .placeholder(chipPlaceholderState)
             )
         },
         icon = {
             Box(
                 modifier = Modifier
                     .clip(CircleShape)
-                    .background(backgroundColor)
                     .size(ChipDefaults.LargeIconSize)
+                    .placeholder(chipPlaceholderState)
             )
         },
-        colors = colors
+        colors = PlaceholderDefaults.placeholderChipColors(
+            originalChipColors = colors,
+            placeholderState = chipPlaceholderState
+        )
     )
+
+    if (!chipPlaceholderState.isShowContent) {
+        LaunchedEffect(chipPlaceholderState) {
+            chipPlaceholderState.startPlaceholderAnimation()
+        }
+    }
 }

--- a/composables/src/test/snapshots/images/com.google.android.horologist.composables_PlaceholderChipTest_default.png
+++ b/composables/src/test/snapshots/images/com.google.android.horologist.composables_PlaceholderChipTest_default.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fe5e866660821960a3e37dda979dd544202eebaebe7b7ec113f2715e22a2df05
-size 43206
+oid sha256:799a3026484255fa99abda6a3e0910e2df8bf9d3246c470f30cd3955d32c63c9
+size 38654

--- a/composables/src/test/snapshots/images/com.google.android.horologist.composables_PlaceholderChipTest_secondaryColors.png
+++ b/composables/src/test/snapshots/images/com.google.android.horologist.composables_PlaceholderChipTest_secondaryColors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b9f13648dbf42a681068bdfe957ad34d5632ee7a80b1bfbcfcbf913b47ea18bc
-size 40449
+oid sha256:855ffa607ddd39f94804cbd242fb6abfa6464b0b78b0ee008d88eb2c488d09c2
+size 36504

--- a/composables/src/test/snapshots/images/com.google.android.horologist.composables_SectionedListTest_emptySection.png
+++ b/composables/src/test/snapshots/images/com.google.android.horologist.composables_SectionedListTest_emptySection.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fc7adb914a701ada52800bd7807313f6adee4a73b9a8fd00987f5984dfb4c745
-size 100076
+oid sha256:1da00426cb274e053cf2644d5cd9a75a9637f60f2b21de32e1bfc5f09417c51b
+size 95641

--- a/composables/src/test/snapshots/images/com.google.android.horologist.composables_SectionedListTest_loadingSection.png
+++ b/composables/src/test/snapshots/images/com.google.android.horologist.composables_SectionedListTest_loadingSection.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6f17777119b4cfc74596e66a8691c59d2f7fb04ef0ac276a02acf6f7b11732c9
-size 117003
+oid sha256:a009b255ba47b6febfb1bcc1a83b31c2fec1a172f17cb6e3a68c1dbe35158f18
+size 112563

--- a/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.screens.entity_PlaylistDownloadScreenA11yScreenshotTest_playlistDownloadScreenPreviewLoading.png
+++ b/media-ui/src/test/snapshots/images/com.google.android.horologist.media.ui.screens.entity_PlaylistDownloadScreenA11yScreenshotTest_playlistDownloadScreenPreviewLoading.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:18a941374c651be534e009d9fe222695bab8f3216650dffce11a3bd8b93e9bb1
-size 118745
+oid sha256:c05886633f4eca4b9170f4e28512c64520efafded615fe008dea083086e673f7
+size 113108


### PR DESCRIPTION
#### WHAT

Change `PlaceholderChip` to have shimmer effect.

https://user-images.githubusercontent.com/878134/198678466-02ab37b8-122a-445e-b433-c6f4ce8545ff.mp4

As per specs, the chip colors will be the same for any chip style (primary, secondary, custom).

Previews :
![Screen Shot 2022-10-28 at 17 38 04](https://user-images.githubusercontent.com/878134/198688276-9bee15fb-7c48-4d41-bceb-4af37df1433d.png)



#### WHY

In order to align with Figma specs.

#### HOW

Use wear compose placeholder modifiers.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
