### PR TITLE
Add OAuth PCKE implementation

### DIFF
--- a/auth-data/api/current.api
+++ b/auth-data/api/current.api
@@ -1,1 +1,121 @@
 // Signature format: 4.0
+package com.google.android.horologist.auth.data {
+
+  @kotlin.RequiresOptIn(message="Horologist Auth Data is experimental. The API may be changed in the future.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.BINARY) public @interface ExperimentalHorologistAuthDataApi {
+  }
+
+}
+
+package com.google.android.horologist.auth.data.pkce {
+
+  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public interface AuthPKCEConfigRepository<Config> {
+    method public suspend Object? fetch(kotlin.coroutines.Continuation<? super Config> p);
+  }
+
+  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public interface AuthPKCEOAuthCodeRepository<AuthPKCEConfig, OAuthCodePayload> {
+    method public suspend Object? fetch(AuthPKCEConfig? config, androidx.wear.phone.interactions.authentication.CodeVerifier codeVerifier, kotlin.coroutines.Continuation<? super kotlin.Result<? extends OAuthCodePayload>> p);
+  }
+
+  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public interface AuthPKCETokenPayloadListener<TokenPayload> {
+    method public suspend Object? onPayloadReceived(TokenPayload? payload, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
+  }
+
+  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public final class AuthPKCETokenPayloadListenerNoOpImpl<TokenPayload> implements com.google.android.horologist.auth.data.pkce.AuthPKCETokenPayloadListener<TokenPayload> {
+    ctor public AuthPKCETokenPayloadListenerNoOpImpl();
+    method public suspend Object? onPayloadReceived(TokenPayload? payload, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
+  }
+
+  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public interface AuthPKCETokenRepository<AuthPKCEConfig, OAuthCodePayload, TokenPayload> {
+    method public suspend Object? fetch(AuthPKCEConfig? config, String codeVerifier, OAuthCodePayload? oAuthCodePayload, kotlin.coroutines.Continuation<? super kotlin.Result<? extends TokenPayload>> p);
+  }
+
+}
+
+package com.google.android.horologist.auth.data.pkce.impl {
+
+  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public final class AuthPKCEDefaultConfig {
+    ctor public AuthPKCEDefaultConfig(String clientId, String clientSecret, android.net.Uri authProviderUrl, optional android.net.Uri? redirectUrl);
+    method public String component1();
+    method public String component2();
+    method public android.net.Uri component3();
+    method public android.net.Uri? component4();
+    method public com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig copy(String clientId, String clientSecret, android.net.Uri authProviderUrl, android.net.Uri? redirectUrl);
+    method public android.net.Uri getAuthProviderUrl();
+    method public String getClientId();
+    method public String getClientSecret();
+    method public android.net.Uri? getRedirectUrl();
+    property public final android.net.Uri authProviderUrl;
+    property public final String clientId;
+    property public final String clientSecret;
+    property public final android.net.Uri? redirectUrl;
+  }
+
+  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public final class AuthPKCEOAuthCodeDefaultPayload {
+    ctor public AuthPKCEOAuthCodeDefaultPayload(String code, String redirectUrl);
+    method public String component1();
+    method public String component2();
+    method public com.google.android.horologist.auth.data.pkce.impl.AuthPKCEOAuthCodeDefaultPayload copy(String code, String redirectUrl);
+    method public String getCode();
+    method public String getRedirectUrl();
+    property public final String code;
+    property public final String redirectUrl;
+  }
+
+  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public final class AuthPKCEOAuthCodeRepositoryImpl implements com.google.android.horologist.auth.data.pkce.AuthPKCEOAuthCodeRepository<com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig,com.google.android.horologist.auth.data.pkce.impl.AuthPKCEOAuthCodeDefaultPayload> {
+    ctor public AuthPKCEOAuthCodeRepositoryImpl(android.app.Application application);
+    method public suspend Object? fetch(com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig config, androidx.wear.phone.interactions.authentication.CodeVerifier codeVerifier, kotlin.coroutines.Continuation<? super kotlin.Result<? extends com.google.android.horologist.auth.data.pkce.impl.AuthPKCEOAuthCodeDefaultPayload>> p);
+  }
+
+}
+
+package com.google.android.horologist.auth.data.pkce.impl.google {
+
+  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public final class AuthPKCETokenRepositoryGoogleImpl implements com.google.android.horologist.auth.data.pkce.AuthPKCETokenRepository<com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig,com.google.android.horologist.auth.data.pkce.impl.AuthPKCEOAuthCodeDefaultPayload,com.google.android.horologist.auth.data.pkce.impl.google.api.TokenResponse> {
+    ctor public AuthPKCETokenRepositoryGoogleImpl(com.google.android.horologist.auth.data.pkce.impl.google.api.GoogleOAuthService googleOAuthService);
+    method public suspend Object? fetch(com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig config, String codeVerifier, com.google.android.horologist.auth.data.pkce.impl.AuthPKCEOAuthCodeDefaultPayload oAuthCodePayload, kotlin.coroutines.Continuation<? super kotlin.Result<? extends com.google.android.horologist.auth.data.pkce.impl.google.api.TokenResponse>> p);
+  }
+
+}
+
+package com.google.android.horologist.auth.data.pkce.impl.google.api {
+
+  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public interface GoogleOAuthService {
+    method @retrofit2.http.FormUrlEncoded @retrofit2.http.POST("token") public suspend Object? token(@retrofit2.http.Field("client_id") String clientId, @retrofit2.http.Field("client_secret") String clientSecret, @retrofit2.http.Field("code") String code, @retrofit2.http.Field("code_verifier") String codeVerifier, @retrofit2.http.Field("grant_type") String grantType, @retrofit2.http.Field("redirect_uri") String redirectUri, kotlin.coroutines.Continuation<? super com.google.android.horologist.auth.data.pkce.impl.google.api.TokenResponse> p);
+    field public static final com.google.android.horologist.auth.data.pkce.impl.google.api.GoogleOAuthService.Companion Companion;
+    field public static final String GOOGLE_OAUTH_SERVER = "https://oauth2.googleapis.com/";
+    field public static final String REQUEST_GRANT_TYPE_PARAM_VALUE = "authorization_code";
+  }
+
+  public static final class GoogleOAuthService.Companion {
+  }
+
+  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public final class GoogleOAuthServiceFactory {
+    ctor public GoogleOAuthServiceFactory(com.squareup.moshi.Moshi moshi);
+    method public com.google.android.horologist.auth.data.pkce.impl.google.api.GoogleOAuthService get();
+  }
+
+  @com.squareup.moshi.JsonClass(generateAdapter=true) public final class TokenResponse {
+    ctor public TokenResponse(@com.squareup.moshi.Json(name="access_token") String accessToken, @com.squareup.moshi.Json(name="expires_in") int expiresIn, @com.squareup.moshi.Json(name="id_token") String? idToken, @com.squareup.moshi.Json(name="refresh_token") String? refreshToken, @com.squareup.moshi.Json(name="scope") String? scope, @com.squareup.moshi.Json(name="token_type") String tokenType);
+    method public String component1();
+    method public int component2();
+    method public String? component3();
+    method public String? component4();
+    method public String? component5();
+    method public String component6();
+    method public com.google.android.horologist.auth.data.pkce.impl.google.api.TokenResponse copy(@com.squareup.moshi.Json(name="access_token") String accessToken, @com.squareup.moshi.Json(name="expires_in") int expiresIn, @com.squareup.moshi.Json(name="id_token") String? idToken, @com.squareup.moshi.Json(name="refresh_token") String? refreshToken, @com.squareup.moshi.Json(name="scope") String? scope, @com.squareup.moshi.Json(name="token_type") String tokenType);
+    method public String getAccessToken();
+    method public int getExpiresIn();
+    method public String? getIdToken();
+    method public String? getRefreshToken();
+    method public String? getScope();
+    method public String getTokenType();
+    property public final String accessToken;
+    property public final int expiresIn;
+    property public final String? idToken;
+    property public final String? refreshToken;
+    property public final String? scope;
+    property public final String tokenType;
+  }
+
+}
+

--- a/auth-data/build.gradle
+++ b/auth-data/build.gradle
@@ -18,6 +18,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jetbrains.dokka'
+    id 'com.google.devtools.ksp'
 }
 
 android {
@@ -89,6 +90,12 @@ dependencies {
     implementation libs.kotlinx.coroutines.core
     implementation libs.androidx.corektx
     implementation libs.androidx.wear
+    implementation libs.androidx.wear.phone.interactions
+    implementation libs.retrofit2.retrofit
+    implementation libs.retrofit2.convertermoshi
+    implementation libs.moshi.adapters
+    implementation libs.moshi.kotlin
+    ksp libs.moshi.kotlin.codegen
 
     debugImplementation projects.composeTools
     debugImplementation libs.compose.ui.toolingpreview

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/ExperimentalHorologistAuthDataApi.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/ExperimentalHorologistAuthDataApi.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.data
+
+@RequiresOptIn(
+    message = "Horologist Auth Data is experimental. The API may be changed in the future."
+)
+@Retention(AnnotationRetention.BINARY)
+public annotation class ExperimentalHorologistAuthDataApi

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/AuthPKCEConfigRepository.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/AuthPKCEConfigRepository.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.data.pkce
+
+import com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi
+
+@ExperimentalHorologistAuthDataApi
+public interface AuthPKCEConfigRepository<Config> {
+
+    public suspend fun fetch(): Config
+}

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/AuthPKCEOAuthCodeRepository.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/AuthPKCEOAuthCodeRepository.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.data.pkce
+
+import androidx.wear.phone.interactions.authentication.CodeVerifier
+import com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi
+
+@ExperimentalHorologistAuthDataApi
+public interface AuthPKCEOAuthCodeRepository<AuthPKCEConfig, OAuthCodePayload> {
+
+    public suspend fun fetch(
+        config: AuthPKCEConfig,
+        codeVerifier: CodeVerifier
+    ): Result<OAuthCodePayload>
+}

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/AuthPKCETokenPayloadListener.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/AuthPKCETokenPayloadListener.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.data.pkce
+
+import com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi
+
+@ExperimentalHorologistAuthDataApi
+public interface AuthPKCETokenPayloadListener<TokenPayload> {
+
+    public suspend fun onPayloadReceived(payload: TokenPayload): Unit
+}
+
+@ExperimentalHorologistAuthDataApi
+public class AuthPKCETokenPayloadListenerNoOpImpl<TokenPayload> :
+    AuthPKCETokenPayloadListener<TokenPayload> {
+    override suspend fun onPayloadReceived(payload: TokenPayload): Unit = Unit
+}

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/AuthPKCETokenRepository.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/AuthPKCETokenRepository.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.data.pkce
+
+import com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi
+
+@ExperimentalHorologistAuthDataApi
+public interface AuthPKCETokenRepository<AuthPKCEConfig, OAuthCodePayload, TokenPayload> {
+
+    public suspend fun fetch(
+        config: AuthPKCEConfig,
+        codeVerifier: String,
+        oAuthCodePayload: OAuthCodePayload
+    ): Result<TokenPayload>
+}

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/impl/AuthPKCEDefaultConfig.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/impl/AuthPKCEDefaultConfig.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.data.pkce.impl
+
+import android.net.Uri
+import com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi
+
+@ExperimentalHorologistAuthDataApi
+public data class AuthPKCEDefaultConfig(
+    val clientId: String,
+    val clientSecret: String,
+    val authProviderUrl: Uri,
+    val redirectUrl: Uri? = null
+)

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/impl/AuthPKCEOAuthCodeDefaultPayload.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/impl/AuthPKCEOAuthCodeDefaultPayload.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.data.pkce.impl
+
+import com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi
+
+@ExperimentalHorologistAuthDataApi
+public data class AuthPKCEOAuthCodeDefaultPayload(
+    val code: String,
+    val redirectUrl: String
+)

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/impl/AuthPKCEOAuthCodeRepositoryImpl.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/impl/AuthPKCEOAuthCodeRepositoryImpl.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.data.pkce.impl
+
+import android.app.Application
+import android.util.Log
+import androidx.wear.phone.interactions.authentication.CodeChallenge
+import androidx.wear.phone.interactions.authentication.CodeVerifier
+import androidx.wear.phone.interactions.authentication.OAuthRequest
+import androidx.wear.phone.interactions.authentication.OAuthResponse
+import androidx.wear.phone.interactions.authentication.RemoteAuthClient
+import com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi
+import com.google.android.horologist.auth.data.pkce.AuthPKCEOAuthCodeRepository
+import java.io.IOException
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+@ExperimentalHorologistAuthDataApi
+public class AuthPKCEOAuthCodeRepositoryImpl(
+    private val application: Application
+) : AuthPKCEOAuthCodeRepository<AuthPKCEDefaultConfig, AuthPKCEOAuthCodeDefaultPayload> {
+
+    /**
+     * Start the authentication flow and do an authenticated request. This method implements
+     * the steps described at
+     * https://d.google.com/identity/protocols/oauth2/native-app#obtainingaccesstokens
+     *
+     * The [androidx.wear.phone.interactions.authentication] package helps with this implementation.
+     * It can generate a code verifier and challenge, and helps to move the consent step to
+     * the phone. After the user consents on their phone, the wearable app is notified and can
+     * continue the authorization process.
+     */
+    override suspend fun fetch(
+        config: AuthPKCEDefaultConfig,
+        codeVerifier: CodeVerifier
+    ): Result<AuthPKCEOAuthCodeDefaultPayload> {
+        val oauthRequest = OAuthRequest.Builder(application)
+            .setAuthProviderUrl(config.authProviderUrl)
+            .setCodeChallenge(CodeChallenge(codeVerifier))
+            .setClientId(config.clientId)
+            .build()
+
+        Log.d(TAG, "Authorization requested. Request URL: ${oauthRequest.requestUrl}")
+
+        // Wrap the callback-based request inside a coroutine wrapper
+        return suspendCoroutine { c ->
+            RemoteAuthClient.create(application).sendAuthorizationRequest(
+                request = oauthRequest,
+                executor = { command -> command?.run() },
+                clientCallback = object : RemoteAuthClient.Callback() {
+                    override fun onAuthorizationError(request: OAuthRequest, errorCode: Int) {
+                        Log.w(TAG, "Authorization failed with errorCode $errorCode")
+                        c.resume(Result.failure(IOException("Authorization failed")))
+                    }
+
+                    override fun onAuthorizationResponse(
+                        request: OAuthRequest,
+                        response: OAuthResponse
+                    ) {
+                        val responseUrl = response.responseUrl
+                        Log.d(TAG, "Authorization success. ResponseUrl: $responseUrl")
+                        val code = responseUrl?.getQueryParameter("code")
+                        if (code.isNullOrBlank()) {
+                            Log.w(
+                                TAG,
+                                "Google OAuth 2.0 API token exchange failed. " +
+                                    "No code query parameter in response URL."
+                            )
+                            c.resume(Result.failure(IOException("Authorization failed")))
+                        } else {
+                            c.resume(
+                                Result.success(
+                                    AuthPKCEOAuthCodeDefaultPayload(code, oauthRequest.redirectUrl)
+                                )
+                            )
+                        }
+                    }
+                }
+            )
+        }
+    }
+
+    private companion object {
+        private val TAG = AuthPKCEOAuthCodeRepositoryImpl::class.java.simpleName
+    }
+}

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/impl/google/AuthPKCETokenRepositoryGoogleImpl.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/impl/google/AuthPKCETokenRepositoryGoogleImpl.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.data.pkce.impl.google
+
+import android.util.Log
+import com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi
+import com.google.android.horologist.auth.data.pkce.AuthPKCETokenRepository
+import com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig
+import com.google.android.horologist.auth.data.pkce.impl.AuthPKCEOAuthCodeDefaultPayload
+import com.google.android.horologist.auth.data.pkce.impl.google.api.GoogleOAuthService
+import com.google.android.horologist.auth.data.pkce.impl.google.api.GoogleOAuthService.Companion.REQUEST_GRANT_TYPE_PARAM_VALUE
+import com.google.android.horologist.auth.data.pkce.impl.google.api.TokenResponse
+import kotlinx.coroutines.CancellationException
+
+@ExperimentalHorologistAuthDataApi
+public class AuthPKCETokenRepositoryGoogleImpl(
+    private val googleOAuthService: GoogleOAuthService
+) : AuthPKCETokenRepository<AuthPKCEDefaultConfig, AuthPKCEOAuthCodeDefaultPayload, TokenResponse> {
+
+    override suspend fun fetch(
+        config: AuthPKCEDefaultConfig,
+        codeVerifier: String,
+        oAuthCodePayload: AuthPKCEOAuthCodeDefaultPayload
+    ): Result<TokenResponse> {
+        Log.d(TAG, "Requesting token...")
+
+        return try {
+            val response = googleOAuthService.token(
+                clientId = config.clientId,
+                clientSecret = config.clientSecret,
+                code = oAuthCodePayload.code,
+                codeVerifier = codeVerifier,
+                grantType = REQUEST_GRANT_TYPE_PARAM_VALUE,
+                redirectUri = oAuthCodePayload.redirectUrl
+            )
+
+            Result.success(response)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            e.printStackTrace()
+            Result.failure(e)
+        }
+    }
+
+    private companion object {
+        private val TAG = AuthPKCETokenRepositoryGoogleImpl::class.java.simpleName
+    }
+}

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/impl/google/api/GoogleOAuthService.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/impl/google/api/GoogleOAuthService.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.data.pkce.impl.google.api
+
+import com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi
+import retrofit2.http.Field
+import retrofit2.http.FormUrlEncoded
+import retrofit2.http.POST
+
+@ExperimentalHorologistAuthDataApi
+public interface GoogleOAuthService {
+
+    // See https://developers.google.com/identity/protocols/oauth2/native-app#exchange-authorization-code
+    @FormUrlEncoded
+    @POST("token")
+    public suspend fun token(
+        @Field("client_id") clientId: String,
+        @Field("client_secret") clientSecret: String,
+        @Field("code") code: String,
+        @Field("code_verifier") codeVerifier: String,
+        @Field("grant_type") grantType: String,
+        @Field("redirect_uri") redirectUri: String
+    ): TokenResponse
+
+    public companion object {
+        internal const val GOOGLE_OAUTH_SERVER = "https://oauth2.googleapis.com/"
+
+        internal const val REQUEST_GRANT_TYPE_PARAM_VALUE = "authorization_code"
+    }
+}

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/impl/google/api/GoogleOAuthServiceFactory.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/impl/google/api/GoogleOAuthServiceFactory.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.data.pkce.impl.google.api
+
+import com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi
+import com.squareup.moshi.Moshi
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+@ExperimentalHorologistAuthDataApi
+public class GoogleOAuthServiceFactory(
+    private val moshi: Moshi
+) {
+
+    public fun get(): GoogleOAuthService = Retrofit.Builder()
+        .addConverterFactory(MoshiConverterFactory.create(moshi))
+        .baseUrl(GoogleOAuthService.GOOGLE_OAUTH_SERVER)
+        .build()
+        .create(GoogleOAuthService::class.java)
+}

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/impl/google/api/TokenResponse.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/impl/google/api/TokenResponse.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.data.pkce.impl.google.api
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+public data class TokenResponse(
+    @Json(name = "access_token") val accessToken: String,
+    @Json(name = "expires_in") val expiresIn: Int,
+    @Json(name = "id_token") val idToken: String?,
+    @Json(name = "refresh_token") val refreshToken: String?,
+    @Json(name = "scope") val scope: String?,
+    @Json(name = "token_type") val tokenType: String
+)

--- a/auth-ui/api/current.api
+++ b/auth-ui/api/current.api
@@ -1,1 +1,54 @@
 // Signature format: 4.0
+package com.google.android.horologist.auth.ui {
+
+  @kotlin.RequiresOptIn(message="Horologist Auth UI is experimental. The API may be changed in the future.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.BINARY) public @interface ExperimentalHorologistAuthUiApi {
+  }
+
+}
+
+package com.google.android.horologist.auth.ui.pkce {
+
+  @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public abstract class AuthPKCEDefaultViewModel extends com.google.android.horologist.auth.ui.pkce.AuthPKCEViewModel<com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig,com.google.android.horologist.auth.data.pkce.impl.AuthPKCEOAuthCodeDefaultPayload,com.google.android.horologist.auth.data.pkce.impl.google.api.TokenResponse> {
+    ctor public AuthPKCEDefaultViewModel(com.google.android.horologist.auth.data.pkce.AuthPKCEConfigRepository<com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig> authPKCEConfigRepository, com.google.android.horologist.auth.data.pkce.AuthPKCEOAuthCodeRepository<com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig,com.google.android.horologist.auth.data.pkce.impl.AuthPKCEOAuthCodeDefaultPayload> authPKCEOAuthCodeRepository, com.google.android.horologist.auth.data.pkce.AuthPKCETokenRepository<com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig,com.google.android.horologist.auth.data.pkce.impl.AuthPKCEOAuthCodeDefaultPayload,com.google.android.horologist.auth.data.pkce.impl.google.api.TokenResponse> authPKCETokenRepository, optional com.google.android.horologist.auth.data.pkce.AuthPKCETokenPayloadListener<com.google.android.horologist.auth.data.pkce.impl.google.api.TokenResponse> authPKCETokenPayloadListener, android.app.Application application);
+    method protected final com.google.android.horologist.auth.data.pkce.AuthPKCEConfigRepository<com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig> getAuthPKCEConfigRepository();
+    method protected final com.google.android.horologist.auth.data.pkce.AuthPKCEOAuthCodeRepository<com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig,com.google.android.horologist.auth.data.pkce.impl.AuthPKCEOAuthCodeDefaultPayload> getAuthPKCEOAuthCodeRepository();
+    method protected final com.google.android.horologist.auth.data.pkce.AuthPKCETokenPayloadListener<com.google.android.horologist.auth.data.pkce.impl.google.api.TokenResponse> getAuthPKCETokenPayloadListener();
+    method protected final com.google.android.horologist.auth.data.pkce.AuthPKCETokenRepository<com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig,com.google.android.horologist.auth.data.pkce.impl.AuthPKCEOAuthCodeDefaultPayload,com.google.android.horologist.auth.data.pkce.impl.google.api.TokenResponse> getAuthPKCETokenRepository();
+    property protected final com.google.android.horologist.auth.data.pkce.AuthPKCEConfigRepository<com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig> authPKCEConfigRepository;
+    property protected final com.google.android.horologist.auth.data.pkce.AuthPKCEOAuthCodeRepository<com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig,com.google.android.horologist.auth.data.pkce.impl.AuthPKCEOAuthCodeDefaultPayload> authPKCEOAuthCodeRepository;
+    property protected final com.google.android.horologist.auth.data.pkce.AuthPKCETokenPayloadListener<com.google.android.horologist.auth.data.pkce.impl.google.api.TokenResponse> authPKCETokenPayloadListener;
+    property protected final com.google.android.horologist.auth.data.pkce.AuthPKCETokenRepository<com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig,com.google.android.horologist.auth.data.pkce.impl.AuthPKCEOAuthCodeDefaultPayload,com.google.android.horologist.auth.data.pkce.impl.google.api.TokenResponse> authPKCETokenRepository;
+  }
+
+  public abstract sealed class AuthPKCEScreenState {
+  }
+
+  public static final class AuthPKCEScreenState.CheckPhone extends com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState {
+    field public static final com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState.CheckPhone INSTANCE;
+  }
+
+  public static final class AuthPKCEScreenState.Failed extends com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState {
+    field public static final com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState.Failed INSTANCE;
+  }
+
+  public static final class AuthPKCEScreenState.Idle extends com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState {
+    field public static final com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState.Idle INSTANCE;
+  }
+
+  public static final class AuthPKCEScreenState.Loading extends com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState {
+    field public static final com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState.Loading INSTANCE;
+  }
+
+  public static final class AuthPKCEScreenState.Success extends com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState {
+    field public static final com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState.Success INSTANCE;
+  }
+
+  @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public class AuthPKCEViewModel<AuthPKCEConfig, OAuthCodePayload, TokenPayload> extends androidx.lifecycle.AndroidViewModel {
+    ctor public AuthPKCEViewModel(com.google.android.horologist.auth.data.pkce.AuthPKCEConfigRepository<AuthPKCEConfig> authPKCEConfigRepository, com.google.android.horologist.auth.data.pkce.AuthPKCEOAuthCodeRepository<AuthPKCEConfig,OAuthCodePayload> authPKCEOAuthCodeRepository, com.google.android.horologist.auth.data.pkce.AuthPKCETokenRepository<AuthPKCEConfig,OAuthCodePayload,TokenPayload> authPKCETokenRepository, optional com.google.android.horologist.auth.data.pkce.AuthPKCETokenPayloadListener<TokenPayload> authPKCETokenPayloadListener, android.app.Application application);
+    method public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState> getUiState();
+    method public final void startAuthFlow();
+    property public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState> uiState;
+  }
+
+}
+

--- a/auth-ui/build.gradle
+++ b/auth-ui/build.gradle
@@ -44,6 +44,7 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
         freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
+        freeCompilerArgs += "-opt-in=com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi"
     }
 
     composeOptions {
@@ -92,8 +93,12 @@ metalava {
 
 dependencies {
 
+    implementation projects.authData
+
     implementation libs.kotlin.stdlib
+    implementation libs.androidx.lifecycle.viewmodel.compose
     implementation libs.androidx.wear
+    implementation libs.androidx.wear.phone.interactions
 
     debugImplementation projects.composeTools
     debugImplementation libs.compose.ui.toolingpreview

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/ExperimentalHorologistAuthUiApi.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/ExperimentalHorologistAuthUiApi.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.ui
+
+@RequiresOptIn(
+    message = "Horologist Auth UI is experimental. The API may be changed in the future."
+)
+@Retention(AnnotationRetention.BINARY)
+public annotation class ExperimentalHorologistAuthUiApi

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/pkce/AuthPKCEDefaultViewModel.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/pkce/AuthPKCEDefaultViewModel.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.ui.pkce
+
+import android.app.Application
+import com.google.android.horologist.auth.data.pkce.AuthPKCEConfigRepository
+import com.google.android.horologist.auth.data.pkce.AuthPKCEOAuthCodeRepository
+import com.google.android.horologist.auth.data.pkce.AuthPKCETokenPayloadListener
+import com.google.android.horologist.auth.data.pkce.AuthPKCETokenPayloadListenerNoOpImpl
+import com.google.android.horologist.auth.data.pkce.AuthPKCETokenRepository
+import com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig
+import com.google.android.horologist.auth.data.pkce.impl.AuthPKCEOAuthCodeDefaultPayload
+import com.google.android.horologist.auth.data.pkce.impl.google.api.TokenResponse
+import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
+
+/**
+ * Default implementation of [AuthPKCEViewModel], using [AuthPKCEDefaultConfig] as config and
+ * [AuthPKCEOAuthCodeDefaultPayload] as payload.
+ */
+@ExperimentalHorologistAuthUiApi
+public abstract class AuthPKCEDefaultViewModel(
+    protected val authPKCEConfigRepository: AuthPKCEConfigRepository<AuthPKCEDefaultConfig>,
+    protected val authPKCEOAuthCodeRepository: AuthPKCEOAuthCodeRepository<AuthPKCEDefaultConfig, AuthPKCEOAuthCodeDefaultPayload>,
+    protected val authPKCETokenRepository: AuthPKCETokenRepository<AuthPKCEDefaultConfig, AuthPKCEOAuthCodeDefaultPayload, TokenResponse>,
+    protected val authPKCETokenPayloadListener: AuthPKCETokenPayloadListener<TokenResponse> = AuthPKCETokenPayloadListenerNoOpImpl(),
+    application: Application
+) : AuthPKCEViewModel<AuthPKCEDefaultConfig, AuthPKCEOAuthCodeDefaultPayload, TokenResponse>(
+    authPKCEConfigRepository = authPKCEConfigRepository,
+    authPKCEOAuthCodeRepository = authPKCEOAuthCodeRepository,
+    authPKCETokenRepository = authPKCETokenRepository,
+    authPKCETokenPayloadListener = authPKCETokenPayloadListener,
+    application = application
+)

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/pkce/AuthPKCEViewModel.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/pkce/AuthPKCEViewModel.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.ui.pkce
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.wear.phone.interactions.authentication.CodeVerifier
+import com.google.android.horologist.auth.data.pkce.AuthPKCEConfigRepository
+import com.google.android.horologist.auth.data.pkce.AuthPKCEOAuthCodeRepository
+import com.google.android.horologist.auth.data.pkce.AuthPKCETokenPayloadListener
+import com.google.android.horologist.auth.data.pkce.AuthPKCETokenPayloadListenerNoOpImpl
+import com.google.android.horologist.auth.data.pkce.AuthPKCETokenRepository
+import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+@ExperimentalHorologistAuthUiApi
+public open class AuthPKCEViewModel<AuthPKCEConfig, OAuthCodePayload, TokenPayload>(
+    private val authPKCEConfigRepository: AuthPKCEConfigRepository<AuthPKCEConfig>,
+    private val authPKCEOAuthCodeRepository: AuthPKCEOAuthCodeRepository<AuthPKCEConfig, OAuthCodePayload>,
+    private val authPKCETokenRepository: AuthPKCETokenRepository<AuthPKCEConfig, OAuthCodePayload, TokenPayload>,
+    private val authPKCETokenPayloadListener: AuthPKCETokenPayloadListener<TokenPayload> = AuthPKCETokenPayloadListenerNoOpImpl(),
+    application: Application
+) : AndroidViewModel(application) {
+
+    private val _uiState = MutableStateFlow<AuthPKCEScreenState>(AuthPKCEScreenState.Idle)
+    public val uiState: StateFlow<AuthPKCEScreenState> = _uiState.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
+        initialValue = AuthPKCEScreenState.Idle
+    )
+
+    public fun startAuthFlow() {
+        viewModelScope.launch {
+            val config = authPKCEConfigRepository.fetch()
+
+            val codeVerifier = CodeVerifier()
+
+            // Step 1: Retrieve the OAuth code
+            _uiState.value = AuthPKCEScreenState.CheckPhone
+            val oAuthCodePayload = authPKCEOAuthCodeRepository.fetch(
+                config = config,
+                codeVerifier = codeVerifier
+            ).getOrElse {
+                _uiState.value = AuthPKCEScreenState.Failed
+                return@launch
+            }
+
+            // Step 2: Retrieve the access token
+            _uiState.value = AuthPKCEScreenState.Loading
+            val token = authPKCETokenRepository.fetch(
+                config = config,
+                codeVerifier = codeVerifier.value,
+                oAuthCodePayload = oAuthCodePayload
+            )
+                .getOrElse {
+                    _uiState.value = AuthPKCEScreenState.Failed
+                    return@launch
+                }
+            authPKCETokenPayloadListener.onPayloadReceived(token)
+            _uiState.value = AuthPKCEScreenState.Success
+        }
+    }
+}
+
+public sealed class AuthPKCEScreenState {
+    public object Idle : AuthPKCEScreenState()
+    public object Loading : AuthPKCEScreenState()
+    public object CheckPhone : AuthPKCEScreenState()
+    public object Success : AuthPKCEScreenState()
+    public object Failed : AuthPKCEScreenState()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ androidxStartup = "1.1.1"
 androidxTracing = "1.1.0"
 androidxWear = "1.3.0-alpha03"
 androidxWork = "2.7.1"
+androidxPhoneInteractions = "1.1.0-alpha03"
 androidxtiles = "1.1.0"
 app-cash-paparazzi = "1.1.0"
 benManes = "0.43.0"
@@ -90,6 +91,7 @@ androidx-test-rules = "androidx.test:rules:1.5.0"
 androidx-test-uiautomator = "androidx.test.uiautomator:uiautomator:2.2.0"
 androidx-tracing-ktx = { module = "androidx.tracing:tracing-ktx", version.ref = "androidxTracing" }
 androidx-wear = { module = "androidx.wear:wear", version.ref = "androidxWear" }
+androidx-wear-phone-interactions = { module = "androidx.wear:wear-phone-interactions", version.ref = "androidxPhoneInteractions" }
 androidx-wear-tiles = { module = "androidx.wear.tiles:tiles", version.ref = "androidxtiles" }
 androidx-wear-tiles-material = { module = "androidx.wear.tiles:tiles-material", version.ref = "androidxtiles" }
 androidx-wear-tiles-renderer = { module = "androidx.wear.tiles:tiles-renderer", version.ref = "androidxtiles" }


### PR DESCRIPTION
#### WHAT

Add [OAuth PCKE](https://developer.android.com/training/wearables/apps/auth-wear#pkce) implementation adapted from [wear-os-samples](https://github.com/android/wear-os-samples/tree/cf28cb3b042ee00ecf1313f067f39c2add243ee7/WearOAuth).

#### HOW

Implementation is coordinated by `AuthPKCEViewModel`. 
The VM needs 3 repositories to perform the auth steps:
- `AuthPKCEConfigRepository` - to get the configurations needed to fetch the necessary info;
- `AuthPKCEOAuthCodeRepository` - to fetch oauth code;
- `AuthPKCETokenRepository` - to fetch the tokens (access/refresh);

The VM is also accepts a `AuthPKCETokenPayloadListener` in case clients are using the default implementations supplied and would like to persist the token themselves.

The implementation of the components above relies on heavy usage of generics in order to allow customisation of each step.


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
