### PR TITLE
Rotary improvements

### DIFF
--- a/compose-layout/api/current.api
+++ b/compose-layout/api/current.api
@@ -139,7 +139,7 @@ package com.google.android.horologist.compose.rotaryinput {
 
   @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public final class AnimationScrollBehavior implements com.google.android.horologist.compose.rotaryinput.RotaryScrollBehavior {
     ctor public AnimationScrollBehavior(androidx.compose.foundation.gestures.ScrollableState scrollableState);
-    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public suspend Object? handleEvent(float pixelsToScroll, long timestamp, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
+    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public suspend Object? handleEvent(float targetValue, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
   }
 
   @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public final class DefaultRotaryFlingBehavior implements com.google.android.horologist.compose.rotaryinput.RotaryFlingBehavior {
@@ -163,8 +163,9 @@ package com.google.android.horologist.compose.rotaryinput {
 
   @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public final class DefaultSnapBehavior implements com.google.android.horologist.compose.rotaryinput.RotarySnapBehavior {
     ctor public DefaultSnapBehavior(com.google.android.horologist.compose.rotaryinput.RotaryScrollAdapter rotaryScrollAdapter, com.google.android.horologist.compose.rotaryinput.SnapParameters snapParameters);
-    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public suspend Object? handleSnap(int moveForElements, boolean sequentialSnap, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
+    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public void prepareSnapForItems(int moveForElements, boolean sequentialSnap);
     method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public float snapThreshold(boolean duringSnap);
+    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public suspend Object? startSnappingSession(boolean toClosestItem, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
   }
 
   public final class GenericMotionRotaryInputAccumulator {
@@ -227,7 +228,7 @@ package com.google.android.horologist.compose.rotaryinput {
   }
 
   @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public interface RotaryScrollBehavior {
-    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public suspend Object? handleEvent(float pixelsToScroll, long timestamp, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
+    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public suspend Object? handleEvent(float targetValue, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
   }
 
   @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public interface RotaryScrollHandler {
@@ -235,8 +236,9 @@ package com.google.android.horologist.compose.rotaryinput {
   }
 
   @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public interface RotarySnapBehavior {
-    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public suspend Object? handleSnap(int moveForElements, boolean sequentialSnap, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
+    method public void prepareSnapForItems(int moveForElements, boolean sequentialSnap);
     method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public float snapThreshold(boolean duringSnap);
+    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public suspend Object? startSnappingSession(boolean toClosestItem, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
   }
 
   public final class RotaryVelocityTracker {


### PR DESCRIPTION
#### WHAT
A rotary was improved by fixing some race conditions on high-res devices

#### WHY
When RSB was scrolled too fast some rotary events were skipped

#### HOW
Snapping: 
Instead of relying on separate flag which was set manually, now we rely on `snapJob.isActive` to clearly distinguish whether the snapping is in progress or not. 
If a new snapping happens when `snapJob.isActive == true` old job is not killed - but rather updated. This helps us to speed up things.

Scrolling :
Method `handleEvent` now accepts `targetValue` which is the absolute number of pixels by which the scroll should happen. Before it was a cumulative sum - every new call would sum up all values. 
Example : 
 - Calling `handleEvent` with  50 , 60, 100, 20 
Before :  would result in  230 px scrolled
Now: would result in 20px scrolled 

Tests will be added in a separate CL 

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
