### PR TITLE
Moves icon out of DeviceChip

### DIFF
--- a/audio-ui/api/current.api
+++ b/audio-ui/api/current.api
@@ -11,13 +11,12 @@ package com.google.android.horologist.audio.ui {
   public final class VolumeScreenDefaults {
     method @androidx.compose.runtime.Composable public void DecreaseIcon();
     method @androidx.compose.runtime.Composable public void IncreaseIcon();
-    method public androidx.compose.ui.graphics.vector.ImageVector audioOutputIcon(com.google.android.horologist.audio.AudioOutput audioOutput);
     field public static final com.google.android.horologist.audio.ui.VolumeScreenDefaults INSTANCE;
   }
 
   public final class VolumeScreenKt {
     method @androidx.compose.runtime.Composable public static void VolumeScreen(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.audio.ui.VolumeViewModel volumeViewModel, optional boolean showVolumeIndicator, optional androidx.compose.ui.focus.FocusRequester focusRequester, optional kotlin.jvm.functions.Function0<kotlin.Unit> increaseIcon, optional kotlin.jvm.functions.Function0<kotlin.Unit> decreaseIcon);
-    method @androidx.compose.runtime.Composable public static void VolumeScreen(kotlin.jvm.functions.Function0<com.google.android.horologist.audio.VolumeState> volume, com.google.android.horologist.audio.AudioOutput audioOutput, kotlin.jvm.functions.Function0<kotlin.Unit> increaseVolume, kotlin.jvm.functions.Function0<kotlin.Unit> decreaseVolume, kotlin.jvm.functions.Function0<kotlin.Unit> onAudioOutputClick, optional androidx.compose.ui.Modifier modifier, optional androidx.compose.ui.graphics.vector.ImageVector audioOutputIcon, optional boolean isAudioOutputConnected, optional kotlin.jvm.functions.Function0<kotlin.Unit> increaseIcon, optional kotlin.jvm.functions.Function0<kotlin.Unit> decreaseIcon, optional boolean showVolumeIndicator, optional androidx.compose.ui.focus.FocusRequester focusRequester, optional kotlin.jvm.functions.Function1<? super java.lang.Float,kotlin.Unit>? onVolumeChangeByScroll);
+    method @androidx.compose.runtime.Composable public static void VolumeScreen(kotlin.jvm.functions.Function0<com.google.android.horologist.audio.VolumeState> volume, com.google.android.horologist.audio.ui.components.AudioOutputUi audioOutputUi, kotlin.jvm.functions.Function0<kotlin.Unit> increaseVolume, kotlin.jvm.functions.Function0<kotlin.Unit> decreaseVolume, kotlin.jvm.functions.Function0<kotlin.Unit> onAudioOutputClick, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit> increaseIcon, optional kotlin.jvm.functions.Function0<kotlin.Unit> decreaseIcon, optional boolean showVolumeIndicator, optional androidx.compose.ui.focus.FocusRequester focusRequester, optional kotlin.jvm.functions.Function1<? super java.lang.Float,kotlin.Unit>? onVolumeChangeByScroll);
   }
 
   @Deprecated public final class VolumeScrollableState implements androidx.compose.foundation.gestures.ScrollableState {
@@ -52,8 +51,26 @@ package com.google.android.horologist.audio.ui {
 
 package com.google.android.horologist.audio.ui.components {
 
+  public final class AudioOutputUi {
+    ctor public AudioOutputUi(String displayName, androidx.compose.ui.graphics.vector.ImageVector imageVector, boolean isConnected);
+    method public String component1();
+    method public androidx.compose.ui.graphics.vector.ImageVector component2();
+    method public boolean component3();
+    method public com.google.android.horologist.audio.ui.components.AudioOutputUi copy(String displayName, androidx.compose.ui.graphics.vector.ImageVector imageVector, boolean isConnected);
+    method public String getDisplayName();
+    method public androidx.compose.ui.graphics.vector.ImageVector getImageVector();
+    method public boolean isConnected();
+    property public final String displayName;
+    property public final androidx.compose.ui.graphics.vector.ImageVector imageVector;
+    property public final boolean isConnected;
+  }
+
+  public final class AudioOutputUiKt {
+    method @androidx.compose.runtime.Composable public static com.google.android.horologist.audio.ui.components.AudioOutputUi toAudioOutputUi(com.google.android.horologist.audio.AudioOutput);
+  }
+
   public final class DeviceChipKt {
-    method @androidx.compose.runtime.Composable public static void DeviceChip(String volumeDescription, String deviceName, androidx.compose.ui.graphics.vector.ImageVector icon, kotlin.jvm.functions.Function0<kotlin.Unit> onAudioOutputClick, optional androidx.compose.ui.Modifier modifier);
+    method @androidx.compose.runtime.Composable public static void DeviceChip(String volumeDescription, String deviceName, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.BoxScope,kotlin.Unit> icon, kotlin.jvm.functions.Function0<kotlin.Unit> onAudioOutputClick, optional androidx.compose.ui.Modifier modifier);
   }
 
   public final class SettingsButtonsDefaults {

--- a/audio-ui/api/current.api
+++ b/audio-ui/api/current.api
@@ -11,12 +11,13 @@ package com.google.android.horologist.audio.ui {
   public final class VolumeScreenDefaults {
     method @androidx.compose.runtime.Composable public void DecreaseIcon();
     method @androidx.compose.runtime.Composable public void IncreaseIcon();
+    method public androidx.compose.ui.graphics.vector.ImageVector audioOutputIcon(com.google.android.horologist.audio.AudioOutput audioOutput);
     field public static final com.google.android.horologist.audio.ui.VolumeScreenDefaults INSTANCE;
   }
 
   public final class VolumeScreenKt {
     method @androidx.compose.runtime.Composable public static void VolumeScreen(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.audio.ui.VolumeViewModel volumeViewModel, optional boolean showVolumeIndicator, optional androidx.compose.ui.focus.FocusRequester focusRequester, optional kotlin.jvm.functions.Function0<kotlin.Unit> increaseIcon, optional kotlin.jvm.functions.Function0<kotlin.Unit> decreaseIcon);
-    method @androidx.compose.runtime.Composable public static void VolumeScreen(kotlin.jvm.functions.Function0<com.google.android.horologist.audio.VolumeState> volume, com.google.android.horologist.audio.AudioOutput audioOutput, kotlin.jvm.functions.Function0<kotlin.Unit> increaseVolume, kotlin.jvm.functions.Function0<kotlin.Unit> decreaseVolume, kotlin.jvm.functions.Function0<kotlin.Unit> onAudioOutputClick, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit> increaseIcon, optional kotlin.jvm.functions.Function0<kotlin.Unit> decreaseIcon, optional boolean showVolumeIndicator, optional androidx.compose.ui.focus.FocusRequester focusRequester, optional kotlin.jvm.functions.Function1<? super java.lang.Float,kotlin.Unit>? onVolumeChangeByScroll);
+    method @androidx.compose.runtime.Composable public static void VolumeScreen(kotlin.jvm.functions.Function0<com.google.android.horologist.audio.VolumeState> volume, com.google.android.horologist.audio.AudioOutput audioOutput, kotlin.jvm.functions.Function0<kotlin.Unit> increaseVolume, kotlin.jvm.functions.Function0<kotlin.Unit> decreaseVolume, kotlin.jvm.functions.Function0<kotlin.Unit> onAudioOutputClick, optional androidx.compose.ui.Modifier modifier, optional androidx.compose.ui.graphics.vector.ImageVector audioOutputIcon, optional boolean isAudioOutputConnected, optional kotlin.jvm.functions.Function0<kotlin.Unit> increaseIcon, optional kotlin.jvm.functions.Function0<kotlin.Unit> decreaseIcon, optional boolean showVolumeIndicator, optional androidx.compose.ui.focus.FocusRequester focusRequester, optional kotlin.jvm.functions.Function1<? super java.lang.Float,kotlin.Unit>? onVolumeChangeByScroll);
   }
 
   @Deprecated public final class VolumeScrollableState implements androidx.compose.foundation.gestures.ScrollableState {
@@ -52,8 +53,7 @@ package com.google.android.horologist.audio.ui {
 package com.google.android.horologist.audio.ui.components {
 
   public final class DeviceChipKt {
-    method @androidx.compose.runtime.Composable public static void DeviceChip(com.google.android.horologist.audio.VolumeState volumeState, com.google.android.horologist.audio.AudioOutput audioOutput, kotlin.jvm.functions.Function0<kotlin.Unit> onAudioOutputClick, optional androidx.compose.ui.Modifier modifier);
-    method @androidx.compose.runtime.Composable public static androidx.compose.ui.graphics.vector.ImageVector icon(com.google.android.horologist.audio.AudioOutput);
+    method @androidx.compose.runtime.Composable public static void DeviceChip(String volumeDescription, String deviceName, androidx.compose.ui.graphics.vector.ImageVector icon, kotlin.jvm.functions.Function0<kotlin.Unit> onAudioOutputClick, optional androidx.compose.ui.Modifier modifier);
   }
 
   public final class SettingsButtonsDefaults {

--- a/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/VolumeScreenTestCase.kt
+++ b/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/VolumeScreenTestCase.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.wear.compose.material.Scaffold
 import com.google.android.horologist.audio.AudioOutput
 import com.google.android.horologist.audio.VolumeState
+import com.google.android.horologist.audio.ui.components.toAudioOutputUi
 
 @Composable
 fun VolumeScreenTestCase(
@@ -36,7 +37,7 @@ fun VolumeScreenTestCase(
     ) {
         VolumeScreen(
             volume = { volumeState },
-            audioOutput = audioOutput,
+            audioOutputUi = audioOutput.toAudioOutputUi(),
             increaseVolume = { },
             decreaseVolume = { },
             onAudioOutputClick = { },

--- a/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/DeviceChipPreview.kt
+++ b/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/DeviceChipPreview.kt
@@ -16,10 +16,10 @@
 
 package com.google.android.horologist.audio.ui
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Headphones
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
-import com.google.android.horologist.audio.AudioOutput
-import com.google.android.horologist.audio.VolumeState
 import com.google.android.horologist.audio.ui.components.DeviceChip
 import com.google.android.horologist.compose.tools.WearPreview
 import com.google.android.horologist.compose.tools.WidthConstrainedBox
@@ -27,15 +27,14 @@ import com.google.android.horologist.compose.tools.WidthConstrainedBox
 @WearPreview
 @Composable
 fun DeviceChipPreview() {
-    val volume = VolumeState(10, 10)
-
     WidthConstrainedBox(
         widths = listOf(100.dp, 164.dp, 192.dp, 227.dp),
         comfortableHeight = 100.dp
     ) {
         DeviceChip(
-            volumeState = volume,
-            audioOutput = AudioOutput.BluetoothHeadset(id = "1", name = "Galaxy Watch 4"),
+            volumeDescription = "",
+            deviceName = "Bluetooth Headphones",
+            icon = Icons.Default.Headphones,
             onAudioOutputClick = {
             }
         )

--- a/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/DeviceChipPreview.kt
+++ b/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/DeviceChipPreview.kt
@@ -20,6 +20,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Headphones
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.MaterialTheme
 import com.google.android.horologist.audio.ui.components.DeviceChip
 import com.google.android.horologist.compose.tools.WearPreview
 import com.google.android.horologist.compose.tools.WidthConstrainedBox
@@ -34,7 +36,13 @@ fun DeviceChipPreview() {
         DeviceChip(
             volumeDescription = "",
             deviceName = "Bluetooth Headphones",
-            icon = Icons.Default.Headphones,
+            icon = {
+                Icon(
+                    imageVector = Icons.Default.Headphones,
+                    contentDescription = "",
+                    tint = MaterialTheme.colors.onSurfaceVariant
+                )
+            },
             onAudioOutputClick = {
             }
         )

--- a/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/VolumeScreenPreview.kt
+++ b/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/VolumeScreenPreview.kt
@@ -26,6 +26,7 @@ import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Scaffold
 import com.google.android.horologist.audio.AudioOutput
 import com.google.android.horologist.audio.VolumeState
+import com.google.android.horologist.audio.ui.components.toAudioOutputUi
 import com.google.android.horologist.compose.tools.ThemeValues
 import com.google.android.horologist.compose.tools.WearLargeRoundDevicePreview
 import com.google.android.horologist.compose.tools.WearPreviewDevices
@@ -49,7 +50,7 @@ fun VolumeScreenGuideWithLongText() {
         ) {
             VolumeScreen(
                 volume = { volume },
-                audioOutput = AudioOutput.BluetoothHeadset(id = "1", name = "Galaxy Watch 4"),
+                audioOutputUi = AudioOutput.BluetoothHeadset(id = "1", name = "Galaxy Watch 4").toAudioOutputUi(),
                 increaseVolume = { },
                 decreaseVolume = { },
                 onAudioOutputClick = {}
@@ -76,7 +77,7 @@ fun VolumeScreenPreview(
     ) {
         VolumeScreen(
             volume = { volume },
-            audioOutput = audioOutput,
+            audioOutputUi = audioOutput.toAudioOutputUi(),
             increaseVolume = { },
             decreaseVolume = { },
             onAudioOutputClick = {}
@@ -103,7 +104,7 @@ fun VolumeScreenTheme(
             ) {
                 VolumeScreen(
                     volume = { volume },
-                    audioOutput = AudioOutput.BluetoothHeadset(id = "1", name = "PixelBuds"),
+                    audioOutputUi = AudioOutput.BluetoothHeadset(id = "1", name = "PixelBuds").toAudioOutputUi(),
                     increaseVolume = { },
                     decreaseVolume = { },
                     onAudioOutputClick = {}

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/AudioOutputUi.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/AudioOutputUi.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.audio.ui.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DeviceUnknown
+import androidx.compose.material.icons.filled.Headphones
+import androidx.compose.material.icons.filled.VolumeOff
+import androidx.compose.material.icons.filled.Watch
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import com.google.android.horologist.audio.AudioOutput
+import com.google.android.horologist.audio.AudioOutput.Companion.TYPE_HEADPHONES
+import com.google.android.horologist.audio.AudioOutput.Companion.TYPE_NONE
+import com.google.android.horologist.audio.AudioOutput.Companion.TYPE_WATCH
+import com.google.android.horologist.audio.ui.R
+
+/**
+ * UI representation of [AudioOutput].
+ */
+public data class AudioOutputUi(
+    val displayName: String,
+    val imageVector: ImageVector,
+    val isConnected: Boolean
+)
+
+@Composable
+public fun AudioOutput.toAudioOutputUi(): AudioOutputUi {
+    return AudioOutputUi(
+        displayName = when (type) {
+            TYPE_WATCH -> stringResource(id = R.string.horologist_speaker_name)
+            TYPE_NONE -> stringResource(id = R.string.horologist_output_none)
+            else -> name
+        },
+        imageVector = when (type) {
+            TYPE_HEADPHONES -> Icons.Default.Headphones
+            TYPE_WATCH -> Icons.Default.Watch
+            TYPE_NONE -> Icons.Default.VolumeOff
+            else -> Icons.Default.DeviceUnknown
+        },
+        isConnected = this is AudioOutput.BluetoothHeadset
+    )
+}

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/DeviceChip.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/DeviceChip.kt
@@ -16,12 +16,12 @@
 
 package com.google.android.horologist.audio.ui.components
 
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.semantics
@@ -29,8 +29,6 @@ import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
-import androidx.wear.compose.material.Icon
-import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.audio.ui.R
 
@@ -38,7 +36,7 @@ import com.google.android.horologist.audio.ui.R
 public fun DeviceChip(
     volumeDescription: String,
     deviceName: String,
-    icon: ImageVector,
+    icon: @Composable BoxScope.() -> Unit,
     onAudioOutputClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -59,13 +57,7 @@ public fun DeviceChip(
                 overflow = TextOverflow.Ellipsis
             )
         },
-        icon = {
-            Icon(
-                imageVector = icon,
-                contentDescription = deviceName,
-                tint = MaterialTheme.colors.onSurfaceVariant
-            )
-        },
+        icon = icon,
         onClick = onAudioOutputClick,
         // Device chip uses secondary colors (surface/onSurface)
         colors = ChipDefaults.secondaryChipColors()

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/DeviceChip.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/DeviceChip.kt
@@ -19,11 +19,6 @@ package com.google.android.horologist.audio.ui.components
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.DeviceUnknown
-import androidx.compose.material.icons.filled.Headphones
-import androidx.compose.material.icons.filled.VolumeOff
-import androidx.compose.material.icons.filled.Watch
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -37,32 +32,23 @@ import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
-import com.google.android.horologist.audio.AudioOutput
-import com.google.android.horologist.audio.VolumeState
 import com.google.android.horologist.audio.ui.R
 
 @Composable
 public fun DeviceChip(
-    volumeState: VolumeState,
-    audioOutput: AudioOutput,
+    volumeDescription: String,
+    deviceName: String,
+    icon: ImageVector,
     onAudioOutputClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val stateDescriptionText = volumeDescription(volumeState, audioOutput)
-
     val onClickLabel = stringResource(id = R.string.horologist_volume_screen_change_audio_output)
-
-    val deviceName = if (audioOutput is AudioOutput.WatchSpeaker) {
-        stringResource(id = R.string.horologist_speaker_name)
-    } else {
-        audioOutput.name
-    }
 
     Chip(
         modifier = modifier
             .width(intrinsicSize = IntrinsicSize.Max)
             .semantics {
-                stateDescription = stateDescriptionText
+                stateDescription = volumeDescription
                 onClick(onClickLabel) { onAudioOutputClick(); true }
             },
         label = {
@@ -75,7 +61,7 @@ public fun DeviceChip(
         },
         icon = {
             Icon(
-                imageVector = audioOutput.icon(),
+                imageVector = icon,
                 contentDescription = deviceName,
                 tint = MaterialTheme.colors.onSurfaceVariant
             )
@@ -84,23 +70,4 @@ public fun DeviceChip(
         // Device chip uses secondary colors (surface/onSurface)
         colors = ChipDefaults.secondaryChipColors()
     )
-}
-
-@Composable
-public fun AudioOutput.icon(): ImageVector {
-    return when (this) {
-        is AudioOutput.BluetoothHeadset -> Icons.Default.Headphones
-        is AudioOutput.WatchSpeaker -> Icons.Default.Watch
-        is AudioOutput.None -> Icons.Default.VolumeOff
-        else -> Icons.Default.DeviceUnknown
-    }
-}
-
-@Composable
-private fun volumeDescription(volumeState: VolumeState, audioOutput: AudioOutput): String {
-    return if (audioOutput is AudioOutput.BluetoothHeadset) {
-        stringResource(id = R.string.horologist_volume_screen_connected_state, volumeState.current)
-    } else {
-        stringResource(id = R.string.horologist_volume_screen_not_connected_state)
-    }
 }

--- a/audio-ui/src/main/res/values/strings.xml
+++ b/audio-ui/src/main/res/values/strings.xml
@@ -20,7 +20,8 @@
     <string description="State description of device output chip. It lets the user know that this device is connected to the watch and what the current volume is. [CHAR_LIMIT=NONE]" name="horologist_volume_screen_connected_state">Connected, Volume %1$d</string>
     <string description="State description of device output chip. It lets the user know that this device is not connected to the watch. [CHAR_LIMIT=NONE]" name="horologist_volume_screen_not_connected_state">Not Connected</string>
     <string description="The description of the click action on the device output chip. It lets the user know the audio output can be changed by clicking on this chip. [CHAR_LIMIT=NONE]" name="horologist_volume_screen_change_audio_output">Change Audio Output</string>
-    <string description="Lets the user know that the current audio output is the watch speaker. Appears on the device output button chip. [CHAR LIMIT=20]" name="horologist_speaker_name">Watch Speaker</string>
+    <string description="Indicates that the current audio output is the watch speaker. Appears on the device output button chip. [CHAR LIMIT=20]" name="horologist_speaker_name">Watch Speaker</string>
+    <string description="Indicates there's nothing to output audio to, e.g. there's no speaker and no headphones connected at the moment. Appears on the device output button chip. [CHAR LIMIT=20]" name="horologist_output_none">None</string>
     <string description="Content description of the SetVolume button. It lets the user navigate to the screen to control the system volume. [CHAR_LIMIT=NONE]" name="horologist_set_volume_content_description">Set Volume</string>
     <string description="Content description of the AudioOutput button. It lets the user navigate to the system bluetooth settings screen to connect to a headset. [CHAR_LIMIT=NONE]" name="horologist_audio_output_content_description">Audio Output</string>
 </resources>

--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenTestCase.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenTestCase.kt
@@ -22,6 +22,7 @@ import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Scaffold
 import com.google.android.horologist.audio.AudioOutput
 import com.google.android.horologist.audio.VolumeState
+import com.google.android.horologist.audio.ui.components.toAudioOutputUi
 import com.google.android.horologist.compose.tools.RoundPreview
 
 @Composable
@@ -42,7 +43,7 @@ fun VolumeScreenTestCase(
             ) {
                 VolumeScreen(
                     volume = { volumeState },
-                    audioOutput = audioOutput,
+                    audioOutputUi = audioOutput.toAudioOutputUi(),
                     increaseVolume = { },
                     decreaseVolume = { },
                     onAudioOutputClick = { },

--- a/audio/api/current.api
+++ b/audio/api/current.api
@@ -4,8 +4,14 @@ package com.google.android.horologist.audio {
   public interface AudioOutput {
     method public String getId();
     method public String getName();
+    method public default String getType();
     property public abstract String id;
     property public abstract String name;
+    property public default String type;
+    field public static final com.google.android.horologist.audio.AudioOutput.Companion Companion;
+    field public static final String TYPE_HEADPHONES = "headphones";
+    field public static final String TYPE_NONE = "none";
+    field public static final String TYPE_WATCH = "watch";
   }
 
   public static final class AudioOutput.BluetoothHeadset implements com.google.android.horologist.audio.AudioOutput {
@@ -17,6 +23,13 @@ package com.google.android.horologist.audio {
     method public String getName();
     property public String id;
     property public String name;
+    property public String type;
+  }
+
+  public static final class AudioOutput.Companion {
+    field public static final String TYPE_HEADPHONES = "headphones";
+    field public static final String TYPE_NONE = "none";
+    field public static final String TYPE_WATCH = "watch";
   }
 
   public static final class AudioOutput.None implements com.google.android.horologist.audio.AudioOutput {
@@ -24,6 +37,7 @@ package com.google.android.horologist.audio {
     method public String getName();
     property public String id;
     property public String name;
+    property public String type;
     field public static final com.google.android.horologist.audio.AudioOutput.None INSTANCE;
   }
 
@@ -47,6 +61,7 @@ package com.google.android.horologist.audio {
     method public String getName();
     property public String id;
     property public String name;
+    property public String type;
   }
 
   public interface AudioOutputRepository extends java.lang.AutoCloseable {

--- a/audio/src/main/java/com/google/android/horologist/audio/AudioOutput.kt
+++ b/audio/src/main/java/com/google/android/horologist/audio/AudioOutput.kt
@@ -33,11 +33,18 @@ public interface AudioOutput {
     public val name: String
 
     /**
+     * Optional type of output which may be associated with an icon or displayed name.
+     */
+    public val type: String
+        get() = ""
+
+    /**
      * No current device.
      */
     public object None : AudioOutput {
-        override val name: String = "None"
-        override val id: String = "None"
+        override val name: String = ""
+        override val id: String = ""
+        override val type: String = TYPE_NONE
     }
 
     /**
@@ -46,7 +53,9 @@ public interface AudioOutput {
     public data class BluetoothHeadset(
         override val id: String,
         override val name: String
-    ) : AudioOutput
+    ) : AudioOutput {
+        override val type: String = TYPE_HEADPHONES
+    }
 
     /**
      * The one device watch speaker.
@@ -54,7 +63,9 @@ public interface AudioOutput {
     public data class WatchSpeaker(
         override val id: String,
         override val name: String
-    ) : AudioOutput
+    ) : AudioOutput {
+        override val type: String = TYPE_WATCH
+    }
 
     /**
      * An unknown audio output device
@@ -63,4 +74,10 @@ public interface AudioOutput {
         override val id: String,
         override val name: String
     ) : AudioOutput
+
+    public companion object {
+        public const val TYPE_WATCH: String = "watch"
+        public const val TYPE_HEADPHONES: String = "headphones"
+        public const val TYPE_NONE: String = "none"
+    }
 }

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/FigmaVolumeScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/FigmaVolumeScreenTest.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Composable
 import com.google.android.horologist.audio.AudioOutput
 import com.google.android.horologist.audio.VolumeState
 import com.google.android.horologist.audio.ui.VolumeScreen
+import com.google.android.horologist.audio.ui.components.toAudioOutputUi
 import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.RoundPreview
 import com.google.android.horologist.media.ui.uamp.UampTheme
@@ -43,7 +44,7 @@ class FigmaVolumeScreenTest {
             UampRoundPreview {
                 VolumeScreen(
                     volume = { VolumeState(5, 10) },
-                    audioOutput = AudioOutput.BluetoothHeadset("1", "Device"),
+                    audioOutputUi = AudioOutput.BluetoothHeadset("1", "Device").toAudioOutputUi(),
                     increaseVolume = { },
                     decreaseVolume = { },
                     onAudioOutputClick = { }


### PR DESCRIPTION
#### WHAT
Makes `DeviceChip` accept parameters like icon and description directly.

#### WHY
To make it easier to have custom icons for any subclass of `AudioOutput`.

#### HOW
By moving most of `DeviceChip` logic into `VolumeScreen` and turning it into parameters with defaults that match current behavior.

#### Checklist :clipboard:
- [X] Add explicit visibility modifier and explicit return types for public declarations
- [X] Run spotless check
- [X] Run tests
- [X] Update metalava's signature text files
