### PR TITLE
Removes named arguments from MediaDownloadServiceImpl

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/service/download/MediaDownloadServiceImpl.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/service/download/MediaDownloadServiceImpl.kt
@@ -31,12 +31,12 @@ import javax.inject.Inject
 @SuppressLint("UnsafeOptInUsageError")
 @AndroidEntryPoint
 class MediaDownloadServiceImpl : MediaDownloadService(
-    foregroundNotificationId = MEDIA_DOWNLOAD_FOREGROUND_NOTIFICATION_ID,
-    foregroundNotificationUpdateInterval = DEFAULT_FOREGROUND_NOTIFICATION_UPDATE_INTERVAL,
-    channelId = MEDIA_DOWNLOAD_CHANNEL_ID,
-    channelNameResourceId = MEDIA_DOWNLOAD_CHANNEL_NAME,
-    channelDescriptionResourceId = MEDIA_DOWNLOAD_CHANNEL_DESCRIPTION_NOT_PROVIDED,
-    notificationIcon = MEDIA_DOWNLOAD_NOTIFICATION_ICON
+    /* foregroundNotificationId= */ MEDIA_DOWNLOAD_FOREGROUND_NOTIFICATION_ID,
+    /* foregroundNotificationUpdateInterval= */ DEFAULT_FOREGROUND_NOTIFICATION_UPDATE_INTERVAL,
+    /* channelId= */ MEDIA_DOWNLOAD_CHANNEL_ID,
+    /* channelNameResourceId= */ MEDIA_DOWNLOAD_CHANNEL_NAME,
+    /* channelDescriptionResourceId= */ MEDIA_DOWNLOAD_CHANNEL_DESCRIPTION_NOT_PROVIDED,
+    /* notificationIcon= */ MEDIA_DOWNLOAD_NOTIFICATION_ICON
 ) {
 
     @Inject


### PR DESCRIPTION
Using named arguments on a Java code can cause problems and generally isn't allowed ([KT-16765](https://youtrack.jetbrains.com/issue/KT-16765/Support-specifying-named-arguments-for-Java-functions-called-from-Kotlin)). I suspect we hit a corner case here because it's technically a super call and not a normal method call, but we should still avoid it.