### PR TITLE
Move permissions to libraries

### DIFF
--- a/media-data/src/main/AndroidManifest.xml
+++ b/media-data/src/main/AndroidManifest.xml
@@ -21,5 +21,7 @@
 
     <uses-feature android:name="android.hardware.type.watch" />
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <uses-sdk android:minSdkVersion="26" tools:ignore="GradleOverrides" />
 </manifest>

--- a/media-sample/src/main/AndroidManifest.xml
+++ b/media-sample/src/main/AndroidManifest.xml
@@ -19,15 +19,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.google.android.horologist.mediasample">
 
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-    <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
-
     <uses-feature android:name="android.hardware.type.watch" />
 
     <uses-feature

--- a/media-ui/src/main/AndroidManifest.xml
+++ b/media-ui/src/main/AndroidManifest.xml
@@ -21,5 +21,7 @@
 
     <uses-feature android:name="android.hardware.type.watch" />
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <uses-sdk android:minSdkVersion="26" tools:ignore="GradleOverrides" />
 </manifest>

--- a/media3-backend/src/main/AndroidManifest.xml
+++ b/media3-backend/src/main/AndroidManifest.xml
@@ -21,5 +21,8 @@
 
     <uses-feature android:name="android.hardware.type.watch" />
 
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
     <uses-sdk android:minSdkVersion="26" tools:ignore="GradleOverrides" />
 </manifest>

--- a/network-awareness/src/main/AndroidManifest.xml
+++ b/network-awareness/src/main/AndroidManifest.xml
@@ -22,6 +22,10 @@
     <uses-feature android:name="android.hardware.type.watch" />
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <uses-sdk android:minSdkVersion="26" tools:ignore="GradleOverrides" />
 </manifest>


### PR DESCRIPTION
#### WHAT

Move permissions to libraries. Also remove READ_EXTERNAL_STORAGE

#### WHY

Problems with permissions in libraries and where permissions are actually needed, wasn't clear.

#### HOW

Move to network-awareness or media3-backend

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
