### PR TITLE
Add file optin for AlertDialogAlertPreview

### DIFF
--- a/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/AlertDialogAlertPreview.kt
+++ b/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/AlertDialogAlertPreview.kt
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalHorologistBaseUiApi::class)
+
 package com.google.android.horologist.base.ui.components
 
 import androidx.compose.runtime.Composable
 import com.google.android.horologist.base.ui.ExperimentalHorologistBaseUiApi
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 
-@OptIn(ExperimentalHorologistBaseUiApi::class)
 @WearPreviewDevices
 @Composable
 fun AlertDialogAlertPreview() {
@@ -34,7 +35,6 @@ fun AlertDialogAlertPreview() {
     )
 }
 
-@OptIn(ExperimentalHorologistBaseUiApi::class)
 @WearPreviewDevices
 @Composable
 fun AlertDialogAlertWithLongBodyPreview() {


### PR DESCRIPTION
#### WHAT
Add optIn for entire file in AlertDialogAlertPreview instead of opting in on each function in the file.

#### WHY
Following up on https://github.com/google/horologist/pull/775#discussion_r1031685145

#### HOW
Adding the optin for the file and removing the annotations on the functions

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
