### PR TITLE
Workaround placeholder inconsistency with PagerItemCard

### DIFF
--- a/sample/src/main/java/com/google/android/horologist/paging/PagingScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/paging/PagingScreen.kt
@@ -16,7 +16,7 @@
 
 package com.google.android.horologist.paging
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
@@ -97,7 +97,9 @@ private fun PagingItemCard(
     modifier: Modifier = Modifier,
     onClick: () -> Unit = {}
 ) {
-    val chipPlaceholderState = rememberPlaceholderState { item != null }
+    // Workaround for https://issuetracker.google.com/issues/260343754
+    val chipPlaceholderState =
+        if (item != null) rememberPlaceholderState { true } else rememberPlaceholderState { false }
 
     TitleCard(
         modifier = modifier
@@ -165,7 +167,6 @@ private class MyBackend {
         }
 
         val itemsAfter = backendDataList.size - to - 1
-        println(itemsAfter)
         return DesiredLoadResultPageResponse(data = currentSublist, itemsAfter = itemsAfter)
     }
 
@@ -222,7 +223,7 @@ data class PagingItem(
 @WearSquareDevicePreview
 @Composable
 fun PagingItemCardPreview() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    Column(modifier = Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
         var item by remember { mutableStateOf<PagingItem?>(null) }
         LaunchedEffect(Unit) {
             delay(1000)
@@ -235,7 +236,7 @@ fun PagingItemCardPreview() {
 @WearSquareDevicePreview
 @Composable
 fun PagingItemCardPreview2() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    Column(modifier = Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
         val item = remember { PagingItem(10) }
         PagingItemCard(modifier = Modifier.fillMaxWidth(), item = item)
     }

--- a/sample/src/main/java/com/google/android/horologist/paging/PagingScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/paging/PagingScreen.kt
@@ -222,7 +222,7 @@ data class PagingItem(
 
 @WearSquareDevicePreview
 @Composable
-fun PagingItemCardPreview() {
+fun PagingItemCardPreviewWithDelayedContent() {
     Column(modifier = Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
         var item by remember { mutableStateOf<PagingItem?>(null) }
         LaunchedEffect(Unit) {
@@ -235,7 +235,7 @@ fun PagingItemCardPreview() {
 
 @WearSquareDevicePreview
 @Composable
-fun PagingItemCardPreview2() {
+fun PagingItemCardPreviewWithInitialContent() {
     Column(modifier = Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
         val item = remember { PagingItem(10) }
         PagingItemCard(modifier = Modifier.fillMaxWidth(), item = item)

--- a/sample/src/main/java/com/google/android/horologist/paging/PagingScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/paging/PagingScreen.kt
@@ -16,11 +16,15 @@
 
 package com.google.android.horologist.paging
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -34,7 +38,6 @@ import androidx.paging.PagingState
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.wear.compose.material.AutoCenteringParams
 import androidx.wear.compose.material.CardDefaults
-import androidx.wear.compose.material.CircularProgressIndicator
 import androidx.wear.compose.material.PlaceholderDefaults
 import androidx.wear.compose.material.ScalingLazyColumn
 import androidx.wear.compose.material.Text
@@ -44,6 +47,7 @@ import androidx.wear.compose.material.placeholderShimmer
 import androidx.wear.compose.material.rememberPlaceholderState
 import androidx.wear.compose.material.rememberScalingLazyListState
 import com.google.android.horologist.compose.paging.items
+import com.google.android.horologist.compose.tools.WearSquareDevicePreview
 import com.google.android.horologist.sample.R
 import kotlinx.coroutines.delay
 import java.time.LocalTime
@@ -73,20 +77,14 @@ fun PagingScreen(navController: NavController) {
     ) {
         if (lazyPagingItems.loadState.refresh == LoadState.Loading) {
             items(10) {
-                PagingItemChip(item = null, navController = navController)
+                PagingItemChip(item = null)
             }
         } else {
             items(lazyPagingItems) { item ->
-                PagingItemChip(item, navController)
-            }
-
-            if (lazyPagingItems.loadState.append == LoadState.Loading) {
-                item {
-                    CircularProgressIndicator(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .wrapContentWidth(Alignment.CenterHorizontally)
-                    )
+                PagingItemChip(item) {
+                    if (item != null) {
+                        navController.navigate("pagingItem?id=${item.item}")
+                    }
                 }
             }
         }
@@ -96,15 +94,17 @@ fun PagingScreen(navController: NavController) {
 @Composable
 private fun PagingItemChip(
     item: PagingItem?,
-    navController: NavController
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {}
 ) {
     val chipPlaceholderState = rememberPlaceholderState { item != null }
 
     TitleCard(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .placeholderShimmer(chipPlaceholderState),
-        onClick = { navController.navigate("pagingItem?id=${item?.item}") },
+        enabled = item != null,
+        onClick = onClick,
         title = {
             Text(
                 modifier = Modifier
@@ -216,5 +216,27 @@ data class PagingItem(
 
     companion object {
         private val timeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("hh:mm:ss")
+    }
+}
+
+@WearSquareDevicePreview
+@Composable
+fun PagingItemChipPreview() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        var item by remember { mutableStateOf<PagingItem?>(null) }
+        LaunchedEffect(Unit) {
+            delay(1000)
+            item = PagingItem(10)
+        }
+        PagingItemChip(modifier = Modifier.fillMaxWidth(), item = item)
+    }
+}
+
+@WearSquareDevicePreview
+@Composable
+fun PagingItemChipPreview2() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        val item = remember { PagingItem(10) }
+        PagingItemChip(modifier = Modifier.fillMaxWidth(), item = item)
     }
 }

--- a/sample/src/main/java/com/google/android/horologist/paging/PagingScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/paging/PagingScreen.kt
@@ -77,11 +77,11 @@ fun PagingScreen(navController: NavController) {
     ) {
         if (lazyPagingItems.loadState.refresh == LoadState.Loading) {
             items(10) {
-                PagingItemChip(item = null)
+                PagingItemCard(item = null)
             }
         } else {
             items(lazyPagingItems) { item ->
-                PagingItemChip(item) {
+                PagingItemCard(item) {
                     if (item != null) {
                         navController.navigate("pagingItem?id=${item.item}")
                     }
@@ -92,7 +92,7 @@ fun PagingScreen(navController: NavController) {
 }
 
 @Composable
-private fun PagingItemChip(
+private fun PagingItemCard(
     item: PagingItem?,
     modifier: Modifier = Modifier,
     onClick: () -> Unit = {}
@@ -221,22 +221,22 @@ data class PagingItem(
 
 @WearSquareDevicePreview
 @Composable
-fun PagingItemChipPreview() {
+fun PagingItemCardPreview() {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         var item by remember { mutableStateOf<PagingItem?>(null) }
         LaunchedEffect(Unit) {
             delay(1000)
             item = PagingItem(10)
         }
-        PagingItemChip(modifier = Modifier.fillMaxWidth(), item = item)
+        PagingItemCard(modifier = Modifier.fillMaxWidth(), item = item)
     }
 }
 
 @WearSquareDevicePreview
 @Composable
-fun PagingItemChipPreview2() {
+fun PagingItemCardPreview2() {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         val item = remember { PagingItem(10) }
-        PagingItemChip(modifier = Modifier.fillMaxWidth(), item = item)
+        PagingItemCard(modifier = Modifier.fillMaxWidth(), item = item)
     }
 }


### PR DESCRIPTION
#### WHAT

Workaround issue with placeholders.
Add a preview of PagingItem with placeholder.
Also removes a CircularProgressIndicator that does nothing.

#### WHY

Repro of a placeholder bug

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files

![image](https://user-images.githubusercontent.com/231923/203945799-7da6f3cb-e4df-43df-9b4e-23383e6e242b.png)
