### PR TITLE
Add Base UI to release list

### DIFF
--- a/base-ui/build.gradle
+++ b/base-ui/build.gradle
@@ -129,3 +129,5 @@ dependencies {
     androidTestImplementation libs.androidx.test.ext
     androidTestImplementation libs.androidx.test.ext.ktx
 }
+
+apply plugin: "com.vanniktech.maven.publish"

--- a/base-ui/gradle.properties
+++ b/base-ui/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=horologist-base-ui
+POM_NAME=Horologist Base UI library
+POM_PACKAGING=aar


### PR DESCRIPTION
#### WHAT

Add Base UI to release list

#### WHY

0.2.0 is broken.

https://repo1.maven.org/maven2/com/google/android/horologist/horologist-media-ui/0.2.0/horologist-media-ui-0.2.0.pom

```
<dependency>
<groupId>horologist</groupId>
<artifactId>base-ui</artifactId>
**<version>unspecified</version>**
<scope>runtime</scope>
</dependency>
```

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
