### PR TITLE
Replace BluetoothFragment explicit intent with androidx.mediarouter call

### DIFF
--- a/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/FakeAudioOutputRepository.kt
+++ b/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/FakeAudioOutputRepository.kt
@@ -25,7 +25,11 @@ class FakeAudioOutputRepository : AudioOutputRepository {
     override val audioOutput: MutableStateFlow<AudioOutput> = MutableStateFlow(AudioOutput.None)
     override val available: MutableStateFlow<List<AudioOutput>> = MutableStateFlow(listOf())
 
+    @Suppress("OVERRIDE_DEPRECATION")
     override fun launchOutputSelection(closeOnConnect: Boolean) {
+    }
+
+    override fun launchOutputSelection() {
     }
 
     override fun close() {

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeViewModel.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeViewModel.kt
@@ -73,7 +73,7 @@ public open class VolumeViewModel(
     }
 
     public fun launchOutputSelection() {
-        audioOutputRepository.launchOutputSelection(closeOnConnect = false)
+        audioOutputRepository.launchOutputSelection()
     }
 
     override fun onCleared() {

--- a/audio/api/current.api
+++ b/audio/api/current.api
@@ -67,14 +67,15 @@ package com.google.android.horologist.audio {
   public interface AudioOutputRepository extends java.lang.AutoCloseable {
     method public kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.AudioOutput> getAudioOutput();
     method public kotlinx.coroutines.flow.StateFlow<java.util.List<com.google.android.horologist.audio.AudioOutput>> getAvailable();
-    method public void launchOutputSelection(boolean closeOnConnect);
+    method @Deprecated public void launchOutputSelection(boolean closeOnConnect);
+    method public void launchOutputSelection();
     property public abstract kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.AudioOutput> audioOutput;
     property public abstract kotlinx.coroutines.flow.StateFlow<java.util.List<com.google.android.horologist.audio.AudioOutput>> available;
   }
 
-  public final class BluetoothSettings {
-    method public void launchBluetoothSettings(android.content.Context, optional boolean closeOnConnect);
-    field public static final com.google.android.horologist.audio.BluetoothSettings INSTANCE;
+  @Deprecated public final class BluetoothSettings {
+    method @Deprecated public void launchBluetoothSettings(android.content.Context, optional boolean closeOnConnect);
+    field @Deprecated public static final com.google.android.horologist.audio.BluetoothSettings INSTANCE;
   }
 
   @kotlin.RequiresOptIn(message="Horologist Audio is experimental. The API may be changed in the future.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.BINARY) public @interface ExperimentalHorologistAudioApi {
@@ -89,6 +90,7 @@ package com.google.android.horologist.audio {
     method public kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.VolumeState> getVolumeState();
     method public void increaseVolume();
     method public void launchOutputSelection(boolean closeOnConnect);
+    method public void launchOutputSelection();
     property public kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.AudioOutput> audioOutput;
     property public kotlinx.coroutines.flow.StateFlow<java.util.List<com.google.android.horologist.audio.AudioOutput>> available;
     property public kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.VolumeState> volumeState;

--- a/audio/src/main/java/com/google/android/horologist/audio/AudioOutputRepository.kt
+++ b/audio/src/main/java/com/google/android/horologist/audio/AudioOutputRepository.kt
@@ -35,5 +35,14 @@ public interface AudioOutputRepository : AutoCloseable {
     /**
      * Action to launch output selection by the user.
      */
+    @Deprecated(
+        "closeOnConnect is always true, use #launchOutputSelection() instead",
+        ReplaceWith("launchOutputSelection()")
+    )
     public fun launchOutputSelection(closeOnConnect: Boolean)
+
+    /**
+     * Action to launch output selection by the user.
+     */
+    public fun launchOutputSelection()
 }

--- a/audio/src/main/java/com/google/android/horologist/audio/BluetoothSettings.kt
+++ b/audio/src/main/java/com/google/android/horologist/audio/BluetoothSettings.kt
@@ -17,8 +17,7 @@
 package com.google.android.horologist.audio
 
 import android.content.Context
-import android.content.Intent
-import android.provider.Settings
+import androidx.mediarouter.app.SystemOutputSwitcherDialogController
 
 /**
  * Support for launching the user directly into the bluetooth settings page in order to connect
@@ -26,21 +25,13 @@ import android.provider.Settings
  *
  * https://developer.android.com/training/wearables/overlays/audio?hl=ca
  */
+@Deprecated(message = "Use https://developer.android.com/reference/androidx/mediarouter/app/SystemOutputSwitcherDialogController instead")
 public object BluetoothSettings {
     /**
      * Open the bluetooth settings activity and optionally close after connection established.
      */
+    @Suppress("UNUSED_PARAMETER")
     public fun Context.launchBluetoothSettings(closeOnConnect: Boolean = true) {
-        val intent = with(Intent(Settings.ACTION_BLUETOOTH_SETTINGS)) {
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-            putExtra("EXTRA_CONNECTION_ONLY", true)
-            if (closeOnConnect) {
-                putExtra("EXTRA_CLOSE_ON_CONNECT", true)
-            }
-            putExtra("android.bluetooth.devicepicker.extra.FILTER_TYPE", FILTER_TYPE_AUDIO)
-        }
-        startActivity(intent)
+        SystemOutputSwitcherDialogController.showDialog(this)
     }
-
-    internal const val FILTER_TYPE_AUDIO = 1
 }

--- a/audio/src/main/java/com/google/android/horologist/audio/SystemAudioRepository.kt
+++ b/audio/src/main/java/com/google/android/horologist/audio/SystemAudioRepository.kt
@@ -17,11 +17,11 @@
 package com.google.android.horologist.audio
 
 import android.content.Context
+import androidx.mediarouter.app.SystemOutputSwitcherDialogController
 import androidx.mediarouter.media.MediaControlIntent
 import androidx.mediarouter.media.MediaRouteSelector
 import androidx.mediarouter.media.MediaRouter
 import androidx.mediarouter.media.MediaRouter.RouteInfo
-import com.google.android.horologist.audio.BluetoothSettings.launchBluetoothSettings
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -96,8 +96,13 @@ public class SystemAudioRepository(
         _available.value = listOf()
     }
 
+    @Suppress("OVERRIDE_DEPRECATION")
     override fun launchOutputSelection(closeOnConnect: Boolean) {
-        application.launchBluetoothSettings(closeOnConnect)
+        launchOutputSelection()
+    }
+
+    override fun launchOutputSelection() {
+        SystemOutputSwitcherDialogController.showDialog(application)
     }
 
     public companion object {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -79,7 +79,7 @@ androidx-media3-exoplayerworkmanager = { module = "androidx.media3:media3-exopla
 androidx-media3-session = { module = "androidx.media3:media3-session", version.ref = "androidx-media3" }
 androidx-media3-testutils = { module = "androidx.media3:media3-test-utils", version.ref = "androidx-media3" }
 androidx-media3-testutils-robolectric = { module = "androidx.media3:media3-test-utils-robolectric", version.ref = "androidx-media3" }
-androidx-mediarouter = "androidx.mediarouter:mediarouter:1.3.1"
+androidx-mediarouter = "androidx.mediarouter:mediarouter:1.4.0-alpha01"
 androidx-metrics-performance = "androidx.metrics:metrics-performance:1.0.0-alpha03"
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidxNavigation" }
 androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidxNavigation" }

--- a/media3-backend/src/main/java/com/google/android/horologist/media3/audio/BluetoothSettingsOutputSelector.kt
+++ b/media3-backend/src/main/java/com/google/android/horologist/media3/audio/BluetoothSettingsOutputSelector.kt
@@ -32,7 +32,7 @@ public class BluetoothSettingsOutputSelector(
     private val audioOutputRepository: AudioOutputRepository
 ) : AudioOutputSelector {
     override suspend fun selectNewOutput(currentAudioOutput: AudioOutput): AudioOutput? {
-        audioOutputRepository.launchOutputSelection(true)
+        audioOutputRepository.launchOutputSelection()
 
         val newAudioOutput = withTimeoutOrNull(15000) {
             audioOutputRepository.audioOutput.filter {
@@ -44,6 +44,6 @@ public class BluetoothSettingsOutputSelector(
     }
 
     override fun launchSelector() {
-        audioOutputRepository.launchOutputSelection(false)
+        audioOutputRepository.launchOutputSelection()
     }
 }

--- a/media3-backend/src/test/java/com/google/android/horologist/media3/FakeAudioOutputRepository.kt
+++ b/media3-backend/src/test/java/com/google/android/horologist/media3/FakeAudioOutputRepository.kt
@@ -25,7 +25,11 @@ open class FakeAudioOutputRepository : AudioOutputRepository {
     override val audioOutput: MutableStateFlow<AudioOutput> = MutableStateFlow(AudioOutput.None)
     override val available: MutableStateFlow<List<AudioOutput>> = MutableStateFlow(listOf())
 
+    @Suppress("OVERRIDE_DEPRECATION")
     override fun launchOutputSelection(closeOnConnect: Boolean) {
+    }
+
+    override fun launchOutputSelection() {
     }
 
     override fun close() {


### PR DESCRIPTION
Androidx.mediarouter now supports the invocation of the Wear Bluetooth fragment. This PR changes the call to the Wear Bluetooth fragment to use [SystemOutputSwitcherDialogController](https://developer.android.com/reference/androidx/mediarouter/app/SystemOutputSwitcherDialogController) instead.

The new API always use `closeOnConnect` as true so this change also deprecates this boolean parameter for the API to be honest about what it does.