### PR TITLE
Add Auth composables

### DIFF
--- a/auth-composables/api/current.api
+++ b/auth-composables/api/current.api
@@ -1,1 +1,30 @@
 // Signature format: 4.0
+package com.google.android.horologist.auth.composables {
+
+  @kotlin.RequiresOptIn(message="Horologist Auth Composables is experimental. The API may be changed in the future.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.BINARY) public @interface ExperimentalHorologistAuthComposablesApi {
+  }
+
+}
+
+package com.google.android.horologist.auth.composables.dialog {
+
+  public final class SignedInConfirmationDialogKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi public static void SignedInConfirmationDialog(String displayName, String email, boolean showDialog, kotlin.jvm.functions.Function0<kotlin.Unit> onDismissOrTimeout, optional androidx.compose.ui.Modifier modifier, optional long durationMillis);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi public static void SignedInConfirmationDialog(boolean showDialog, kotlin.jvm.functions.Function0<kotlin.Unit> onDismissOrTimeout, optional androidx.compose.ui.Modifier modifier, optional long durationMillis);
+  }
+
+}
+
+package com.google.android.horologist.auth.composables.screens {
+
+  public final class AuthErrorScreenKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi public static void AuthErrorScreen(optional androidx.compose.ui.Modifier modifier);
+  }
+
+  public final class CheckYourPhoneScreenKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi public static void CheckYourPhoneScreen(optional androidx.compose.ui.Modifier modifier);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi public static void CheckYourPhoneScreen(optional androidx.compose.ui.Modifier modifier, String message);
+  }
+
+}
+

--- a/auth-composables/build.gradle
+++ b/auth-composables/build.gradle
@@ -92,26 +92,32 @@ metalava {
 
 dependencies {
 
-    implementation libs.kotlin.stdlib
+    implementation projects.baseUi
+
     implementation libs.androidx.wear
+    implementation libs.compose.material.iconscore
+    implementation libs.compose.material.iconsext
+    implementation libs.kotlin.stdlib
+    implementation libs.wearcompose.material
+    implementation libs.wearcompose.foundation
 
     debugImplementation projects.composeTools
     debugImplementation libs.compose.ui.toolingpreview
 
-    testImplementation libs.junit
-    testImplementation libs.androidx.test.ext.ktx
-    testImplementation libs.kotlinx.coroutines.test
-    testImplementation libs.truth
-    testImplementation libs.robolectric
     testImplementation projects.paparazzi
+    testImplementation libs.androidx.test.ext.ktx
+    testImplementation libs.junit
+    testImplementation libs.kotlinx.coroutines.test
     testImplementation libs.paparazzi
+    testImplementation libs.robolectric
+    testImplementation libs.truth
 
-    androidTestImplementation libs.compose.ui.test.junit4
-    androidTestImplementation libs.truth
-    androidTestImplementation libs.espresso.core
-    androidTestImplementation libs.junit
     androidTestImplementation libs.androidx.test.ext
     androidTestImplementation libs.androidx.test.ext.ktx
+    androidTestImplementation libs.compose.ui.test.junit4
+    androidTestImplementation libs.espresso.core
+    androidTestImplementation libs.junit
+    androidTestImplementation libs.truth
 }
 
 // Not publishing it until it's ready

--- a/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/dialog/SignedInConfirmationDialogPreview.kt
+++ b/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/dialog/SignedInConfirmationDialogPreview.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistAuthComposablesApi::class)
+
+package com.google.android.horologist.auth.composables.dialog
+
+import androidx.compose.runtime.Composable
+import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
+import com.google.android.horologist.compose.tools.WearPreviewDevices
+
+@WearPreviewDevices
+@Composable
+fun SignedInConfirmationDialogPreview() {
+    SignedInConfirmationDialogContent(
+        displayName = "Maggie",
+        email = "maggie@gmail.com"
+    )
+}

--- a/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/screens/AuthErrorScreenPreview.kt
+++ b/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/screens/AuthErrorScreenPreview.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistAuthComposablesApi::class)
+
+package com.google.android.horologist.auth.composables.screens
+
+import androidx.compose.runtime.Composable
+import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
+import com.google.android.horologist.compose.tools.WearPreviewDevices
+
+@WearPreviewDevices
+@Composable
+fun AuthErrorScreenPreview() {
+    AuthErrorScreen()
+}

--- a/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/screens/CheckYourPhoneScreenPreview.kt
+++ b/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/screens/CheckYourPhoneScreenPreview.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistAuthComposablesApi::class)
+
+package com.google.android.horologist.auth.composables.screens
+
+import androidx.compose.runtime.Composable
+import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
+import com.google.android.horologist.compose.tools.WearPreviewDevices
+
+@WearPreviewDevices
+@Composable
+fun CheckYourPhoneScreenPreview() {
+    CheckYourPhoneScreen()
+}
+
+@WearPreviewDevices
+@Composable
+fun CheckYourPhoneScreenPreviewWithMessage() {
+    CheckYourPhoneScreen(message = "XXXX-YYYY")
+}

--- a/auth-composables/src/main/java/com/google/android/horologist/auth/composables/ExperimentalHorologistAuthComposablesApi.kt
+++ b/auth-composables/src/main/java/com/google/android/horologist/auth/composables/ExperimentalHorologistAuthComposablesApi.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.composables
+
+@RequiresOptIn(
+    message = "Horologist Auth Composables is experimental. The API may be changed in the future."
+)
+@Retention(AnnotationRetention.BINARY)
+public annotation class ExperimentalHorologistAuthComposablesApi

--- a/auth-composables/src/main/java/com/google/android/horologist/auth/composables/dialog/SignedInConfirmationDialog.kt
+++ b/auth-composables/src/main/java/com/google/android/horologist/auth/composables/dialog/SignedInConfirmationDialog.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.composables.dialog
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.ChipDefaults
+import androidx.wear.compose.material.Text
+import androidx.wear.compose.material.dialog.Dialog
+import androidx.wear.compose.material.dialog.DialogDefaults
+import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
+import com.google.android.horologist.auth.composables.R
+import kotlinx.coroutines.delay
+
+@ExperimentalHorologistAuthComposablesApi
+@Composable
+public fun SignedInConfirmationDialog(
+    displayName: String,
+    email: String,
+    showDialog: Boolean,
+    onDismissOrTimeout: () -> Unit,
+    modifier: Modifier = Modifier,
+    durationMillis: Long = DialogDefaults.ShortDurationMillis
+) {
+    val currentOnDismissOrTimeout by rememberUpdatedState(onDismissOrTimeout)
+
+    LaunchedEffect(durationMillis) {
+        delay(durationMillis)
+        currentOnDismissOrTimeout()
+    }
+
+    Dialog(
+        showDialog = showDialog,
+        onDismissRequest = currentOnDismissOrTimeout,
+        modifier = modifier
+    ) {
+        SignedInConfirmationDialogContent(
+            displayName = displayName,
+            email = email,
+            modifier = modifier
+        )
+    }
+}
+
+@ExperimentalHorologistAuthComposablesApi
+@Composable
+internal fun SignedInConfirmationDialogContent(
+    displayName: String,
+    email: String,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(
+            modifier = modifier
+                .size(ChipDefaults.LargeIconSize)
+                .background(color = Color.Blue, shape = CircleShape)
+        ) {
+            Text(
+                text = displayName.first().uppercase(),
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .fillMaxWidth(),
+                textAlign = TextAlign.Center
+            )
+        }
+
+        Text(
+            text = stringResource(
+                id = R.string.horologist_signedin_confirmation_greeting,
+                displayName
+            ),
+            modifier = Modifier
+                .padding(top = 20.dp)
+                .fillMaxWidth(),
+            textAlign = TextAlign.Center
+        )
+
+        Text(
+            text = email,
+            modifier = Modifier
+                .padding(top = 5.dp)
+                .fillMaxWidth(),
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@ExperimentalHorologistAuthComposablesApi
+@Composable
+public fun SignedInConfirmationDialog(
+    showDialog: Boolean,
+    onDismissOrTimeout: () -> Unit,
+    modifier: Modifier = Modifier,
+    durationMillis: Long = DialogDefaults.ShortDurationMillis
+) {
+    val currentOnDismissOrTimeout by rememberUpdatedState(onDismissOrTimeout)
+
+    LaunchedEffect(durationMillis) {
+        delay(durationMillis)
+        currentOnDismissOrTimeout()
+    }
+
+    Dialog(
+        showDialog = showDialog,
+        onDismissRequest = currentOnDismissOrTimeout,
+        modifier = modifier
+    ) {
+        Column(
+            modifier = modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Center
+
+        ) {
+            Text(
+                text = "Success!",
+                modifier = Modifier
+                    .fillMaxWidth(),
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}

--- a/auth-composables/src/main/java/com/google/android/horologist/auth/composables/screens/AuthErrorScreen.kt
+++ b/auth-composables/src/main/java/com/google/android/horologist/auth/composables/screens/AuthErrorScreen.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.composables.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.wear.compose.material.Text
+import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
+import com.google.android.horologist.auth.composables.R
+
+@ExperimentalHorologistAuthComposablesApi
+@Composable
+public fun AuthErrorScreen(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center
+
+    ) {
+        Text(
+            text = stringResource(id = R.string.horologist_auth_error_message),
+            modifier = Modifier
+                .fillMaxWidth(),
+            textAlign = TextAlign.Center
+        )
+    }
+}

--- a/auth-composables/src/main/java/com/google/android/horologist/auth/composables/screens/CheckYourPhoneScreen.kt
+++ b/auth-composables/src/main/java/com/google/android/horologist/auth/composables/screens/CheckYourPhoneScreen.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.composables.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.SecurityUpdateGood
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.CircularProgressIndicator
+import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.Text
+import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
+import com.google.android.horologist.auth.composables.R
+import com.google.android.horologist.base.ui.util.DECORATIVE_ELEMENT_CONTENT_DESCRIPTION
+
+private val indicatorPadding = 8.dp
+private val iconSize = 48.dp
+private val progressBarStrokeWidth = 4.dp
+
+@ExperimentalHorologistAuthComposablesApi
+@Composable
+public fun CheckYourPhoneScreen(
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier.fillMaxSize()
+    ) {
+        Text(
+            text = stringResource(id = R.string.horologist_check_your_phone_title),
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.Center),
+            textAlign = TextAlign.Center
+        )
+
+        Box(
+            modifier = modifier
+                .padding(bottom = 20.dp)
+                .align(Alignment.BottomCenter)
+                .size(iconSize)
+                .clip(CircleShape)
+        ) {
+            CircularProgressIndicator(
+                modifier = modifier
+                    .size(iconSize - progressBarStrokeWidth + indicatorPadding),
+                strokeWidth = progressBarStrokeWidth
+            )
+            Icon(
+                imageVector = Icons.Default.SecurityUpdateGood,
+                contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .size(iconSize - indicatorPadding - 8.dp)
+                    .clip(CircleShape)
+            )
+        }
+    }
+}
+
+@ExperimentalHorologistAuthComposablesApi
+@Composable
+public fun CheckYourPhoneScreen(
+    modifier: Modifier = Modifier,
+    message: String
+) {
+    Column(
+        modifier = modifier.fillMaxSize()
+    ) {
+        Text(
+            text = stringResource(id = R.string.horologist_check_your_phone_title),
+            modifier = Modifier
+                .padding(top = 60.dp)
+                .fillMaxWidth()
+                .align(Alignment.CenterHorizontally),
+            textAlign = TextAlign.Center
+        )
+
+        Text(
+            text = message,
+            modifier = Modifier
+                .padding(top = 20.dp)
+                .fillMaxWidth()
+                .align(Alignment.CenterHorizontally),
+            textAlign = TextAlign.Center
+        )
+
+        Box(
+            modifier = modifier
+                .padding(vertical = 20.dp)
+                .fillMaxWidth()
+                .size(iconSize)
+                .clip(CircleShape),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator(
+                modifier = modifier
+                    .size(iconSize - progressBarStrokeWidth + indicatorPadding),
+                strokeWidth = progressBarStrokeWidth
+            )
+            Icon(
+                imageVector = Icons.Default.SecurityUpdateGood,
+                contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
+                modifier = Modifier
+                    .size(iconSize - indicatorPadding - 8.dp)
+                    .clip(CircleShape)
+            )
+        }
+    }
+}

--- a/auth-composables/src/main/res/values/strings.xml
+++ b/auth-composables/src/main/res/values/strings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2022 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <string name="horologist_check_your_phone_title">Check your phone</string>
+    <string name="horologist_auth_error_message">Error authenticating.</string>
+    <string name="horologist_signedin_confirmation_greeting">Hi, %s</string>
+</resources>

--- a/auth-ui/api/current.api
+++ b/auth-ui/api/current.api
@@ -24,11 +24,21 @@ package com.google.android.horologist.auth.ui.googlesignin {
   }
 
   public static final class AuthGoogleSignInScreenState.Success extends com.google.android.horologist.auth.ui.googlesignin.AuthGoogleSignInScreenState {
-    field public static final com.google.android.horologist.auth.ui.googlesignin.AuthGoogleSignInScreenState.Success INSTANCE;
+    ctor public AuthGoogleSignInScreenState.Success(String? displayName, String? email, android.net.Uri? photoUrl);
+    method public String? component1();
+    method public String? component2();
+    method public android.net.Uri? component3();
+    method public com.google.android.horologist.auth.ui.googlesignin.AuthGoogleSignInScreenState.Success copy(String? displayName, String? email, android.net.Uri? photoUrl);
+    method public String? getDisplayName();
+    method public String? getEmail();
+    method public android.net.Uri? getPhotoUrl();
+    property public final String? displayName;
+    property public final String? email;
+    property public final android.net.Uri? photoUrl;
   }
 
   public final class GoogleSignInScreenKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public static void GoogleSignInScreen(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.auth.ui.googlesignin.GoogleSignInViewModel viewModel);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public static void GoogleSignInScreen(optional com.google.android.horologist.auth.ui.googlesignin.GoogleSignInViewModel viewModel);
   }
 
   @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public class GoogleSignInViewModel extends androidx.lifecycle.ViewModel {
@@ -43,6 +53,10 @@ package com.google.android.horologist.auth.ui.googlesignin {
 }
 
 package com.google.android.horologist.auth.ui.oauth.devicegrant {
+
+  public final class AuthDeviceGrantScreenKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public static <AuthDeviceGrantConfig, VerificationInfoPayload, TokenPayload> void AuthDeviceGrantScreen(com.google.android.horologist.auth.ui.oauth.devicegrant.AuthDeviceGrantViewModel<AuthDeviceGrantConfig,VerificationInfoPayload,TokenPayload> viewModel);
+  }
 
   @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public abstract sealed class AuthDeviceGrantScreenState {
   }
@@ -81,6 +95,10 @@ package com.google.android.horologist.auth.ui.oauth.devicegrant {
 }
 
 package com.google.android.horologist.auth.ui.oauth.pkce {
+
+  public final class AuthPKCEScreenKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public static <AuthPKCEConfig, OAuthCodePayload, TokenPayload> void AuthPKCEScreen(com.google.android.horologist.auth.ui.oauth.pkce.AuthPKCEViewModel<AuthPKCEConfig,OAuthCodePayload,TokenPayload> viewModel);
+  }
 
   @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public abstract sealed class AuthPKCEScreenState {
   }

--- a/auth-ui/build.gradle
+++ b/auth-ui/build.gradle
@@ -44,6 +44,7 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
         freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
+        freeCompilerArgs += "-opt-in=com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi"
         freeCompilerArgs += "-opt-in=androidx.lifecycle.compose.ExperimentalLifecycleComposeApi"
     }
@@ -94,6 +95,7 @@ metalava {
 
 dependencies {
 
+    implementation projects.authComposables
     implementation projects.authData
 
     implementation libs.androidx.activity.compose

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/GoogleSignInScreen.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/GoogleSignInScreen.kt
@@ -21,10 +21,8 @@ import android.content.Intent
 import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContract
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
@@ -32,12 +30,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.wear.compose.material.Text
+import androidx.wear.compose.material.CircularProgressIndicator
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
@@ -49,7 +47,6 @@ import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
 @ExperimentalHorologistAuthUiApi
 @Composable
 public fun GoogleSignInScreen(
-    modifier: Modifier = Modifier,
     viewModel: GoogleSignInViewModel = viewModel()
 ) {
     var executedOnce by rememberSaveable { mutableStateOf(false) }
@@ -99,29 +96,18 @@ public fun GoogleSignInScreen(
             }
         }
 
-        else -> {
+        AuthGoogleSignInScreenState.Failed,
+        is AuthGoogleSignInScreenState.Success -> {
             // do nothing
         }
     }
 
-    val stateText = when (state) {
-        AuthGoogleSignInScreenState.Idle -> "Idle"
-        AuthGoogleSignInScreenState.SelectAccount -> "SelectAccount"
-        AuthGoogleSignInScreenState.Failed -> "Failed"
-        AuthGoogleSignInScreenState.Success -> "Success"
-    }
-
-    Column(
-        modifier = modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.Center
-
+    Box(
+        modifier = Modifier
+            .fillMaxSize(),
+        contentAlignment = Alignment.Center
     ) {
-        Text(
-            text = stateText,
-            modifier = Modifier
-                .fillMaxWidth(),
-            textAlign = TextAlign.Center
-        )
+        CircularProgressIndicator()
     }
 }
 

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/GoogleSignInViewModel.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/GoogleSignInViewModel.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.horologist.auth.ui.googlesignin
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
@@ -50,7 +51,11 @@ public open class GoogleSignInViewModel(
             authGoogleSignInAccountListener.onAccountReceived(account)
         }
 
-        _uiState.value = AuthGoogleSignInScreenState.Success
+        _uiState.value = AuthGoogleSignInScreenState.Success(
+            displayName = account.displayName,
+            email = account.email,
+            photoUrl = account.photoUrl
+        )
     }
 
     public fun onAccountSelectionFailed() {
@@ -62,6 +67,11 @@ public open class GoogleSignInViewModel(
 public sealed class AuthGoogleSignInScreenState {
     public object Idle : AuthGoogleSignInScreenState()
     public object SelectAccount : AuthGoogleSignInScreenState()
-    public object Success : AuthGoogleSignInScreenState()
+    public data class Success(
+        val displayName: String?,
+        val email: String?,
+        val photoUrl: Uri?
+    ) : AuthGoogleSignInScreenState()
+
     public object Failed : AuthGoogleSignInScreenState()
 }

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/oauth/devicegrant/AuthDeviceGrantScreen.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/oauth/devicegrant/AuthDeviceGrantScreen.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.ui.oauth.devicegrant
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.google.android.horologist.auth.composables.screens.CheckYourPhoneScreen
+import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
+
+@ExperimentalHorologistAuthUiApi
+@Composable
+public fun <AuthDeviceGrantConfig, VerificationInfoPayload, TokenPayload> AuthDeviceGrantScreen(
+    viewModel: AuthDeviceGrantViewModel<AuthDeviceGrantConfig, VerificationInfoPayload, TokenPayload>
+) {
+    var executedOnce by rememberSaveable { mutableStateOf(false) }
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    when (state) {
+        AuthDeviceGrantScreenState.Idle -> {
+            SideEffect {
+                if (!executedOnce) {
+                    executedOnce = true
+                    viewModel.startAuthFlow()
+                }
+            }
+        }
+
+        AuthDeviceGrantScreenState.Loading -> {
+            CheckYourPhoneScreen()
+        }
+
+        is AuthDeviceGrantScreenState.CheckPhone -> {
+            val code = (state as AuthDeviceGrantScreenState.CheckPhone).code
+            CheckYourPhoneScreen(message = code)
+        }
+
+        AuthDeviceGrantScreenState.Success,
+        AuthDeviceGrantScreenState.Failed -> {
+            // do nothing
+        }
+    }
+}

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/oauth/pkce/AuthPKCEScreen.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/oauth/pkce/AuthPKCEScreen.kt
@@ -14,52 +14,44 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.auth.oauth.pkce
+package com.google.android.horologist.auth.ui.oauth.pkce
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
-import com.google.android.horologist.auth.composables.dialog.SignedInConfirmationDialog
-import com.google.android.horologist.auth.composables.screens.AuthErrorScreen
-import com.google.android.horologist.auth.ui.oauth.pkce.AuthPKCEScreen
-import com.google.android.horologist.auth.ui.oauth.pkce.AuthPKCEScreenState
+import com.google.android.horologist.auth.composables.screens.CheckYourPhoneScreen
+import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
 
+@ExperimentalHorologistAuthUiApi
 @Composable
-fun AuthPKCESampleScreen(
-    onAuthSuccess: () -> Unit,
-    modifier: Modifier = Modifier,
-    viewModel: AuthPKCESampleViewModel = viewModel(factory = AuthPKCESampleViewModel.Factory)
+public fun <AuthPKCEConfig, OAuthCodePayload, TokenPayload> AuthPKCEScreen(
+    viewModel: AuthPKCEViewModel<AuthPKCEConfig, OAuthCodePayload, TokenPayload>
 ) {
+    var executedOnce by rememberSaveable { mutableStateOf(false) }
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
     when (state) {
-        AuthPKCEScreenState.Idle,
+        AuthPKCEScreenState.Idle -> {
+            SideEffect {
+                if (!executedOnce) {
+                    executedOnce = true
+                    viewModel.startAuthFlow()
+                }
+            }
+        }
+
         AuthPKCEScreenState.Loading,
         AuthPKCEScreenState.CheckPhone -> {
-            AuthPKCEScreen(viewModel = viewModel)
+            CheckYourPhoneScreen()
         }
 
+        AuthPKCEScreenState.Success,
         AuthPKCEScreenState.Failed -> {
-            AuthErrorScreen(modifier)
-        }
-
-        AuthPKCEScreenState.Success -> {
-            var showDialog by rememberSaveable { mutableStateOf(true) }
-
-            SignedInConfirmationDialog(
-                showDialog = showDialog,
-                onDismissOrTimeout = {
-                    showDialog = false
-
-                    onAuthSuccess()
-                },
-                modifier = modifier
-            )
+            // do nothing
         }
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -68,6 +68,7 @@ android {
         freeCompilerArgs += "-opt-in=com.google.accompanist.pager.ExperimentalPagerApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.audio.ExperimentalHorologistAudioApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi"
+        freeCompilerArgs += "-opt-in=com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.base.ui.ExperimentalHorologistBaseUiApi"
@@ -123,6 +124,7 @@ dependencies {
     implementation projects.composeLayout
     implementation projects.audio
     implementation projects.audioUi
+    implementation projects.authComposables
     implementation projects.authData
     implementation projects.authUi
     implementation projects.tiles

--- a/sample/src/main/java/com/google/android/horologist/auth/googlesignin/GoogleSignInSampleScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/googlesignin/GoogleSignInSampleScreen.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.googlesignin
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.google.android.horologist.auth.composables.dialog.SignedInConfirmationDialog
+import com.google.android.horologist.auth.composables.screens.AuthErrorScreen
+import com.google.android.horologist.auth.ui.googlesignin.AuthGoogleSignInScreenState
+import com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreen
+import com.google.android.horologist.auth.ui.googlesignin.GoogleSignInViewModel
+
+@Composable
+fun GoogleSignInSampleScreen(
+    onAuthSuccess: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: GoogleSignInViewModel = viewModel()
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    when (state) {
+        AuthGoogleSignInScreenState.Idle,
+        AuthGoogleSignInScreenState.SelectAccount -> {
+            GoogleSignInScreen(viewModel)
+        }
+
+        AuthGoogleSignInScreenState.Failed -> {
+            AuthErrorScreen(modifier)
+        }
+
+        is AuthGoogleSignInScreenState.Success -> {
+            var showDialog by rememberSaveable { mutableStateOf(true) }
+            val successState = state as AuthGoogleSignInScreenState.Success
+
+            if (successState.displayName != null && successState.email != null) {
+                SignedInConfirmationDialog(
+                    displayName = successState.displayName!!,
+                    email = successState.email!!,
+                    showDialog = showDialog,
+                    onDismissOrTimeout = {
+                        showDialog = false
+
+                        onAuthSuccess()
+                    },
+                    modifier = modifier
+                )
+            } else {
+                SignedInConfirmationDialog(
+                    showDialog = showDialog,
+                    onDismissOrTimeout = {
+                        showDialog = false
+
+                        onAuthSuccess()
+                    },
+                    modifier = modifier
+                )
+            }
+        }
+    }
+}

--- a/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
@@ -30,10 +30,10 @@ import androidx.wear.compose.navigation.composable
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import com.google.android.horologist.audio.ui.VolumeScreen
 import com.google.android.horologist.auth.AuthMenuScreen
+import com.google.android.horologist.auth.googlesignin.GoogleSignInSampleScreen
 import com.google.android.horologist.auth.googlesignin.GoogleSignOutScreen
 import com.google.android.horologist.auth.oauth.devicegrant.AuthDeviceGrantSampleScreen
 import com.google.android.horologist.auth.oauth.pkce.AuthPKCESampleScreen
-import com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreen
 import com.google.android.horologist.composables.DatePicker
 import com.google.android.horologist.composables.TimePicker
 import com.google.android.horologist.composables.TimePickerWith12HourClock
@@ -166,13 +166,19 @@ fun SampleWearApp() {
                 )
             }
             composable(route = Screen.AuthPKCEScreen.route) {
-                AuthPKCESampleScreen()
+                AuthPKCESampleScreen(
+                    onAuthSuccess = { navController.popBackStack() }
+                )
             }
             composable(route = Screen.AuthDeviceGrantScreen.route) {
-                AuthDeviceGrantSampleScreen()
+                AuthDeviceGrantSampleScreen(
+                    onAuthSuccess = { navController.popBackStack() }
+                )
             }
             composable(route = Screen.AuthGoogleSignInScreen.route) {
-                GoogleSignInScreen()
+                GoogleSignInSampleScreen(
+                    onAuthSuccess = { navController.popBackStack() }
+                )
             }
             composable(route = Screen.AuthGoogleSignOutScreen.route) {
                 GoogleSignOutScreen(navController = navController)


### PR DESCRIPTION
#### WHAT

Add prototype versions of the following Auth composables:
- CheckYourPhoneScreen
- SignedInConfirmationDialog
- AuthErrorScreen

Update samples to use them.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
