### PR TITLE
Removed scrolling delay from Rotary algorithm.

### DIFF
--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Rotary.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Rotary.kt
@@ -835,8 +835,9 @@ internal class HighResRotaryScrollHandler(
             resetTracking(time)
             rotaryScrollDistance = event.delta
         } else {
-            // Filter out opposite axis values from end of scroll, also some values
-            // at the start of motion which sometimes appear with a different sign
+            // Due to the physics of Rotary side button, some events might come
+            // with an opposite axis value - either at the start or at the end of the motion.
+            // We don't want to use these values for fling calculations.
             if (!isOppositeScrollValue) {
                 rotaryFlingBehavior?.observeEvent(event.timestamp, event.delta)
             } else {

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Rotary.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Rotary.kt
@@ -855,7 +855,7 @@ internal class HighResRotaryScrollHandler(
             scrollBehavior.handleEvent(rotaryScrollDistance)
         }
 
-        if(rotaryFlingBehavior != null) {
+        if (rotaryFlingBehavior != null) {
             flingJob.cancel()
             flingJob = coroutineScope.async {
                 rotaryFlingBehavior?.trackFling(


### PR DESCRIPTION
#### WHAT
Removed scrolling delay from Rotary algorithm.

#### WHY
Scrolling delay is used for filtering negative values at the end of RSB scroll. It was done for a proper fling tracking. This delay was also causing scrolling to have a pretty long delay when direction of the scroll was reversed.


#### HOW
This delay was removed and was left only for Fling tracking and not for scrolling

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
