### PR TITLE
Makes media-data take MediaMetadata into account

### DIFF
--- a/media-data/api/current.api
+++ b/media-data/api/current.api
@@ -240,11 +240,11 @@ package com.google.android.horologist.media.data.mapper {
   }
 
   @com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi public interface MediaExtrasMapper {
-    method public java.util.Map<java.lang.String,java.lang.Object> map(androidx.media3.common.MediaItem mediaItem);
+    method public java.util.Map<java.lang.String,java.lang.Object> map(androidx.media3.common.MediaItem mediaItem, androidx.media3.common.MediaMetadata? mediaMetadata);
   }
 
   @com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi public final class MediaExtrasMapperNoopImpl implements com.google.android.horologist.media.data.mapper.MediaExtrasMapper {
-    method public java.util.Map<java.lang.String,java.lang.Object> map(androidx.media3.common.MediaItem mediaItem);
+    method public java.util.Map<java.lang.String,java.lang.Object> map(androidx.media3.common.MediaItem mediaItem, androidx.media3.common.MediaMetadata? mediaMetadata);
     field public static final com.google.android.horologist.media.data.mapper.MediaExtrasMapperNoopImpl INSTANCE;
   }
 
@@ -264,7 +264,7 @@ package com.google.android.horologist.media.data.mapper {
 
   @com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi public final class MediaMapper {
     ctor public MediaMapper(com.google.android.horologist.media.data.mapper.MediaExtrasMapper mediaExtrasMapper);
-    method public com.google.android.horologist.media.model.Media map(androidx.media3.common.MediaItem mediaItem, optional String defaultArtist);
+    method public com.google.android.horologist.media.model.Media map(androidx.media3.common.MediaItem mediaItem, androidx.media3.common.MediaMetadata? mediaMetadata, optional String defaultArtist);
     method public com.google.android.horologist.media.model.Media map(com.google.android.horologist.media.data.database.model.MediaEntity media);
   }
 

--- a/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaExtrasMapper.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaExtrasMapper.kt
@@ -17,6 +17,7 @@
 package com.google.android.horologist.media.data.mapper
 
 import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
 import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi
 import com.google.android.horologist.media.model.Media
 
@@ -26,11 +27,11 @@ import com.google.android.horologist.media.model.Media
 @ExperimentalHorologistMediaDataApi
 public interface MediaExtrasMapper {
 
-    public fun map(mediaItem: MediaItem): Map<String, Any>
+    public fun map(mediaItem: MediaItem, mediaMetadata: MediaMetadata?): Map<String, Any>
 }
 
 @ExperimentalHorologistMediaDataApi
 public object MediaExtrasMapperNoopImpl : MediaExtrasMapper {
 
-    override fun map(mediaItem: MediaItem): Map<String, Any> = emptyMap()
+    override fun map(mediaItem: MediaItem, mediaMetadata: MediaMetadata?): Map<String, Any> = emptyMap()
 }

--- a/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaMapper.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaMapper.kt
@@ -38,16 +38,22 @@ public class MediaMapper(
      */
     public fun map(
         mediaItem: MediaItem,
+        mediaMetadata: MediaMetadata?,
         defaultArtist: String = ""
     ): Media = Media(
         id = mediaItem.mediaId,
         uri = mediaItem.localConfiguration?.uri?.toString() ?: "",
-        title = mediaItem.mediaMetadata.displayTitle?.toString()
-            ?: mediaItem.mediaMetadata.title?.toString() ?: "",
-        artist = mediaItem.mediaMetadata.artist?.toString()
-            ?: mediaItem.mediaMetadata.albumArtist?.toString() ?: defaultArtist,
-        artworkUri = mediaItem.mediaMetadata.artworkUri?.toString(),
-        extras = mediaExtrasMapper.map(mediaItem)
+        title = mediaMetadata?.title?.toString()
+            ?: mediaItem.mediaMetadata.displayTitle?.toString()
+            ?: mediaItem.mediaMetadata.title?.toString()
+            ?: "",
+        artist = mediaMetadata?.artist?.toString()
+            ?: mediaItem.mediaMetadata.artist?.toString()
+            ?: mediaItem.mediaMetadata.albumArtist?.toString()
+            ?: defaultArtist,
+        artworkUri = mediaMetadata?.artworkUri?.toString()
+            ?: mediaItem.mediaMetadata.artworkUri?.toString(),
+        extras = mediaExtrasMapper.map(mediaItem, mediaMetadata)
     )
 
     /**

--- a/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImpl.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImpl.kt
@@ -100,11 +100,12 @@ public class PlayerRepositoryImpl(
     private val listener = object : Player.Listener {
         private val eventHandlers = mapOf(
             Player.EVENT_AVAILABLE_COMMANDS_CHANGED to ::updateAvailableCommands,
-            Player.EVENT_MEDIA_ITEM_TRANSITION to ::updateCurrentMediaItem,
+            Player.EVENT_MEDIA_ITEM_TRANSITION to ::updateCurrentMedia,
             Player.EVENT_SHUFFLE_MODE_ENABLED_CHANGED to ::updateShuffleMode,
             Player.EVENT_PLAYBACK_PARAMETERS_CHANGED to ::updatePlaybackSpeed,
             Player.EVENT_SEEK_BACK_INCREMENT_CHANGED to ::updateSeekBackIncrement,
             Player.EVENT_SEEK_FORWARD_INCREMENT_CHANGED to ::updateSeekForwardIncrement,
+            Player.EVENT_MEDIA_METADATA_CHANGED to ::updateCurrentMedia,
             // Moved below until https://github.com/google/horologist/issues/496 solved
 //            Player.EVENT_TIMELINE_CHANGED to ::updateTimeline,
 
@@ -143,8 +144,8 @@ public class PlayerRepositoryImpl(
         _shuffleModeEnabled.value = player.shuffleModeEnabled
     }
 
-    private fun updateCurrentMediaItem(player: Player) {
-        _currentMedia.value = player.currentMediaItem?.let(mediaMapper::map)
+    private fun updateCurrentMedia(player: Player) {
+        _currentMedia.value = player.currentMediaItem?.let { mediaMapper.map(it, player.mediaMetadata) }
         updatePosition()
     }
 
@@ -198,7 +199,7 @@ public class PlayerRepositoryImpl(
         _connected.value = true
         player.addListener(listener)
 
-        updateCurrentMediaItem(player)
+        updateCurrentMedia(player)
         updateAvailableCommands(player)
         updateShuffleMode(player)
         updateState(player)
@@ -374,7 +375,7 @@ public class PlayerRepositoryImpl(
     override fun getMediaAt(index: Int): Media? {
         checkNotClosed()
 
-        return player.value?.getMediaItemAt(index)?.let(mediaMapper::map)
+        return player.value?.getMediaItemAt(index)?.let { mediaMapper.map(it, null) }
     }
 
     override fun getCurrentMediaIndex(): Int {

--- a/media-data/src/test/java/com/google/android/horologist/media/data/mapper/MediaMapperTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/mapper/MediaMapperTest.kt
@@ -67,7 +67,7 @@ class MediaMapperTest {
             .build()
 
         // when
-        val result = sut.map(mediaItem)
+        val result = sut.map(mediaItem, null)
 
         // then
         assertThat(result.id).isEqualTo(id)
@@ -95,7 +95,7 @@ class MediaMapperTest {
             .build()
 
         // when
-        val result = sut.map(mediaItem)
+        val result = sut.map(mediaItem, null)
 
         // then
         assertThat(result.id).isEqualTo(id)
@@ -125,7 +125,7 @@ class MediaMapperTest {
             .build()
 
         // when
-        val result = sut.map(mediaItem)
+        val result = sut.map(mediaItem, null)
 
         // then
         assertThat(result.id).isEqualTo(id)
@@ -142,10 +142,41 @@ class MediaMapperTest {
         val mediaItem = MediaItem.Builder().build()
 
         // when
-        val result = sut.map(mediaItem, defaultArtist)
+        val result = sut.map(mediaItem, null, defaultArtist)
 
         // then
         assertThat(result.artist).isEqualTo(defaultArtist)
+    }
+
+    @Test
+    fun `given MediaItem and MediaMetadata metadata takes precedence`() {
+        // given
+        val id = "id"
+        val title = "title"
+        val artist = "artist"
+
+        val mediaItem = MediaItem.Builder()
+            .setMediaId(id)
+            .setMediaMetadata(
+                MediaMetadata.Builder()
+                    .setTitle("ignore")
+                    .setArtist("ignore")
+                    .build()
+            )
+            .build()
+
+        val mediaMetadata = MediaMetadata.Builder()
+            .setTitle(title)
+            .setArtist(artist)
+            .build()
+
+        // when
+        val result = sut.map(mediaItem, mediaMetadata)
+
+        // then
+        assertThat(result.id).isEqualTo(id)
+        assertThat(result.title).isEqualTo(title)
+        assertThat(result.artist).isEqualTo(artist)
     }
 
     @Test
@@ -166,7 +197,10 @@ class MediaMapperTest {
             .build()
 
         val sut = MediaMapper(object : MediaExtrasMapper {
-            override fun map(mediaItem: MediaItem): Map<String, Any> = buildMap {
+            override fun map(
+                mediaItem: MediaItem,
+                mediaMetadata: MediaMetadata?
+            ): Map<String, Any> = buildMap {
                 put(id, mediaItem.mediaId)
                 put(uri, mediaItem.localConfiguration!!.uri)
                 put(artist, mediaItem.mediaMetadata.artist!!)
@@ -174,7 +208,7 @@ class MediaMapperTest {
         })
 
         // when
-        val result = sut.map(mediaItem)
+        val result = sut.map(mediaItem, null)
 
         // then
         assertThat(result.extras[id]).isEqualTo(id)

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -91,7 +91,7 @@ package com.google.android.horologist.media.ui.components {
   }
 
   public final class TextMediaDisplayKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void TextMediaDisplay(optional androidx.compose.ui.Modifier modifier, optional String? title, optional String? artist);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void TextMediaDisplay(optional androidx.compose.ui.Modifier modifier, optional String? title, optional String? subtitle);
   }
 
 }
@@ -751,19 +751,19 @@ package com.google.android.horologist.media.ui.state.model {
   }
 
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public final class MediaUiModel {
-    ctor public MediaUiModel(String id, optional String? title, optional String? artist, optional String? artworkUri);
+    ctor public MediaUiModel(String id, optional String? title, optional String? subtitle, optional String? artworkUri);
     method public String component1();
     method public String? component2();
     method public String? component3();
     method public String? component4();
-    method public com.google.android.horologist.media.ui.state.model.MediaUiModel copy(String id, String? title, String? artist, String? artworkUri);
-    method public String? getArtist();
+    method public com.google.android.horologist.media.ui.state.model.MediaUiModel copy(String id, String? title, String? subtitle, String? artworkUri);
     method public String? getArtworkUri();
     method public String getId();
+    method public String? getSubtitle();
     method public String? getTitle();
-    property public final String? artist;
     property public final String? artworkUri;
     property public final String id;
+    property public final String? subtitle;
     property public final String? title;
   }
 

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/DefaultMediaDisplayPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/DefaultMediaDisplayPreview.kt
@@ -31,7 +31,7 @@ fun DefaultMediaDisplayPreview() {
         media = MediaUiModel(
             id = "id",
             title = "Song title",
-            artist = "Artist name"
+            subtitle = "Artist name"
         )
     )
 }
@@ -47,7 +47,7 @@ fun DefaultMediaDisplayPreviewLongText() {
         media = MediaUiModel(
             id = "id",
             title = "I Predict That You Look Good In A Riot",
-            artist = "Arctic Monkeys feat Kaiser Chiefs"
+            subtitle = "Arctic Monkeys feat Kaiser Chiefs"
         )
     )
 }

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/TextMediaDisplayPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/TextMediaDisplayPreview.kt
@@ -28,7 +28,7 @@ import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 fun TextMediaDisplayPreview() {
     TextMediaDisplay(
         title = "Song title",
-        artist = "Artist name"
+        subtitle = "Artist name"
     )
 }
 
@@ -41,6 +41,6 @@ fun TextMediaDisplayPreview() {
 fun TextMediaDisplayPreviewLongText() {
     TextMediaDisplay(
         title = "I Predict That You Look Good In A Riot",
-        artist = "Arctic Monkeys feat Kaiser Chiefs"
+        subtitle = "Arctic Monkeys feat Kaiser Chiefs"
     )
 }

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenPreview.kt
@@ -83,7 +83,7 @@ fun PlayerScreenPreview() {
             PlayerScreen(
                 mediaDisplay = {
                     TextMediaDisplay(
-                        artist = "Journey",
+                        subtitle = "Journey",
                         title = "Don't Stop Believin'"
                     )
                 },
@@ -222,7 +222,7 @@ fun PlayerScreenPreviewCustomBackground() {
             PlayerScreen(
                 mediaDisplay = {
                     TextMediaDisplay(
-                        artist = "Casaca",
+                        subtitle = "Casaca",
                         title = "Da Da Da"
                     )
                 },
@@ -310,7 +310,7 @@ fun DefaultMediaPreview() {
             PlayerScreen(
                 mediaDisplay = {
                     TextMediaDisplay(
-                        artist = "Journey",
+                        subtitle = "Journey",
                         title = "Don't Stop Believin'"
                     )
                 },

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/DefaultMediaDisplay.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/DefaultMediaDisplay.kt
@@ -33,6 +33,6 @@ public fun DefaultMediaDisplay(
     TextMediaDisplay(
         modifier = modifier,
         title = media?.title,
-        artist = media?.artist
+        subtitle = media?.subtitle
     )
 }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/TextMediaDisplay.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/TextMediaDisplay.kt
@@ -35,7 +35,7 @@ import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 public fun TextMediaDisplay(
     modifier: Modifier = Modifier,
     title: String? = null,
-    artist: String? = null
+    subtitle: String? = null
 ) {
     Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
         Text(
@@ -47,7 +47,7 @@ public fun TextMediaDisplay(
             style = MaterialTheme.typography.button
         )
         Text(
-            text = artist.orEmpty(),
+            text = subtitle.orEmpty(),
             modifier = Modifier.fillMaxWidth(0.8f),
             color = MaterialTheme.colors.onBackground,
             textAlign = TextAlign.Center,

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/animated/AnimatedPlayerScreenMediaDisplay.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/animated/AnimatedPlayerScreenMediaDisplay.kt
@@ -41,7 +41,7 @@ public fun AnimatedPlayerScreenMediaDisplay(
         MarqueeTextMediaDisplay(
             modifier = modifier,
             title = media.title,
-            artist = media.artist
+            artist = media.subtitle
         )
     } else {
         InfoMediaDisplay(

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/MediaUiModelMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/MediaUiModelMapper.kt
@@ -32,7 +32,7 @@ public object MediaUiModelMapper {
     public fun map(media: Media): MediaUiModel = MediaUiModel(
         id = media.id,
         title = media.title,
-        artist = media.artist,
+        subtitle = media.artist,
         artworkUri = media.artworkUri
     )
 }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/MediaUiModel.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/MediaUiModel.kt
@@ -22,6 +22,6 @@ import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 public data class MediaUiModel(
     val id: String,
     val title: String? = null,
-    val artist: String? = null,
+    val subtitle: String? = null,
     val artworkUri: String? = null
 )

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/FigmaPlayerScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/FigmaPlayerScreenTest.kt
@@ -68,7 +68,7 @@ class FigmaPlayerScreenTest(
             media = MediaUiModel(
                 id = "",
                 title = "Bat Out of Hell",
-                artist = "Meat Loaf"
+                subtitle = "Meat Loaf"
             ),
             trackPosition = TrackPositionUiModel(current = 75, duration = 100, percent = 0.75f, showProgress = true),
             connected = true

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerA11yScreenshotTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerA11yScreenshotTest.kt
@@ -80,7 +80,7 @@ class MediaPlayerA11yScreenshotTest(
             media = MediaUiModel(
                 id = "",
                 title = "Weather with You",
-                artist = "Crowded House"
+                subtitle = "Crowded House"
             ),
             trackPosition = TrackPositionUiModel(current = 30, duration = 225, percent = 0.133f, showProgress = true),
             connected = true

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerDeviceScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerDeviceScreenTest.kt
@@ -62,7 +62,7 @@ class MediaPlayerDeviceScreenTest(
             media = MediaUiModel(
                 id = "",
                 title = "Weather with You",
-                artist = "Crowded House"
+                subtitle = "Crowded House"
             ),
             trackPosition = TrackPositionUiModel(current = 30, duration = 225, percent = 0.133f, showProgress = true),
             connected = true

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerScreenTest.kt
@@ -62,7 +62,7 @@ class MediaPlayerScreenTest(
             media = MediaUiModel(
                 id = "",
                 title = "Weather with You",
-                artist = "Crowded House"
+                subtitle = "Crowded House"
             ),
             trackPosition = TrackPositionUiModel(current = 30, duration = 225, percent = 0.133f, showProgress = true),
             connected = true

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerStatesScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerStatesScreenTest.kt
@@ -61,7 +61,7 @@ class MediaPlayerStatesScreenTest(
                 MediaUiModel(
                     id = "",
                     title = "Weather with You",
-                    artist = "Crowded House"
+                    subtitle = "Crowded House"
                 )
             } else {
                 null

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/PodcastPlayerScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/PodcastPlayerScreenTest.kt
@@ -57,7 +57,7 @@ class PodcastPlayerScreenTest(
             media = MediaUiModel(
                 id = "",
                 title = "The power of types",
-                artist = "Kotlinconf"
+                subtitle = "Kotlinconf"
             ),
             trackPosition = TrackPositionUiModel(current = 30, duration = 225, percent = 0.133f, showProgress = true),
             connected = true

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/PlayerUiStateProducerTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/PlayerUiStateProducerTest.kt
@@ -69,7 +69,7 @@ class PlayerUiStateProducerTest {
                 shuffleOn = false,
                 playPauseEnabled = true,
                 playing = true,
-                media = MediaUiModel(id = "id", title = "title", artist = "artist"),
+                media = MediaUiModel(id = "id", title = "title", subtitle = "artist"),
                 trackPosition = TrackPositionUiModel(current = 2000, duration = 20000, percent = 0.1f, showProgress = true),
                 seekBackButtonIncrement = SeekButtonIncrement.Unknown,
                 seekForwardButtonIncrement = SeekButtonIncrement.Unknown,

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/MediaUiModelMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/MediaUiModelMapperTest.kt
@@ -46,7 +46,7 @@ class MediaUiModelMapperTest {
         // then
         assertThat(result.id).isEqualTo(id)
         assertThat(result.title).isEqualTo(title)
-        assertThat(result.artist).isEqualTo(artist)
+        assertThat(result.subtitle).isEqualTo(artist)
         assertThat(result.artworkUri).isEqualTo(artworkUri)
     }
 }

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/PlayerUiStateMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/PlayerUiStateMapperTest.kt
@@ -346,7 +346,7 @@ class PlayerUiStateMapperTest {
         val expectedMediaItem = result.media!!
         assertThat(expectedMediaItem.id).isEqualTo(id)
         assertThat(expectedMediaItem.title).isEqualTo(title)
-        assertThat(expectedMediaItem.artist).isEqualTo(artist)
+        assertThat(expectedMediaItem.subtitle).isEqualTo(artist)
     }
 
     @Test


### PR DESCRIPTION
#### WHAT
Improves how we determine title and artist of playing media. Also modifies our UI model names from "arist" -> "subtitle" which makes it clearer how the string is used.

#### WHY
The current method relies solely on data provided inside `MediaItem`. In practice, this means adding a `MediaItem` with only a URL will result in empty title and artist.

#### HOW
ExoPlayer extracts metadata after playback starts and emits a `EVENT_MEDIA_METADATA_CHANGED`. We can leverage this event and update the metadata when it happens, otherwise fallback to `MediaItem`.

#### Checklist :clipboard:
- [X] Add explicit visibility modifier and explicit return types for public declarations
- [X] Run spotless check
- [X] Run tests
- [X] Update metalava's signature text files
