### PR TITLE
Add Auth PKCE to sample app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 captures
 
 /local.properties
+/secrets.properties
 
 # IntelliJ .idea folder
 .idea/workspace.xml

--- a/auth-data/api/current.api
+++ b/auth-data/api/current.api
@@ -70,6 +70,18 @@ package com.google.android.horologist.auth.data.pkce.impl {
 
 package com.google.android.horologist.auth.data.pkce.impl.google {
 
+  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public final class AuthPKCEConfigRepositoryImpl implements com.google.android.horologist.auth.data.pkce.AuthPKCEConfigRepository<com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig> {
+    ctor public AuthPKCEConfigRepositoryImpl(String clientId, String clientSecret, optional String encodedPath, optional java.util.Map<java.lang.String,java.lang.String> queryParameters);
+    method public suspend Object? fetch(kotlin.coroutines.Continuation<? super com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig> p);
+    field public static final com.google.android.horologist.auth.data.pkce.impl.google.AuthPKCEConfigRepositoryImpl.Companion Companion;
+    field public static final String ENCODED_PATH = "https://accounts.google.com/o/oauth2/v2/auth";
+    field public static final String QUERY_PARAM_SCOPE_KEY = "scope";
+    field public static final String QUERY_PARAM_SCOPE_VALUE = "https://www.googleapis.com/auth/userinfo.profile";
+  }
+
+  public static final class AuthPKCEConfigRepositoryImpl.Companion {
+  }
+
   @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public final class AuthPKCETokenRepositoryGoogleImpl implements com.google.android.horologist.auth.data.pkce.AuthPKCETokenRepository<com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig,com.google.android.horologist.auth.data.pkce.impl.AuthPKCEOAuthCodeDefaultPayload,com.google.android.horologist.auth.data.pkce.impl.google.api.TokenResponse> {
     ctor public AuthPKCETokenRepositoryGoogleImpl(com.google.android.horologist.auth.data.pkce.impl.google.api.GoogleOAuthService googleOAuthService);
     method public suspend Object? fetch(com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig config, String codeVerifier, com.google.android.horologist.auth.data.pkce.impl.AuthPKCEOAuthCodeDefaultPayload oAuthCodePayload, kotlin.coroutines.Continuation<? super kotlin.Result<? extends com.google.android.horologist.auth.data.pkce.impl.google.api.TokenResponse>> p);

--- a/auth-data/api/current.api
+++ b/auth-data/api/current.api
@@ -70,16 +70,16 @@ package com.google.android.horologist.auth.data.pkce.impl {
 
 package com.google.android.horologist.auth.data.pkce.impl.google {
 
-  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public final class AuthPKCEConfigRepositoryImpl implements com.google.android.horologist.auth.data.pkce.AuthPKCEConfigRepository<com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig> {
-    ctor public AuthPKCEConfigRepositoryImpl(String clientId, String clientSecret, optional String encodedPath, optional java.util.Map<java.lang.String,java.lang.String> queryParameters);
+  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public final class AuthPKCEConfigRepositoryGoogleImpl implements com.google.android.horologist.auth.data.pkce.AuthPKCEConfigRepository<com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig> {
+    ctor public AuthPKCEConfigRepositoryGoogleImpl(String clientId, String clientSecret, optional String encodedPath, optional java.util.Map<java.lang.String,java.lang.String> queryParameters);
     method public suspend Object? fetch(kotlin.coroutines.Continuation<? super com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig> p);
-    field public static final com.google.android.horologist.auth.data.pkce.impl.google.AuthPKCEConfigRepositoryImpl.Companion Companion;
+    field public static final com.google.android.horologist.auth.data.pkce.impl.google.AuthPKCEConfigRepositoryGoogleImpl.Companion Companion;
     field public static final String ENCODED_PATH = "https://accounts.google.com/o/oauth2/v2/auth";
     field public static final String QUERY_PARAM_SCOPE_KEY = "scope";
     field public static final String QUERY_PARAM_SCOPE_VALUE = "https://www.googleapis.com/auth/userinfo.profile";
   }
 
-  public static final class AuthPKCEConfigRepositoryImpl.Companion {
+  public static final class AuthPKCEConfigRepositoryGoogleImpl.Companion {
   }
 
   @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public final class AuthPKCETokenRepositoryGoogleImpl implements com.google.android.horologist.auth.data.pkce.AuthPKCETokenRepository<com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig,com.google.android.horologist.auth.data.pkce.impl.AuthPKCEOAuthCodeDefaultPayload,com.google.android.horologist.auth.data.pkce.impl.google.api.TokenResponse> {

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/impl/google/AuthPKCEConfigRepositoryGoogleImpl.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/impl/google/AuthPKCEConfigRepositoryGoogleImpl.kt
@@ -22,7 +22,7 @@ import com.google.android.horologist.auth.data.pkce.AuthPKCEConfigRepository
 import com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig
 
 @ExperimentalHorologistAuthDataApi
-public class AuthPKCEConfigRepositoryImpl(
+public class AuthPKCEConfigRepositoryGoogleImpl(
     private val clientId: String,
     private val clientSecret: String,
     private val encodedPath: String = ENCODED_PATH,

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/impl/google/AuthPKCEConfigRepositoryImpl.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/pkce/impl/google/AuthPKCEConfigRepositoryImpl.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.data.pkce.impl.google
+
+import android.net.Uri
+import com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi
+import com.google.android.horologist.auth.data.pkce.AuthPKCEConfigRepository
+import com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig
+
+@ExperimentalHorologistAuthDataApi
+public class AuthPKCEConfigRepositoryImpl(
+    private val clientId: String,
+    private val clientSecret: String,
+    private val encodedPath: String = ENCODED_PATH,
+    private val queryParameters: Map<String, String> = mapOf(QUERY_PARAM_SCOPE_KEY to QUERY_PARAM_SCOPE_VALUE)
+) : AuthPKCEConfigRepository<AuthPKCEDefaultConfig> {
+
+    override suspend fun fetch(): AuthPKCEDefaultConfig {
+        val uri = Uri.Builder()
+            .encodedPath(encodedPath)
+            .also { builder ->
+                queryParameters.forEach { (key, value) ->
+                    builder.appendQueryParameter(key, value)
+                }
+            }
+            .build()
+
+        return AuthPKCEDefaultConfig(
+            clientId = clientId,
+            clientSecret = clientSecret,
+            authProviderUrl = uri
+        )
+    }
+
+    public companion object {
+        public const val ENCODED_PATH: String = "https://accounts.google.com/o/oauth2/v2/auth"
+        public const val QUERY_PARAM_SCOPE_KEY: String = "scope"
+        public const val QUERY_PARAM_SCOPE_VALUE: String =
+            "https://www.googleapis.com/auth/userinfo.profile"
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ buildscript {
         classpath libs.paparazziPlugin
 
         classpath libs.dagger.hiltandroidplugin
+
+        classpath libs.googleSecretsGradlePlugin
     }
 }
 
@@ -53,6 +55,7 @@ plugins {
 
 apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'com.dropbox.affectedmoduledetector'
+apply plugin: "com.google.android.libraries.mapsplatform.secrets-gradle-plugin"
 
 tasks.withType(org.jetbrains.dokka.gradle.DokkaMultiModuleTask).configureEach {
     outputDirectory = rootProject.file('docs/api')

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ ktlint = "0.46.1"
 metalava = "0.2.3"
 moshi = "1.14.0"
 room = "2.4.3"
+googleSecretsGradlePlugin = "2.0.1"
 spotless = "6.11.0"
 truth = "1.1.3"
 versionCatalogUpdate = "0.7.0"
@@ -116,6 +117,7 @@ dagger-hiltandroidplugin = { module = "com.google.dagger:hilt-android-gradle-plu
 dagger-hiltandroidtesting = { module = "com.google.dagger:hilt-android-testing", version.ref = "googledagger" }
 dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
+googleSecretsGradlePlugin = { module = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin", version.ref = "googleSecretsGradlePlugin" }
 gradleMavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.20.0"
 hilt-ext-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "androidx-hilt" }
 hilt-ext-work = { module = "androidx.hilt:hilt-work", version.ref = "androidx-hilt" }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: "com.google.protobuf"
+apply plugin: "com.google.android.libraries.mapsplatform.secrets-gradle-plugin"
 
 android {
     compileSdkVersion 33
@@ -65,6 +66,8 @@ android {
         freeCompilerArgs += "-opt-in=com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.audio.ExperimentalHorologistAudioApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi"
+        freeCompilerArgs += "-opt-in=com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi"
+        freeCompilerArgs += "-opt-in=com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.media.ExperimentalHorologistMediaApi"
         freeCompilerArgs += "-opt-in=androidx.compose.ui.ExperimentalComposeUiApi"
@@ -119,6 +122,8 @@ dependencies {
     implementation projects.composeLayout
     implementation projects.audio
     implementation projects.audioUi
+    implementation projects.authData
+    implementation projects.authUi
     implementation projects.tiles
     implementation projects.composables
     implementation projects.media
@@ -145,15 +150,17 @@ dependencies {
     implementation libs.androidx.activity.compose
     implementation libs.androidx.wear.tiles
     implementation libs.androidx.wear.tiles.material
+
     implementation libs.kotlinx.coroutines.playservices
+    implementation libs.kotlin.stdlib
 
     implementation libs.coil
 
     implementation libs.lottie.compose
 
-    implementation libs.kotlin.stdlib
-
     implementation libs.protobuf.kotlin.lite
+
+    implementation libs.moshi.kotlin
 
     debugImplementation projects.composeTools
 
@@ -162,4 +169,9 @@ dependencies {
     androidTestImplementation libs.junit
     androidTestImplementation libs.androidx.test.ext
     androidTestImplementation libs.androidx.test.ext.ktx
+}
+
+secrets {
+    propertiesFileName "secrets.properties"
+    defaultPropertiesFileName = 'secrets.defaults.properties'
 }

--- a/sample/src/main/java/com/google/android/horologist/auth/AuthMenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/AuthMenuScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.wear.compose.material.ScalingLazyColumn
 import androidx.wear.compose.material.ScalingLazyListState
 import androidx.wear.compose.material.rememberScalingLazyListState
@@ -31,6 +30,7 @@ import com.google.android.horologist.base.ui.components.StandardChip
 import com.google.android.horologist.base.ui.components.StandardChipType
 import com.google.android.horologist.compose.rotaryinput.rotaryWithSnap
 import com.google.android.horologist.compose.rotaryinput.toRotaryScrollAdapter
+import com.google.android.horologist.compose.tools.WearPreviewDevices
 import com.google.android.horologist.sample.R
 import com.google.android.horologist.sample.Screen
 
@@ -62,14 +62,14 @@ fun AuthMenuScreen(
             StandardChip(
                 label = stringResource(id = R.string.auth_menu_oauth_device_grant_item),
                 modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.AuthPKCEScreen.route) },
+                onClick = { navigateToRoute(Screen.AuthDeviceGrantScreen.route) },
                 chipType = StandardChipType.Primary
             )
         }
     }
 }
 
-@Preview
+@WearPreviewDevices
 @Composable
 fun AuthMenuScreenPreview() {
     AuthMenuScreen(navigateToRoute = {})

--- a/sample/src/main/java/com/google/android/horologist/auth/oauth/pkce/AuthPKCEScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/oauth/pkce/AuthPKCEScreen.kt
@@ -16,23 +16,47 @@
 
 package com.google.android.horologist.auth.oauth.pkce
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.wear.compose.material.Text
+import com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState
 
 @Composable
-fun AuthPKCEScreen() {
-    Box(modifier = Modifier.fillMaxSize()) {
+fun AuthPKCEScreen(
+    modifier: Modifier = Modifier,
+    viewModel: AuthPKCEScreenViewModel = viewModel()
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    if (state == AuthPKCEScreenState.Idle) {
+        viewModel.startAuthFlow()
+    }
+
+    val stateText = when (state) {
+        AuthPKCEScreenState.Idle -> "Idle"
+        AuthPKCEScreenState.Loading -> "Loading"
+        AuthPKCEScreenState.CheckPhone -> "CheckPhone"
+        AuthPKCEScreenState.Failed -> "Failed"
+        AuthPKCEScreenState.Success -> "Success"
+    }
+
+    Column(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center
+
+    ) {
         Text(
-            text = "Not implemented yet!",
+            text = stateText,
             modifier = Modifier
-                .fillMaxWidth()
-                .align(Alignment.Center),
+                .fillMaxWidth(),
             textAlign = TextAlign.Center
         )
     }

--- a/sample/src/main/java/com/google/android/horologist/auth/oauth/pkce/AuthPKCEScreenViewModel.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/oauth/pkce/AuthPKCEScreenViewModel.kt
@@ -18,7 +18,7 @@ package com.google.android.horologist.auth.oauth.pkce
 
 import android.app.Application
 import com.google.android.horologist.auth.data.pkce.impl.AuthPKCEOAuthCodeRepositoryImpl
-import com.google.android.horologist.auth.data.pkce.impl.google.AuthPKCEConfigRepositoryImpl
+import com.google.android.horologist.auth.data.pkce.impl.google.AuthPKCEConfigRepositoryGoogleImpl
 import com.google.android.horologist.auth.data.pkce.impl.google.AuthPKCETokenRepositoryGoogleImpl
 import com.google.android.horologist.auth.data.pkce.impl.google.api.GoogleOAuthServiceFactory
 import com.google.android.horologist.auth.ui.pkce.AuthPKCEDefaultViewModel
@@ -26,7 +26,7 @@ import com.google.android.horologist.sample.BuildConfig
 import com.squareup.moshi.Moshi
 
 class AuthPKCEScreenViewModel(application: Application) : AuthPKCEDefaultViewModel(
-    authPKCEConfigRepository = AuthPKCEConfigRepositoryImpl(
+    authPKCEConfigRepository = AuthPKCEConfigRepositoryGoogleImpl(
         BuildConfig.AUTH_CLIENT_ID,
         BuildConfig.AUTH_CLIENT_SECRET
     ),

--- a/sample/src/main/java/com/google/android/horologist/auth/oauth/pkce/AuthPKCEScreenViewModel.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/oauth/pkce/AuthPKCEScreenViewModel.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.oauth.pkce
+
+import android.app.Application
+import com.google.android.horologist.auth.data.pkce.impl.AuthPKCEOAuthCodeRepositoryImpl
+import com.google.android.horologist.auth.data.pkce.impl.google.AuthPKCEConfigRepositoryImpl
+import com.google.android.horologist.auth.data.pkce.impl.google.AuthPKCETokenRepositoryGoogleImpl
+import com.google.android.horologist.auth.data.pkce.impl.google.api.GoogleOAuthServiceFactory
+import com.google.android.horologist.auth.ui.pkce.AuthPKCEDefaultViewModel
+import com.google.android.horologist.sample.BuildConfig
+import com.squareup.moshi.Moshi
+
+class AuthPKCEScreenViewModel(application: Application) : AuthPKCEDefaultViewModel(
+    authPKCEConfigRepository = AuthPKCEConfigRepositoryImpl(
+        BuildConfig.AUTH_CLIENT_ID,
+        BuildConfig.AUTH_CLIENT_SECRET
+    ),
+    authPKCEOAuthCodeRepository = AuthPKCEOAuthCodeRepositoryImpl(application),
+    authPKCETokenRepository = AuthPKCETokenRepositoryGoogleImpl(
+        GoogleOAuthServiceFactory(Moshi.Builder().build()).get()
+    ),
+    application = application
+)

--- a/secrets.defaults.properties
+++ b/secrets.defaults.properties
@@ -1,0 +1,20 @@
+#
+# Copyright 2022 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Secrets should be added to "secrets.properties" file using this file as template.
+# Do NOT add your secrets here.
+AUTH_CLIENT_ID="client_id"
+AUTH_CLIENT_SECRET="client_secret"


### PR DESCRIPTION
#### WHAT

Add Auth PKCE to sample app.

#### HOW

Add [secrets-gradle-plugin](https://developers.google.com/maps/documentation/android-sdk/secrets-gradle-plugin) to `sample` app and configure secrets to be placed in `secrets.properties` file locally.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
