### PR TITLE
Drop datalayer to targetSdk 21

### DIFF
--- a/datalayer/build.gradle
+++ b/datalayer/build.gradle
@@ -72,7 +72,6 @@ android {
 dependencies {
     implementation libs.kotlin.stdlib
     implementation libs.kotlinx.coroutines.core
-    implementation libs.androidx.wear
 
     api libs.playservices.wearable
     implementation libs.kotlinx.coroutines.playservices

--- a/datalayer/build.gradle
+++ b/datalayer/build.gradle
@@ -24,7 +24,8 @@ android {
     compileSdkVersion 33
 
     defaultConfig {
-        minSdk 26
+        minSdk 21
+        //noinspection ExpiredTargetSdkVersion
         targetSdk 30
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
#### WHAT

Drop datalayer to targetSdk 21

#### WHY

It accidentally makes it hard to use from a phone app.

#### HOW

Change minSdk and remove androidx.wear dependency

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
