### PR TITLE
Rotary and haptics

### DIFF
--- a/composables/src/main/java/com/google/android/horologist/composables/SectionedList.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/SectionedList.kt
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistComposablesApi::class)
+@file:OptIn(
+    ExperimentalHorologistComposablesApi::class,
+    ExperimentalHorologistComposeLayoutApi::class
+)
 
 package com.google.android.horologist.composables
 
@@ -29,6 +32,7 @@ import androidx.wear.compose.material.ScalingLazyListScope
 import androidx.wear.compose.material.ScalingLazyListState
 import androidx.wear.compose.material.ScalingParams
 import com.google.android.horologist.composables.Section.Companion.DEFAULT_LOADING_CONTENT_COUNT
+import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 import com.google.android.horologist.compose.rotaryinput.rotaryWithFling
 
 /**

--- a/composables/src/main/java/com/google/android/horologist/composables/SectionedList.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/SectionedList.kt
@@ -29,7 +29,7 @@ import androidx.wear.compose.material.ScalingLazyListScope
 import androidx.wear.compose.material.ScalingLazyListState
 import androidx.wear.compose.material.ScalingParams
 import com.google.android.horologist.composables.Section.Companion.DEFAULT_LOADING_CONTENT_COUNT
-import com.google.android.horologist.compose.navscaffold.scrollableColumn
+import com.google.android.horologist.compose.rotaryinput.rotaryWithFling
 
 /**
  * A list component that is split into [sections][Section].
@@ -72,7 +72,7 @@ public fun SectionedList(
     ScalingLazyColumn(
         modifier = modifier
             .fillMaxSize()
-            .scrollableColumn(focusRequester, scalingLazyListState),
+            .rotaryWithFling(focusRequester, scalingLazyListState),
         state = scalingLazyListState,
         scalingParams = scalingParams,
         autoCentering = autoCentering

--- a/compose-layout/api/current.api
+++ b/compose-layout/api/current.api
@@ -92,7 +92,7 @@ package com.google.android.horologist.compose.navscaffold {
   }
 
   public final class ScrollableColumnKt {
-    method public static androidx.compose.ui.Modifier scrollableColumn(androidx.compose.ui.Modifier, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.compose.foundation.gestures.ScrollableState scrollableState);
+    method @Deprecated public static androidx.compose.ui.Modifier scrollableColumn(androidx.compose.ui.Modifier, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.compose.foundation.gestures.ScrollableState scrollableState);
   }
 
   public final class WearNavScaffoldKt {
@@ -130,9 +130,111 @@ package com.google.android.horologist.compose.rotaryinput {
     method public static androidx.compose.ui.Modifier onRotaryInputAccumulated(androidx.compose.ui.Modifier, kotlin.jvm.functions.Function1<? super java.lang.Float,kotlin.Unit> onValueChange);
   }
 
+  public final class AnimationScrollBehavior implements com.google.android.horologist.compose.rotaryinput.RotaryScrollBehavior {
+    ctor public AnimationScrollBehavior(androidx.compose.foundation.gestures.ScrollableState scrollableState);
+    method public suspend Object? handleEvent(float pixelsToScroll, long timestamp, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
+  }
+
+  public final class DefaultRotaryFlingBehavior implements com.google.android.horologist.compose.rotaryinput.RotaryFlingBehavior {
+    ctor public DefaultRotaryFlingBehavior(androidx.compose.foundation.gestures.ScrollableState scrollableState, androidx.compose.foundation.gestures.FlingBehavior flingBehavior, android.view.ViewConfiguration viewConfiguration);
+    method public void observeEvent(long timestamp, float delta);
+    method public void startFlingTracking(long timestamp);
+    method public suspend Object? trackFling(kotlin.jvm.functions.Function0<kotlin.Unit> beforeFling, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
+  }
+
+  public final class DefaultRotaryHapticFeedback implements com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback {
+    ctor public DefaultRotaryHapticFeedback(android.view.View view);
+    method public void performHapticFeedback(int type);
+    field public static final com.google.android.horologist.compose.rotaryinput.DefaultRotaryHapticFeedback.Companion Companion;
+    field public static final int ROTARY_SCROLL_ITEM_FOCUS = 19; // 0x13
+    field public static final int ROTARY_SCROLL_LIMIT = 20; // 0x14
+    field public static final int ROTARY_SCROLL_TICK = 18; // 0x12
+  }
+
+  public static final class DefaultRotaryHapticFeedback.Companion {
+  }
+
   public final class GenericMotionRotaryInputAccumulator {
     ctor public GenericMotionRotaryInputAccumulator(android.content.Context context, kotlin.jvm.functions.Function1<? super java.lang.Float,kotlin.Unit> onValueChange);
     method public boolean onGenericMotionEvent(android.view.MotionEvent event);
+  }
+
+  public final class HapticsKt {
+    method @androidx.compose.runtime.Composable public static com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rememberDefaultRotaryHapticFeedback();
+    method @androidx.compose.runtime.Composable public static com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rememberRotaryHapticFeedback(optional long throttleThresholdMs, optional kotlinx.coroutines.channels.Channel<com.google.android.horologist.compose.rotaryinput.RotaryHapticsType> hapticsChannel, optional com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rotaryHaptics);
+    method public static <T> kotlinx.coroutines.flow.Flow<T> throttleLatest(kotlinx.coroutines.flow.Flow<? extends T>, long timeframe);
+  }
+
+  public final class RotaryDefaults {
+    method @androidx.compose.runtime.Composable public com.google.android.horologist.compose.rotaryinput.RotaryScrollHandler rememberFlingHandler(androidx.compose.foundation.gestures.ScrollableState scrollableState, optional androidx.compose.foundation.gestures.FlingBehavior? flingBehavior, optional boolean isLowRes);
+    field public static final com.google.android.horologist.compose.rotaryinput.RotaryDefaults INSTANCE;
+  }
+
+  public interface RotaryFlingBehavior {
+    method public void observeEvent(long timestamp, float delta);
+    method public void startFlingTracking(long timestamp);
+    method public suspend Object? trackFling(kotlin.jvm.functions.Function0<kotlin.Unit> beforeFling, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
+  }
+
+  public interface RotaryHapticFeedback {
+    method public void performHapticFeedback(int type);
+  }
+
+  @kotlin.jvm.JvmInline public final value class RotaryHapticsType {
+    ctor public RotaryHapticsType(int type);
+    field public static final com.google.android.horologist.compose.rotaryinput.RotaryHapticsType.Companion Companion;
+  }
+
+  public static final class RotaryHapticsType.Companion {
+    method public int getScrollItemFocus();
+    method public int getScrollLimit();
+    method public int getScrollTick();
+    property public final int ScrollItemFocus;
+    property public final int ScrollLimit;
+    property public final int ScrollTick;
+  }
+
+  public final class RotaryKt {
+    method public static kotlinx.coroutines.flow.Flow<com.google.android.horologist.compose.rotaryinput.TimestampedDelta> batchRequestsWithinTimeframe(kotlinx.coroutines.flow.Flow<com.google.android.horologist.compose.rotaryinput.TimestampedDelta>, long timeframe);
+    method public static androidx.compose.ui.Modifier rotaryHandler(androidx.compose.ui.Modifier, com.google.android.horologist.compose.rotaryinput.RotaryScrollHandler rotaryScrollHandler, optional long batchTimeframe, com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rotaryHaptics);
+    method @androidx.compose.runtime.Composable public static androidx.compose.ui.Modifier rotaryWithFling(androidx.compose.ui.Modifier, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.compose.foundation.gestures.ScrollableState scrollableState, optional androidx.compose.foundation.gestures.FlingBehavior flingBehavior, optional com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rotaryHaptics);
+    method @androidx.compose.runtime.Composable public static androidx.compose.ui.Modifier rotaryWithScroll(androidx.compose.ui.Modifier, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.compose.foundation.gestures.ScrollableState scrollableState, optional com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rotaryHaptics);
+  }
+
+  public interface RotaryScrollAdapter {
+    method public float averageItemSize();
+    method public int currentItemIndex();
+    method public float currentItemOffset();
+    method public androidx.compose.foundation.gestures.ScrollableState getScrollableState();
+    property public abstract androidx.compose.foundation.gestures.ScrollableState scrollableState;
+  }
+
+  public interface RotaryScrollBehavior {
+    method public suspend Object? handleEvent(float pixelsToScroll, long timestamp, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
+  }
+
+  public interface RotaryScrollHandler {
+    method public suspend Object? handleScrollEvent(kotlinx.coroutines.CoroutineScope coroutineScope, com.google.android.horologist.compose.rotaryinput.TimestampedDelta event, com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rotaryHaptics, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
+  }
+
+  public final class RotaryVelocityTracker {
+    ctor public RotaryVelocityTracker();
+    method public void end();
+    method public float getVelocity();
+    method public void move(long currentTime, float delta);
+    method public void start(long currentTime);
+    property public final float velocity;
+  }
+
+  public final class TimestampedDelta {
+    ctor public TimestampedDelta(long timestamp, float delta);
+    method public long component1();
+    method public float component2();
+    method public com.google.android.horologist.compose.rotaryinput.TimestampedDelta copy(long timestamp, float delta);
+    method public float getDelta();
+    method public long getTimestamp();
+    property public final float delta;
+    property public final long timestamp;
   }
 
 }

--- a/compose-layout/api/current.api
+++ b/compose-layout/api/current.api
@@ -130,21 +130,21 @@ package com.google.android.horologist.compose.rotaryinput {
     method public static androidx.compose.ui.Modifier onRotaryInputAccumulated(androidx.compose.ui.Modifier, kotlin.jvm.functions.Function1<? super java.lang.Float,kotlin.Unit> onValueChange);
   }
 
-  public final class AnimationScrollBehavior implements com.google.android.horologist.compose.rotaryinput.RotaryScrollBehavior {
+  @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public final class AnimationScrollBehavior implements com.google.android.horologist.compose.rotaryinput.RotaryScrollBehavior {
     ctor public AnimationScrollBehavior(androidx.compose.foundation.gestures.ScrollableState scrollableState);
-    method public suspend Object? handleEvent(float pixelsToScroll, long timestamp, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
+    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public suspend Object? handleEvent(float pixelsToScroll, long timestamp, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
   }
 
-  public final class DefaultRotaryFlingBehavior implements com.google.android.horologist.compose.rotaryinput.RotaryFlingBehavior {
+  @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public final class DefaultRotaryFlingBehavior implements com.google.android.horologist.compose.rotaryinput.RotaryFlingBehavior {
     ctor public DefaultRotaryFlingBehavior(androidx.compose.foundation.gestures.ScrollableState scrollableState, androidx.compose.foundation.gestures.FlingBehavior flingBehavior, android.view.ViewConfiguration viewConfiguration, long flingTimeframe);
-    method public void observeEvent(long timestamp, float delta);
-    method public void startFlingTracking(long timestamp);
-    method public suspend Object? trackFling(kotlin.jvm.functions.Function0<kotlin.Unit> beforeFling, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
+    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public void observeEvent(long timestamp, float delta);
+    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public void startFlingTracking(long timestamp);
+    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public suspend Object? trackFling(kotlin.jvm.functions.Function0<kotlin.Unit> beforeFling, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
   }
 
-  public final class DefaultRotaryHapticFeedback implements com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback {
+  @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public final class DefaultRotaryHapticFeedback implements com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback {
     ctor public DefaultRotaryHapticFeedback(android.view.View view);
-    method public void performHapticFeedback(int type);
+    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public void performHapticFeedback(int type);
     field public static final com.google.android.horologist.compose.rotaryinput.DefaultRotaryHapticFeedback.Companion Companion;
     field public static final int ROTARY_SCROLL_ITEM_FOCUS = 19; // 0x13
     field public static final int ROTARY_SCROLL_LIMIT = 20; // 0x14
@@ -160,26 +160,26 @@ package com.google.android.horologist.compose.rotaryinput {
   }
 
   public final class HapticsKt {
-    method @androidx.compose.runtime.Composable public static com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rememberDefaultRotaryHapticFeedback();
-    method @androidx.compose.runtime.Composable public static com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rememberRotaryHapticFeedback(optional long throttleThresholdMs, optional kotlinx.coroutines.channels.Channel<com.google.android.horologist.compose.rotaryinput.RotaryHapticsType> hapticsChannel, optional com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rotaryHaptics);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public static com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rememberDefaultRotaryHapticFeedback();
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public static com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rememberRotaryHapticFeedback(optional long throttleThresholdMs, optional kotlinx.coroutines.channels.Channel<com.google.android.horologist.compose.rotaryinput.RotaryHapticsType> hapticsChannel, optional com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rotaryHaptics);
   }
 
-  public final class RotaryDefaults {
-    method @androidx.compose.runtime.Composable public com.google.android.horologist.compose.rotaryinput.RotaryScrollHandler rememberFlingHandler(androidx.compose.foundation.gestures.ScrollableState scrollableState, optional androidx.compose.foundation.gestures.FlingBehavior? flingBehavior, optional boolean isLowRes);
+  @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public final class RotaryDefaults {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public com.google.android.horologist.compose.rotaryinput.RotaryScrollHandler rememberFlingHandler(androidx.compose.foundation.gestures.ScrollableState scrollableState, optional androidx.compose.foundation.gestures.FlingBehavior? flingBehavior, optional boolean isLowRes);
     field public static final com.google.android.horologist.compose.rotaryinput.RotaryDefaults INSTANCE;
   }
 
-  public interface RotaryFlingBehavior {
-    method public void observeEvent(long timestamp, float delta);
-    method public void startFlingTracking(long timestamp);
-    method public suspend Object? trackFling(kotlin.jvm.functions.Function0<kotlin.Unit> beforeFling, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
+  @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public interface RotaryFlingBehavior {
+    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public void observeEvent(long timestamp, float delta);
+    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public void startFlingTracking(long timestamp);
+    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public suspend Object? trackFling(kotlin.jvm.functions.Function0<kotlin.Unit> beforeFling, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
   }
 
-  public interface RotaryHapticFeedback {
-    method public void performHapticFeedback(int type);
+  @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public interface RotaryHapticFeedback {
+    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public void performHapticFeedback(int type);
   }
 
-  @kotlin.jvm.JvmInline public final value class RotaryHapticsType {
+  @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi @kotlin.jvm.JvmInline public final value class RotaryHapticsType {
     ctor public RotaryHapticsType(int type);
     field public static final com.google.android.horologist.compose.rotaryinput.RotaryHapticsType.Companion Companion;
   }
@@ -194,26 +194,26 @@ package com.google.android.horologist.compose.rotaryinput {
   }
 
   public final class RotaryKt {
-    method public static kotlinx.coroutines.flow.Flow<com.google.android.horologist.compose.rotaryinput.TimestampedDelta> batchRequestsWithinTimeframe(kotlinx.coroutines.flow.Flow<com.google.android.horologist.compose.rotaryinput.TimestampedDelta>, long timeframe);
-    method public static androidx.compose.ui.Modifier rotaryHandler(androidx.compose.ui.Modifier, com.google.android.horologist.compose.rotaryinput.RotaryScrollHandler rotaryScrollHandler, optional long batchTimeframe, com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rotaryHaptics);
-    method @androidx.compose.runtime.Composable public static androidx.compose.ui.Modifier rotaryWithFling(androidx.compose.ui.Modifier, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.compose.foundation.gestures.ScrollableState scrollableState, optional androidx.compose.foundation.gestures.FlingBehavior flingBehavior, optional com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rotaryHaptics);
-    method @androidx.compose.runtime.Composable public static androidx.compose.ui.Modifier rotaryWithScroll(androidx.compose.ui.Modifier, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.compose.foundation.gestures.ScrollableState scrollableState, optional com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rotaryHaptics);
+    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public static kotlinx.coroutines.flow.Flow<com.google.android.horologist.compose.rotaryinput.TimestampedDelta> batchRequestsWithinTimeframe(kotlinx.coroutines.flow.Flow<com.google.android.horologist.compose.rotaryinput.TimestampedDelta>, long timeframe);
+    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public static androidx.compose.ui.Modifier rotaryHandler(androidx.compose.ui.Modifier, com.google.android.horologist.compose.rotaryinput.RotaryScrollHandler rotaryScrollHandler, optional long batchTimeframe, com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rotaryHaptics);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public static androidx.compose.ui.Modifier rotaryWithFling(androidx.compose.ui.Modifier, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.compose.foundation.gestures.ScrollableState scrollableState, optional androidx.compose.foundation.gestures.FlingBehavior flingBehavior, optional com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rotaryHaptics);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public static androidx.compose.ui.Modifier rotaryWithScroll(androidx.compose.ui.Modifier, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.compose.foundation.gestures.ScrollableState scrollableState, optional com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rotaryHaptics);
   }
 
-  public interface RotaryScrollAdapter {
-    method public float averageItemSize();
-    method public int currentItemIndex();
-    method public float currentItemOffset();
+  @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public interface RotaryScrollAdapter {
+    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public float averageItemSize();
+    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public int currentItemIndex();
+    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public float currentItemOffset();
     method public androidx.compose.foundation.gestures.ScrollableState getScrollableState();
     property public abstract androidx.compose.foundation.gestures.ScrollableState scrollableState;
   }
 
-  public interface RotaryScrollBehavior {
-    method public suspend Object? handleEvent(float pixelsToScroll, long timestamp, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
+  @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public interface RotaryScrollBehavior {
+    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public suspend Object? handleEvent(float pixelsToScroll, long timestamp, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
   }
 
-  public interface RotaryScrollHandler {
-    method public suspend Object? handleScrollEvent(kotlinx.coroutines.CoroutineScope coroutineScope, com.google.android.horologist.compose.rotaryinput.TimestampedDelta event, com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rotaryHaptics, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
+  @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public interface RotaryScrollHandler {
+    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public suspend Object? handleScrollEvent(kotlinx.coroutines.CoroutineScope coroutineScope, com.google.android.horologist.compose.rotaryinput.TimestampedDelta event, com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rotaryHaptics, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
   }
 
   public final class RotaryVelocityTracker {
@@ -225,7 +225,7 @@ package com.google.android.horologist.compose.rotaryinput {
     property public final float velocity;
   }
 
-  public final class TimestampedDelta {
+  @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public final class TimestampedDelta {
     ctor public TimestampedDelta(long timestamp, float delta);
     method public long component1();
     method public float component2();

--- a/compose-layout/api/current.api
+++ b/compose-layout/api/current.api
@@ -136,7 +136,7 @@ package com.google.android.horologist.compose.rotaryinput {
   }
 
   public final class DefaultRotaryFlingBehavior implements com.google.android.horologist.compose.rotaryinput.RotaryFlingBehavior {
-    ctor public DefaultRotaryFlingBehavior(androidx.compose.foundation.gestures.ScrollableState scrollableState, androidx.compose.foundation.gestures.FlingBehavior flingBehavior, android.view.ViewConfiguration viewConfiguration);
+    ctor public DefaultRotaryFlingBehavior(androidx.compose.foundation.gestures.ScrollableState scrollableState, androidx.compose.foundation.gestures.FlingBehavior flingBehavior, android.view.ViewConfiguration viewConfiguration, long flingTimeframe);
     method public void observeEvent(long timestamp, float delta);
     method public void startFlingTracking(long timestamp);
     method public suspend Object? trackFling(kotlin.jvm.functions.Function0<kotlin.Unit> beforeFling, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
@@ -162,7 +162,6 @@ package com.google.android.horologist.compose.rotaryinput {
   public final class HapticsKt {
     method @androidx.compose.runtime.Composable public static com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rememberDefaultRotaryHapticFeedback();
     method @androidx.compose.runtime.Composable public static com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rememberRotaryHapticFeedback(optional long throttleThresholdMs, optional kotlinx.coroutines.channels.Channel<com.google.android.horologist.compose.rotaryinput.RotaryHapticsType> hapticsChannel, optional com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rotaryHaptics);
-    method public static <T> kotlinx.coroutines.flow.Flow<T> throttleLatest(kotlinx.coroutines.flow.Flow<? extends T>, long timeframe);
   }
 
   public final class RotaryDefaults {

--- a/compose-layout/src/androidTest/java/com/google/android/horologist/compose/navscaffold/NavScaffoldTest.kt
+++ b/compose-layout/src/androidTest/java/com/google/android/horologist/compose/navscaffold/NavScaffoldTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalCoroutinesApi::class)
+@file:OptIn(ExperimentalCoroutinesApi::class, ExperimentalHorologistComposeLayoutApi::class)
 
 package com.google.android.horologist.compose.navscaffold
 

--- a/compose-layout/src/androidTest/java/com/google/android/horologist/compose/navscaffold/NavScaffoldTest.kt
+++ b/compose-layout/src/androidTest/java/com/google/android/horologist/compose/navscaffold/NavScaffoldTest.kt
@@ -47,6 +47,7 @@ import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.TimeText
 import androidx.wear.compose.material.rememberScalingLazyListState
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
+import com.google.android.horologist.compose.rotaryinput.rotaryWithFling
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -84,7 +85,7 @@ class NavScaffoldTest {
                 ScalingLazyColumn(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .scrollableColumn(
+                        .rotaryWithFling(
                             it.viewModel.focusRequester,
                             it.scrollableState
                         ),
@@ -158,7 +159,7 @@ class NavScaffoldTest {
                 ) {
                     ScalingLazyColumn(
                         modifier = Modifier
-                            .scrollableColumn(
+                            .rotaryWithFling(
                                 it.viewModel.focusRequester,
                                 it.scrollableState
                             )
@@ -182,7 +183,7 @@ class NavScaffoldTest {
                         modifier = Modifier
                             .testTag("columnb")
                             .fillMaxSize()
-                            .scrollableColumn(it.viewModel.focusRequester, it.scrollableState)
+                            .rotaryWithFling(it.viewModel.focusRequester, it.scrollableState)
                             .verticalScroll(it.scrollableState)
                     ) {
                         (1..100).forEach { i ->

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/ScrollableColumn.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/ScrollableColumn.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.launch
  * }
  * ```
  */
+@Deprecated("Use .rotaryWithFling or .rotaryWithScroll instead")
 public fun Modifier.scrollableColumn(
     focusRequester: FocusRequester,
     scrollableState: ScrollableState

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * Copyright 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.google.android.horologist.compose.rotaryinput
 
 import android.view.HapticFeedbackConstants
@@ -79,19 +63,19 @@ public fun <T> Flow<T>.throttleLatest(timeframe: Long): Flow<T> =
 /**
  * Interface for Rotary haptic feedback
  */
-interface RotaryHapticFeedback {
-    fun performHapticFeedback(type: RotaryHapticsType)
+public interface RotaryHapticFeedback {
+    public fun performHapticFeedback(type: RotaryHapticsType)
 }
 
 /**
  * Rotary haptic types
  */
 @JvmInline
-value class RotaryHapticsType(val type: Int) {
-    companion object {
-        val ScrollTick = RotaryHapticsType(1)
-        val ScrollItemFocus = RotaryHapticsType(2)
-        val ScrollLimit = RotaryHapticsType(3)
+public value class RotaryHapticsType(private val type: Int) {
+    public companion object {
+        public val ScrollTick: RotaryHapticsType = RotaryHapticsType(1)
+        public val ScrollItemFocus: RotaryHapticsType = RotaryHapticsType(2)
+        public val ScrollLimit: RotaryHapticsType = RotaryHapticsType(3)
     }
 }
 
@@ -99,10 +83,10 @@ value class RotaryHapticsType(val type: Int) {
  * Remember rotary haptic feedback.
  */
 @Composable
-fun rememberRotaryHapticFeedback(
+public fun rememberRotaryHapticFeedback(
     throttleThresholdMs: Long = 40,
     hapticsChannel: Channel<RotaryHapticsType> = rememberHapticChannel(),
-    rotaryHaptics: RotaryHapticFeedback = rememberDefaultRotaryHapticFeedback(),
+    rotaryHaptics: RotaryHapticFeedback = rememberDefaultRotaryHapticFeedback()
 ): RotaryHapticFeedback {
     return remember(throttleThresholdMs, hapticsChannel, rotaryHaptics) {
         object : RotaryHapticFeedback {
@@ -141,35 +125,36 @@ private fun rememberHapticChannel() =
     }
 
 @Composable
-fun rememberDefaultRotaryHapticFeedback() =
+public fun rememberDefaultRotaryHapticFeedback(): RotaryHapticFeedback =
     LocalView.current.let { view -> remember { DefaultRotaryHapticFeedback(view) } }
 
 /**
  * Default Rotary implementation for [RotaryHapticFeedback]
  */
-class DefaultRotaryHapticFeedback(private val view: View) : RotaryHapticFeedback {
+public class DefaultRotaryHapticFeedback(private val view: View) : RotaryHapticFeedback {
 
     override fun performHapticFeedback(
-        hapticType: RotaryHapticsType,
+        type: RotaryHapticsType
     ) {
-
-        when (hapticType) {
+        when (type) {
             RotaryHapticsType.ScrollItemFocus -> {
                 view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
             }
+
             RotaryHapticsType.ScrollTick -> {
                 view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
             }
+
             RotaryHapticsType.ScrollLimit -> {
                 view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
             }
         }
     }
 
-    companion object {
+    public companion object {
         // Hidden constants from HapticFeedbackConstants.java
-        const val ROTARY_SCROLL_TICK = 18
-        const val ROTARY_SCROLL_ITEM_FOCUS = 19
-        const val ROTARY_SCROLL_LIMIT = 20
+        public const val ROTARY_SCROLL_TICK: Int = 18
+        public const val ROTARY_SCROLL_ITEM_FOCUS: Int = 19
+        public const val ROTARY_SCROLL_LIMIT: Int = 20
     }
 }

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
@@ -160,7 +160,7 @@ public class DefaultRotaryHapticFeedback(private val view: View) : RotaryHapticF
             }
 
             RotaryHapticsType.ScrollTick -> {
-                view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
+                view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
             }
 
             RotaryHapticsType.ScrollLimit -> {

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.compose.rotaryinput
+
+import android.view.HapticFeedbackConstants
+import android.view.View
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalView
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.withContext
+
+private const val DEBUG = false
+private inline fun debugLog(generateMsg: () -> String) {
+    if (DEBUG) {
+        println("RotaryHaptics: ${generateMsg()}")
+    }
+}
+
+/**
+ * Throttling events within specified timeframe. Only first and last events will be received.
+ * For a flow emitting elements 1 to 30, with a 100ms delay between them:
+ * ```
+ * val flow = flow {
+ *     for (i in 1..30) {
+ *         delay(100)
+ *         emit(i)
+ *     }
+ * }
+ * ```
+ * With timeframe=1000 only those integers will be received: 1, 10, 20, 30 .
+ */
+public fun <T> Flow<T>.throttleLatest(timeframe: Long): Flow<T> =
+    flow {
+        conflate().collect {
+            emit(it)
+            delay(timeframe)
+        }
+    }
+
+/**
+ * Interface for Rotary haptic feedback
+ */
+interface RotaryHapticFeedback {
+    fun performHapticFeedback(type: RotaryHapticsType)
+}
+
+/**
+ * Rotary haptic types
+ */
+@JvmInline
+value class RotaryHapticsType(val type: Int) {
+    companion object {
+        val ScrollTick = RotaryHapticsType(1)
+        val ScrollItemFocus = RotaryHapticsType(2)
+        val ScrollLimit = RotaryHapticsType(3)
+    }
+}
+
+/**
+ * Remember rotary haptic feedback.
+ */
+@Composable
+fun rememberRotaryHapticFeedback(
+    throttleThresholdMs: Long = 40,
+    hapticsChannel: Channel<RotaryHapticsType> = rememberHapticChannel(),
+    rotaryHaptics: RotaryHapticFeedback = rememberDefaultRotaryHapticFeedback(),
+): RotaryHapticFeedback {
+    return remember(throttleThresholdMs, hapticsChannel, rotaryHaptics) {
+        object : RotaryHapticFeedback {
+            override fun performHapticFeedback(type: RotaryHapticsType) {
+                hapticsChannel.trySend(type)
+            }
+        }
+    }.apply {
+        LaunchedEffect(hapticsChannel) {
+            hapticsChannel.receiveAsFlow()
+                .throttleLatest(throttleThresholdMs)
+                .collect { hapticType ->
+                    // 'withContext' launches performHapticFeedback in a separate thread,
+                    // as otherwise it produces a visible lag (b/219776664)
+                    val currentTime = System.currentTimeMillis()
+                    debugLog { "Haptics started" }
+                    withContext(Dispatchers.Default) {
+                        debugLog {
+                            "Performing haptics, delay: " +
+                                "${System.currentTimeMillis() - currentTime}"
+                        }
+                        rotaryHaptics.performHapticFeedback(hapticType)
+                    }
+                }
+        }
+    }
+}
+
+@Composable
+private fun rememberHapticChannel() =
+    remember {
+        Channel<RotaryHapticsType>(
+            capacity = 2,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST
+        )
+    }
+
+@Composable
+fun rememberDefaultRotaryHapticFeedback() =
+    LocalView.current.let { view -> remember { DefaultRotaryHapticFeedback(view) } }
+
+/**
+ * Default Rotary implementation for [RotaryHapticFeedback]
+ */
+class DefaultRotaryHapticFeedback(private val view: View) : RotaryHapticFeedback {
+
+    override fun performHapticFeedback(
+        hapticType: RotaryHapticsType,
+    ) {
+
+        when (hapticType) {
+            RotaryHapticsType.ScrollItemFocus -> {
+                view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+            }
+            RotaryHapticsType.ScrollTick -> {
+                view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
+            }
+            RotaryHapticsType.ScrollLimit -> {
+                view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+            }
+        }
+    }
+
+    companion object {
+        // Hidden constants from HapticFeedbackConstants.java
+        const val ROTARY_SCROLL_TICK = 18
+        const val ROTARY_SCROLL_ITEM_FOCUS = 19
+        const val ROTARY_SCROLL_LIMIT = 20
+    }
+}

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalView
+import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
@@ -67,13 +68,16 @@ internal fun <T> Flow<T>.throttleLatest(timeframe: Long): Flow<T> =
 /**
  * Interface for Rotary haptic feedback
  */
+@ExperimentalHorologistComposeLayoutApi
 public interface RotaryHapticFeedback {
+    @ExperimentalHorologistComposeLayoutApi
     public fun performHapticFeedback(type: RotaryHapticsType)
 }
 
 /**
  * Rotary haptic types
  */
+@ExperimentalHorologistComposeLayoutApi
 @JvmInline
 public value class RotaryHapticsType(private val type: Int) {
     public companion object {
@@ -81,18 +85,21 @@ public value class RotaryHapticsType(private val type: Int) {
          * A scroll ticking haptic. Similar to texture haptic - performed each time when
          * a scrollable content is scrolled by a certain distance
          */
+        @ExperimentalHorologistComposeLayoutApi
         public val ScrollTick: RotaryHapticsType = RotaryHapticsType(1)
 
         /**
          * An item focus (snap) haptic. Performed when a scrollable content is snapped
          * to a specific item.
          */
+        @ExperimentalHorologistComposeLayoutApi
         public val ScrollItemFocus: RotaryHapticsType = RotaryHapticsType(2)
 
         /**
          * A limit(overscroll) haptic. Performed when a list reaches the limit
          * (start or end) and can't scroll further
          */
+        @ExperimentalHorologistComposeLayoutApi
         public val ScrollLimit: RotaryHapticsType = RotaryHapticsType(3)
     }
 }
@@ -100,6 +107,7 @@ public value class RotaryHapticsType(private val type: Int) {
 /**
  * Remember rotary haptic feedback.
  */
+@ExperimentalHorologistComposeLayoutApi
 @Composable
 public fun rememberRotaryHapticFeedback(
     throttleThresholdMs: Long = 40,
@@ -133,6 +141,7 @@ public fun rememberRotaryHapticFeedback(
     }
 }
 
+@OptIn(ExperimentalHorologistComposeLayoutApi::class)
 @Composable
 private fun rememberHapticChannel() =
     remember {
@@ -142,6 +151,7 @@ private fun rememberHapticChannel() =
         )
     }
 
+@ExperimentalHorologistComposeLayoutApi
 @Composable
 public fun rememberDefaultRotaryHapticFeedback(): RotaryHapticFeedback =
     LocalView.current.let { view -> remember { DefaultRotaryHapticFeedback(view) } }
@@ -149,8 +159,10 @@ public fun rememberDefaultRotaryHapticFeedback(): RotaryHapticFeedback =
 /**
  * Default Rotary implementation for [RotaryHapticFeedback]
  */
+@ExperimentalHorologistComposeLayoutApi
 public class DefaultRotaryHapticFeedback(private val view: View) : RotaryHapticFeedback {
 
+    @ExperimentalHorologistComposeLayoutApi
     override fun performHapticFeedback(
         type: RotaryHapticsType
     ) {

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
@@ -33,6 +33,10 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.withContext
 
 private const val DEBUG = false
+
+/**
+ * Debug logging that can be enabled.
+ */
 private inline fun debugLog(generateMsg: () -> String) {
     if (DEBUG) {
         println("RotaryHaptics: ${generateMsg()}")
@@ -52,7 +56,7 @@ private inline fun debugLog(generateMsg: () -> String) {
  * ```
  * With timeframe=1000 only those integers will be received: 1, 10, 20, 30 .
  */
-public fun <T> Flow<T>.throttleLatest(timeframe: Long): Flow<T> =
+internal fun <T> Flow<T>.throttleLatest(timeframe: Long): Flow<T> =
     flow {
         conflate().collect {
             emit(it)
@@ -73,8 +77,22 @@ public interface RotaryHapticFeedback {
 @JvmInline
 public value class RotaryHapticsType(private val type: Int) {
     public companion object {
+        /**
+         * A scroll ticking haptic. Similar to texture haptic - performed each time when
+         * a scrollable content is scrolled by a certain distance
+         */
         public val ScrollTick: RotaryHapticsType = RotaryHapticsType(1)
+
+        /**
+         * An item focus (snap) haptic. Performed when a scrollable content is snapped
+         * to a specific item.
+         */
         public val ScrollItemFocus: RotaryHapticsType = RotaryHapticsType(2)
+
+        /**
+         * A limit(overscroll) haptic. Performed when a list reaches the limit
+         * (start or end) and can't scroll further
+         */
         public val ScrollLimit: RotaryHapticsType = RotaryHapticsType(3)
     }
 }
@@ -88,7 +106,7 @@ public fun rememberRotaryHapticFeedback(
     hapticsChannel: Channel<RotaryHapticsType> = rememberHapticChannel(),
     rotaryHaptics: RotaryHapticFeedback = rememberDefaultRotaryHapticFeedback()
 ): RotaryHapticFeedback {
-    return remember(throttleThresholdMs, hapticsChannel, rotaryHaptics) {
+    return remember(hapticsChannel, rotaryHaptics) {
         object : RotaryHapticFeedback {
             override fun performHapticFeedback(type: RotaryHapticsType) {
                 hapticsChannel.trySend(type)

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Rotary.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Rotary.kt
@@ -1,0 +1,615 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.compose.rotaryinput
+
+import android.view.ViewConfiguration
+import androidx.compose.animation.core.AnimationState
+import androidx.compose.animation.core.animateTo
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.MutatePriority
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.gestures.FlingBehavior
+import androidx.compose.foundation.gestures.ScrollableDefaults
+import androidx.compose.foundation.gestures.ScrollableState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.rotary.onRotaryScrollEvent
+import androidx.compose.ui.platform.LocalContext
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.transformLatest
+import kotlin.math.abs
+import kotlin.math.sign
+
+private const val DEBUG = false
+private inline fun debugLog(generateMsg: () -> String) {
+    if (DEBUG) {
+        println("RotaryScroll: ${generateMsg()}")
+    }
+}
+
+/**
+ * A modifier which connects rotary events with scrollable.
+ * This modifier supports fling.
+ *
+ * The screen containing the scrollable item should request the focus
+ * by calling [requestFocus] method
+ *
+ * ```
+ * LaunchedEffect(Unit) {
+ *   focusRequester.requestFocus()
+ * }
+ * ```
+ * @param focusRequester Requests the focus for rotary input
+ * @param scrollableState Scrollable state which will be scrolled while receiving rotary events
+ * @param flingBehavior Logic describing fling behavior.
+ * @param rotaryHaptics Class which will handle haptic feedback
+ */
+@Suppress("ComposableModifierFactory")
+@Composable
+public fun Modifier.rotaryWithFling(
+    focusRequester: FocusRequester,
+    scrollableState: ScrollableState,
+    flingBehavior: FlingBehavior = ScrollableDefaults.flingBehavior(),
+    rotaryHaptics: RotaryHapticFeedback = rememberRotaryHapticFeedback(),
+): Modifier = rotaryHandler(
+    rotaryScrollHandler = RotaryDefaults.rememberFlingHandler(scrollableState, flingBehavior),
+    rotaryHaptics = rotaryHaptics
+)
+    .focusRequester(focusRequester)
+    .focusable()
+
+/**
+ * A modifier which connects rotary events with scrollable.
+ *
+ * The screen containing the scrollable item should request the focus
+ * by calling [requestFocus] method
+ *
+ * ```
+ * LaunchedEffect(Unit) {
+ *   focusRequester.requestFocus()
+ * }
+ * ```
+ * @param focusRequester Requests the focus for rotary input
+ * @param scrollableState Scrollable state which will be scrolled while receiving rotary events
+ * @param rotaryHaptics Class which will handle haptic feedback
+ */
+@Suppress("ComposableModifierFactory")
+@Composable
+public fun Modifier.rotaryWithScroll(
+    focusRequester: FocusRequester,
+    scrollableState: ScrollableState,
+    rotaryHaptics: RotaryHapticFeedback = rememberRotaryHapticFeedback(),
+): Modifier = rotaryHandler(
+    rotaryScrollHandler = RotaryDefaults.rememberFlingHandler(scrollableState, null),
+    rotaryHaptics = rotaryHaptics
+)
+    .focusRequester(focusRequester)
+    .focusable()
+
+/**
+ * An adapter which connects scrollableState to Rotary
+ */
+public interface RotaryScrollAdapter {
+
+    /**
+     * A scrollable state. Used for performing scroll when Rotary events received
+     */
+    val scrollableState: ScrollableState
+
+    /**
+     * Average size of an item. Used for estimating the scrollable distance
+     */
+    fun averageItemSize(): Float
+
+    /**
+     * A current item index. Used for scrolling
+     */
+    fun currentItemIndex(): Int
+
+    /**
+     * An offset from the centre or the border of the current item.
+     */
+    fun currentItemOffset(): Float
+}
+
+/**
+ * Defaults for rotary modifiers
+ */
+public object RotaryDefaults {
+
+    /**
+     * Handles scroll with fling.
+     * @param scrollableState Scrollable state which will be scrolled while receiving rotary events
+     * @param flingBehavior Logic describing Fling behaviour. If null - fling will not happen
+     * @param isLowRes Whether the input is Low-res (a bezel) or high-res(a crown/rsb)
+     */
+    @Composable
+    public fun rememberFlingHandler(
+        scrollableState: ScrollableState,
+        flingBehavior: FlingBehavior? = null,
+        isLowRes: Boolean = isLowResInput(),
+    ): RotaryScrollHandler {
+        val viewConfiguration = ViewConfiguration.get(LocalContext.current)
+
+        return remember(scrollableState, flingBehavior, isLowRes) {
+            fun rotaryFlingBehavior() = flingBehavior?.run {
+                DefaultRotaryFlingBehavior(
+                    scrollableState,
+                    flingBehavior,
+                    viewConfiguration
+                )
+            }
+
+            fun scrollBehavior() = AnimationScrollBehavior(scrollableState)
+
+            if (isLowRes) {
+                LowResRotaryScrollHandler(
+                    rotaryFlingBehaviorFactory = { rotaryFlingBehavior() },
+                    scrollBehaviourFactory = { scrollBehavior() }
+                )
+            } else {
+                HighResRotaryScrollHandler(
+                    rotaryFlingBehaviorFactory = { rotaryFlingBehavior() },
+                    scrollBehaviourFactory = { scrollBehavior() }
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun isLowResInput(): Boolean = LocalContext.current.packageManager
+        .hasSystemFeature("android.hardware.rotaryencoder.lowres")
+}
+
+/**
+ * An interface for handling scroll events
+ */
+public interface RotaryScrollHandler {
+    /**
+     * Handles scrolling events
+     * @param coroutineScope A scope for performing async actions
+     * @param event A scrollable event from rotary input, containing scrollable delta and timestamp
+     * @param rotaryHaptics
+     */
+    suspend fun handleScrollEvent(
+        coroutineScope: CoroutineScope,
+        event: TimestampedDelta,
+        rotaryHaptics: RotaryHapticFeedback,
+    )
+}
+
+/**
+ * An interface for scrolling behaviour
+ */
+public interface RotaryScrollBehavior {
+    /**
+     * Handles scroll event with [pixelsToScroll] and [timestamp]
+     */
+    suspend fun handleEvent(
+        pixelsToScroll: Float,
+        timestamp: Long,
+    )
+}
+
+/**
+ * Default implementation of [RotaryFlingBehavior]
+ */
+public class DefaultRotaryFlingBehavior(
+    val scrollableState: ScrollableState,
+    val flingBehavior: FlingBehavior,
+    viewConfiguration: ViewConfiguration,
+) : RotaryFlingBehavior {
+
+    val rangeToFling = 100L
+    val lastEventFlingDelay = 60L
+
+    //  Constant which was taken from SysUi fling CL https://critique.corp.google.com/cl/462558138
+    val flingScaleFactor = 0.7f
+
+    var previousVelocity = 0f
+
+    val rotaryVelocityTracker = RotaryVelocityTracker()
+
+    val minFlingSpeed = viewConfiguration.scaledMinimumFlingVelocity.toFloat()
+    val maxFlingSpeed = viewConfiguration.scaledMaximumFlingVelocity.toFloat()
+    var latestEventTimestamp: Long = 0
+
+    var flingVelocity: Float = 0f
+    var flingTimestamp: Long = 0
+
+    override fun startFlingTracking(timestamp: Long) {
+        rotaryVelocityTracker.start(timestamp)
+        latestEventTimestamp = timestamp
+        previousVelocity = 0f
+    }
+
+    override fun observeEvent(timestamp: Long, delta: Float) {
+        rotaryVelocityTracker.move(timestamp, delta)
+        latestEventTimestamp = timestamp
+    }
+
+    override suspend fun trackFling(beforeFling: () -> Unit) {
+        val currentVelocity = rotaryVelocityTracker.velocity
+        debugLog { "currentVelocity: $currentVelocity" }
+
+        if (abs(currentVelocity) >= abs(previousVelocity)) {
+            flingTimestamp = latestEventTimestamp
+            flingVelocity = currentVelocity * flingScaleFactor
+        }
+        previousVelocity = currentVelocity
+
+        // Waiting for a fixed amount of time before checking the fling
+        delay(lastEventFlingDelay)
+
+        // For making a fling 2 criteria should be met:
+        // 1) no more than
+        // `rangeToFling` ms should pass between last fling detection
+        // and the time of last motion event
+        // 2) flingVelocity should exceed the minFlingSpeed
+        debugLog {
+            "Check fling:  flingVelocity: ${flingVelocity} " +
+                "minFlingSpeed: $minFlingSpeed, maxFlingSpeed: $maxFlingSpeed"
+        }
+        if (latestEventTimestamp - flingTimestamp < rangeToFling &&
+            abs(flingVelocity) > minFlingSpeed
+        ) {
+            //Stops scrollAnimationCoroutine because a fling will be performed
+            beforeFling()
+            val velocity = flingVelocity.coerceIn(-maxFlingSpeed, maxFlingSpeed)
+            scrollableState.scroll(MutatePriority.UserInput) {
+                with(flingBehavior) {
+                    debugLog { "Flinging with velocity ${velocity}" }
+                    performFling(velocity)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * An interface for flinging with rotary
+ */
+public interface RotaryFlingBehavior {
+
+    /**
+     * Observing new event within a fling tracking session with new timestamp and delta
+     */
+    fun observeEvent(timestamp: Long, delta: Float)
+
+    /**
+     * Performing fling if necessary and calling [beforeFling] lambda before it is triggered
+     */
+    suspend fun trackFling(beforeFling: () -> Unit)
+
+    /**
+     * Starts a new fling tracking session
+     * with specified timestamp
+     */
+    fun startFlingTracking(timestamp: Long)
+}
+
+/**
+ * A rotary event object which contains a [timestamp] of the rotary event and a scrolled [delta].
+ */
+data class TimestampedDelta(val timestamp: Long, val delta: Float)
+
+/** Animation implementation of ScrollBehaviour.
+ * This class does a smooth animation when the scroll by N pixels is done.
+ * This animation works well on Rsb(high-res) and Bezel(low-res) devices.
+ */
+public class AnimationScrollBehavior(
+    val scrollableState: ScrollableState,
+) : RotaryScrollBehavior {
+    var rotaryScrollDistance = 0f
+
+    var sequentialAnimation = false
+    var scrollAnimation = AnimationState(0f)
+    var prevPosition = 0f
+    var previousScrollEventTime = 0L
+
+    override suspend fun handleEvent(
+        pixelsToScroll: Float,
+        timestamp: Long,
+    ) {
+        rotaryScrollDistance += pixelsToScroll
+        debugLog { "Rotary scroll distance ${rotaryScrollDistance}" }
+
+        previousScrollEventTime = timestamp
+        scrollableState.scroll(MutatePriority.UserInput) {
+            debugLog {
+                "Rotary scroll distance ${rotaryScrollDistance}, " +
+                    "ScrollAnimation value before start: ${scrollAnimation.value}"
+            }
+
+            scrollAnimation.animateTo(
+                rotaryScrollDistance,
+                animationSpec = spring(),
+                sequentialAnimation = sequentialAnimation
+            ) {
+                val delta = value - prevPosition
+                debugLog { "Animated by $delta, value: ${value}" }
+                scrollBy(delta)
+                prevPosition = value
+                sequentialAnimation = value != this.targetValue
+            }
+        }
+    }
+}
+
+/**
+ * A modifier which handles rotary events.
+ * It accepts ScrollHandler as the input - a class where main logic about how
+ * scroll should be handled is lying
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+public fun Modifier.rotaryHandler(
+    rotaryScrollHandler: RotaryScrollHandler,
+    batchTimeframe: Long = 0L,
+    rotaryHaptics: RotaryHapticFeedback,
+): Modifier = composed {
+    val channel = rememberTimestampChannel()
+    val eventsFlow = remember(channel) { channel.receiveAsFlow() }
+
+    composed {
+        LaunchedEffect(eventsFlow) {
+            eventsFlow
+                //TODO: batching causes additional delays.
+                // Do we really need to do this on this level?
+                .batchRequestsWithinTimeframe(batchTimeframe)
+                .collectLatest {
+                    rotaryScrollHandler.handleScrollEvent(this, it, rotaryHaptics)
+                }
+        }
+        this
+            .onRotaryScrollEvent {
+                channel.trySend(
+                    TimestampedDelta(
+                        it.uptimeMillis,
+                        it.verticalScrollPixels
+                    )
+                )
+                true
+            }
+    }
+}
+
+/**
+ * Batching requests for scrolling events. This function combines all events together
+ * (except first) within specified timeframe. Should help with performance on high-res devices.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+public fun Flow<TimestampedDelta>.batchRequestsWithinTimeframe(timeframe: Long): Flow<TimestampedDelta> {
+    var delta = 0f
+    var lastTimestamp = -timeframe
+    return if (timeframe == 0L)
+        this
+    else
+        this.transformLatest {
+            delta += it.delta
+            debugLog { "Batching requests. delta:$delta" }
+            if (lastTimestamp + timeframe <= it.timestamp) {
+                lastTimestamp = it.timestamp
+                debugLog { "No events before, delta= $delta" }
+                emit(TimestampedDelta(it.timestamp, delta))
+            } else {
+                delay(timeframe)
+                debugLog { "After delay, delta= $delta" }
+                if (delta > 0f) {
+                    emit(TimestampedDelta(it.timestamp, delta))
+                }
+            }
+            delta = 0f
+        }
+}
+
+/**
+ * A scroll handler for RSB(high-res) without snapping and with or without fling
+ * A list is scrolled by the number of pixels received from the rotary device.
+ *
+ * This class is a little bit different from LowResScrollHandler class - it has a filtering
+ * for events which are coming with wrong sign ( this happens to rsb devices,
+ * especially at the end of the scroll)
+ *
+ * This scroll handler supports fling. It can be set with FlingBehaviour.
+ */
+internal class HighResRotaryScrollHandler(
+    val rotaryFlingBehaviorFactory: () -> RotaryFlingBehavior?,
+    val scrollBehaviourFactory: () -> RotaryScrollBehavior,
+) : RotaryScrollHandler {
+
+    // This constant is specific for high-res devices. Because that input values
+    // can sometimes come with different sign, we have to filter them in this threshold
+    val gestureThresholdTime = 200L
+    var scrollJob: Job = CompletableDeferred<Unit>()
+    var flingJob: Job = CompletableDeferred<Unit>()
+
+    var previousScrollEventTime = 0L
+    var rotaryScrollDistance = 0f
+
+    var rotaryFlingBehavior: RotaryFlingBehavior? = rotaryFlingBehaviorFactory()
+    var scrollBehaviour: RotaryScrollBehavior = scrollBehaviourFactory()
+
+    private var prevHapticsPosition = 0f
+    private var currScrollPosition = 0f
+    private val hapticsThreshold: Long = 100
+
+    override suspend fun handleScrollEvent(
+        coroutineScope: CoroutineScope,
+        event: TimestampedDelta,
+        rotaryHaptics: RotaryHapticFeedback,
+    ) {
+        val time = event.timestamp
+
+        if (isNewScrollEvent(time)) {
+            debugLog { "New scroll event" }
+            resetTracking(time)
+            rotaryScrollDistance = event.delta
+        } else {
+            // Filter out opposite axis values from end of scroll, also some values
+            // at the start of motion which sometimes appear with a different sign
+            if (isOppositeValueAfterScroll(event.delta)) {
+                debugLog { "Opposite value after scroll. Filtering:${event.delta}" }
+                return
+            }
+            rotaryScrollDistance += event.delta
+            rotaryFlingBehavior?.observeEvent(event.timestamp, event.delta)
+        }
+
+        scrollJob.cancel()
+        flingJob.cancel()
+
+        handleHaptic(rotaryHaptics, event.delta)
+        debugLog { "Rotary scroll distance: $rotaryScrollDistance" }
+
+        previousScrollEventTime = time
+        scrollJob = coroutineScope.async {
+            scrollBehaviour.handleEvent(event.delta, event.timestamp)
+        }
+
+        flingJob = coroutineScope.async {
+            rotaryFlingBehavior?.trackFling(
+                beforeFling = {
+                    debugLog { "Calling before fling section" }
+                    scrollJob.cancel()
+                    scrollBehaviour = scrollBehaviourFactory()
+                })
+        }
+    }
+
+    private fun isOppositeValueAfterScroll(delta: Float): Boolean =
+        sign(rotaryScrollDistance) * sign(delta) == -1f &&
+            (abs(delta) < abs(rotaryScrollDistance))
+
+    private fun isNewScrollEvent(timestamp: Long): Boolean {
+        val timeDelta = timestamp - previousScrollEventTime
+        return previousScrollEventTime == 0L || timeDelta > gestureThresholdTime
+    }
+
+    private fun resetTracking(timestamp: Long) {
+        scrollBehaviour = scrollBehaviourFactory()
+        rotaryFlingBehavior = rotaryFlingBehaviorFactory()
+        rotaryFlingBehavior?.startFlingTracking(timestamp)
+    }
+
+    private fun handleHaptic(rotaryHaptics: RotaryHapticFeedback, scrollDelta: Float) {
+        currScrollPosition += scrollDelta
+        val diff = abs(currScrollPosition - prevHapticsPosition)
+
+        if (diff >= hapticsThreshold) {
+            rotaryHaptics.performHapticFeedback(RotaryHapticsType.ScrollItemFocus)
+            prevHapticsPosition = currScrollPosition
+        }
+    }
+}
+
+/**
+ * A scroll handler for Bezel(low-res) without snapping.
+ * This scroll handler supports fling. It can be set with RotaryFlingBehavior.
+ */
+internal class LowResRotaryScrollHandler(
+    val rotaryFlingBehaviorFactory: () -> RotaryFlingBehavior?,
+    val scrollBehaviourFactory: () -> RotaryScrollBehavior,
+) : RotaryScrollHandler {
+
+    val gestureThresholdTime = 200L
+    var previousScrollEventTime = 0L
+    var rotaryScrollDistance = 0f
+
+    var scrollJob: Job = CompletableDeferred<Unit>()
+
+    var rotaryFlingBehavior: RotaryFlingBehavior? = rotaryFlingBehaviorFactory()
+    var scrollBehaviour: RotaryScrollBehavior = scrollBehaviourFactory()
+
+    override suspend fun handleScrollEvent(
+        coroutineScope: CoroutineScope,
+        event: TimestampedDelta,
+        rotaryHaptics: RotaryHapticFeedback,
+    ) {
+        scrollJob.cancel()
+
+        val time = event.timestamp
+
+        if (isNewScrollEvent(time)) {
+            resetTracking(time)
+        } else {
+            rotaryFlingBehavior?.observeEvent(event.timestamp, event.delta)
+        }
+
+        rotaryHaptics.performHapticFeedback(RotaryHapticsType.ScrollItemFocus)
+        debugLog { "Rotary scroll distance: $rotaryScrollDistance" }
+
+        previousScrollEventTime = time
+        scrollJob = coroutineScope.async {
+            scrollBehaviour.handleEvent(event.delta, event.timestamp)
+        }
+
+        rotaryFlingBehavior?.trackFling(
+            beforeFling = {
+                scrollBehaviour = scrollBehaviourFactory()
+            }
+        )
+    }
+
+    private fun isNewScrollEvent(timestamp: Long): Boolean {
+        val timeDelta = timestamp - previousScrollEventTime
+        return previousScrollEventTime == 0L || timeDelta > gestureThresholdTime
+    }
+
+    private fun resetTracking(timestamp: Long) {
+        scrollBehaviour = scrollBehaviourFactory()
+        debugLog { "Velocity tracker reset" }
+        rotaryFlingBehavior = rotaryFlingBehaviorFactory()
+        rotaryFlingBehavior?.startFlingTracking(timestamp)
+    }
+}
+
+@Composable
+private fun rememberTimestampChannel() =
+    remember {
+        Channel<TimestampedDelta>(capacity = Channel.CONFLATED)
+    }

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Rotary.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Rotary.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.rotary.onRotaryScrollEvent
 import androidx.compose.ui.platform.LocalContext
+import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -90,6 +91,7 @@ private inline fun debugLog(generateMsg: () -> String) {
  * @param flingBehavior Logic describing fling behavior.
  * @param rotaryHaptics Class which will handle haptic feedback
  */
+@ExperimentalHorologistComposeLayoutApi
 @Suppress("ComposableModifierFactory")
 @Composable
 public fun Modifier.rotaryWithFling(
@@ -119,6 +121,7 @@ public fun Modifier.rotaryWithFling(
  * @param scrollableState Scrollable state which will be scrolled while receiving rotary events
  * @param rotaryHaptics Class which will handle haptic feedback
  */
+@ExperimentalHorologistComposeLayoutApi
 @Suppress("ComposableModifierFactory")
 @Composable
 public fun Modifier.rotaryWithScroll(
@@ -135,32 +138,38 @@ public fun Modifier.rotaryWithScroll(
 /**
  * An adapter which connects scrollableState to Rotary
  */
+@ExperimentalHorologistComposeLayoutApi
 public interface RotaryScrollAdapter {
 
     /**
      * A scrollable state. Used for performing scroll when Rotary events received
      */
+    @ExperimentalHorologistComposeLayoutApi
     public val scrollableState: ScrollableState
 
     /**
      * Average size of an item. Used for estimating the scrollable distance
      */
+    @ExperimentalHorologistComposeLayoutApi
     public fun averageItemSize(): Float
 
     /**
      * A current item index. Used for scrolling
      */
+    @ExperimentalHorologistComposeLayoutApi
     public fun currentItemIndex(): Int
 
     /**
      * An offset from the centre or the border of the current item.
      */
+    @ExperimentalHorologistComposeLayoutApi
     public fun currentItemOffset(): Float
 }
 
 /**
  * Defaults for rotary modifiers
  */
+@ExperimentalHorologistComposeLayoutApi
 public object RotaryDefaults {
 
     /**
@@ -169,6 +178,7 @@ public object RotaryDefaults {
      * @param flingBehavior Logic describing Fling behavior. If null - fling will not happen
      * @param isLowRes Whether the input is Low-res (a bezel) or high-res(a crown/rsb)
      */
+    @ExperimentalHorologistComposeLayoutApi
     @Composable
     public fun rememberFlingHandler(
         scrollableState: ScrollableState,
@@ -204,6 +214,7 @@ public object RotaryDefaults {
         }
     }
 
+    @ExperimentalHorologistComposeLayoutApi
     @Composable
     private fun isLowResInput(): Boolean = LocalContext.current.packageManager
         .hasSystemFeature("android.hardware.rotaryencoder.lowres")
@@ -215,6 +226,7 @@ public object RotaryDefaults {
 /**
  * An interface for handling scroll events
  */
+@ExperimentalHorologistComposeLayoutApi
 public interface RotaryScrollHandler {
     /**
      * Handles scrolling events
@@ -222,6 +234,7 @@ public interface RotaryScrollHandler {
      * @param event A scrollable event from rotary input, containing scrollable delta and timestamp
      * @param rotaryHaptics
      */
+    @ExperimentalHorologistComposeLayoutApi
     public suspend fun handleScrollEvent(
         coroutineScope: CoroutineScope,
         event: TimestampedDelta,
@@ -232,10 +245,12 @@ public interface RotaryScrollHandler {
 /**
  * An interface for scrolling behavior
  */
+@ExperimentalHorologistComposeLayoutApi
 public interface RotaryScrollBehavior {
     /**
      * Handles scroll event with [pixelsToScroll] and [timestamp]
      */
+    @ExperimentalHorologistComposeLayoutApi
     public suspend fun handleEvent(
         pixelsToScroll: Float,
         timestamp: Long
@@ -245,6 +260,7 @@ public interface RotaryScrollBehavior {
 /**
  * Default implementation of [RotaryFlingBehavior]
  */
+@ExperimentalHorologistComposeLayoutApi
 public class DefaultRotaryFlingBehavior(
     private val scrollableState: ScrollableState,
     private val flingBehavior: FlingBehavior,
@@ -270,17 +286,20 @@ public class DefaultRotaryFlingBehavior(
     private var flingVelocity: Float = 0f
     private var flingTimestamp: Long = 0
 
+    @ExperimentalHorologistComposeLayoutApi
     override fun startFlingTracking(timestamp: Long) {
         rotaryVelocityTracker.start(timestamp)
         latestEventTimestamp = timestamp
         previousVelocity = 0f
     }
 
+    @ExperimentalHorologistComposeLayoutApi
     override fun observeEvent(timestamp: Long, delta: Float) {
         rotaryVelocityTracker.move(timestamp, delta)
         latestEventTimestamp = timestamp
     }
 
+    @ExperimentalHorologistComposeLayoutApi
     override suspend fun trackFling(beforeFling: () -> Unit) {
         val currentVelocity = rotaryVelocityTracker.velocity
         debugLog { "currentVelocity: $currentVelocity" }
@@ -322,34 +341,40 @@ public class DefaultRotaryFlingBehavior(
 /**
  * An interface for flinging with rotary
  */
+@ExperimentalHorologistComposeLayoutApi
 public interface RotaryFlingBehavior {
 
     /**
      * Observing new event within a fling tracking session with new timestamp and delta
      */
+    @ExperimentalHorologistComposeLayoutApi
     public fun observeEvent(timestamp: Long, delta: Float)
 
     /**
      * Performing fling if necessary and calling [beforeFling] lambda before it is triggered
      */
+    @ExperimentalHorologistComposeLayoutApi
     public suspend fun trackFling(beforeFling: () -> Unit)
 
     /**
      * Starts a new fling tracking session
      * with specified timestamp
      */
+    @ExperimentalHorologistComposeLayoutApi
     public fun startFlingTracking(timestamp: Long)
 }
 
 /**
  * A rotary event object which contains a [timestamp] of the rotary event and a scrolled [delta].
  */
+@ExperimentalHorologistComposeLayoutApi
 public data class TimestampedDelta(val timestamp: Long, val delta: Float)
 
 /** Animation implementation of [RotaryScrollBehavior].
  * This class does a smooth animation when the scroll by N pixels is done.
  * This animation works well on Rsb(high-res) and Bezel(low-res) devices.
  */
+@ExperimentalHorologistComposeLayoutApi
 public class AnimationScrollBehavior(
     private val scrollableState: ScrollableState
 ) : RotaryScrollBehavior {
@@ -360,6 +385,7 @@ public class AnimationScrollBehavior(
     private var prevPosition = 0f
     private var previousScrollEventTime = 0L
 
+    @ExperimentalHorologistComposeLayoutApi
     override suspend fun handleEvent(
         pixelsToScroll: Float,
         timestamp: Long
@@ -390,6 +416,7 @@ public class AnimationScrollBehavior(
  * It accepts ScrollHandler as the input - a class where main logic about how
  * scroll should be handled is lying
  */
+@ExperimentalHorologistComposeLayoutApi
 @OptIn(ExperimentalComposeUiApi::class)
 public fun Modifier.rotaryHandler(
     rotaryScrollHandler: RotaryScrollHandler,
@@ -430,6 +457,7 @@ public fun Modifier.rotaryHandler(
  * Batching requests for scrolling events. This function combines all events together
  * (except first) within specified timeframe. Should help with performance on high-res devices.
  */
+@ExperimentalHorologistComposeLayoutApi
 @OptIn(ExperimentalCoroutinesApi::class)
 public fun Flow<TimestampedDelta>.batchRequestsWithinTimeframe(timeframe: Long): Flow<TimestampedDelta> {
     var delta = 0f
@@ -466,6 +494,7 @@ public fun Flow<TimestampedDelta>.batchRequestsWithinTimeframe(timeframe: Long):
  *
  * This scroll handler supports fling. It can be set with [RotaryFlingBehavior].
  */
+@OptIn(ExperimentalHorologistComposeLayoutApi::class)
 internal class HighResRotaryScrollHandler(
     private val rotaryFlingBehaviorFactory: () -> RotaryFlingBehavior?,
     private val scrollBehaviorFactory: () -> RotaryScrollBehavior,
@@ -561,6 +590,7 @@ internal class HighResRotaryScrollHandler(
  * A scroll handler for Bezel(low-res) without snapping.
  * This scroll handler supports fling. It can be set with RotaryFlingBehavior.
  */
+@OptIn(ExperimentalHorologistComposeLayoutApi::class)
 internal class LowResRotaryScrollHandler(
     private val rotaryFlingBehaviorFactory: () -> RotaryFlingBehavior?,
     private val scrollBehaviorFactory: () -> RotaryScrollBehavior
@@ -624,6 +654,7 @@ internal class LowResRotaryScrollHandler(
     }
 }
 
+@OptIn(ExperimentalHorologistComposeLayoutApi::class)
 @Composable
 private fun rememberTimestampChannel() =
     remember {

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Rotary.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Rotary.kt
@@ -232,7 +232,7 @@ public class DefaultRotaryFlingBehavior(
     private val rangeToFling = 100L
     private val lastEventFlingDelay = 60L
 
-    //  Constant which was taken from SysUi fling CL https://critique.corp.google.com/cl/462558138
+    //  A default fling factor for making fling slower
     private val flingScaleFactor = 0.7f
 
     private var previousVelocity = 0f

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Rotary.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Rotary.kt
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * Copyright 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.google.android.horologist.compose.rotaryinput
 
 import android.view.ViewConfiguration
@@ -95,7 +79,7 @@ public fun Modifier.rotaryWithFling(
     focusRequester: FocusRequester,
     scrollableState: ScrollableState,
     flingBehavior: FlingBehavior = ScrollableDefaults.flingBehavior(),
-    rotaryHaptics: RotaryHapticFeedback = rememberRotaryHapticFeedback(),
+    rotaryHaptics: RotaryHapticFeedback = rememberRotaryHapticFeedback()
 ): Modifier = rotaryHandler(
     rotaryScrollHandler = RotaryDefaults.rememberFlingHandler(scrollableState, flingBehavior),
     rotaryHaptics = rotaryHaptics
@@ -123,7 +107,7 @@ public fun Modifier.rotaryWithFling(
 public fun Modifier.rotaryWithScroll(
     focusRequester: FocusRequester,
     scrollableState: ScrollableState,
-    rotaryHaptics: RotaryHapticFeedback = rememberRotaryHapticFeedback(),
+    rotaryHaptics: RotaryHapticFeedback = rememberRotaryHapticFeedback()
 ): Modifier = rotaryHandler(
     rotaryScrollHandler = RotaryDefaults.rememberFlingHandler(scrollableState, null),
     rotaryHaptics = rotaryHaptics
@@ -139,22 +123,22 @@ public interface RotaryScrollAdapter {
     /**
      * A scrollable state. Used for performing scroll when Rotary events received
      */
-    val scrollableState: ScrollableState
+    public val scrollableState: ScrollableState
 
     /**
      * Average size of an item. Used for estimating the scrollable distance
      */
-    fun averageItemSize(): Float
+    public fun averageItemSize(): Float
 
     /**
      * A current item index. Used for scrolling
      */
-    fun currentItemIndex(): Int
+    public fun currentItemIndex(): Int
 
     /**
      * An offset from the centre or the border of the current item.
      */
-    fun currentItemOffset(): Float
+    public fun currentItemOffset(): Float
 }
 
 /**
@@ -172,7 +156,7 @@ public object RotaryDefaults {
     public fun rememberFlingHandler(
         scrollableState: ScrollableState,
         flingBehavior: FlingBehavior? = null,
-        isLowRes: Boolean = isLowResInput(),
+        isLowRes: Boolean = isLowResInput()
     ): RotaryScrollHandler {
         val viewConfiguration = ViewConfiguration.get(LocalContext.current)
 
@@ -216,10 +200,10 @@ public interface RotaryScrollHandler {
      * @param event A scrollable event from rotary input, containing scrollable delta and timestamp
      * @param rotaryHaptics
      */
-    suspend fun handleScrollEvent(
+    public suspend fun handleScrollEvent(
         coroutineScope: CoroutineScope,
         event: TimestampedDelta,
-        rotaryHaptics: RotaryHapticFeedback,
+        rotaryHaptics: RotaryHapticFeedback
     )
 }
 
@@ -230,9 +214,9 @@ public interface RotaryScrollBehavior {
     /**
      * Handles scroll event with [pixelsToScroll] and [timestamp]
      */
-    suspend fun handleEvent(
+    public suspend fun handleEvent(
         pixelsToScroll: Float,
-        timestamp: Long,
+        timestamp: Long
     )
 }
 
@@ -240,27 +224,27 @@ public interface RotaryScrollBehavior {
  * Default implementation of [RotaryFlingBehavior]
  */
 public class DefaultRotaryFlingBehavior(
-    val scrollableState: ScrollableState,
-    val flingBehavior: FlingBehavior,
-    viewConfiguration: ViewConfiguration,
+    private val scrollableState: ScrollableState,
+    private val flingBehavior: FlingBehavior,
+    viewConfiguration: ViewConfiguration
 ) : RotaryFlingBehavior {
 
-    val rangeToFling = 100L
-    val lastEventFlingDelay = 60L
+    private val rangeToFling = 100L
+    private val lastEventFlingDelay = 60L
 
     //  Constant which was taken from SysUi fling CL https://critique.corp.google.com/cl/462558138
-    val flingScaleFactor = 0.7f
+    private val flingScaleFactor = 0.7f
 
-    var previousVelocity = 0f
+    private var previousVelocity = 0f
 
-    val rotaryVelocityTracker = RotaryVelocityTracker()
+    private val rotaryVelocityTracker = RotaryVelocityTracker()
 
-    val minFlingSpeed = viewConfiguration.scaledMinimumFlingVelocity.toFloat()
-    val maxFlingSpeed = viewConfiguration.scaledMaximumFlingVelocity.toFloat()
-    var latestEventTimestamp: Long = 0
+    private val minFlingSpeed = viewConfiguration.scaledMinimumFlingVelocity.toFloat()
+    private val maxFlingSpeed = viewConfiguration.scaledMaximumFlingVelocity.toFloat()
+    private var latestEventTimestamp: Long = 0
 
-    var flingVelocity: Float = 0f
-    var flingTimestamp: Long = 0
+    private var flingVelocity: Float = 0f
+    private var flingTimestamp: Long = 0
 
     override fun startFlingTracking(timestamp: Long) {
         rotaryVelocityTracker.start(timestamp)
@@ -292,18 +276,18 @@ public class DefaultRotaryFlingBehavior(
         // and the time of last motion event
         // 2) flingVelocity should exceed the minFlingSpeed
         debugLog {
-            "Check fling:  flingVelocity: ${flingVelocity} " +
+            "Check fling:  flingVelocity: $flingVelocity " +
                 "minFlingSpeed: $minFlingSpeed, maxFlingSpeed: $maxFlingSpeed"
         }
         if (latestEventTimestamp - flingTimestamp < rangeToFling &&
             abs(flingVelocity) > minFlingSpeed
         ) {
-            //Stops scrollAnimationCoroutine because a fling will be performed
+            // Stops scrollAnimationCoroutine because a fling will be performed
             beforeFling()
             val velocity = flingVelocity.coerceIn(-maxFlingSpeed, maxFlingSpeed)
             scrollableState.scroll(MutatePriority.UserInput) {
                 with(flingBehavior) {
-                    debugLog { "Flinging with velocity ${velocity}" }
+                    debugLog { "Flinging with velocity $velocity" }
                     performFling(velocity)
                 }
             }
@@ -319,50 +303,50 @@ public interface RotaryFlingBehavior {
     /**
      * Observing new event within a fling tracking session with new timestamp and delta
      */
-    fun observeEvent(timestamp: Long, delta: Float)
+    public fun observeEvent(timestamp: Long, delta: Float)
 
     /**
      * Performing fling if necessary and calling [beforeFling] lambda before it is triggered
      */
-    suspend fun trackFling(beforeFling: () -> Unit)
+    public suspend fun trackFling(beforeFling: () -> Unit)
 
     /**
      * Starts a new fling tracking session
      * with specified timestamp
      */
-    fun startFlingTracking(timestamp: Long)
+    public fun startFlingTracking(timestamp: Long)
 }
 
 /**
  * A rotary event object which contains a [timestamp] of the rotary event and a scrolled [delta].
  */
-data class TimestampedDelta(val timestamp: Long, val delta: Float)
+public data class TimestampedDelta(val timestamp: Long, val delta: Float)
 
 /** Animation implementation of ScrollBehaviour.
  * This class does a smooth animation when the scroll by N pixels is done.
  * This animation works well on Rsb(high-res) and Bezel(low-res) devices.
  */
 public class AnimationScrollBehavior(
-    val scrollableState: ScrollableState,
+    private val scrollableState: ScrollableState
 ) : RotaryScrollBehavior {
-    var rotaryScrollDistance = 0f
+    private var rotaryScrollDistance = 0f
 
-    var sequentialAnimation = false
-    var scrollAnimation = AnimationState(0f)
-    var prevPosition = 0f
-    var previousScrollEventTime = 0L
+    private var sequentialAnimation = false
+    private var scrollAnimation = AnimationState(0f)
+    private var prevPosition = 0f
+    private var previousScrollEventTime = 0L
 
     override suspend fun handleEvent(
         pixelsToScroll: Float,
-        timestamp: Long,
+        timestamp: Long
     ) {
         rotaryScrollDistance += pixelsToScroll
-        debugLog { "Rotary scroll distance ${rotaryScrollDistance}" }
+        debugLog { "Rotary scroll distance $rotaryScrollDistance" }
 
         previousScrollEventTime = timestamp
         scrollableState.scroll(MutatePriority.UserInput) {
             debugLog {
-                "Rotary scroll distance ${rotaryScrollDistance}, " +
+                "Rotary scroll distance $rotaryScrollDistance, " +
                     "ScrollAnimation value before start: ${scrollAnimation.value}"
             }
 
@@ -372,7 +356,7 @@ public class AnimationScrollBehavior(
                 sequentialAnimation = sequentialAnimation
             ) {
                 val delta = value - prevPosition
-                debugLog { "Animated by $delta, value: ${value}" }
+                debugLog { "Animated by $delta, value: $value" }
                 scrollBy(delta)
                 prevPosition = value
                 sequentialAnimation = value != this.targetValue
@@ -390,7 +374,7 @@ public class AnimationScrollBehavior(
 public fun Modifier.rotaryHandler(
     rotaryScrollHandler: RotaryScrollHandler,
     batchTimeframe: Long = 0L,
-    rotaryHaptics: RotaryHapticFeedback,
+    rotaryHaptics: RotaryHapticFeedback
 ): Modifier = composed {
     val channel = rememberTimestampChannel()
     val eventsFlow = remember(channel) { channel.receiveAsFlow() }
@@ -398,7 +382,7 @@ public fun Modifier.rotaryHandler(
     composed {
         LaunchedEffect(eventsFlow) {
             eventsFlow
-                //TODO: batching causes additional delays.
+                // TODO: batching causes additional delays.
                 // Do we really need to do this on this level?
                 .batchRequestsWithinTimeframe(batchTimeframe)
                 .collectLatest {
@@ -426,9 +410,9 @@ public fun Modifier.rotaryHandler(
 public fun Flow<TimestampedDelta>.batchRequestsWithinTimeframe(timeframe: Long): Flow<TimestampedDelta> {
     var delta = 0f
     var lastTimestamp = -timeframe
-    return if (timeframe == 0L)
+    return if (timeframe == 0L) {
         this
-    else
+    } else {
         this.transformLatest {
             delta += it.delta
             debugLog { "Batching requests. delta:$delta" }
@@ -445,6 +429,7 @@ public fun Flow<TimestampedDelta>.batchRequestsWithinTimeframe(timeframe: Long):
             }
             delta = 0f
         }
+    }
 }
 
 /**
@@ -459,7 +444,7 @@ public fun Flow<TimestampedDelta>.batchRequestsWithinTimeframe(timeframe: Long):
  */
 internal class HighResRotaryScrollHandler(
     val rotaryFlingBehaviorFactory: () -> RotaryFlingBehavior?,
-    val scrollBehaviourFactory: () -> RotaryScrollBehavior,
+    val scrollBehaviourFactory: () -> RotaryScrollBehavior
 ) : RotaryScrollHandler {
 
     // This constant is specific for high-res devices. Because that input values
@@ -481,7 +466,7 @@ internal class HighResRotaryScrollHandler(
     override suspend fun handleScrollEvent(
         coroutineScope: CoroutineScope,
         event: TimestampedDelta,
-        rotaryHaptics: RotaryHapticFeedback,
+        rotaryHaptics: RotaryHapticFeedback
     ) {
         val time = event.timestamp
 
@@ -517,7 +502,8 @@ internal class HighResRotaryScrollHandler(
                     debugLog { "Calling before fling section" }
                     scrollJob.cancel()
                     scrollBehaviour = scrollBehaviourFactory()
-                })
+                }
+            )
         }
     }
 
@@ -553,7 +539,7 @@ internal class HighResRotaryScrollHandler(
  */
 internal class LowResRotaryScrollHandler(
     val rotaryFlingBehaviorFactory: () -> RotaryFlingBehavior?,
-    val scrollBehaviourFactory: () -> RotaryScrollBehavior,
+    val scrollBehaviourFactory: () -> RotaryScrollBehavior
 ) : RotaryScrollHandler {
 
     val gestureThresholdTime = 200L
@@ -568,7 +554,7 @@ internal class LowResRotaryScrollHandler(
     override suspend fun handleScrollEvent(
         coroutineScope: CoroutineScope,
         event: TimestampedDelta,
-        rotaryHaptics: RotaryHapticFeedback,
+        rotaryHaptics: RotaryHapticFeedback
     ) {
         scrollJob.cancel()
 

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/RotaryVelocityTracker.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/RotaryVelocityTracker.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.compose.rotaryinput
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.util.VelocityTracker
+
+/**
+ * Intercepts VelocityTracker to provide support for rotary input.
+ */
+class RotaryVelocityTracker {
+    //TODO(b/32830165): Current implementation of VelocityTracker resets the speed after 40ms
+    // if no motion events received. This threshold can't be changed.
+    // The solution will be to use updated impulse-based velocityTracker from Android
+    // or write similar in compose.
+    private var velocityTracker: VelocityTracker = VelocityTracker()
+    private var position: Float = 0f
+
+    /**
+     * Retrieve the last computed Y velocity.
+     */
+    val velocity: Float
+        get() = velocityTracker.calculateVelocity().y
+
+    /**
+     * Start tracking motion.
+     */
+    fun start(currentTime: Long) {
+        velocityTracker.resetTracking()
+        position = 0f
+        velocityTracker.addPosition(currentTime, Offset(0f, position))
+    }
+
+    /**
+     * Continue tracking motion as the input rotates.
+     */
+    fun move(currentTime: Long, delta: Float) {
+        position += delta
+        velocityTracker.addPosition(currentTime, Offset(0f, position))
+    }
+
+    /**
+     * Stop tracking motion.
+     */
+    fun end() {
+        velocityTracker.resetTracking()
+    }
+}

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/RotaryVelocityTracker.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/RotaryVelocityTracker.kt
@@ -22,8 +22,8 @@ import androidx.compose.ui.input.pointer.util.VelocityTracker
 /**
  * Intercepts VelocityTracker to provide support for rotary input.
  */
-class RotaryVelocityTracker {
-    //TODO(b/32830165): Current implementation of VelocityTracker resets the speed after 40ms
+public class RotaryVelocityTracker {
+    // TODO(b/32830165): Current implementation of VelocityTracker resets the speed after 40ms
     // if no motion events received. This threshold can't be changed.
     // The solution will be to use updated impulse-based velocityTracker from Android
     // or write similar in compose.
@@ -33,13 +33,13 @@ class RotaryVelocityTracker {
     /**
      * Retrieve the last computed Y velocity.
      */
-    val velocity: Float
+    public val velocity: Float
         get() = velocityTracker.calculateVelocity().y
 
     /**
      * Start tracking motion.
      */
-    fun start(currentTime: Long) {
+    public fun start(currentTime: Long) {
         velocityTracker.resetTracking()
         position = 0f
         velocityTracker.addPosition(currentTime, Offset(0f, position))
@@ -48,7 +48,7 @@ class RotaryVelocityTracker {
     /**
      * Continue tracking motion as the input rotates.
      */
-    fun move(currentTime: Long, delta: Float) {
+    public fun move(currentTime: Long, delta: Float) {
         position += delta
         velocityTracker.addPosition(currentTime, Offset(0f, position))
     }
@@ -56,7 +56,7 @@ class RotaryVelocityTracker {
     /**
      * Stop tracking motion.
      */
-    fun end() {
+    public fun end() {
         velocityTracker.resetTracking()
     }
 }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/debug/AudioDebugScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/debug/AudioDebugScreen.kt
@@ -32,7 +32,7 @@ import androidx.wear.compose.material.ScalingLazyColumn
 import androidx.wear.compose.material.ScalingLazyListState
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.items
-import com.google.android.horologist.compose.navscaffold.scrollableColumn
+import com.google.android.horologist.compose.rotaryinput.rotaryWithFling
 import com.google.android.horologist.mediasample.R
 import java.time.Instant
 import java.time.ZoneId
@@ -50,7 +50,7 @@ fun AudioDebugScreen(
     ScalingLazyColumn(
         modifier = modifier
             .fillMaxSize()
-            .scrollableColumn(focusRequester, state),
+            .rotaryWithFling(focusRequester, state),
         state = state
     ) {
         item {

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/debug/SamplesScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/debug/SamplesScreen.kt
@@ -31,7 +31,7 @@ import androidx.wear.compose.material.ScalingLazyListState
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.items
 import com.google.android.horologist.compose.layout.StateUtils.rememberStateWithLifecycle
-import com.google.android.horologist.compose.navscaffold.scrollableColumn
+import com.google.android.horologist.compose.rotaryinput.rotaryWithFling
 import com.google.android.horologist.media.ui.navigation.MediaNavController.navigateToPlayer
 import com.google.android.horologist.mediasample.R
 import com.google.android.horologist.mediasample.ui.settings.ActionSetting
@@ -49,7 +49,7 @@ fun SamplesScreen(
     ScalingLazyColumn(
         modifier = modifier
             .fillMaxSize()
-            .scrollableColumn(focusRequester, state),
+            .rotaryWithFling(focusRequester, state),
         state = state
     ) {
         item {

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/settings/DeveloperOptionsScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/settings/DeveloperOptionsScreen.kt
@@ -34,7 +34,7 @@ import androidx.wear.compose.material.ScalingLazyListState
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.ToggleChip
 import androidx.wear.compose.material.ToggleChipDefaults
-import com.google.android.horologist.compose.navscaffold.scrollableColumn
+import com.google.android.horologist.compose.rotaryinput.rotaryWithFling
 import com.google.android.horologist.mediasample.R
 import com.google.android.horologist.mediasample.domain.proto.SettingsProto.OffloadMode
 import com.google.android.horologist.mediasample.ui.navigation.navigateToAudioDebug
@@ -53,7 +53,7 @@ fun DeveloperOptionsScreen(
     ScalingLazyColumn(
         modifier = modifier
             .fillMaxSize()
-            .scrollableColumn(focusRequester, state),
+            .rotaryWithFling(focusRequester, state),
         state = state
     ) {
         item {

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/settings/UampSettingsScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/settings/UampSettingsScreen.kt
@@ -40,7 +40,7 @@ import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.ScalingLazyColumn
 import androidx.wear.compose.material.ScalingLazyListState
 import androidx.wear.compose.material.Text
-import com.google.android.horologist.compose.navscaffold.scrollableColumn
+import com.google.android.horologist.compose.rotaryinput.rotaryWithFling
 import com.google.android.horologist.mediasample.R
 import com.google.android.horologist.mediasample.ui.navigation.navigateToDeveloperOptions
 
@@ -55,7 +55,7 @@ fun UampSettingsScreen(
     ScalingLazyColumn(
         modifier = modifier
             .fillMaxSize()
-            .scrollableColumn(focusRequester, state),
+            .rotaryWithFling(focusRequester, state),
         state = state
     ) {
         item {

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/EntityScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/EntityScreen.kt
@@ -32,7 +32,7 @@ import androidx.wear.compose.material.ScalingLazyListScope
 import androidx.wear.compose.material.ScalingLazyListState
 import androidx.wear.compose.material.ScalingParams
 import com.google.android.horologist.base.ui.components.Title
-import com.google.android.horologist.compose.navscaffold.scrollableColumn
+import com.google.android.horologist.compose.rotaryinput.rotaryWithFling
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 
 /**
@@ -53,7 +53,7 @@ public fun EntityScreen(
     ScalingLazyColumn(
         modifier = modifier
             .fillMaxSize()
-            .scrollableColumn(focusRequester, scalingLazyListState),
+            .rotaryWithFling(focusRequester, scalingLazyListState),
         state = scalingLazyListState,
         scalingParams = scalingParams,
         autoCentering = autoCentering

--- a/sample/src/main/java/com/google/android/horologist/navsample/FillerScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/navsample/FillerScreen.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.ScalingLazyColumn
 import androidx.wear.compose.material.ScalingLazyListState
 import androidx.wear.compose.material.Text
-import com.google.android.horologist.compose.navscaffold.scrollableColumn
+import com.google.android.horologist.compose.rotaryinput.rotaryWithFling
 
 @Composable
 fun FillerScreen(label: String, modifier: Modifier = Modifier) {
@@ -50,7 +50,7 @@ fun BigScalingLazyColumn(
     ScalingLazyColumn(
         modifier = modifier
             .fillMaxSize()
-            .scrollableColumn(focusRequester, scrollState),
+            .rotaryWithFling(focusRequester, scrollState),
         state = scrollState,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
@@ -70,7 +70,7 @@ fun BigColumn(
         modifier = modifier
             .fillMaxSize()
             .verticalScroll(scrollState)
-            .scrollableColumn(focusRequester, scrollState),
+            .rotaryWithFling(focusRequester, scrollState),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Spacer(modifier = Modifier.size(30.dp))

--- a/sample/src/main/java/com/google/android/horologist/navsample/NavMenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/navsample/NavMenuScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.wear.compose.material.AutoCenteringParams
 import androidx.wear.compose.material.ScalingLazyColumn
 import androidx.wear.compose.material.ScalingLazyListState
-import com.google.android.horologist.compose.navscaffold.scrollableColumn
+import com.google.android.horologist.compose.rotaryinput.rotaryWithFling
 import com.google.android.horologist.sample.SampleChip
 
 @Composable
@@ -35,7 +35,7 @@ fun NavMenuScreen(
     focusRequester: FocusRequester = remember { FocusRequester() }
 ) {
     ScalingLazyColumn(
-        modifier = modifier.scrollableColumn(focusRequester, scrollState),
+        modifier = modifier.rotaryWithFling(focusRequester, scrollState),
         state = scrollState,
         horizontalAlignment = Alignment.CenterHorizontally,
         autoCentering = AutoCenteringParams(itemIndex = 0)

--- a/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview

--- a/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
@@ -37,8 +37,8 @@ import androidx.wear.compose.material.ScalingLazyColumn
 import androidx.wear.compose.material.ScalingLazyListState
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.rememberScalingLazyListState
-import com.google.android.horologist.compose.navscaffold.scrollableColumn
 import com.google.android.horologist.compose.pager.FocusOnResume
+import com.google.android.horologist.compose.rotaryinput.rotaryWithFling
 import java.time.LocalDateTime
 
 @Composable
@@ -51,9 +51,7 @@ fun MenuScreen(
 ) {
     ScalingLazyColumn(
         modifier = modifier
-            .scrollableColumn(focusRequester, scrollState)
-            .focusRequester(focusRequester)
-            .focusable(),
+            .rotaryWithFling(focusRequester, scalingLazyListState),
         horizontalAlignment = Alignment.CenterHorizontally,
         state = scrollState
     ) {

--- a/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
@@ -16,7 +16,6 @@
 
 package com.google.android.horologist.sample
 
-import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -51,7 +50,7 @@ fun MenuScreen(
 ) {
     ScalingLazyColumn(
         modifier = modifier
-            .rotaryWithFling(focusRequester, scalingLazyListState),
+            .rotaryWithFling(focusRequester, scrollState),
         horizontalAlignment = Alignment.CenterHorizontally,
         state = scrollState
     ) {

--- a/sample/src/main/java/com/google/android/horologist/sample/ScrollAwayScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/ScrollAwayScreen.kt
@@ -42,7 +42,7 @@ import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.TimeText
 import androidx.wear.compose.material.rememberScalingLazyListState
 import androidx.wear.compose.material.scrollAway
-import com.google.android.horologist.compose.navscaffold.scrollableColumn
+import com.google.android.horologist.compose.rotaryinput.rotaryWithFling
 import com.google.android.horologist.compose.tools.WearLargeRoundDevicePreview
 
 @Composable
@@ -60,7 +60,7 @@ fun ScrollScreenLazyColumn() {
         }
     ) {
         LazyColumn(
-            modifier = Modifier.scrollableColumn(focusRequester, scrollState),
+            modifier = Modifier.rotaryWithFling(focusRequester, scrollState),
             state = scrollState
         ) {
             items(3) { i ->
@@ -90,7 +90,7 @@ fun ScrollAwayScreenScalingLazyColumn() {
         }
     ) {
         ScalingLazyColumn(
-            modifier = Modifier.scrollableColumn(focusRequester, scrollState),
+            modifier = Modifier.rotaryWithFling(focusRequester, scrollState),
             state = scrollState
         ) {
             items(3) { i ->
@@ -120,7 +120,7 @@ fun ScrollAwayScreenColumn() {
     ) {
         Column(
             modifier = Modifier
-                .scrollableColumn(focusRequester, scrollState)
+                .rotaryWithFling(focusRequester, scrollState)
                 .verticalScroll(scrollState)
         ) {
             val modifier = Modifier.height(LocalConfiguration.current.screenHeightDp.dp / 2)


### PR DESCRIPTION
#### WHAT
Add 2 new modifiers for rotary input - `rotaryWithFling` and `rotaryWithScroll`. Those modifiers should be used  instead of `scrollableColumn` modifier. 

Both modifiers support haptics out of the box.

#### WHY
Rotary support improvements

#### HOW
`rotaryWithFling` modifier: 
For a proper fling support a `velocityTracker` is used for speed tracking. Once the speed goes up to some threshold and no other scroll events come - fling starts with the tracked speed. `FlingBehavior` is used for proper fling and can be changed in the parameters of the modifier. 

`rotaryWithScroll` modifier: 
An animation between scroll values was added for properly supporting Bezel rotary input. 

Haptics: 
A separate haptics implementation was added for producing haptics when scrolling happens. Haptics can be changed or switched off by reimplementing proper haptic classes


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [ ] Run tests
- [x] Update metalava's signature text files
