### PR TITLE
Add baseline file for lint in order to disable ExpiredTargetSdkVersion

### DIFF
--- a/datalayer/build.gradle
+++ b/datalayer/build.gradle
@@ -62,6 +62,8 @@ android {
     lint {
         checkReleaseBuilds false
         textReport true
+
+        baseline(file("quality/lint/lint-baseline.xml"))
     }
     namespace 'com.google.android.horologist.datalayer'
 }

--- a/datalayer/quality/lint/lint-baseline.xml
+++ b/datalayer/quality/lint/lint-baseline.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 7.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (7.3.1)" variant="all" version="7.3.1">
+
+    <issue
+        id="ExpiredTargetSdkVersion"
+        message="Google Play requires that apps target API level 31 or higher.&#xA;"
+        errorLine1="        targetSdk 30"
+        errorLine2="        ~~~~~~~~~~~~">
+        <location
+            file="build.gradle"
+            line="28"
+            column="9"/>
+    </issue>
+
+</issues>

--- a/media-sync/src/main/AndroidManifest.xml
+++ b/media-sync/src/main/AndroidManifest.xml
@@ -19,6 +19,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.google.android.horologist.media.sync">
 
+    <uses-feature android:name="android.hardware.type.watch" />
+
     <application>
         <provider
             android:name="androidx.startup.InitializationProvider"


### PR DESCRIPTION
#### WHAT

Disable `ExpiredTargetSdkVersion` lint check.

Related issue: https://issuetracker.google.com/issues/196420849

#### WHY

Our builds are now failing with:

```
Error: Google Play requires that apps target API level 31 or higher.
 [ExpiredTargetSdkVersion]
        targetSdk 30
```

Due to this [check](https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:lint/libs/lint-checks/src/main/java/com/android/tools/lint/checks/GradleDetector.kt;l=252;drc=2457a6388492397c8bb0d6f1af7f6e00cdfb2d49).

However, Wear OS apps required target API level are still 30, according to: https://support.google.com/googleplay/android-developer/answer/11926878

#### HOW

Add baseline lint files for each module, with only `ExpiredTargetSdkVersion` listed there.

Other alternatives that were tried but did NOT work:

- Current disable lint option is not being taken into consideration: https://github.com/google/horologist/blob/8d1b285f5819a9cdc17185217fef4f1bdd1d041b/build.gradle#L209
- Disable lint option in each module's build.gradle
- Comment suppress
```groovy
        //noinspection ExpiredTargetSdkVersion
        targetSdk 30
```

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
