### PR TITLE
Fix scrollAway with non zero offset with ScalingLazyColumn.

### DIFF
--- a/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/NavScaffoldViewModel.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/NavScaffoldViewModel.kt
@@ -50,7 +50,7 @@ public open class NavScaffoldViewModel(
     private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
     internal var initialIndex: Int? = null
-    internal var initialOffset: Int? = null
+    internal var initialOffsetPx: Int? = null
     internal var scrollType by mutableStateOf<ScrollType?>(null)
 
     private lateinit var _scrollableState: ScrollableState
@@ -116,7 +116,7 @@ public open class NavScaffoldViewModel(
             ) {
                 scrollableStateBuilder().also {
                     initialIndex = it.centerItemIndex
-                    initialOffset = it.centerItemScrollOffset
+                    initialOffsetPx = it.centerItemScrollOffset
                 }
             }
         }

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/WearNavScaffold.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/WearNavScaffold.kt
@@ -31,8 +31,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -101,11 +101,15 @@ public fun WearNavScaffold(
                                 val scalingLazyListState =
                                     viewModel.scrollableState as ScalingLazyListState
 
+                                val offsetDp = with(LocalDensity.current) {
+                                    (viewModel.initialOffset ?: 0).toDp()
+                                }
+
                                 timeText(
                                     Modifier.scrollAway(
                                         scalingLazyListState,
                                         viewModel.initialIndex ?: 1,
-                                        (viewModel.initialOffset ?: 0).dp
+                                        offsetDp
                                     )
                                 )
                             }

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/WearNavScaffold.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/WearNavScaffold.kt
@@ -102,7 +102,7 @@ public fun WearNavScaffold(
                                     viewModel.scrollableState as ScalingLazyListState
 
                                 val offsetDp = with(LocalDensity.current) {
-                                    (viewModel.initialOffset ?: 0).toDp()
+                                    (viewModel.initialOffsetPx ?: 0).toDp()
                                 }
 
                                 timeText(


### PR DESCRIPTION
#### WHAT

Fix scrollAway with non zero offset with ScalingLazyColumn.

#### WHY

When using WearNavScaffold with ScalingLazyColumn and initial item = 0 and initial offset = ~120, scrolling starts very late.

#### HOW

When we use ints, we should remember these are pixels.

TODO

- [ ]  Add a video of before and after.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
