### PR TITLE
Added fromDate and toDate parameter to DatePicker

### DIFF
--- a/composables/api/current.api
+++ b/composables/api/current.api
@@ -2,7 +2,7 @@
 package com.google.android.horologist.composables {
 
   public final class DatePickerKt {
-    method @androidx.compose.runtime.Composable public static void DatePicker(kotlin.jvm.functions.Function1<? super java.time.LocalDate,kotlin.Unit> onDateConfirm, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalDate date);
+    method @androidx.compose.runtime.Composable public static void DatePicker(kotlin.jvm.functions.Function1<? super java.time.LocalDate,kotlin.Unit> onDateConfirm, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalDate date, optional java.time.LocalDate? fromDate, optional java.time.LocalDate? toDate);
   }
 
   @kotlin.RequiresOptIn(message="Horologist Composables is experimental. The API may be changed in the future.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.BINARY) public @interface ExperimentalHorologistComposablesApi {

--- a/composables/api/current.api
+++ b/composables/api/current.api
@@ -2,7 +2,7 @@
 package com.google.android.horologist.composables {
 
   public final class DatePickerKt {
-    method @androidx.compose.runtime.Composable public static void DatePicker(kotlin.jvm.functions.Function1<? super java.time.LocalDate,kotlin.Unit> onDateConfirm, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalDate date, optional java.time.LocalDate? fromDate, optional java.time.LocalDate? toDate);
+    method @androidx.compose.runtime.Composable public static void DatePicker(kotlin.jvm.functions.Function1<? super java.time.LocalDate,kotlin.Unit> onDateConfirm, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalDate date, optional java.time.LocalDate fromDate, optional java.time.LocalDate toDate);
   }
 
   @kotlin.RequiresOptIn(message="Horologist Composables is experimental. The API may be changed in the future.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.BINARY) public @interface ExperimentalHorologistComposablesApi {

--- a/composables/api/current.api
+++ b/composables/api/current.api
@@ -2,7 +2,7 @@
 package com.google.android.horologist.composables {
 
   public final class DatePickerKt {
-    method @androidx.compose.runtime.Composable public static void DatePicker(kotlin.jvm.functions.Function1<? super java.time.LocalDate,kotlin.Unit> onDateConfirm, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalDate date, optional java.time.LocalDate fromDate, optional java.time.LocalDate toDate);
+    method @androidx.compose.runtime.Composable public static void DatePicker(kotlin.jvm.functions.Function1<? super java.time.LocalDate,kotlin.Unit> onDateConfirm, optional androidx.compose.ui.Modifier modifier, optional java.time.LocalDate date, optional java.time.LocalDate? fromDate, optional java.time.LocalDate? toDate);
   }
 
   @kotlin.RequiresOptIn(message="Horologist Composables is experimental. The API may be changed in the future.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.BINARY) public @interface ExperimentalHorologistComposablesApi {

--- a/composables/src/androidTest/java/com/google/android/horologist/DatePickerTest.kt
+++ b/composables/src/androidTest/java/com/google/android/horologist/DatePickerTest.kt
@@ -28,13 +28,12 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
-import androidx.wear.compose.material.PickerState
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.composables.DatePicker
-import com.google.android.horologist.composables.DatePickerMonthState
-import com.google.android.horologist.composables.DatePickerYearState
+import com.google.android.horologist.composables.DatePickerState
 import com.google.android.horologist.composables.ExperimentalHorologistComposablesApi
 import com.google.common.truth.Truth.assertThat
+import org.junit.Assert
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
@@ -46,7 +45,7 @@ class DatePickerTest {
     val composeTestRule = createComposeRule()
 
     @Test
-    fun testDate() {
+    fun onDateConfirm_called_when_confirm_clicked() {
         var date by mutableStateOf<LocalDate?>(null)
         composeTestRule.setContent {
             if (date == null) {
@@ -67,9 +66,8 @@ class DatePickerTest {
     }
 
     @Test
-    fun fromDate_after_toDate() {
-        var exception: Exception? = null
-        try {
+    fun should_throw_if_fromDate_after_toDate() {
+        Assert.assertThrows(IllegalArgumentException::class.java) {
             composeTestRule.setContent {
                 DatePicker(
                     onDateConfirm = {},
@@ -78,19 +76,12 @@ class DatePickerTest {
                     toDate = LocalDate.of(2022, 2, 25)
                 )
             }
-        } catch (e: Exception) {
-            exception = e
-        }
-
-        composeTestRule.runOnIdle {
-            assertThat(exception).isInstanceOf(IllegalArgumentException::class.java)
         }
     }
 
     @Test
-    fun date_outsideRange() {
-        var exception: Exception? = null
-        try {
+    fun should_throw_if_date_outside_from_to_range() {
+        Assert.assertThrows(IllegalArgumentException::class.java) {
             composeTestRule.setContent {
                 DatePicker(
                     onDateConfirm = {},
@@ -99,26 +90,61 @@ class DatePickerTest {
                     toDate = LocalDate.of(2022, 3, 25)
                 )
             }
-        } catch (e: Exception) {
-            exception = e
-        }
-
-        composeTestRule.runOnIdle {
-            assertThat(exception).isInstanceOf(IllegalArgumentException::class.java)
         }
     }
 
     @Test
-    fun testDatePickerState() {
-        val yearState: PickerState = PickerState(initialNumberOfOptions = 100, initiallySelectedOption = 0)
-        val monthState: PickerState = PickerState(initialNumberOfOptions = 12, initiallySelectedOption = 0)
+    fun current_values_checked_in_date_picker_state() {
+        val date = LocalDate.of(2022, 4, 25)
 
-        val datePickerYearState = DatePickerYearState(yearState)
-        val datePickerMonthState = DatePickerMonthState(datePickerYearState, monthState)
+        val datePickerState = DatePickerState(date, date, date)
 
-        assertThat(datePickerYearState.selectedYearEqualsFromYear).isTrue()
-        assertThat(datePickerYearState.selectedYearEqualsToYear).isFalse()
-        assertThat(datePickerMonthState.selectedMonthEqualsFromMonth).isTrue()
-        assertThat(datePickerMonthState.selectedMonthEqualsToMonth).isFalse()
+        assertThat(datePickerState.currentYear()).isEqualTo(2022)
+        assertThat(datePickerState.currentMonth()).isEqualTo(4)
+        assertThat(datePickerState.currentDay()).isEqualTo(25)
+    }
+
+    @Test
+    fun year_state_initialised_to_fromYear() {
+        val date = LocalDate.of(2022, 4, 25)
+
+        val datePickerState = DatePickerState(date = date, fromDate = date, toDate = date.plusYears(1))
+
+        assertThat(datePickerState.selectedYearEqualsFromYear).isTrue()
+        assertThat(datePickerState.selectedYearEqualsToYear).isFalse()
+        assertThat(datePickerState.numOfMonths).isEqualTo(9)
+    }
+
+    @Test
+    fun month_state_initialised_to_fromMonth() {
+        val date = LocalDate.of(2022, 4, 25)
+
+        val datePickerState = DatePickerState(date = date, fromDate = date, toDate = date.plusYears(1))
+
+        assertThat(datePickerState.selectedMonthEqualsFromMonth).isTrue()
+        assertThat(datePickerState.selectedMonthEqualsToMonth).isFalse()
+        assertThat(datePickerState.numOfDays).isEqualTo(6)
+    }
+
+    @Test
+    fun year_state_initialised_to_toYear() {
+        val date = LocalDate.of(2022, 4, 25)
+
+        val datePickerState = DatePickerState(date = date, fromDate = date.minusYears(1), toDate = date)
+
+        assertThat(datePickerState.selectedYearEqualsFromYear).isFalse()
+        assertThat(datePickerState.selectedYearEqualsToYear).isTrue()
+        assertThat(datePickerState.numOfMonths).isEqualTo(4)
+    }
+
+    @Test
+    fun month_state_initialised_to_toMonth() {
+        val date = LocalDate.of(2022, 4, 25)
+
+        val datePickerState = DatePickerState(date = date, fromDate = date.minusYears(1), toDate = date)
+
+        assertThat(datePickerState.selectedMonthEqualsFromMonth).isFalse()
+        assertThat(datePickerState.selectedMonthEqualsToMonth).isTrue()
+        assertThat(datePickerState.numOfDays).isEqualTo(25)
     }
 }

--- a/composables/src/androidTest/java/com/google/android/horologist/DatePickerTest.kt
+++ b/composables/src/androidTest/java/com/google/android/horologist/DatePickerTest.kt
@@ -28,9 +28,13 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.wear.compose.material.PickerState
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.composables.DatePicker
+import com.google.android.horologist.composables.DatePickerMonthState
+import com.google.android.horologist.composables.DatePickerYearState
 import com.google.android.horologist.composables.ExperimentalHorologistComposablesApi
+import com.google.common.truth.Truth.assertThat
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
@@ -60,5 +64,61 @@ class DatePickerTest {
         composeTestRule.onNodeWithContentDescription("Confirm").performClick()
 
         composeTestRule.onNodeWithTag("date").assertTextEquals("2022-04-25")
+    }
+
+    @Test
+    fun fromDate_after_toDate() {
+        var exception: Exception? = null
+        try {
+            composeTestRule.setContent {
+                DatePicker(
+                    onDateConfirm = {},
+                    date = LocalDate.of(2022, 3, 25),
+                    fromDate = LocalDate.of(2022, 3, 25),
+                    toDate = LocalDate.of(2022, 2, 25)
+                )
+            }
+        } catch (e: Exception) {
+            exception = e
+        }
+
+        composeTestRule.runOnIdle {
+            assertThat(exception).isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Test
+    fun date_outsideRange() {
+        var exception: Exception? = null
+        try {
+            composeTestRule.setContent {
+                DatePicker(
+                    onDateConfirm = {},
+                    date = LocalDate.of(2022, 4, 25),
+                    fromDate = LocalDate.of(2022, 2, 25),
+                    toDate = LocalDate.of(2022, 3, 25)
+                )
+            }
+        } catch (e: Exception) {
+            exception = e
+        }
+
+        composeTestRule.runOnIdle {
+            assertThat(exception).isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Test
+    fun testDatePickerState() {
+        val yearState: PickerState = PickerState(initialNumberOfOptions = 100, initiallySelectedOption = 0)
+        val monthState: PickerState = PickerState(initialNumberOfOptions = 12, initiallySelectedOption = 0)
+
+        val datePickerYearState = DatePickerYearState(yearState)
+        val datePickerMonthState = DatePickerMonthState(datePickerYearState, monthState)
+
+        assertThat(datePickerYearState.selectedYearEqualsFromYear).isTrue()
+        assertThat(datePickerYearState.selectedYearEqualsToYear).isFalse()
+        assertThat(datePickerMonthState.selectedMonthEqualsFromMonth).isTrue()
+        assertThat(datePickerMonthState.selectedMonthEqualsToMonth).isFalse()
     }
 }

--- a/composables/src/androidTest/java/com/google/android/horologist/DatePickerTest.kt
+++ b/composables/src/androidTest/java/com/google/android/horologist/DatePickerTest.kt
@@ -33,6 +33,7 @@ import com.google.android.horologist.composables.DatePicker
 import com.google.android.horologist.composables.DatePickerState
 import com.google.android.horologist.composables.ExperimentalHorologistComposablesApi
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Ignore
 import org.junit.Rule
@@ -112,7 +113,6 @@ class DatePickerTest {
 
         assertThat(datePickerState.selectedYearEqualsFromYear).isTrue()
         assertThat(datePickerState.selectedYearEqualsToYear).isFalse()
-        assertThat(datePickerState.numOfMonths).isEqualTo(9)
     }
 
     @Test
@@ -123,7 +123,6 @@ class DatePickerTest {
 
         assertThat(datePickerState.selectedMonthEqualsFromMonth).isTrue()
         assertThat(datePickerState.selectedMonthEqualsToMonth).isFalse()
-        assertThat(datePickerState.numOfDays).isEqualTo(6)
     }
 
     @Test
@@ -134,7 +133,6 @@ class DatePickerTest {
 
         assertThat(datePickerState.selectedYearEqualsFromYear).isFalse()
         assertThat(datePickerState.selectedYearEqualsToYear).isTrue()
-        assertThat(datePickerState.numOfMonths).isEqualTo(4)
     }
 
     @Test
@@ -145,6 +143,101 @@ class DatePickerTest {
 
         assertThat(datePickerState.selectedMonthEqualsFromMonth).isFalse()
         assertThat(datePickerState.selectedMonthEqualsToMonth).isTrue()
+    }
+
+    @Test
+    fun year_options_restricted_correctly_when_fromDate_and_toDate_provided() {
+        val date = LocalDate.of(2022, 4, 25)
+
+        val datePickerState = DatePickerState(date = date, fromDate = date, toDate = date.plusYears(1))
+
+        assertThat(datePickerState.numOfYears).isEqualTo(2)
+    }
+
+    @Test
+    fun month_options_restricted_correctly_for_fromDate() {
+        val date = LocalDate.of(2022, 4, 25)
+
+        val datePickerState = DatePickerState(date = date, fromDate = date, toDate = date.plusYears(1))
+
+        assertThat(datePickerState.numOfMonths).isEqualTo(9)
+    }
+
+    @Test
+    fun month_options_restricted_correctly_for_toDate() {
+        val date = LocalDate.of(2022, 4, 25)
+
+        val datePickerState = DatePickerState(date = date, fromDate = date.minusYears(1), toDate = date)
+
+        assertThat(datePickerState.numOfMonths).isEqualTo(4)
+    }
+
+    @Test
+    fun day_options_restricted_correctly_for_fromDate() {
+        val date = LocalDate.of(2022, 4, 25)
+
+        val datePickerState = DatePickerState(date = date, fromDate = date, toDate = date.plusYears(1))
+
+        assertThat(datePickerState.numOfDays).isEqualTo(6)
+    }
+
+    @Test
+    fun day_options_restricted_correctly_for_toDate() {
+        val date = LocalDate.of(2022, 4, 25)
+
+        val datePickerState = DatePickerState(date = date, fromDate = date.minusYears(1), toDate = date)
+
         assertThat(datePickerState.numOfDays).isEqualTo(25)
+    }
+
+    @Test
+    fun picker_options_restricted_correctly_when_fromDate_equals_toDate() {
+        val date = LocalDate.of(2022, 4, 25)
+
+        val datePickerState = DatePickerState(date = date, fromDate = date, toDate = date)
+
+        assertThat(datePickerState.numOfYears).isEqualTo(1)
+        assertThat(datePickerState.numOfMonths).isEqualTo(1)
+        assertThat(datePickerState.numOfDays).isEqualTo(1)
+    }
+
+    @Test
+    fun picker_first_options_set_correctly_for_fromDate() {
+        val date = LocalDate.of(2022, 4, 25)
+        val datePickerState = DatePickerState(
+            date = date,
+            fromDate = date.minusYears(1),
+            toDate = date.plusYears(1)
+        )
+
+        runBlocking { // to run suspend methods sequentially
+            datePickerState.yearState.scrollToOption(0)
+            datePickerState.monthState.scrollToOption(0)
+            datePickerState.dayState.scrollToOption(0)
+        }
+
+        assertThat(datePickerState.currentYear()).isEqualTo(2021)
+        assertThat(datePickerState.currentMonth()).isEqualTo(4)
+        assertThat(datePickerState.currentDay()).isEqualTo(25)
+    }
+
+    @Test
+    fun picker_last_options_set_correctly_for_toDate() {
+        val date = LocalDate.of(2022, 4, 25)
+        val datePickerState = DatePickerState(
+            date = date,
+            fromDate = date.minusYears(1),
+            toDate = date.plusYears(1)
+        )
+
+        runBlocking { // to run suspend methods sequentially
+            datePickerState.yearState.scrollToOption(datePickerState.numOfYears - 1)
+            datePickerState.monthState.scrollToOption(datePickerState.numOfMonths - 1)
+            datePickerState.dayState.scrollToOption(datePickerState.numOfDays - 1)
+        }
+
+        assertThat(datePickerState.currentYear()).isEqualTo(2023)
+        assertThat(datePickerState.currentMonth()).isEqualTo(4)
+        assertThat(datePickerState.currentDay()).isEqualTo(25)
     }
 }

--- a/composables/src/main/java/com/google/android/horologist/composables/DatePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/DatePicker.kt
@@ -261,9 +261,10 @@ internal class DatePickerState constructor(
     private val toDate: LocalDate?
 ) {
     private val yearOffset = fromDate?.year ?: 1
+    val numOfYears = (toDate?.year ?: 3000) - (yearOffset - 1)
     val yearState =
         PickerState(
-            initialNumberOfOptions = (toDate?.year ?: 3000) - (yearOffset - 1),
+            initialNumberOfOptions = numOfYears,
             initiallySelectedOption = date.year - yearOffset
         )
     val selectedYearEqualsFromYear: Boolean


### PR DESCRIPTION
#### WHAT
Added `fromDate` and `toDate` parameter to `DatePicker` in composables.

#### WHY
DatePicker didn't support adding restrictions on dates both before and after. This change will allow restricting the user from picking a date before `fromDate` and after `toDate`.


#### HOW
Adjusted number of items in pickers and offsets using `fromDate` and `toDate` values to restrict the display of date picker. 
Both of these parameters are kept optional making it backward compatible.
