### PR TITLE
Disable ExpiredTargetSdkVersion lint check

### DIFF
--- a/audio-ui/quality/lint/lint-baseline.xml
+++ b/audio-ui/quality/lint/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 7.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (7.3.1)" variant="all" version="7.3.1">
+
+</issues>

--- a/audio/quality/lint/lint-baseline.xml
+++ b/audio/quality/lint/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 7.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (7.3.1)" variant="all" version="7.3.1">
+
+</issues>

--- a/base-ui/quality/lint/lint-baseline.xml
+++ b/base-ui/quality/lint/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 7.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (7.3.1)" variant="all" version="7.3.1">
+
+</issues>

--- a/build.gradle
+++ b/build.gradle
@@ -205,6 +205,8 @@ subprojects {
         plugins.withId('com.android.library') {
             android {
                 lint {
+                    baseline(file("$projectDir/quality/lint/lint-baseline.xml"))
+
                     // Remove once fixed: https://issuetracker.google.com/196420849
                     disable("ExpiringTargetSdkVersion")
                 }

--- a/composables/quality/lint/lint-baseline.xml
+++ b/composables/quality/lint/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 7.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (7.3.1)" variant="all" version="7.3.1">
+
+</issues>

--- a/compose-layout/quality/lint/lint-baseline.xml
+++ b/compose-layout/quality/lint/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 7.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (7.3.1)" variant="all" version="7.3.1">
+
+</issues>

--- a/compose-tools/quality/lint/lint-baseline.xml
+++ b/compose-tools/quality/lint/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 7.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (7.3.1)" variant="all" version="7.3.1">
+
+</issues>

--- a/datalayer/quality/lint/lint-baseline.xml
+++ b/datalayer/quality/lint/lint-baseline.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 7.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (7.3.1)" variant="all" version="7.3.1">
+
+    <issue
+        id="ExpiredTargetSdkVersion"
+        message="Google Play requires that apps target API level 31 or higher.&#xA;"
+        errorLine1="        targetSdk 30"
+        errorLine2="        ~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="28"
+            column="9"/>
+    </issue>
+
+</issues>

--- a/media-data/quality/lint/lint-baseline.xml
+++ b/media-data/quality/lint/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 7.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (7.3.1)" variant="all" version="7.3.1">
+
+</issues>

--- a/media-sync/quality/lint/lint-baseline.xml
+++ b/media-sync/quality/lint/lint-baseline.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 7.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (7.3.1)" variant="all" version="7.3.1">
+
+    <issue
+        id="ExpiredTargetSdkVersion"
+        message="Google Play requires that apps target API level 31 or higher.&#xA;"
+        errorLine1="        targetSdk 30"
+        errorLine2="        ~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="29"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; SDK_INT is always >= 26"
+        errorLine1="    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/google/android/horologist/media/sync/workers/SyncWorkHelpers.kt"
+            line="68"
+            column="9"/>
+    </issue>
+
+</issues>

--- a/media-ui/quality/lint/lint-baseline.xml
+++ b/media-ui/quality/lint/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 7.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (7.3.1)" variant="all" version="7.3.1">
+
+</issues>

--- a/media3-backend/quality/lint/lint-baseline.xml
+++ b/media3-backend/quality/lint/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 7.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (7.3.1)" variant="all" version="7.3.1">
+
+</issues>

--- a/network-awareness/quality/lint/lint-baseline.xml
+++ b/network-awareness/quality/lint/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 7.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (7.3.1)" variant="all" version="7.3.1">
+
+</issues>

--- a/tiles/quality/lint/lint-baseline.xml
+++ b/tiles/quality/lint/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 7.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (7.3.1)" variant="all" version="7.3.1">
+
+</issues>


### PR DESCRIPTION
#### WHAT

Disable `ExpiredTargetSdkVersion` lint check.

Related issue: https://issuetracker.google.com/issues/196420849

#### WHY

Our builds are now failing with:

```
Error: Google Play requires that apps target API level 31 or higher.
 [ExpiredTargetSdkVersion]
        targetSdk 30
```

Due to this [check](https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:lint/libs/lint-checks/src/main/java/com/android/tools/lint/checks/GradleDetector.kt;l=252;drc=2457a6388492397c8bb0d6f1af7f6e00cdfb2d49).

However, Wear OS apps required target API level are still 30, according to: https://support.google.com/googleplay/android-developer/answer/11926878

#### HOW

Add baseline lint files for each module, with only `ExpiredTargetSdkVersion` listed there.

Other alternatives that were tried but did NOT work:

- Current disable lint option is not being taken into consideration: https://github.com/google/horologist/blob/8d1b285f5819a9cdc17185217fef4f1bdd1d041b/build.gradle#L209
- Disable lint option in each module's build.gradle
- Comment suppress
```groovy
        //noinspection ExpiredTargetSdkVersion
        targetSdk 30
```

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
