### PR TITLE
Player Screen uses showProgress flag

### DIFF
--- a/media-data/src/test/java/com/google/android/horologist/media/data/mapper/MediaPositionMapperTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/mapper/MediaPositionMapperTest.kt
@@ -27,7 +27,7 @@ import org.junit.Test
 import kotlin.time.Duration.Companion.milliseconds
 
 class MediaPositionMapperTest {
-    val fakeStatePlayer = FakeStatePlayer()
+    private val fakeStatePlayer = FakeStatePlayer()
 
     @Test
     fun `check position calculations null`() {

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/player/UampMediaPlayerScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/player/UampMediaPlayerScreen.kt
@@ -74,7 +74,8 @@ fun UampMediaPlayerScreen(
                         seekToPreviousButtonEnabled = playerUiState.seekToPreviousEnabled,
                         onSeekToNextButtonClick = { playerUiController.skipToNextMedia() },
                         seekToNextButtonEnabled = playerUiState.seekToNextEnabled,
-                        percent = playerUiState.trackPosition?.percent ?: 0f
+                        percent = playerUiState.trackPosition?.percent ?: 0f,
+                        showProgress = playerUiState.trackPosition?.showProgress ?: false
                     )
                 } else {
                     DefaultPlayerScreenControlButtons(playerUiController, playerUiState)
@@ -107,6 +108,7 @@ public fun PlayerScreenPodcastControlButtons(
         playPauseButtonEnabled = playerUiState.playPauseEnabled,
         playing = playerUiState.playing,
         percent = playerUiState.trackPosition?.percent ?: 0f,
+        showProgress = playerUiState.trackPosition?.showProgress ?: false,
         onSeekBackButtonClick = { playerUiController.seekBack() },
         seekBackButtonEnabled = playerUiState.seekBackEnabled,
         onSeekForwardButtonClick = { playerUiController.seekForward() },

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -84,9 +84,10 @@ package com.google.android.horologist.media.ui.components {
   }
 
   public final class PodcastControlButtonsKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PodcastControlButtons(com.google.android.horologist.media.ui.state.PlayerUiController playerController, com.google.android.horologist.media.ui.state.PlayerUiState playerUiState, optional androidx.compose.ui.Modifier modifier, optional boolean showProgress, optional androidx.wear.compose.material.ButtonColors colors);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PodcastControlButtons(com.google.android.horologist.media.ui.state.PlayerUiController playerController, com.google.android.horologist.media.ui.state.PlayerUiState playerUiState, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PodcastControlButtons(kotlin.jvm.functions.Function0<kotlin.Unit> onPlayButtonClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPauseButtonClick, boolean playPauseButtonEnabled, boolean playing, float percent, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekBackButtonClick, boolean seekBackButtonEnabled, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekForwardButtonClick, boolean seekForwardButtonEnabled, optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement seekBackButtonIncrement, optional com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement seekForwardButtonIncrement, optional androidx.wear.compose.material.ButtonColors colors);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PodcastControlButtons(kotlin.jvm.functions.Function0<kotlin.Unit> onPlayButtonClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPauseButtonClick, boolean playPauseButtonEnabled, boolean playing, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekBackButtonClick, boolean seekBackButtonEnabled, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekForwardButtonClick, boolean seekForwardButtonEnabled, optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement seekBackButtonIncrement, optional com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement seekForwardButtonIncrement, optional androidx.wear.compose.material.ButtonColors colors);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PodcastControlButtons(kotlin.jvm.functions.Function0<kotlin.Unit> onPlayButtonClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPauseButtonClick, boolean playPauseButtonEnabled, boolean playing, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekBackButtonClick, com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement seekBackButtonIncrement, boolean seekBackButtonEnabled, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekForwardButtonClick, com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement seekForwardButtonIncrement, boolean seekForwardButtonEnabled, boolean showProgress, optional androidx.compose.ui.Modifier modifier, optional Float? percent, optional androidx.wear.compose.material.ButtonColors colors);
   }
 
   public final class TextMediaDisplayKt {
@@ -111,6 +112,7 @@ package com.google.android.horologist.media.ui.components.animated {
 
   public final class AnimatedMediaControlButtonsKt {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void AnimatedMediaControlButtons(kotlin.jvm.functions.Function0<kotlin.Unit> onPlayButtonClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPauseButtonClick, boolean playPauseButtonEnabled, boolean playing, float percent, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekToPreviousButtonClick, boolean seekToPreviousButtonEnabled, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekToNextButtonClick, boolean seekToNextButtonEnabled, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void AnimatedMediaControlButtons(kotlin.jvm.functions.Function0<kotlin.Unit> onPlayButtonClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPauseButtonClick, boolean playPauseButtonEnabled, boolean playing, float percent, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekToPreviousButtonClick, boolean seekToPreviousButtonEnabled, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekToNextButtonClick, boolean seekToNextButtonEnabled, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors, boolean showProgress);
   }
 
   public final class AnimatedPlayPauseButtonKt {
@@ -446,7 +448,7 @@ package com.google.android.horologist.media.ui.screens.entity {
 package com.google.android.horologist.media.ui.screens.player {
 
   public final class PlayerScreenKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void DefaultPlayerScreenControlButtons(com.google.android.horologist.media.ui.state.PlayerUiController playerController, com.google.android.horologist.media.ui.state.PlayerUiState playerUiState, optional boolean showProgress);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void DefaultPlayerScreenControlButtons(com.google.android.horologist.media.ui.state.PlayerUiController playerController, com.google.android.horologist.media.ui.state.PlayerUiState playerUiState);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void DefaultPlayerScreenMediaDisplay(com.google.android.horologist.media.ui.state.PlayerUiState playerUiState, optional androidx.compose.ui.Modifier modifier);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PlayerScreen(com.google.android.horologist.media.ui.state.PlayerViewModel playerViewModel, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function2<? super androidx.compose.foundation.layout.ColumnScope,? super com.google.android.horologist.media.ui.state.PlayerUiState,kotlin.Unit> mediaDisplay, optional kotlin.jvm.functions.Function3<? super androidx.compose.foundation.layout.RowScope,? super com.google.android.horologist.media.ui.state.PlayerUiController,? super com.google.android.horologist.media.ui.state.PlayerUiState,kotlin.Unit> controlButtons, optional kotlin.jvm.functions.Function2<? super androidx.compose.foundation.layout.RowScope,? super com.google.android.horologist.media.ui.state.PlayerUiState,kotlin.Unit> buttons, optional kotlin.jvm.functions.Function2<? super androidx.compose.foundation.layout.BoxScope,? super com.google.android.horologist.media.ui.state.PlayerUiState,kotlin.Unit> background);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PlayerScreen(kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.ColumnScope,kotlin.Unit> mediaDisplay, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.RowScope,kotlin.Unit> controlButtons, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.RowScope,kotlin.Unit> buttons, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.BoxScope,kotlin.Unit> background);
@@ -802,17 +804,20 @@ package com.google.android.horologist.media.ui.state.model {
   }
 
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public final class TrackPositionUiModel {
-    ctor public TrackPositionUiModel(long current, long duration, float percent);
+    ctor public TrackPositionUiModel(long current, long duration, float percent, boolean showProgress);
     method public long component1();
     method public long component2();
     method public float component3();
-    method public com.google.android.horologist.media.ui.state.model.TrackPositionUiModel copy(long current, long duration, float percent);
+    method public boolean component4();
+    method public com.google.android.horologist.media.ui.state.model.TrackPositionUiModel copy(long current, long duration, float percent, boolean showProgress);
     method public long getCurrent();
     method public long getDuration();
     method public float getPercent();
+    method public boolean getShowProgress();
     property public final long current;
     property public final long duration;
     property public final float percent;
+    property public final boolean showProgress;
   }
 
 }

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/PodcastControlButtonsTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/PodcastControlButtonsTest.kt
@@ -212,6 +212,7 @@ class PodcastControlButtonsTest {
                 seekBackButtonEnabled = true,
                 onSeekForwardButtonClick = {},
                 seekForwardButtonEnabled = true
+
             )
         }
 

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenTest.kt
@@ -32,6 +32,7 @@ import androidx.test.filters.LargeTest
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.media.model.Command
 import com.google.android.horologist.media.model.Media
+import com.google.android.horologist.media.model.MediaPosition
 import com.google.android.horologist.media.model.PlayerState
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.state.PlayerViewModel
@@ -51,7 +52,7 @@ class PlayerScreenTest {
     @Test
     fun givenShowProgressIsTrue_thenProgressBarIsDisplayed() {
         // given
-        val playerRepository = FakePlayerRepository()
+        var playerRepository = FakePlayerRepository()
         val playerViewModel = PlayerViewModel(playerRepository)
 
         composeTestRule.setContent { PlayerScreen(playerViewModel = playerViewModel) }
@@ -64,9 +65,8 @@ class PlayerScreenTest {
     @Test
     fun givenShowProgressIsFalse_thenProgressBarIsNOTDisplayed() {
         // given
-        val showProgress = false
-
         val playerRepository = FakePlayerRepository()
+        playerRepository.setPosition(MediaPosition.Unknown)
         val playerViewModel = PlayerViewModel(playerRepository)
 
         composeTestRule.setContent {
@@ -75,8 +75,7 @@ class PlayerScreenTest {
                 controlButtons = { playerUiController, playerUiState ->
                     DefaultPlayerScreenControlButtons(
                         playerController = playerUiController,
-                        playerUiState = playerUiState,
-                        showProgress = showProgress
+                        playerUiState = playerUiState
                     )
                 }
             )

--- a/media-ui/src/androidTest/java/com/google/android/horologist/test/toolbox/testdoubles/FakePlayerRepository.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/test/toolbox/testdoubles/FakePlayerRepository.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
-class FakePlayerRepository : PlayerRepository {
+class FakePlayerRepository() : PlayerRepository {
 
     private val _connected = MutableStateFlow(true)
     override val connected: StateFlow<Boolean> = _connected
@@ -149,6 +149,10 @@ class FakePlayerRepository : PlayerRepository {
             val newCurrent = (it as MediaPosition.KnownDuration).current + 1.seconds
             MediaPosition.create(newCurrent, it.duration)
         } ?: MediaPosition.create(1.seconds, 10.seconds)
+    }
+
+    fun setPosition(mediaPosition: MediaPosition) {
+        _mediaPosition.value = mediaPosition
     }
 
     fun addCommand(command: Command) {

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/PodcastControlButtons.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/PodcastControlButtons.kt
@@ -38,11 +38,10 @@ public fun PodcastControlButtons(
     playerController: PlayerUiController,
     playerUiState: PlayerUiState,
     modifier: Modifier = Modifier,
-    showProgress: Boolean = true,
     colors: ButtonColors = MediaButtonDefaults.mediaButtonDefaultColors
 ) {
-    val percent = if (showProgress) {
-        playerUiState.trackPosition?.percent ?: 0f
+    val percent = if (playerUiState.trackPosition?.showProgress == true) {
+        playerUiState.trackPosition.percent
     } else {
         null
     }
@@ -58,7 +57,7 @@ public fun PodcastControlButtons(
         onSeekForwardButtonClick = { playerController.skipToNextMedia() },
         seekForwardButtonIncrement = playerUiState.seekForwardButtonIncrement,
         seekForwardButtonEnabled = playerUiState.seekForwardEnabled,
-        showProgress = showProgress,
+        showProgress = playerUiState.trackPosition?.showProgress ?: false,
         modifier = modifier,
         percent = percent,
         colors = colors
@@ -66,7 +65,7 @@ public fun PodcastControlButtons(
 }
 
 /**
- * Standard Podcast control buttons, showing [SeekBackButton], [PlayPauseProgressButton] and
+ * Standard Podcast control buttons with progress indicator, showing [SeekBackButton], [PlayPauseProgressButton] and
  * [SeekForwardButton].
  */
 @ExperimentalHorologistMediaUiApi
@@ -141,9 +140,12 @@ public fun PodcastControlButtons(
     )
 }
 
+/**
+ * Standard Podcast control buttons showing [SeekBackButton], [PlayPauseProgressButton] and [SeekForwardButton].
+ */
 @ExperimentalHorologistMediaUiApi
 @Composable
-private fun PodcastControlButtons(
+public fun PodcastControlButtons(
     onPlayButtonClick: () -> Unit,
     onPauseButtonClick: () -> Unit,
     playPauseButtonEnabled: Boolean,

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/animated/AnimatedMediaControlButtons.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/animated/AnimatedMediaControlButtons.kt
@@ -66,6 +66,38 @@ public fun AnimatedMediaControlButtons(
 
 @ExperimentalHorologistMediaUiApi
 @Composable
+public fun AnimatedMediaControlButtons(
+    onPlayButtonClick: () -> Unit,
+    onPauseButtonClick: () -> Unit,
+    playPauseButtonEnabled: Boolean,
+    playing: Boolean,
+    percent: Float,
+    onSeekToPreviousButtonClick: () -> Unit,
+    seekToPreviousButtonEnabled: Boolean,
+    onSeekToNextButtonClick: () -> Unit,
+    seekToNextButtonEnabled: Boolean,
+    modifier: Modifier = Modifier,
+    colors: ButtonColors = MediaButtonDefaults.mediaButtonDefaultColors,
+    showProgress: Boolean
+) {
+    AnimatedMediaControlButtons(
+        onPlayButtonClick = onPlayButtonClick,
+        onPauseButtonClick = onPauseButtonClick,
+        playPauseButtonEnabled = playPauseButtonEnabled,
+        playing = playing,
+        onSeekToPreviousButtonClick = onSeekToPreviousButtonClick,
+        seekToPreviousButtonEnabled = seekToPreviousButtonEnabled,
+        onSeekToNextButtonClick = onSeekToNextButtonClick,
+        seekToNextButtonEnabled = seekToNextButtonEnabled,
+        showProgress = showProgress,
+        modifier = modifier,
+        percent = percent,
+        colors = colors
+    )
+}
+
+@ExperimentalHorologistMediaUiApi
+@Composable
 internal fun AnimatedMediaControlButtons(
     onPlayButtonClick: () -> Unit,
     onPauseButtonClick: () -> Unit,

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/player/PlayerScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/player/PlayerScreen.kt
@@ -122,8 +122,7 @@ public fun DefaultPlayerScreenMediaDisplay(
 @Composable
 public fun DefaultPlayerScreenControlButtons(
     playerController: PlayerUiController,
-    playerUiState: PlayerUiState,
-    showProgress: Boolean = true
+    playerUiState: PlayerUiState
 ) {
     MediaControlButtons(
         onPlayButtonClick = { playerController.play() },
@@ -134,7 +133,7 @@ public fun DefaultPlayerScreenControlButtons(
         seekToPreviousButtonEnabled = playerUiState.seekToPreviousEnabled,
         onSeekToNextButtonClick = { playerController.skipToNextMedia() },
         seekToNextButtonEnabled = playerUiState.seekToNextEnabled,
-        showProgress = showProgress,
+        showProgress = playerUiState.trackPosition?.showProgress ?: true,
         percent = playerUiState.trackPosition?.percent ?: 0f
     )
 }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
@@ -29,17 +29,20 @@ import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
 @ExperimentalHorologistMediaUiApi
 public object TrackPositionUiModelMapper {
 
+    internal data class TrackPositionValues(val current: Long, val duration: Long, val percent: Float, val showProgressBar: Boolean)
+
     public fun map(mediaPosition: MediaPosition): TrackPositionUiModel {
-        val (current, duration, percent) = if (mediaPosition is MediaPosition.KnownDuration) {
-            Triple(mediaPosition.current.inWholeMilliseconds, mediaPosition.duration.inWholeMilliseconds, mediaPosition.percent)
+        val (current, duration, percent, showProgress) = if (mediaPosition is MediaPosition.KnownDuration) {
+            TrackPositionValues(mediaPosition.current.inWholeMilliseconds, mediaPosition.duration.inWholeMilliseconds, mediaPosition.percent, true)
         } else {
-            Triple(0L, 0L, 0F)
+            TrackPositionValues(0L, 0L, 0F, false)
         }
 
         return TrackPositionUiModel(
             current = current,
             duration = duration,
-            percent = percent
+            percent = percent,
+            showProgress = showProgress
         )
     }
 }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
@@ -22,5 +22,6 @@ import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 public data class TrackPositionUiModel(
     val current: Long,
     val duration: Long,
-    val percent: Float
+    val percent: Float,
+    val showProgress: Boolean
 )

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/FigmaPlayerScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/FigmaPlayerScreenTest.kt
@@ -70,7 +70,7 @@ class FigmaPlayerScreenTest(
                 title = "Bat Out of Hell",
                 artist = "Meat Loaf"
             ),
-            trackPosition = TrackPositionUiModel(current = 75, duration = 100, percent = 0.75f),
+            trackPosition = TrackPositionUiModel(current = 75, duration = 100, percent = 0.75f, showProgress = true),
             connected = true
         )
 

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerA11yScreenshotTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerA11yScreenshotTest.kt
@@ -82,7 +82,7 @@ class MediaPlayerA11yScreenshotTest(
                 title = "Weather with You",
                 artist = "Crowded House"
             ),
-            trackPosition = TrackPositionUiModel(current = 30, duration = 225, percent = 0.133f),
+            trackPosition = TrackPositionUiModel(current = 30, duration = 225, percent = 0.133f, showProgress = true),
             connected = true
         )
 

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerDeviceScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerDeviceScreenTest.kt
@@ -64,7 +64,7 @@ class MediaPlayerDeviceScreenTest(
                 title = "Weather with You",
                 artist = "Crowded House"
             ),
-            trackPosition = TrackPositionUiModel(current = 30, duration = 225, percent = 0.133f),
+            trackPosition = TrackPositionUiModel(current = 30, duration = 225, percent = 0.133f, showProgress = true),
             connected = true
         )
 

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerScreenTest.kt
@@ -64,7 +64,7 @@ class MediaPlayerScreenTest(
                 title = "Weather with You",
                 artist = "Crowded House"
             ),
-            trackPosition = TrackPositionUiModel(current = 30, duration = 225, percent = 0.133f),
+            trackPosition = TrackPositionUiModel(current = 30, duration = 225, percent = 0.133f, showProgress = true),
             connected = true
         )
 

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerStatesScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerStatesScreenTest.kt
@@ -70,7 +70,8 @@ class MediaPlayerStatesScreenTest(
                 TrackPositionUiModel(
                     current = 30,
                     duration = 225,
-                    percent = 0.133f
+                    percent = 0.133f,
+                    showProgress = true
                 )
             } else {
                 null

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/PodcastPlayerScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/PodcastPlayerScreenTest.kt
@@ -59,7 +59,7 @@ class PodcastPlayerScreenTest(
                 title = "The power of types",
                 artist = "Kotlinconf"
             ),
-            trackPosition = TrackPositionUiModel(current = 30, duration = 225, percent = 0.133f),
+            trackPosition = TrackPositionUiModel(current = 30, duration = 225, percent = 0.133f, showProgress = true),
             connected = true
         )
 
@@ -72,6 +72,7 @@ class PodcastPlayerScreenTest(
                         playPauseButtonEnabled = playerUiState.playPauseEnabled,
                         playing = playerUiState.playing,
                         percent = playerUiState.trackPosition?.percent ?: 0f,
+                        showProgress = playerUiState.trackPosition?.showProgress ?: false,
                         onSeekBackButtonClick = { },
                         seekBackButtonEnabled = playerUiState.seekBackEnabled,
                         onSeekForwardButtonClick = { },

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/PlayerUiStateProducerTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/PlayerUiStateProducerTest.kt
@@ -70,7 +70,7 @@ class PlayerUiStateProducerTest {
                 playPauseEnabled = true,
                 playing = true,
                 media = MediaUiModel(id = "id", title = "title", artist = "artist"),
-                trackPosition = TrackPositionUiModel(current = 2000, duration = 20000, percent = 0.1f),
+                trackPosition = TrackPositionUiModel(current = 2000, duration = 20000, percent = 0.1f, showProgress = true),
                 seekBackButtonIncrement = SeekButtonIncrement.Unknown,
                 seekForwardButtonIncrement = SeekButtonIncrement.Unknown,
                 connected = true

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapperTest.kt
@@ -40,5 +40,21 @@ class TrackPositionUiModelMapperTest {
         assertThat(result.current).isEqualTo(current.inWholeMilliseconds)
         assertThat(result.duration).isEqualTo(duration.inWholeMilliseconds)
         assertThat(result.percent).isEqualTo(0.5f)
+        assertThat(result.showProgress).isEqualTo(true)
+    }
+
+    @Test
+    fun givenUnknownMediaPosition_thenMapsCorrectly() {
+        // given
+        val mediaPosition = MediaPosition.Unknown
+
+        // when
+        val result = TrackPositionUiModelMapper.map(mediaPosition)
+
+        // then
+        assertThat(result.current).isEqualTo(0L)
+        assertThat(result.duration).isEqualTo(0L)
+        assertThat(result.percent).isEqualTo(0F)
+        assertThat(result.showProgress).isEqualTo(false)
     }
 }


### PR DESCRIPTION
#### WHAT
Updates PlayerScreen to hide progress bar when the track position is Unknown at the domain level

#### WHY
Progress bar should not be shown when position or duration are unknown

#### HOW
add a filed to TrackPositionUiModel that gets used in the UI

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
