### PR TITLE
Document paparazzi steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,19 @@ $ ./gradlew spotlessApply spotlessCheck compileDebugSources compileReleaseSource
 
 Also make sure you have [Git LFS]([url](https://git-lfs.github.com/)) installed.
 
+If you change any code affecting screenshot tests, then run the following and check the failures in the `out` directory.
+
+```
+$ ./gradlew verifyPaparazziDebug
+```
+
+To record the new golden images, run the following and check in the specific files that failed. Paparazzi has some tolerance for minor changes,
+so not all diffs need be committed.
+
+```
+$ ./gradlew recordPaparazziDebug
+```
+
 ## Contributor License Agreement
 
 Contributions to this project must be accompanied by a Contributor License


### PR DESCRIPTION
#### WHAT

Document paparazzi steps.

#### WHY

Screenshot failures can be confusing.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
