### PR TITLE
Change Auth PKCE package

### DIFF
--- a/auth-data/api/current.api
+++ b/auth-data/api/current.api
@@ -152,7 +152,7 @@ package com.google.android.horologist.auth.data.oauth.devicegrant.impl.google {
 
 }
 
-package com.google.android.horologist.auth.data.pkce {
+package com.google.android.horologist.auth.data.oauth.pkce {
 
   @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public interface AuthPKCEConfigRepository<Config> {
     method public suspend Object? fetch(kotlin.coroutines.Continuation<? super Config> p);
@@ -166,7 +166,7 @@ package com.google.android.horologist.auth.data.pkce {
     method public suspend Object? onPayloadReceived(TokenPayload? payload, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
   }
 
-  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public final class AuthPKCETokenPayloadListenerNoOpImpl<TokenPayload> implements com.google.android.horologist.auth.data.pkce.AuthPKCETokenPayloadListener<TokenPayload> {
+  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public final class AuthPKCETokenPayloadListenerNoOpImpl<TokenPayload> implements com.google.android.horologist.auth.data.oauth.pkce.AuthPKCETokenPayloadListener<TokenPayload> {
     ctor public AuthPKCETokenPayloadListenerNoOpImpl();
     method public suspend Object? onPayloadReceived(TokenPayload? payload, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
   }
@@ -177,7 +177,7 @@ package com.google.android.horologist.auth.data.pkce {
 
 }
 
-package com.google.android.horologist.auth.data.pkce.impl {
+package com.google.android.horologist.auth.data.oauth.pkce.impl {
 
   @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public final class AuthPKCEDefaultConfig {
     ctor public AuthPKCEDefaultConfig(String clientId, String clientSecret, android.net.Uri authProviderUrl, optional android.net.Uri? redirectUrl);
@@ -185,7 +185,7 @@ package com.google.android.horologist.auth.data.pkce.impl {
     method public String component2();
     method public android.net.Uri component3();
     method public android.net.Uri? component4();
-    method public com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig copy(String clientId, String clientSecret, android.net.Uri authProviderUrl, android.net.Uri? redirectUrl);
+    method public com.google.android.horologist.auth.data.oauth.pkce.impl.AuthPKCEDefaultConfig copy(String clientId, String clientSecret, android.net.Uri authProviderUrl, android.net.Uri? redirectUrl);
     method public android.net.Uri getAuthProviderUrl();
     method public String getClientId();
     method public String getClientSecret();
@@ -196,34 +196,34 @@ package com.google.android.horologist.auth.data.pkce.impl {
     property public final android.net.Uri? redirectUrl;
   }
 
-  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public final class AuthPKCEOAuthCodeRepositoryImpl implements com.google.android.horologist.auth.data.pkce.AuthPKCEOAuthCodeRepository<com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig,com.google.android.horologist.auth.data.pkce.impl.google.AuthPKCEOAuthCodeGooglePayload> {
+  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public final class AuthPKCEOAuthCodeRepositoryImpl implements com.google.android.horologist.auth.data.oauth.pkce.AuthPKCEOAuthCodeRepository<com.google.android.horologist.auth.data.oauth.pkce.impl.AuthPKCEDefaultConfig,com.google.android.horologist.auth.data.oauth.pkce.impl.google.AuthPKCEOAuthCodeGooglePayload> {
     ctor public AuthPKCEOAuthCodeRepositoryImpl(android.app.Application application);
-    method public suspend Object? fetch(com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig config, androidx.wear.phone.interactions.authentication.CodeVerifier codeVerifier, kotlin.coroutines.Continuation<? super kotlin.Result<? extends com.google.android.horologist.auth.data.pkce.impl.google.AuthPKCEOAuthCodeGooglePayload>> p);
+    method public suspend Object? fetch(com.google.android.horologist.auth.data.oauth.pkce.impl.AuthPKCEDefaultConfig config, androidx.wear.phone.interactions.authentication.CodeVerifier codeVerifier, kotlin.coroutines.Continuation<? super kotlin.Result<? extends com.google.android.horologist.auth.data.oauth.pkce.impl.google.AuthPKCEOAuthCodeGooglePayload>> p);
   }
 
 }
 
-package com.google.android.horologist.auth.data.pkce.impl.google {
+package com.google.android.horologist.auth.data.oauth.pkce.impl.google {
 
-  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public final class AuthPKCEConfigRepositoryGoogleImpl implements com.google.android.horologist.auth.data.pkce.AuthPKCEConfigRepository<com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig> {
+  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public final class AuthPKCEConfigRepositoryGoogleImpl implements com.google.android.horologist.auth.data.oauth.pkce.AuthPKCEConfigRepository<com.google.android.horologist.auth.data.oauth.pkce.impl.AuthPKCEDefaultConfig> {
     ctor public AuthPKCEConfigRepositoryGoogleImpl(String clientId, String clientSecret, optional String encodedPath, optional java.util.Map<java.lang.String,java.lang.String> queryParameters);
-    method public suspend Object? fetch(kotlin.coroutines.Continuation<? super com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig> p);
+    method public suspend Object? fetch(kotlin.coroutines.Continuation<? super com.google.android.horologist.auth.data.oauth.pkce.impl.AuthPKCEDefaultConfig> p);
   }
 
   @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public final class AuthPKCEOAuthCodeGooglePayload {
     ctor public AuthPKCEOAuthCodeGooglePayload(String code, String redirectUrl);
     method public String component1();
     method public String component2();
-    method public com.google.android.horologist.auth.data.pkce.impl.google.AuthPKCEOAuthCodeGooglePayload copy(String code, String redirectUrl);
+    method public com.google.android.horologist.auth.data.oauth.pkce.impl.google.AuthPKCEOAuthCodeGooglePayload copy(String code, String redirectUrl);
     method public String getCode();
     method public String getRedirectUrl();
     property public final String code;
     property public final String redirectUrl;
   }
 
-  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public final class AuthPKCETokenRepositoryGoogleImpl implements com.google.android.horologist.auth.data.pkce.AuthPKCETokenRepository<com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig,com.google.android.horologist.auth.data.pkce.impl.google.AuthPKCEOAuthCodeGooglePayload,com.google.android.horologist.auth.data.oauth.common.impl.google.api.TokenResponse> {
+  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public final class AuthPKCETokenRepositoryGoogleImpl implements com.google.android.horologist.auth.data.oauth.pkce.AuthPKCETokenRepository<com.google.android.horologist.auth.data.oauth.pkce.impl.AuthPKCEDefaultConfig,com.google.android.horologist.auth.data.oauth.pkce.impl.google.AuthPKCEOAuthCodeGooglePayload,com.google.android.horologist.auth.data.oauth.common.impl.google.api.TokenResponse> {
     ctor public AuthPKCETokenRepositoryGoogleImpl(com.google.android.horologist.auth.data.oauth.common.impl.google.api.GoogleOAuthService googleOAuthService);
-    method public suspend Object? fetch(com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig config, String codeVerifier, com.google.android.horologist.auth.data.pkce.impl.google.AuthPKCEOAuthCodeGooglePayload oAuthCodePayload, kotlin.coroutines.Continuation<? super kotlin.Result<? extends com.google.android.horologist.auth.data.oauth.common.impl.google.api.TokenResponse>> p);
+    method public suspend Object? fetch(com.google.android.horologist.auth.data.oauth.pkce.impl.AuthPKCEDefaultConfig config, String codeVerifier, com.google.android.horologist.auth.data.oauth.pkce.impl.google.AuthPKCEOAuthCodeGooglePayload oAuthCodePayload, kotlin.coroutines.Continuation<? super kotlin.Result<? extends com.google.android.horologist.auth.data.oauth.common.impl.google.api.TokenResponse>> p);
   }
 
 }

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/AuthPKCEConfigRepository.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/AuthPKCEConfigRepository.kt
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.auth.data.pkce.impl.google
+package com.google.android.horologist.auth.data.oauth.pkce
 
 import com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi
 
 @ExperimentalHorologistAuthDataApi
-public data class AuthPKCEOAuthCodeGooglePayload(
-    val code: String,
-    val redirectUrl: String
-)
+public interface AuthPKCEConfigRepository<Config> {
+
+    public suspend fun fetch(): Config
+}

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/AuthPKCEOAuthCodeRepository.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/AuthPKCEOAuthCodeRepository.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.auth.data.pkce
+package com.google.android.horologist.auth.data.oauth.pkce
 
 import androidx.wear.phone.interactions.authentication.CodeVerifier
 import com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/AuthPKCETokenPayloadListener.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/AuthPKCETokenPayloadListener.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.auth.data.pkce
+package com.google.android.horologist.auth.data.oauth.pkce
 
 import com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi
 

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/AuthPKCETokenRepository.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/AuthPKCETokenRepository.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.auth.data.pkce
+package com.google.android.horologist.auth.data.oauth.pkce
 
 import com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi
 

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/impl/AuthPKCEDefaultConfig.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/impl/AuthPKCEDefaultConfig.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.auth.data.pkce.impl
+package com.google.android.horologist.auth.data.oauth.pkce.impl
 
 import android.net.Uri
 import com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/impl/AuthPKCEOAuthCodeRepositoryImpl.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/impl/AuthPKCEOAuthCodeRepositoryImpl.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.auth.data.pkce.impl
+package com.google.android.horologist.auth.data.oauth.pkce.impl
 
 import android.app.Application
 import android.util.Log
@@ -24,8 +24,8 @@ import androidx.wear.phone.interactions.authentication.OAuthRequest
 import androidx.wear.phone.interactions.authentication.OAuthResponse
 import androidx.wear.phone.interactions.authentication.RemoteAuthClient
 import com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi
-import com.google.android.horologist.auth.data.pkce.AuthPKCEOAuthCodeRepository
-import com.google.android.horologist.auth.data.pkce.impl.google.AuthPKCEOAuthCodeGooglePayload
+import com.google.android.horologist.auth.data.oauth.pkce.AuthPKCEOAuthCodeRepository
+import com.google.android.horologist.auth.data.oauth.pkce.impl.google.AuthPKCEOAuthCodeGooglePayload
 import java.io.IOException
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/impl/google/AuthPKCEConfigRepositoryGoogleImpl.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/impl/google/AuthPKCEConfigRepositoryGoogleImpl.kt
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.auth.data.pkce.impl.google
+package com.google.android.horologist.auth.data.oauth.pkce.impl.google
 
 import android.net.Uri
 import com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi
 import com.google.android.horologist.auth.data.oauth.common.impl.google.api.GoogleOAuthService.Companion.SCOPE_KEY
 import com.google.android.horologist.auth.data.oauth.common.impl.google.api.GoogleOAuthService.Companion.USER_AUTH_ENDPOINT
 import com.google.android.horologist.auth.data.oauth.common.impl.google.api.GoogleOAuthService.Companion.USER_INFO_PROFILE_SCOPE_VALUE
-import com.google.android.horologist.auth.data.pkce.AuthPKCEConfigRepository
-import com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig
+import com.google.android.horologist.auth.data.oauth.pkce.AuthPKCEConfigRepository
+import com.google.android.horologist.auth.data.oauth.pkce.impl.AuthPKCEDefaultConfig
 
 @ExperimentalHorologistAuthDataApi
 public class AuthPKCEConfigRepositoryGoogleImpl(

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/impl/google/AuthPKCEOAuthCodeGooglePayload.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/impl/google/AuthPKCEOAuthCodeGooglePayload.kt
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.auth.data.pkce
+package com.google.android.horologist.auth.data.oauth.pkce.impl.google
 
 import com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi
 
 @ExperimentalHorologistAuthDataApi
-public interface AuthPKCEConfigRepository<Config> {
-
-    public suspend fun fetch(): Config
-}
+public data class AuthPKCEOAuthCodeGooglePayload(
+    val code: String,
+    val redirectUrl: String
+)

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/impl/google/AuthPKCETokenRepositoryGoogleImpl.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/impl/google/AuthPKCETokenRepositoryGoogleImpl.kt
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.auth.data.pkce.impl.google
+package com.google.android.horologist.auth.data.oauth.pkce.impl.google
 
 import android.util.Log
 import com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi
 import com.google.android.horologist.auth.data.oauth.common.impl.google.api.GoogleOAuthService
 import com.google.android.horologist.auth.data.oauth.common.impl.google.api.GoogleOAuthService.Companion.GRANT_TYPE_PARAM_AUTH_CODE_GRANT_VALUE
 import com.google.android.horologist.auth.data.oauth.common.impl.google.api.TokenResponse
-import com.google.android.horologist.auth.data.pkce.AuthPKCETokenRepository
-import com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig
+import com.google.android.horologist.auth.data.oauth.pkce.AuthPKCETokenRepository
+import com.google.android.horologist.auth.data.oauth.pkce.impl.AuthPKCEDefaultConfig
 import kotlinx.coroutines.CancellationException
 
 @ExperimentalHorologistAuthDataApi

--- a/auth-ui/api/current.api
+++ b/auth-ui/api/current.api
@@ -80,36 +80,36 @@ package com.google.android.horologist.auth.ui.oauth.devicegrant {
 
 }
 
-package com.google.android.horologist.auth.ui.pkce {
+package com.google.android.horologist.auth.ui.oauth.pkce {
 
   @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public abstract sealed class AuthPKCEScreenState {
   }
 
-  public static final class AuthPKCEScreenState.CheckPhone extends com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState {
-    field public static final com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState.CheckPhone INSTANCE;
+  public static final class AuthPKCEScreenState.CheckPhone extends com.google.android.horologist.auth.ui.oauth.pkce.AuthPKCEScreenState {
+    field public static final com.google.android.horologist.auth.ui.oauth.pkce.AuthPKCEScreenState.CheckPhone INSTANCE;
   }
 
-  public static final class AuthPKCEScreenState.Failed extends com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState {
-    field public static final com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState.Failed INSTANCE;
+  public static final class AuthPKCEScreenState.Failed extends com.google.android.horologist.auth.ui.oauth.pkce.AuthPKCEScreenState {
+    field public static final com.google.android.horologist.auth.ui.oauth.pkce.AuthPKCEScreenState.Failed INSTANCE;
   }
 
-  public static final class AuthPKCEScreenState.Idle extends com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState {
-    field public static final com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState.Idle INSTANCE;
+  public static final class AuthPKCEScreenState.Idle extends com.google.android.horologist.auth.ui.oauth.pkce.AuthPKCEScreenState {
+    field public static final com.google.android.horologist.auth.ui.oauth.pkce.AuthPKCEScreenState.Idle INSTANCE;
   }
 
-  public static final class AuthPKCEScreenState.Loading extends com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState {
-    field public static final com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState.Loading INSTANCE;
+  public static final class AuthPKCEScreenState.Loading extends com.google.android.horologist.auth.ui.oauth.pkce.AuthPKCEScreenState {
+    field public static final com.google.android.horologist.auth.ui.oauth.pkce.AuthPKCEScreenState.Loading INSTANCE;
   }
 
-  public static final class AuthPKCEScreenState.Success extends com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState {
-    field public static final com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState.Success INSTANCE;
+  public static final class AuthPKCEScreenState.Success extends com.google.android.horologist.auth.ui.oauth.pkce.AuthPKCEScreenState {
+    field public static final com.google.android.horologist.auth.ui.oauth.pkce.AuthPKCEScreenState.Success INSTANCE;
   }
 
   @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public class AuthPKCEViewModel<AuthPKCEConfig, OAuthCodePayload, TokenPayload> extends androidx.lifecycle.ViewModel {
-    ctor public AuthPKCEViewModel(com.google.android.horologist.auth.data.pkce.AuthPKCEConfigRepository<AuthPKCEConfig> authPKCEConfigRepository, com.google.android.horologist.auth.data.pkce.AuthPKCEOAuthCodeRepository<AuthPKCEConfig,OAuthCodePayload> authPKCEOAuthCodeRepository, com.google.android.horologist.auth.data.pkce.AuthPKCETokenRepository<AuthPKCEConfig,OAuthCodePayload,TokenPayload> authPKCETokenRepository, optional com.google.android.horologist.auth.data.pkce.AuthPKCETokenPayloadListener<TokenPayload> authPKCETokenPayloadListener);
-    method public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState> getUiState();
+    ctor public AuthPKCEViewModel(com.google.android.horologist.auth.data.oauth.pkce.AuthPKCEConfigRepository<AuthPKCEConfig> authPKCEConfigRepository, com.google.android.horologist.auth.data.oauth.pkce.AuthPKCEOAuthCodeRepository<AuthPKCEConfig,OAuthCodePayload> authPKCEOAuthCodeRepository, com.google.android.horologist.auth.data.oauth.pkce.AuthPKCETokenRepository<AuthPKCEConfig,OAuthCodePayload,TokenPayload> authPKCETokenRepository, optional com.google.android.horologist.auth.data.oauth.pkce.AuthPKCETokenPayloadListener<TokenPayload> authPKCETokenPayloadListener);
+    method public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.auth.ui.oauth.pkce.AuthPKCEScreenState> getUiState();
     method public final void startAuthFlow();
-    property public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState> uiState;
+    property public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.auth.ui.oauth.pkce.AuthPKCEScreenState> uiState;
   }
 
 }

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/oauth/pkce/AuthPKCEViewModel.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/oauth/pkce/AuthPKCEViewModel.kt
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.auth.ui.pkce
+package com.google.android.horologist.auth.ui.oauth.pkce
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.wear.phone.interactions.authentication.CodeVerifier
-import com.google.android.horologist.auth.data.pkce.AuthPKCEConfigRepository
-import com.google.android.horologist.auth.data.pkce.AuthPKCEOAuthCodeRepository
-import com.google.android.horologist.auth.data.pkce.AuthPKCETokenPayloadListener
-import com.google.android.horologist.auth.data.pkce.AuthPKCETokenPayloadListenerNoOpImpl
-import com.google.android.horologist.auth.data.pkce.AuthPKCETokenRepository
+import com.google.android.horologist.auth.data.oauth.pkce.AuthPKCEConfigRepository
+import com.google.android.horologist.auth.data.oauth.pkce.AuthPKCEOAuthCodeRepository
+import com.google.android.horologist.auth.data.oauth.pkce.AuthPKCETokenPayloadListener
+import com.google.android.horologist.auth.data.oauth.pkce.AuthPKCETokenPayloadListenerNoOpImpl
+import com.google.android.horologist.auth.data.oauth.pkce.AuthPKCETokenRepository
 import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted

--- a/sample/src/main/java/com/google/android/horologist/auth/oauth/devicegrant/AuthDeviceGrantSampleScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/oauth/devicegrant/AuthDeviceGrantSampleScreen.kt
@@ -21,7 +21,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -30,14 +34,20 @@ import androidx.wear.compose.material.Text
 import com.google.android.horologist.auth.ui.oauth.devicegrant.AuthDeviceGrantScreenState
 
 @Composable
-fun AuthDeviceGrantScreen(
+fun AuthDeviceGrantSampleScreen(
     modifier: Modifier = Modifier,
-    viewModel: AuthDeviceGrantScreenViewModel = viewModel(factory = AuthDeviceGrantScreenViewModel.Factory)
+    viewModel: AuthDeviceGrantSampleViewModel = viewModel(factory = AuthDeviceGrantSampleViewModel.Factory)
 ) {
+    var executedOnce by rememberSaveable { mutableStateOf(false) }
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
     if (state == AuthDeviceGrantScreenState.Idle) {
-        viewModel.startAuthFlow()
+        SideEffect {
+            if (!executedOnce) {
+                executedOnce = true
+                viewModel.startAuthFlow()
+            }
+        }
     }
 
     val stateText = when (state) {
@@ -47,6 +57,7 @@ fun AuthDeviceGrantScreen(
             val code = (state as AuthDeviceGrantScreenState.CheckPhone).code
             "CheckPhone: $code"
         }
+
         AuthDeviceGrantScreenState.Failed -> "Failed"
         AuthDeviceGrantScreenState.Success -> "Success"
     }

--- a/sample/src/main/java/com/google/android/horologist/auth/oauth/devicegrant/AuthDeviceGrantSampleViewModel.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/oauth/devicegrant/AuthDeviceGrantSampleViewModel.kt
@@ -35,7 +35,7 @@ import com.squareup.moshi.Moshi
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 
-class AuthDeviceGrantScreenViewModel(
+class AuthDeviceGrantSampleViewModel(
     private val authDeviceGrantConfigRepository: AuthDeviceGrantConfigRepository<AuthDeviceGrantDefaultConfig>,
     private val authDeviceGrantVerificationInfoRepository: AuthDeviceGrantVerificationInfoRepository<AuthDeviceGrantDefaultConfig, DeviceCodeResponse>,
     private val authDeviceGrantTokenRepository: AuthDeviceGrantTokenRepository<AuthDeviceGrantDefaultConfig, DeviceCodeResponse, String>,
@@ -64,7 +64,7 @@ class AuthDeviceGrantScreenViewModel(
                     moshi = Moshi.Builder().build()
                 ).get()
 
-                AuthDeviceGrantScreenViewModel(
+                AuthDeviceGrantSampleViewModel(
                     authDeviceGrantConfigRepository = AuthDeviceGrantConfigRepositoryDefaultImpl(
                         clientId = BuildConfig.OAUTH_DEVICE_GRANT_CLIENT_ID,
                         clientSecret = BuildConfig.OAUTH_DEVICE_GRANT_CLIENT_SECRET

--- a/sample/src/main/java/com/google/android/horologist/auth/oauth/pkce/AuthPKCESampleScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/oauth/pkce/AuthPKCESampleScreen.kt
@@ -21,23 +21,33 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.wear.compose.material.Text
-import com.google.android.horologist.auth.ui.pkce.AuthPKCEScreenState
+import com.google.android.horologist.auth.ui.oauth.pkce.AuthPKCEScreenState
 
 @Composable
-fun AuthPKCEScreen(
+fun AuthPKCESampleScreen(
     modifier: Modifier = Modifier,
-    viewModel: AuthPKCEScreenViewModel = viewModel(factory = AuthPKCEScreenViewModel.Factory)
+    viewModel: AuthPKCESampleViewModel = viewModel(factory = AuthPKCESampleViewModel.Factory)
 ) {
+    var executedOnce by rememberSaveable { mutableStateOf(false) }
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
     if (state == AuthPKCEScreenState.Idle) {
-        viewModel.startAuthFlow()
+        SideEffect {
+            if (!executedOnce) {
+                executedOnce = true
+                viewModel.startAuthFlow()
+            }
+        }
     }
 
     val stateText = when (state) {

--- a/sample/src/main/java/com/google/android/horologist/auth/oauth/pkce/AuthPKCESampleViewModel.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/oauth/pkce/AuthPKCESampleViewModel.kt
@@ -22,21 +22,21 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.google.android.horologist.auth.data.oauth.common.impl.google.api.GoogleOAuthServiceFactory
 import com.google.android.horologist.auth.data.oauth.common.impl.google.api.TokenResponse
-import com.google.android.horologist.auth.data.pkce.AuthPKCEConfigRepository
-import com.google.android.horologist.auth.data.pkce.AuthPKCEOAuthCodeRepository
-import com.google.android.horologist.auth.data.pkce.AuthPKCETokenRepository
-import com.google.android.horologist.auth.data.pkce.impl.AuthPKCEDefaultConfig
-import com.google.android.horologist.auth.data.pkce.impl.AuthPKCEOAuthCodeRepositoryImpl
-import com.google.android.horologist.auth.data.pkce.impl.google.AuthPKCEConfigRepositoryGoogleImpl
-import com.google.android.horologist.auth.data.pkce.impl.google.AuthPKCEOAuthCodeGooglePayload
-import com.google.android.horologist.auth.data.pkce.impl.google.AuthPKCETokenRepositoryGoogleImpl
-import com.google.android.horologist.auth.ui.pkce.AuthPKCEViewModel
+import com.google.android.horologist.auth.data.oauth.pkce.AuthPKCEConfigRepository
+import com.google.android.horologist.auth.data.oauth.pkce.AuthPKCEOAuthCodeRepository
+import com.google.android.horologist.auth.data.oauth.pkce.AuthPKCETokenRepository
+import com.google.android.horologist.auth.data.oauth.pkce.impl.AuthPKCEDefaultConfig
+import com.google.android.horologist.auth.data.oauth.pkce.impl.AuthPKCEOAuthCodeRepositoryImpl
+import com.google.android.horologist.auth.data.oauth.pkce.impl.google.AuthPKCEConfigRepositoryGoogleImpl
+import com.google.android.horologist.auth.data.oauth.pkce.impl.google.AuthPKCEOAuthCodeGooglePayload
+import com.google.android.horologist.auth.data.oauth.pkce.impl.google.AuthPKCETokenRepositoryGoogleImpl
+import com.google.android.horologist.auth.ui.oauth.pkce.AuthPKCEViewModel
 import com.google.android.horologist.sample.BuildConfig
 import com.squareup.moshi.Moshi
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 
-class AuthPKCEScreenViewModel(
+class AuthPKCESampleViewModel(
     private val authPKCEConfigRepository: AuthPKCEConfigRepository<AuthPKCEDefaultConfig>,
     private val authPKCEOAuthCodeRepository: AuthPKCEOAuthCodeRepository<AuthPKCEDefaultConfig, AuthPKCEOAuthCodeGooglePayload>,
     private val authPKCETokenRepository: AuthPKCETokenRepository<AuthPKCEDefaultConfig, AuthPKCEOAuthCodeGooglePayload, TokenResponse>
@@ -51,7 +51,7 @@ class AuthPKCEScreenViewModel(
             initializer {
                 val application = this[APPLICATION_KEY]!!
 
-                AuthPKCEScreenViewModel(
+                AuthPKCESampleViewModel(
                     authPKCEConfigRepository = AuthPKCEConfigRepositoryGoogleImpl(
                         clientId = BuildConfig.OAUTH_PKCE_CLIENT_ID,
                         clientSecret = BuildConfig.OAUTH_PKCE_CLIENT_SECRET

--- a/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
@@ -30,8 +30,8 @@ import androidx.wear.compose.navigation.composable
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import com.google.android.horologist.audio.ui.VolumeScreen
 import com.google.android.horologist.auth.AuthMenuScreen
-import com.google.android.horologist.auth.oauth.devicegrant.AuthDeviceGrantScreen
-import com.google.android.horologist.auth.oauth.pkce.AuthPKCEScreen
+import com.google.android.horologist.auth.oauth.devicegrant.AuthDeviceGrantSampleScreen
+import com.google.android.horologist.auth.oauth.pkce.AuthPKCESampleScreen
 import com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreen
 import com.google.android.horologist.composables.DatePicker
 import com.google.android.horologist.composables.TimePicker
@@ -165,10 +165,10 @@ fun SampleWearApp() {
                 )
             }
             composable(route = Screen.AuthPKCEScreen.route) {
-                AuthPKCEScreen()
+                AuthPKCESampleScreen()
             }
             composable(route = Screen.AuthDeviceGrantScreen.route) {
-                AuthDeviceGrantScreen()
+                AuthDeviceGrantSampleScreen()
             }
             composable(route = Screen.AuthGoogleSignInScreen.route) {
                 GoogleSignInScreen()


### PR DESCRIPTION
#### WHAT

- Change Auth PKCE package;
- Rename AuthPKCEScreen and AuthPKCEScreenViewModel to avoid naming clash with components from the lib;
- Address https://github.com/google/horologist/pull/767#discussion_r1029331349

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
