### PR TITLE
Fix lint error ExpiredTargetSdkVersion

### DIFF
--- a/datalayer/src/main/AndroidManifest.xml
+++ b/datalayer/src/main/AndroidManifest.xml
@@ -18,4 +18,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.google.android.horologist.datalayer">
 
+    <uses-feature android:name="android.hardware.type.watch" />
+
 </manifest>

--- a/media-sync/src/main/AndroidManifest.xml
+++ b/media-sync/src/main/AndroidManifest.xml
@@ -19,6 +19,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.google.android.horologist.media.sync">
 
+    <uses-feature android:name="android.hardware.type.watch" />
+
     <application>
         <provider
             android:name="androidx.startup.InitializationProvider"


### PR DESCRIPTION
#### WHAT

Fix lint error `ExpiredTargetSdkVersion`.

#### WHY

Our builds are now failing with:

```
Error: Google Play requires that apps target API level 31 or higher.
 [ExpiredTargetSdkVersion]
        targetSdk 30
```

#### HOW

Add uses-feature hardware type watch to AndroidManifest file of `media-sync` and `datalayer` modules.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
