### PR TITLE
Add Google Sign-Out functionality to sample app

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -164,6 +164,8 @@ dependencies {
 
     implementation libs.moshi.kotlin
 
+    implementation libs.playservices.auth
+
     debugImplementation projects.composeTools
 
     androidTestImplementation libs.compose.ui.test.junit4

--- a/sample/src/main/java/com/google/android/horologist/auth/AuthMenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/AuthMenuScreen.kt
@@ -74,6 +74,14 @@ fun AuthMenuScreen(
                 chipType = StandardChipType.Primary
             )
         }
+        item {
+            StandardChip(
+                label = stringResource(id = R.string.auth_menu_google_sign_out_item),
+                modifier = modifier.fillMaxWidth(),
+                onClick = { navigateToRoute(Screen.AuthGoogleSignOutScreen.route) },
+                chipType = StandardChipType.Primary
+            )
+        }
     }
 }
 

--- a/sample/src/main/java/com/google/android/horologist/auth/googlesignin/GoogleSignOutScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/googlesignin/GoogleSignOutScreen.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.googlesignin
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavHostController
+import androidx.wear.compose.material.Text
+import androidx.wear.compose.material.dialog.Confirmation
+import com.google.android.horologist.sample.R
+
+@Composable
+fun GoogleSignOutScreen(
+    navController: NavHostController,
+    viewModel: GoogleSignOutViewModel = viewModel(factory = GoogleSignOutViewModel.Factory)
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    when (state) {
+        GoogleSignOutScreenState.Idle -> {
+            // do nothing
+        }
+
+        GoogleSignOutScreenState.Success -> {
+            Confirmation(
+                onTimeout = { navController.popBackStack() }
+            ) {
+                Text(
+                    modifier = Modifier.align(Alignment.CenterHorizontally),
+                    textAlign = TextAlign.Center,
+                    text = stringResource(id = R.string.google_sign_out_success_message)
+                )
+            }
+        }
+
+        GoogleSignOutScreenState.Failed -> {
+            SideEffect {
+                navController.popBackStack()
+            }
+        }
+    }
+}

--- a/sample/src/main/java/com/google/android/horologist/auth/googlesignin/GoogleSignOutViewModel.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/googlesignin/GoogleSignOutViewModel.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.googlesignin
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInClient
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import com.google.android.gms.common.api.ApiException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+
+class GoogleSignOutViewModel(
+    private val googleSignInClient: GoogleSignInClient
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(GoogleSignOutScreenState.Idle)
+    public val uiState: StateFlow<GoogleSignOutScreenState> = _uiState.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
+        initialValue = GoogleSignOutScreenState.Idle
+    )
+
+    init {
+        viewModelScope.launch {
+            try {
+                googleSignInClient.signOut().await()
+                _uiState.value = GoogleSignOutScreenState.Success
+            } catch (apiException: ApiException) {
+                Log.w("GoogleSignOut", "Sign out failed: $apiException")
+                _uiState.value = GoogleSignOutScreenState.Failed
+            }
+        }
+    }
+
+    companion object {
+
+        val Factory: ViewModelProvider.Factory = viewModelFactory {
+            initializer {
+                val application = this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY]!!
+
+                val googleSignInClient = GoogleSignIn.getClient(
+                    application,
+                    GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+                        .requestEmail()
+                        .build()
+                )
+
+                GoogleSignOutViewModel(googleSignInClient)
+            }
+        }
+    }
+}
+
+enum class GoogleSignOutScreenState {
+    Idle,
+    Success,
+    Failed
+}

--- a/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
@@ -30,6 +30,7 @@ import androidx.wear.compose.navigation.composable
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import com.google.android.horologist.audio.ui.VolumeScreen
 import com.google.android.horologist.auth.AuthMenuScreen
+import com.google.android.horologist.auth.googlesignin.GoogleSignOutScreen
 import com.google.android.horologist.auth.oauth.devicegrant.AuthDeviceGrantSampleScreen
 import com.google.android.horologist.auth.oauth.pkce.AuthPKCESampleScreen
 import com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreen
@@ -172,6 +173,9 @@ fun SampleWearApp() {
             }
             composable(route = Screen.AuthGoogleSignInScreen.route) {
                 GoogleSignInScreen()
+            }
+            composable(route = Screen.AuthGoogleSignOutScreen.route) {
+                GoogleSignOutScreen(navController = navController)
             }
         }
     }

--- a/sample/src/main/java/com/google/android/horologist/sample/Screen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/Screen.kt
@@ -48,4 +48,5 @@ sealed class Screen(
     object AuthPKCEScreen : Screen("authPKCEScreen")
     object AuthDeviceGrantScreen : Screen("authDeviceGrantScreen")
     object AuthGoogleSignInScreen : Screen("authGoogleSignInScreen")
+    object AuthGoogleSignOutScreen : Screen("authGoogleSignOutScreen")
 }

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="auth_menu_oauth_pkce_item">OAuth PKCE</string>
     <string name="auth_menu_oauth_device_grant_item">OAuth Device Grant</string>
     <string name="auth_menu_google_sign_in_item">Google Sign-In</string>
+    <string name="auth_menu_google_sign_out_item">Sign out (Google)</string>
     <string name="sectionedlist_stateless_sections_menu">Stateless sections</string>
     <string name="sectionedlist_stateful_sections_menu">Stateful sections</string>
     <string name="sectionedlist_expandable_sections_menu">Expandable sections</string>
@@ -44,6 +45,7 @@
     <string name="sectionedlist_tomorrow">Tomorrow</string>
     <string name="sectionedlist_later_week">Later this week</string>
     <string name="sectionedlist_more_tasks">More tasks…</string>
+    <string name="google_sign_out_success_message">Signed out successfully!</string>
 
     <string name="rotarymenu_scroll">Scroll</string>
     <string name="rotarymenu_scroll_list">Scroll list</string>


### PR DESCRIPTION
#### WHAT

Add Google Sign-Out functionality to sample app

#### WHY

In order to allow to sign out so the sign-in flow can be tested multiples times.

#### HOW

Add the logic into AuthGoogleSignOutScreen / AuthGoogleSignOutViewModel, display a success confirmation message when successfully or fail silently for now.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
