### PR TITLE
Add Google Sign-In implementation and sample

### DIFF
--- a/auth-data/api/current.api
+++ b/auth-data/api/current.api
@@ -6,6 +6,19 @@ package com.google.android.horologist.auth.data {
 
 }
 
+package com.google.android.horologist.auth.data.googlesignin {
+
+  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public interface AuthGoogleSignInAccountListener {
+    method public suspend Object? onAccountReceived(com.google.android.gms.auth.api.signin.GoogleSignInAccount account, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
+  }
+
+  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public final class AuthGoogleSignInAccountListenerNoOpImpl implements com.google.android.horologist.auth.data.googlesignin.AuthGoogleSignInAccountListener {
+    ctor public AuthGoogleSignInAccountListenerNoOpImpl();
+    method public suspend Object? onAccountReceived(com.google.android.gms.auth.api.signin.GoogleSignInAccount account, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
+  }
+
+}
+
 package com.google.android.horologist.auth.data.oauth.common.impl.google.api {
 
   @com.squareup.moshi.JsonClass(generateAdapter=true) public final class DeviceCodeResponse {

--- a/auth-data/build.gradle
+++ b/auth-data/build.gradle
@@ -92,6 +92,7 @@ dependencies {
     implementation libs.androidx.wear
     implementation libs.androidx.wear.phone.interactions
     implementation libs.androidx.wear.remote.interactions
+    implementation libs.playservices.auth
     implementation libs.retrofit2.retrofit
     implementation libs.retrofit2.convertermoshi
     implementation libs.moshi.adapters

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/googlesignin/AuthGoogleSignInAccountListener.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/googlesignin/AuthGoogleSignInAccountListener.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.data.googlesignin
+
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi
+
+@ExperimentalHorologistAuthDataApi
+public interface AuthGoogleSignInAccountListener {
+
+    public suspend fun onAccountReceived(account: GoogleSignInAccount): Unit
+}
+
+@ExperimentalHorologistAuthDataApi
+public class AuthGoogleSignInAccountListenerNoOpImpl : AuthGoogleSignInAccountListener {
+
+    override suspend fun onAccountReceived(account: GoogleSignInAccount): Unit = Unit
+}

--- a/auth-ui/api/current.api
+++ b/auth-ui/api/current.api
@@ -6,6 +6,42 @@ package com.google.android.horologist.auth.ui {
 
 }
 
+package com.google.android.horologist.auth.ui.googlesignin {
+
+  @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public abstract sealed class AuthGoogleSignInScreenState {
+  }
+
+  public static final class AuthGoogleSignInScreenState.Failed extends com.google.android.horologist.auth.ui.googlesignin.AuthGoogleSignInScreenState {
+    field public static final com.google.android.horologist.auth.ui.googlesignin.AuthGoogleSignInScreenState.Failed INSTANCE;
+  }
+
+  public static final class AuthGoogleSignInScreenState.Idle extends com.google.android.horologist.auth.ui.googlesignin.AuthGoogleSignInScreenState {
+    field public static final com.google.android.horologist.auth.ui.googlesignin.AuthGoogleSignInScreenState.Idle INSTANCE;
+  }
+
+  public static final class AuthGoogleSignInScreenState.SelectAccount extends com.google.android.horologist.auth.ui.googlesignin.AuthGoogleSignInScreenState {
+    field public static final com.google.android.horologist.auth.ui.googlesignin.AuthGoogleSignInScreenState.SelectAccount INSTANCE;
+  }
+
+  public static final class AuthGoogleSignInScreenState.Success extends com.google.android.horologist.auth.ui.googlesignin.AuthGoogleSignInScreenState {
+    field public static final com.google.android.horologist.auth.ui.googlesignin.AuthGoogleSignInScreenState.Success INSTANCE;
+  }
+
+  public final class GoogleSignInScreenKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public static void GoogleSignInScreen(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.auth.ui.googlesignin.GoogleSignInViewModel viewModel);
+  }
+
+  @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public class GoogleSignInViewModel extends androidx.lifecycle.ViewModel {
+    ctor public GoogleSignInViewModel(optional com.google.android.horologist.auth.data.googlesignin.AuthGoogleSignInAccountListener authGoogleSignInAccountListener);
+    method public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.auth.ui.googlesignin.AuthGoogleSignInScreenState> getUiState();
+    method public final void onAccountSelected(com.google.android.gms.auth.api.signin.GoogleSignInAccount account);
+    method public final void onAccountSelectionFailed();
+    method public final void startAuthFlow();
+    property public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.auth.ui.googlesignin.AuthGoogleSignInScreenState> uiState;
+  }
+
+}
+
 package com.google.android.horologist.auth.ui.oauth.devicegrant {
 
   @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public abstract sealed class AuthDeviceGrantScreenState {

--- a/auth-ui/build.gradle
+++ b/auth-ui/build.gradle
@@ -45,6 +45,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi"
+        freeCompilerArgs += "-opt-in=androidx.lifecycle.compose.ExperimentalLifecycleComposeApi"
     }
 
     composeOptions {
@@ -95,28 +96,34 @@ dependencies {
 
     implementation projects.authData
 
-    implementation libs.kotlin.stdlib
+    implementation libs.androidx.activity.compose
     implementation libs.androidx.lifecycle.viewmodel.compose
+    implementation libs.androidx.lifecycle.runtime.compose
     implementation libs.androidx.wear
     implementation libs.androidx.wear.phone.interactions
+    implementation libs.compose.foundation.foundation
+    implementation libs.kotlin.stdlib
+    implementation libs.playservices.auth
+    implementation libs.wearcompose.material
+    implementation libs.wearcompose.foundation
 
     debugImplementation projects.composeTools
     debugImplementation libs.compose.ui.toolingpreview
 
-    testImplementation libs.junit
-    testImplementation libs.androidx.test.ext.ktx
-    testImplementation libs.kotlinx.coroutines.test
-    testImplementation libs.truth
-    testImplementation libs.robolectric
     testImplementation projects.paparazzi
+    testImplementation libs.androidx.test.ext.ktx
+    testImplementation libs.junit
+    testImplementation libs.kotlinx.coroutines.test
     testImplementation libs.paparazzi
+    testImplementation libs.robolectric
+    testImplementation libs.truth
 
-    androidTestImplementation libs.compose.ui.test.junit4
-    androidTestImplementation libs.truth
-    androidTestImplementation libs.espresso.core
-    androidTestImplementation libs.junit
     androidTestImplementation libs.androidx.test.ext
     androidTestImplementation libs.androidx.test.ext.ktx
+    androidTestImplementation libs.compose.ui.test.junit4
+    androidTestImplementation libs.espresso.core
+    androidTestImplementation libs.junit
+    androidTestImplementation libs.truth
 }
 
 // Not publishing it until it's ready

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/GoogleSignInScreen.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/GoogleSignInScreen.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.ui.googlesignin
+
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.wear.compose.material.Text
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import com.google.android.gms.auth.api.signin.GoogleSignInClient
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import com.google.android.gms.auth.api.signin.GoogleSignInStatusCodes
+import com.google.android.gms.common.api.ApiException
+import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
+
+@ExperimentalHorologistAuthUiApi
+@Composable
+public fun GoogleSignInScreen(
+    modifier: Modifier = Modifier,
+    viewModel: GoogleSignInViewModel = viewModel()
+) {
+    var executedOnce by rememberSaveable { mutableStateOf(false) }
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    when (state) {
+        AuthGoogleSignInScreenState.Idle -> {
+            SideEffect {
+                if (!executedOnce) {
+                    executedOnce = true
+                    viewModel.startAuthFlow()
+                }
+            }
+        }
+
+        AuthGoogleSignInScreenState.SelectAccount -> {
+            val context = LocalContext.current
+
+            var googleSignInAccount by remember {
+                mutableStateOf(GoogleSignIn.getLastSignedInAccount(context))
+            }
+
+            googleSignInAccount?.let { account ->
+                SideEffect {
+                    viewModel.onAccountSelected(account)
+                }
+            } ?: run {
+                val googleSignInClient = GoogleSignIn.getClient(
+                    context,
+                    GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+                        .requestEmail()
+                        .build()
+                )
+
+                val signInRequestLauncher = rememberLauncherForActivityResult(
+                    contract = GoogleSignInContract(googleSignInClient) { viewModel.onAccountSelectionFailed() }
+                ) { account ->
+                    googleSignInAccount = account
+                    googleSignInAccount?.let {
+                        viewModel.onAccountSelected(it)
+                    }
+                }
+
+                SideEffect {
+                    signInRequestLauncher.launch(Unit)
+                }
+            }
+        }
+
+        else -> {
+            // do nothing
+        }
+    }
+
+    val stateText = when (state) {
+        AuthGoogleSignInScreenState.Idle -> "Idle"
+        AuthGoogleSignInScreenState.SelectAccount -> "SelectAccount"
+        AuthGoogleSignInScreenState.Failed -> "Failed"
+        AuthGoogleSignInScreenState.Success -> "Success"
+    }
+
+    Column(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center
+
+    ) {
+        Text(
+            text = stateText,
+            modifier = Modifier
+                .fillMaxWidth(),
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+/**
+ * An [ActivityResultContract] for signing in with the given [GoogleSignInClient].
+ */
+private class GoogleSignInContract(
+    private val googleSignInClient: GoogleSignInClient,
+    private val onTaskFailed: () -> Unit
+) : ActivityResultContract<Unit, GoogleSignInAccount?>() {
+
+    override fun createIntent(context: Context, input: Unit): Intent =
+        googleSignInClient.signInIntent
+
+    override fun parseResult(resultCode: Int, intent: Intent?): GoogleSignInAccount? {
+        val task = GoogleSignIn.getSignedInAccountFromIntent(intent)
+        // As documented, this task must be complete
+        check(task.isComplete)
+
+        return if (task.isSuccessful) {
+            task.result
+        } else {
+            val exception = task.exception
+            check(exception is ApiException)
+            val message = GoogleSignInStatusCodes.getStatusCodeString(exception.statusCode)
+            Log.w(TAG, "Sign in failed: code=${exception.statusCode}, message=$message")
+
+            onTaskFailed()
+
+            null
+        }
+    }
+
+    private companion object {
+        private val TAG = GoogleSignInContract::class.java.simpleName
+    }
+}

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/GoogleSignInViewModel.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/GoogleSignInViewModel.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.ui.googlesignin
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import com.google.android.horologist.auth.data.googlesignin.AuthGoogleSignInAccountListener
+import com.google.android.horologist.auth.data.googlesignin.AuthGoogleSignInAccountListenerNoOpImpl
+import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+@ExperimentalHorologistAuthUiApi
+public open class GoogleSignInViewModel(
+    private val authGoogleSignInAccountListener: AuthGoogleSignInAccountListener = AuthGoogleSignInAccountListenerNoOpImpl()
+) : ViewModel() {
+
+    private val _uiState =
+        MutableStateFlow<AuthGoogleSignInScreenState>(AuthGoogleSignInScreenState.Idle)
+    public val uiState: StateFlow<AuthGoogleSignInScreenState> = _uiState.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
+        initialValue = AuthGoogleSignInScreenState.Idle
+    )
+
+    public fun startAuthFlow() {
+        _uiState.value = AuthGoogleSignInScreenState.SelectAccount
+    }
+
+    public fun onAccountSelected(account: GoogleSignInAccount) {
+        viewModelScope.launch {
+            authGoogleSignInAccountListener.onAccountReceived(account)
+        }
+
+        _uiState.value = AuthGoogleSignInScreenState.Success
+    }
+
+    public fun onAccountSelectionFailed() {
+        _uiState.value = AuthGoogleSignInScreenState.Failed
+    }
+}
+
+@ExperimentalHorologistAuthUiApi
+public sealed class AuthGoogleSignInScreenState {
+    public object Idle : AuthGoogleSignInScreenState()
+    public object SelectAccount : AuthGoogleSignInScreenState()
+    public object Success : AuthGoogleSignInScreenState()
+    public object Failed : AuthGoogleSignInScreenState()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ ksp = "1.7.20-1.0.8"
 ktlint = "0.46.1"
 metalava = "0.2.3"
 moshi = "1.14.0"
+playServicesAuth = "20.3.0"
 room = "2.4.3"
 googleSecretsGradlePlugin = "2.0.1"
 spotless = "6.11.0"
@@ -139,6 +140,7 @@ moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "mosh
 moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
 paparazzi = { module = "app.cash.paparazzi:paparazzi", version.ref = "app-cash-paparazzi" }
 paparazziPlugin = "dev.chrisbanes.paparazzi:paparazzi-gradle-plugin:1.1.0-sdk33-alpha02"
+playservices-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "playServicesAuth" }
 playservices-wearable = "com.google.android.gms:play-services-wearable:18.0.0"
 protobuf-kotlin-lite = "com.google.protobuf:protobuf-kotlin-lite:3.21.9"
 retrofit2-convertermoshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "com-squareup-retrofit2" }

--- a/sample/src/main/java/com/google/android/horologist/auth/AuthMenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/AuthMenuScreen.kt
@@ -66,6 +66,14 @@ fun AuthMenuScreen(
                 chipType = StandardChipType.Primary
             )
         }
+        item {
+            StandardChip(
+                label = stringResource(id = R.string.auth_menu_google_sign_in_item),
+                modifier = modifier.fillMaxWidth(),
+                onClick = { navigateToRoute(Screen.AuthGoogleSignInScreen.route) },
+                chipType = StandardChipType.Primary
+            )
+        }
     }
 }
 

--- a/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
@@ -32,6 +32,7 @@ import com.google.android.horologist.audio.ui.VolumeScreen
 import com.google.android.horologist.auth.AuthMenuScreen
 import com.google.android.horologist.auth.oauth.devicegrant.AuthDeviceGrantScreen
 import com.google.android.horologist.auth.oauth.pkce.AuthPKCEScreen
+import com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreen
 import com.google.android.horologist.composables.DatePicker
 import com.google.android.horologist.composables.TimePicker
 import com.google.android.horologist.composables.TimePickerWith12HourClock
@@ -168,6 +169,9 @@ fun SampleWearApp() {
             }
             composable(route = Screen.AuthDeviceGrantScreen.route) {
                 AuthDeviceGrantScreen()
+            }
+            composable(route = Screen.AuthGoogleSignInScreen.route) {
+                GoogleSignInScreen()
             }
         }
     }

--- a/sample/src/main/java/com/google/android/horologist/sample/Screen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/Screen.kt
@@ -47,4 +47,5 @@ sealed class Screen(
     object AuthMenuScreen : Screen("authMenuScreen")
     object AuthPKCEScreen : Screen("authPKCEScreen")
     object AuthDeviceGrantScreen : Screen("authDeviceGrantScreen")
+    object AuthGoogleSignInScreen : Screen("authGoogleSignInScreen")
 }

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="auth_samples_menu">Auth Samples</string>
     <string name="auth_menu_oauth_pkce_item">OAuth PKCE</string>
     <string name="auth_menu_oauth_device_grant_item">OAuth Device Grant</string>
+    <string name="auth_menu_google_sign_in_item">Google Sign-In</string>
     <string name="sectionedlist_stateless_sections_menu">Stateless sections</string>
     <string name="sectionedlist_stateful_sections_menu">Stateful sections</string>
     <string name="sectionedlist_expandable_sections_menu">Expandable sections</string>


### PR DESCRIPTION
#### WHAT

Add [Google Sign-In](https://developer.android.com/training/wearables/apps/auth-wear#Google-Sign-in) implementation adapted from [wear-os-samples](https://github.com/android/wear-os-samples/tree/cf28cb3b042ee00ecf1313f067f39c2add243ee7/WearStandaloneGoogleSignIn).

#### HOW

Implementation is done in `GoogleSignInScreen` with `GoogleSignInViewModel` coordinating the screen states and allowing a listener to the account (`AuthGoogleSignInAccountListener`) to be hooked into it.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
