### PR TITLE
Add SignInPromptScreen auth composable

### DIFF
--- a/auth-composables/api/current.api
+++ b/auth-composables/api/current.api
@@ -46,5 +46,9 @@ package com.google.android.horologist.auth.composables.screens {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi public static void CheckYourPhoneScreen(optional androidx.compose.ui.Modifier modifier, String message);
   }
 
+  public final class SignInPromptScreenKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi public static void SignInPromptScreen(String message, optional androidx.compose.ui.Modifier modifier, optional String title, optional androidx.wear.compose.material.ScalingLazyListState scalingLazyListState, optional androidx.wear.compose.material.ScalingParams scalingParams, optional androidx.wear.compose.material.AutoCenteringParams? autoCentering, kotlin.jvm.functions.Function1<? super androidx.wear.compose.material.ScalingLazyListScope,kotlin.Unit> content);
+  }
+
 }
 

--- a/auth-composables/build.gradle
+++ b/auth-composables/build.gradle
@@ -45,6 +45,7 @@ android {
         jvmTarget = '1.8'
         freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.base.ui.ExperimentalHorologistBaseUiApi"
+        freeCompilerArgs += "-opt-in=com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi"
     }
 
     composeOptions {
@@ -94,6 +95,7 @@ metalava {
 dependencies {
 
     implementation projects.baseUi
+    implementation projects.composeLayout
 
     implementation libs.androidx.wear
     implementation libs.compose.material.iconscore

--- a/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/screens/SignInPromptScreenPreview.kt
+++ b/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/screens/SignInPromptScreenPreview.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistAuthComposablesApi::class)
+
+package com.google.android.horologist.auth.composables.screens
+
+import androidx.compose.runtime.Composable
+import androidx.wear.compose.material.ScalingLazyListState
+import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
+import com.google.android.horologist.auth.composables.chips.GuestModeChip
+import com.google.android.horologist.auth.composables.chips.SignInChip
+import com.google.android.horologist.base.ui.components.StandardChipType
+import com.google.android.horologist.compose.tools.WearPreviewDevices
+
+@WearPreviewDevices
+@Composable
+fun SignInPromptScreenPreview() {
+    SignInPromptScreen(
+        message = "Send messages and create chat groups with your friends",
+        scalingLazyListState = ScalingLazyListState()
+    ) {
+        item {
+            SignInChip(
+                onClick = { },
+                chipType = StandardChipType.Secondary
+            )
+        }
+        item {
+            GuestModeChip(
+                onClick = { },
+                chipType = StandardChipType.Secondary
+            )
+        }
+    }
+}

--- a/auth-composables/src/main/java/com/google/android/horologist/auth/composables/screens/SignInPromptScreen.kt
+++ b/auth-composables/src/main/java/com/google/android/horologist/auth/composables/screens/SignInPromptScreen.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.composables.screens
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.AutoCenteringParams
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.ScalingLazyColumn
+import androidx.wear.compose.material.ScalingLazyColumnDefaults
+import androidx.wear.compose.material.ScalingLazyListScope
+import androidx.wear.compose.material.ScalingLazyListState
+import androidx.wear.compose.material.ScalingParams
+import androidx.wear.compose.material.Text
+import androidx.wear.compose.material.rememberScalingLazyListState
+import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
+import com.google.android.horologist.auth.composables.R
+import com.google.android.horologist.base.ui.components.Title
+import com.google.android.horologist.compose.focus.RequestFocusWhenActive
+import com.google.android.horologist.compose.rotaryinput.rotaryWithFling
+
+@ExperimentalHorologistAuthComposablesApi
+@Composable
+public fun SignInPromptScreen(
+    message: String,
+    modifier: Modifier = Modifier,
+    title: String = stringResource(id = R.string.horologist_signin_prompt_title),
+    scalingLazyListState: ScalingLazyListState = rememberScalingLazyListState(),
+    scalingParams: ScalingParams = ScalingLazyColumnDefaults.scalingParams(),
+    autoCentering: AutoCenteringParams? = AutoCenteringParams(),
+    content: ScalingLazyListScope.() -> Unit
+) {
+    val focusRequester = remember { FocusRequester() }
+
+    ScalingLazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .rotaryWithFling(focusRequester, scalingLazyListState),
+        state = scalingLazyListState,
+        scalingParams = scalingParams,
+        autoCentering = autoCentering
+    ) {
+        item { Title(text = title) }
+        item {
+            Text(
+                text = message,
+                modifier = Modifier.padding(top = 8.dp, bottom = 12.dp, start = 10.dp, end = 10.dp),
+                color = MaterialTheme.colors.onBackground,
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.body2
+            )
+        }
+        apply(content)
+    }
+
+    RequestFocusWhenActive(focusRequester)
+}

--- a/auth-composables/src/main/res/values/strings.xml
+++ b/auth-composables/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="horologist_check_your_phone_title">Check your phone</string>
     <string name="horologist_auth_error_message">Error authenticating.</string>
     <string name="horologist_signedin_confirmation_greeting">Hi, %s</string>
+    <string name="horologist_signin_prompt_title">Sign In</string>
     <string name="horologist_sign_in_chip_label">Sign in</string>
     <string name="horologist_guest_mode_chip_label">Use without account</string>
     <string name="horologist_other_options_chip_label">Other options</string>

--- a/sample/src/main/java/com/google/android/horologist/auth/AuthMenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/AuthMenuScreen.kt
@@ -19,15 +19,17 @@ package com.google.android.horologist.auth
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.res.stringResource
-import androidx.wear.compose.material.ScalingLazyColumn
 import androidx.wear.compose.material.ScalingLazyListState
 import androidx.wear.compose.material.rememberScalingLazyListState
 import com.google.android.horologist.base.ui.components.StandardChip
 import com.google.android.horologist.base.ui.components.StandardChipType
+import com.google.android.horologist.base.ui.components.Title
+import com.google.android.horologist.composables.SectionedList
+import com.google.android.horologist.composables.SectionedListScope
+import com.google.android.horologist.compose.focus.RequestFocusWhenActive
 import com.google.android.horologist.compose.rotaryinput.rotaryWithSnap
 import com.google.android.horologist.compose.rotaryinput.toRotaryScrollAdapter
 import com.google.android.horologist.compose.tools.WearPreviewDevices
@@ -36,49 +38,91 @@ import com.google.android.horologist.sample.Screen
 
 @Composable
 fun AuthMenuScreen(
-    modifier: Modifier = Modifier,
     navigateToRoute: (String) -> Unit,
+    modifier: Modifier = Modifier,
     scalingLazyListState: ScalingLazyListState = rememberScalingLazyListState(),
     focusRequester: FocusRequester = remember { FocusRequester() }
 ) {
-    ScalingLazyColumn(
+    SectionedList(
+        focusRequester = focusRequester,
+        scalingLazyListState = scalingLazyListState,
         modifier = modifier
             .rotaryWithSnap(
                 focusRequester,
                 scalingLazyListState.toRotaryScrollAdapter()
-            ),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        state = scalingLazyListState
+            )
     ) {
-        item {
+        authPKCESection(navigateToRoute)
+
+        authDeviceGrantSection(navigateToRoute)
+
+        googleSignInSection(navigateToRoute)
+    }
+
+    RequestFocusWhenActive(focusRequester)
+}
+
+private fun SectionedListScope.authPKCESection(navigateToRoute: (String) -> Unit) {
+    section(
+        listOf(
+            Pair(R.string.auth_menu_oauth_pkce_item, Screen.AuthPKCESignInPromptScreen.route)
+        )
+    ) {
+        header {
+            Title(stringResource(id = R.string.auth_menu_oauth_pkce_header))
+        }
+        loaded { (textId, route) ->
             StandardChip(
-                label = stringResource(id = R.string.auth_menu_oauth_pkce_item),
-                modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.AuthPKCEScreen.route) },
+                label = stringResource(id = textId),
+                modifier = Modifier.fillMaxWidth(),
+                onClick = { navigateToRoute(route) },
                 chipType = StandardChipType.Primary
             )
         }
-        item {
+    }
+}
+
+private fun SectionedListScope.authDeviceGrantSection(navigateToRoute: (String) -> Unit) {
+    section(
+        listOf(
+            Pair(
+                R.string.auth_menu_oauth_device_grant_item,
+                Screen.AuthDeviceGrantSignInPromptScreen.route
+            )
+        )
+    ) {
+        header {
+            Title(stringResource(id = R.string.auth_menu_oauth_device_grant_header))
+        }
+        loaded { (textId, route) ->
             StandardChip(
-                label = stringResource(id = R.string.auth_menu_oauth_device_grant_item),
-                modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.AuthDeviceGrantScreen.route) },
+                label = stringResource(id = textId),
+                modifier = Modifier.fillMaxWidth(),
+                onClick = { navigateToRoute(route) },
                 chipType = StandardChipType.Primary
             )
         }
-        item {
-            StandardChip(
-                label = stringResource(id = R.string.auth_menu_google_sign_in_item),
-                modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.AuthGoogleSignInScreen.route) },
-                chipType = StandardChipType.Primary
-            )
+    }
+}
+
+private fun SectionedListScope.googleSignInSection(navigateToRoute: (String) -> Unit) {
+    section(
+        listOf(
+            Pair(
+                R.string.auth_menu_google_sign_in_item,
+                Screen.GoogleSignInPromptSampleScreen.route
+            ),
+            Pair(R.string.auth_menu_google_sign_out_item, Screen.AuthGoogleSignOutScreen.route)
+        )
+    ) {
+        header {
+            Title(stringResource(id = R.string.auth_menu_google_sign_in_header))
         }
-        item {
+        loaded { (textId, route) ->
             StandardChip(
-                label = stringResource(id = R.string.auth_menu_google_sign_out_item),
-                modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.AuthGoogleSignOutScreen.route) },
+                label = stringResource(id = textId),
+                modifier = Modifier.fillMaxWidth(),
+                onClick = { navigateToRoute(route) },
                 chipType = StandardChipType.Primary
             )
         }

--- a/sample/src/main/java/com/google/android/horologist/auth/googlesignin/GoogleSignInPromptSampleScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/googlesignin/GoogleSignInPromptSampleScreen.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.googlesignin
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavHostController
+import com.google.android.horologist.auth.composables.chips.GuestModeChip
+import com.google.android.horologist.auth.composables.chips.SignInChip
+import com.google.android.horologist.auth.composables.screens.SignInPromptScreen
+import com.google.android.horologist.base.ui.components.StandardChipType
+import com.google.android.horologist.compose.tools.WearPreviewDevices
+import com.google.android.horologist.sample.R
+import com.google.android.horologist.sample.Screen
+
+@Composable
+fun GoogleSignInPromptSampleScreen(
+    navController: NavHostController,
+    modifier: Modifier = Modifier
+) {
+    SignInPromptScreen(
+        message = stringResource(id = R.string.google_sign_in_prompt_message),
+        modifier = modifier
+    ) {
+        item {
+            SignInChip(
+                onClick = {
+                    navController.navigate(Screen.AuthGoogleSignInScreen.route) {
+                        popUpTo(Screen.AuthMenuScreen.route)
+                    }
+                },
+                chipType = StandardChipType.Secondary
+            )
+        }
+        item {
+            GuestModeChip(
+                onClick = { navController.popBackStack() },
+                chipType = StandardChipType.Secondary
+            )
+        }
+    }
+}
+
+@WearPreviewDevices
+@Composable
+fun GoogleSignInPromptSampleScreenPreview() {
+    GoogleSignInPromptSampleScreen(navController = NavHostController(LocalContext.current))
+}

--- a/sample/src/main/java/com/google/android/horologist/auth/oauth/devicegrant/AuthDeviceGrantSignInPromptScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/oauth/devicegrant/AuthDeviceGrantSignInPromptScreen.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.oauth.devicegrant
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavHostController
+import com.google.android.horologist.auth.composables.chips.GuestModeChip
+import com.google.android.horologist.auth.composables.chips.SignInChip
+import com.google.android.horologist.auth.composables.screens.SignInPromptScreen
+import com.google.android.horologist.base.ui.components.StandardChipType
+import com.google.android.horologist.compose.tools.WearPreviewDevices
+import com.google.android.horologist.sample.R
+import com.google.android.horologist.sample.Screen
+
+@Composable
+fun AuthDeviceGrantSignInPromptScreen(
+    navController: NavHostController,
+    modifier: Modifier = Modifier
+) {
+    SignInPromptScreen(
+        message = stringResource(id = R.string.auth_device_grant_sign_in_prompt_message),
+        modifier = modifier
+    ) {
+        item {
+            SignInChip(
+                onClick = {
+                    navController.navigate(Screen.AuthDeviceGrantScreen.route) {
+                        popUpTo(Screen.AuthMenuScreen.route)
+                    }
+                },
+                chipType = StandardChipType.Secondary
+            )
+        }
+        item {
+            GuestModeChip(
+                onClick = { navController.popBackStack() },
+                chipType = StandardChipType.Secondary
+            )
+        }
+    }
+}
+
+@WearPreviewDevices
+@Composable
+fun AuthDeviceGrantSignInPromptScreenPreview() {
+    AuthDeviceGrantSignInPromptScreen(navController = NavHostController(LocalContext.current))
+}

--- a/sample/src/main/java/com/google/android/horologist/auth/oauth/pkce/AuthPKCESignInPromptScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/oauth/pkce/AuthPKCESignInPromptScreen.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.oauth.pkce
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavHostController
+import com.google.android.horologist.auth.composables.chips.GuestModeChip
+import com.google.android.horologist.auth.composables.chips.SignInChip
+import com.google.android.horologist.auth.composables.screens.SignInPromptScreen
+import com.google.android.horologist.base.ui.components.StandardChipType
+import com.google.android.horologist.compose.tools.WearPreviewDevices
+import com.google.android.horologist.sample.R
+import com.google.android.horologist.sample.Screen
+
+@Composable
+fun AuthPKCESignInPromptScreen(
+    navController: NavHostController,
+    modifier: Modifier = Modifier
+) {
+    SignInPromptScreen(
+        message = stringResource(id = R.string.auth_pkce_sign_in_prompt_message),
+        modifier = modifier
+    ) {
+        item {
+            SignInChip(
+                onClick = {
+                    navController.navigate(Screen.AuthPKCEScreen.route) {
+                        popUpTo(Screen.AuthMenuScreen.route)
+                    }
+                },
+                chipType = StandardChipType.Secondary
+            )
+        }
+        item {
+            GuestModeChip(
+                onClick = { navController.popBackStack() },
+                chipType = StandardChipType.Secondary
+            )
+        }
+    }
+}
+
+@WearPreviewDevices
+@Composable
+fun AuthPKCESignInPromptScreenPreview() {
+    AuthPKCESignInPromptScreen(navController = NavHostController(LocalContext.current))
+}

--- a/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
@@ -32,10 +32,13 @@ import androidx.wear.compose.navigation.composable
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import com.google.android.horologist.audio.ui.VolumeScreen
 import com.google.android.horologist.auth.AuthMenuScreen
+import com.google.android.horologist.auth.googlesignin.GoogleSignInPromptSampleScreen
 import com.google.android.horologist.auth.googlesignin.GoogleSignInSampleScreen
 import com.google.android.horologist.auth.googlesignin.GoogleSignOutScreen
 import com.google.android.horologist.auth.oauth.devicegrant.AuthDeviceGrantSampleScreen
+import com.google.android.horologist.auth.oauth.devicegrant.AuthDeviceGrantSignInPromptScreen
 import com.google.android.horologist.auth.oauth.pkce.AuthPKCESampleScreen
+import com.google.android.horologist.auth.oauth.pkce.AuthPKCESignInPromptScreen
 import com.google.android.horologist.composables.DatePicker
 import com.google.android.horologist.composables.TimePicker
 import com.google.android.horologist.composables.TimePickerWith12HourClock
@@ -165,19 +168,28 @@ fun SampleWearApp() {
             }
             composable(route = Screen.AuthMenuScreen.route) {
                 AuthMenuScreen(
-                    modifier = Modifier.fillMaxSize(),
-                    navigateToRoute = { route -> navController.navigate(route) }
+                    navigateToRoute = { route -> navController.navigate(route) },
+                    modifier = Modifier.fillMaxSize()
                 )
+            }
+            composable(route = Screen.AuthPKCESignInPromptScreen.route) {
+                AuthPKCESignInPromptScreen(navController = navController)
             }
             composable(route = Screen.AuthPKCEScreen.route) {
                 AuthPKCESampleScreen(
                     onAuthSuccess = { navController.popBackStack() }
                 )
             }
+            composable(route = Screen.AuthDeviceGrantSignInPromptScreen.route) {
+                AuthDeviceGrantSignInPromptScreen(navController = navController)
+            }
             composable(route = Screen.AuthDeviceGrantScreen.route) {
                 AuthDeviceGrantSampleScreen(
                     onAuthSuccess = { navController.popBackStack() }
                 )
+            }
+            composable(route = Screen.GoogleSignInPromptSampleScreen.route) {
+                GoogleSignInPromptSampleScreen(navController = navController)
             }
             composable(route = Screen.AuthGoogleSignInScreen.route) {
                 GoogleSignInSampleScreen(
@@ -188,7 +200,7 @@ fun SampleWearApp() {
                 GoogleSignOutScreen(navController = navController)
             }
             composable(route = Screen.Paging.route) {
-                PagingScreen(navController)
+                PagingScreen(navController = navController)
             }
             composable(
                 route = Screen.PagingItem.route,

--- a/sample/src/main/java/com/google/android/horologist/sample/Screen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/Screen.kt
@@ -45,8 +45,11 @@ sealed class Screen(
     object RotarySnapListScreen : Screen("rotarySnapListScreen")
 
     object AuthMenuScreen : Screen("authMenuScreen")
+    object AuthPKCESignInPromptScreen : Screen("authPKCESignInPromptScreen")
     object AuthPKCEScreen : Screen("authPKCEScreen")
+    object AuthDeviceGrantSignInPromptScreen : Screen("authDeviceGrantSignInPromptScreen")
     object AuthDeviceGrantScreen : Screen("authDeviceGrantScreen")
+    object GoogleSignInPromptSampleScreen : Screen("googleSignInPromptSampleScreen")
     object AuthGoogleSignInScreen : Screen("authGoogleSignInScreen")
     object AuthGoogleSignOutScreen : Screen("authGoogleSignOutScreen")
     object Paging : Screen("paging")

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -23,12 +23,8 @@
     <string name="tile_text">Hello world</string>
     <string name="tile_sample_label">Sample Tile</string>
     <string name="sample_tile_description">Sample tile description</string>
+
     <string name="sectionedlist_samples_menu">SectionedList Samples</string>
-    <string name="auth_samples_menu">Auth Samples</string>
-    <string name="auth_menu_oauth_pkce_item">OAuth PKCE</string>
-    <string name="auth_menu_oauth_device_grant_item">OAuth Device Grant</string>
-    <string name="auth_menu_google_sign_in_item">Google Sign-In</string>
-    <string name="auth_menu_google_sign_out_item">Sign out (Google)</string>
     <string name="sectionedlist_stateless_sections_menu">Stateless sections</string>
     <string name="sectionedlist_stateful_sections_menu">Stateful sections</string>
     <string name="sectionedlist_expandable_sections_menu">Expandable sections</string>
@@ -45,6 +41,18 @@
     <string name="sectionedlist_tomorrow">Tomorrow</string>
     <string name="sectionedlist_later_week">Later this week</string>
     <string name="sectionedlist_more_tasks">More tasks…</string>
+
+    <string name="auth_samples_menu">Auth Samples</string>
+    <string name="auth_menu_oauth_pkce_header">OAuth PKCE</string>
+    <string name="auth_menu_oauth_pkce_item">Sign in</string>
+    <string name="auth_menu_oauth_device_grant_header">OAuth Device Grant</string>
+    <string name="auth_menu_oauth_device_grant_item">Sign in</string>
+    <string name="auth_menu_google_sign_in_header">Google Sign-In</string>
+    <string name="auth_menu_google_sign_in_item">Sign in</string>
+    <string name="auth_menu_google_sign_out_item">Sign out</string>
+    <string name="auth_pkce_sign_in_prompt_message">Share workouts and compete with your friends and family</string>
+    <string name="auth_device_grant_sign_in_prompt_message">Sign in to download and stream music</string>
+    <string name="google_sign_in_prompt_message">Send messages and create chat groups with your friends</string>
     <string name="google_sign_out_success_message">Signed out successfully!</string>
 
     <string name="rotarymenu_scroll">Scroll</string>


### PR DESCRIPTION
#### WHAT

Add `SignInPromptScreen` auth composable - simple version, to be improved.

Change samples to use it.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
