### PR TITLE
Add AuthMenuScreen in sample app

### DIFF
--- a/sample/src/main/java/com/google/android/horologist/auth/AuthMenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/AuthMenuScreen.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.wear.compose.material.ScalingLazyColumn
+import androidx.wear.compose.material.ScalingLazyListState
+import androidx.wear.compose.material.rememberScalingLazyListState
+import com.google.android.horologist.base.ui.components.StandardChip
+import com.google.android.horologist.base.ui.components.StandardChipType
+import com.google.android.horologist.compose.rotaryinput.rotaryWithSnap
+import com.google.android.horologist.compose.rotaryinput.toRotaryScrollAdapter
+import com.google.android.horologist.sample.R
+import com.google.android.horologist.sample.Screen
+
+@Composable
+fun AuthMenuScreen(
+    modifier: Modifier = Modifier,
+    navigateToRoute: (String) -> Unit,
+    scalingLazyListState: ScalingLazyListState = rememberScalingLazyListState(),
+    focusRequester: FocusRequester = remember { FocusRequester() }
+) {
+    ScalingLazyColumn(
+        modifier = modifier
+            .rotaryWithSnap(
+                focusRequester,
+                scalingLazyListState.toRotaryScrollAdapter()
+            ),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        state = scalingLazyListState
+    ) {
+        item {
+            StandardChip(
+                label = stringResource(id = R.string.auth_menu_oauth_pkce_item),
+                modifier = modifier.fillMaxWidth(),
+                onClick = { navigateToRoute(Screen.AuthPKCEScreen.route) },
+                chipType = StandardChipType.Primary
+            )
+        }
+        item {
+            StandardChip(
+                label = stringResource(id = R.string.auth_menu_oauth_device_grant_item),
+                modifier = modifier.fillMaxWidth(),
+                onClick = { navigateToRoute(Screen.AuthPKCEScreen.route) },
+                chipType = StandardChipType.Primary
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun AuthMenuScreenPreview() {
+    AuthMenuScreen(navigateToRoute = {})
+}

--- a/sample/src/main/java/com/google/android/horologist/auth/oauth/devicegrant/AuthDeviceGrantScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/oauth/devicegrant/AuthDeviceGrantScreen.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.oauth.devicegrant
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.wear.compose.material.Text
+
+@Composable
+fun AuthDeviceGrantScreen() {
+    Box(modifier = Modifier.fillMaxSize()) {
+        Text(
+            text = "Not implemented yet!",
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.Center),
+            textAlign = TextAlign.Center
+        )
+    }
+}

--- a/sample/src/main/java/com/google/android/horologist/auth/oauth/pkce/AuthPKCEScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/oauth/pkce/AuthPKCEScreen.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.oauth.pkce
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.wear.compose.material.Text
+
+@Composable
+fun AuthPKCEScreen() {
+    Box(modifier = Modifier.fillMaxSize()) {
+        Text(
+            text = "Not implemented yet!",
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.Center),
+            textAlign = TextAlign.Center
+        )
+    }
+}

--- a/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
@@ -35,6 +35,8 @@ import androidx.wear.compose.material.ScalingLazyColumn
 import androidx.wear.compose.material.ScalingLazyListState
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.rememberScalingLazyListState
+import com.google.android.horologist.base.ui.components.StandardChip
+import com.google.android.horologist.base.ui.components.StandardChipType
 import com.google.android.horologist.compose.focus.RequestFocusWhenActive
 import com.google.android.horologist.compose.rotaryinput.rotaryWithSnap
 import com.google.android.horologist.compose.rotaryinput.toRotaryScrollAdapter
@@ -92,13 +94,19 @@ fun MenuScreen(
             TimeWithoutSecondsPickerChip(time) { navigateToRoute(Screen.TimeWithoutSecondsPicker.route) }
         }
         item {
-            Chip(
-                label = {
-                    Text(text = stringResource(id = R.string.sectionedlist_samples_menu))
-                },
+            StandardChip(
+                label = stringResource(id = R.string.sectionedlist_samples_menu),
                 modifier = modifier.fillMaxWidth(),
                 onClick = { navigateToRoute(Screen.SectionedListMenuScreen.route) },
-                colors = ChipDefaults.primaryChipColors()
+                chipType = StandardChipType.Primary
+            )
+        }
+        item {
+            StandardChip(
+                label = stringResource(id = R.string.auth_samples_menu),
+                modifier = modifier.fillMaxWidth(),
+                onClick = { navigateToRoute(Screen.AuthMenuScreen.route) },
+                chipType = StandardChipType.Primary
             )
         }
         item {

--- a/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
@@ -29,6 +29,9 @@ import androidx.wear.compose.navigation.SwipeDismissableNavHost
 import androidx.wear.compose.navigation.composable
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import com.google.android.horologist.audio.ui.VolumeScreen
+import com.google.android.horologist.auth.AuthMenuScreen
+import com.google.android.horologist.auth.oauth.devicegrant.AuthDeviceGrantScreen
+import com.google.android.horologist.auth.oauth.pkce.AuthPKCEScreen
 import com.google.android.horologist.composables.DatePicker
 import com.google.android.horologist.composables.TimePicker
 import com.google.android.horologist.composables.TimePickerWith12HourClock
@@ -153,6 +156,18 @@ fun SampleWearApp() {
             }
             composable(route = Screen.RotarySnapListScreen.route) {
                 RotaryScrollWithFlingOrSnapScreen(isFling = false, isSnap = true)
+            }
+            composable(route = Screen.AuthMenuScreen.route) {
+                AuthMenuScreen(
+                    modifier = Modifier.fillMaxSize(),
+                    navigateToRoute = { route -> navController.navigate(route) }
+                )
+            }
+            composable(route = Screen.AuthPKCEScreen.route) {
+                AuthPKCEScreen()
+            }
+            composable(route = Screen.AuthDeviceGrantScreen.route) {
+                AuthDeviceGrantScreen()
             }
         }
     }

--- a/sample/src/main/java/com/google/android/horologist/sample/Screen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/Screen.kt
@@ -43,4 +43,8 @@ sealed class Screen(
     object RotaryScrollScreen : Screen("rotaryScrollScreen")
     object RotaryScrollWithFlingScreen : Screen("rotaryScrollWithFlingScreen")
     object RotarySnapListScreen : Screen("rotarySnapListScreen")
+
+    object AuthMenuScreen : Screen("authMenuScreen")
+    object AuthPKCEScreen : Screen("authPKCEScreen")
+    object AuthDeviceGrantScreen : Screen("authDeviceGrantScreen")
 }

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -24,6 +24,9 @@
     <string name="tile_sample_label">Sample Tile</string>
     <string name="sample_tile_description">Sample tile description</string>
     <string name="sectionedlist_samples_menu">SectionedList Samples</string>
+    <string name="auth_samples_menu">Auth Samples</string>
+    <string name="auth_menu_oauth_pkce_item">OAuth PKCE</string>
+    <string name="auth_menu_oauth_device_grant_item">OAuth Device Grant</string>
     <string name="sectionedlist_stateless_sections_menu">Stateless sections</string>
     <string name="sectionedlist_stateful_sections_menu">Stateful sections</string>
     <string name="sectionedlist_expandable_sections_menu">Expandable sections</string>


### PR DESCRIPTION
#### WHAT

Add `AuthMenuScreen` in sample app with no implementation yet.

#### WHY

To be used in future PRs to demonstrate the usage of the auth libs.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
