### PR TITLE
Improve SignedInConfirmationDialog

### DIFF
--- a/auth-composables/api/current.api
+++ b/auth-composables/api/current.api
@@ -29,7 +29,7 @@ package com.google.android.horologist.auth.composables.chips {
 package com.google.android.horologist.auth.composables.dialogs {
 
   public final class SignedInConfirmationDialogKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi public static void SignedInConfirmationDialog(boolean showDialog, kotlin.jvm.functions.Function0<kotlin.Unit> onDismissOrTimeout, optional androidx.compose.ui.Modifier modifier, optional String? displayName, optional String? email, optional Object? avatarUri, optional java.time.Duration duration);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi public static void SignedInConfirmationDialog(boolean showDialog, kotlin.jvm.functions.Function0<kotlin.Unit> onDismissOrTimeout, optional androidx.compose.ui.Modifier modifier, optional String? name, optional String? email, optional Object? avatarUri, optional java.time.Duration duration);
   }
 
 }

--- a/auth-composables/api/current.api
+++ b/auth-composables/api/current.api
@@ -29,8 +29,7 @@ package com.google.android.horologist.auth.composables.chips {
 package com.google.android.horologist.auth.composables.dialogs {
 
   public final class SignedInConfirmationDialogKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi public static void SignedInConfirmationDialog(String displayName, String email, boolean showDialog, kotlin.jvm.functions.Function0<kotlin.Unit> onDismissOrTimeout, optional androidx.compose.ui.Modifier modifier, optional long durationMillis);
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi public static void SignedInConfirmationDialog(boolean showDialog, kotlin.jvm.functions.Function0<kotlin.Unit> onDismissOrTimeout, optional androidx.compose.ui.Modifier modifier, optional long durationMillis);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi public static void SignedInConfirmationDialog(boolean showDialog, kotlin.jvm.functions.Function0<kotlin.Unit> onDismissOrTimeout, optional androidx.compose.ui.Modifier modifier, optional String? displayName, optional String? email, optional Object? avatarUri, optional java.time.Duration duration);
   }
 
 }

--- a/auth-composables/build.gradle
+++ b/auth-composables/build.gradle
@@ -98,6 +98,7 @@ dependencies {
     implementation projects.composeLayout
 
     implementation libs.androidx.wear
+    implementation libs.coil
     implementation libs.compose.material.iconscore
     implementation libs.compose.material.iconsext
     implementation libs.kotlin.stdlib

--- a/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogPreview.kt
+++ b/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogPreview.kt
@@ -27,6 +27,37 @@ import com.google.android.horologist.compose.tools.WearPreviewDevices
 fun SignedInConfirmationDialogPreview() {
     SignedInConfirmationDialogContent(
         displayName = "Maggie",
-        email = "maggie@gmail.com"
+        email = "maggie@example.com"
+    )
+}
+
+@WearPreviewDevices
+@Composable
+fun SignedInConfirmationDialogPreviewNoName() {
+    SignedInConfirmationDialogContent(
+        email = "maggie@example.com"
+    )
+}
+
+@WearPreviewDevices
+@Composable
+fun SignedInConfirmationDialogPreviewNoEmail() {
+    SignedInConfirmationDialogContent(
+        displayName = "Maggie"
+    )
+}
+
+@WearPreviewDevices
+@Composable
+fun SignedInConfirmationDialogPreviewNoInformation() {
+    SignedInConfirmationDialogContent()
+}
+
+@WearPreviewDevices
+@Composable
+fun SignedInConfirmationDialogPreviewTruncation() {
+    SignedInConfirmationDialogContent(
+        displayName = "Wolfeschlegelsteinhausenbergerdorff",
+        email = "wolfeschlegelsteinhausenbergerdorff@example.com"
     )
 }

--- a/auth-composables/src/main/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialog.kt
+++ b/auth-composables/src/main/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialog.kt
@@ -53,13 +53,21 @@ import com.google.android.horologist.base.ui.util.DECORATIVE_ELEMENT_CONTENT_DES
 import kotlinx.coroutines.delay
 import java.time.Duration
 
+private const val AVATAR_BACKGROUND_COLOR = 0xFF4ECDE6
+private const val AVATAR_TEXT_COLOR = 0xFF202124
+private const val BOTTOM_PADDING_SCREEN_PERCENTAGE = 0.094
+private const val HORIZONTAL_PADDING_SCREEN_PERCENTAGE = 0.094
+
+/**
+ * A signed in confirmation dialog that can display the name, email and avatar image of the user.
+ */
 @ExperimentalHorologistAuthComposablesApi
 @Composable
 public fun SignedInConfirmationDialog(
     showDialog: Boolean,
     onDismissOrTimeout: () -> Unit,
     modifier: Modifier = Modifier,
-    displayName: String? = null,
+    name: String? = null,
     email: String? = null,
     avatarUri: Any? = null,
     duration: Duration = Duration.ofMillis(DialogDefaults.ShortDurationMillis)
@@ -71,9 +79,7 @@ public fun SignedInConfirmationDialog(
         containsIcons = false,
         containsText = true,
         containsControls = false
-    ) ?: run {
-        duration.toMillis()
-    }
+    ) ?: duration.toMillis()
 
     LaunchedEffect(durationMillis) {
         delay(durationMillis)
@@ -87,7 +93,7 @@ public fun SignedInConfirmationDialog(
     ) {
         SignedInConfirmationDialogContent(
             modifier = modifier,
-            displayName = displayName,
+            displayName = name,
             email = email,
             avatarUri = avatarUri
         )
@@ -103,8 +109,8 @@ internal fun SignedInConfirmationDialogContent(
     avatarUri: Any? = null
 ) {
     val configuration = LocalConfiguration.current
-    val horizontalPadding = (configuration.screenWidthDp * 0.094).dp
-    val bottomPadding = (configuration.screenHeightDp * 0.094).dp
+    val horizontalPadding = (configuration.screenWidthDp * HORIZONTAL_PADDING_SCREEN_PERCENTAGE).dp
+    val bottomPadding = (configuration.screenHeightDp * BOTTOM_PADDING_SCREEN_PERCENTAGE).dp
 
     Column(
         modifier = modifier
@@ -115,13 +121,12 @@ internal fun SignedInConfirmationDialogContent(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         val hasName = displayName != null
-        val hasEmail = email != null
         val hasAvatar = avatarUri != null
 
         Box(
             modifier = Modifier
                 .size(60.dp)
-                .background(color = Color(0xFF4ECDE6), shape = CircleShape),
+                .background(color = Color(AVATAR_BACKGROUND_COLOR), shape = CircleShape),
             contentAlignment = Alignment.Center
         ) {
             if (hasAvatar) {
@@ -137,7 +142,7 @@ internal fun SignedInConfirmationDialogContent(
                     modifier = Modifier
                         .align(Alignment.Center)
                         .fillMaxWidth(),
-                    color = Color(0xFF202124),
+                    color = Color(AVATAR_TEXT_COLOR),
                     fontSize = 24.sp,
                     textAlign = TextAlign.Center
                 )
@@ -162,9 +167,9 @@ internal fun SignedInConfirmationDialogContent(
             style = MaterialTheme.typography.title3
         )
 
-        if (hasEmail) {
+        email?.let {
             Text(
-                text = email!!,
+                text = email,
                 modifier = Modifier
                     .padding(top = 4.dp)
                     .fillMaxWidth(),

--- a/auth-composables/src/main/res/values/strings.xml
+++ b/auth-composables/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="horologist_check_your_phone_title">Check your phone</string>
     <string name="horologist_auth_error_message">Error authenticating.</string>
     <string name="horologist_signedin_confirmation_greeting">Hi, %s</string>
+    <string name="horologist_signedin_confirmation_greeting_no_name">Hi!</string>
     <string name="horologist_signin_prompt_title">Sign In</string>
     <string name="horologist_sign_in_chip_label">Sign in</string>
     <string name="horologist_guest_mode_chip_label">Use without account</string>

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogTest.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(
+    ExperimentalHorologistPaparazziApi::class,
+    ExperimentalHorologistAuthComposablesApi::class
+)
+
+package com.google.android.horologist.auth.composables.dialogs
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
+import com.google.android.horologist.compose.tools.coil.FakeImageLoader
+import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
+import com.google.android.horologist.paparazzi.WearPaparazzi
+import org.junit.Rule
+import org.junit.Test
+
+class SignedInConfirmationDialogTest {
+
+    @get:Rule
+    val paparazzi = WearPaparazzi()
+
+    @Test
+    fun signedInConfirmationDialog() {
+        paparazzi.snapshot {
+            FakeImageLoader.Resources.override {
+                Box(
+                    modifier = Modifier.background(Color.Black),
+                    contentAlignment = Alignment.Center
+                ) {
+                    SignedInConfirmationDialogContent(
+                        displayName = "Maggie",
+                        email = "maggie@example.com",
+                        avatarUri = android.R.drawable.sym_def_app_icon
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun signedInConfirmationDialogNoName() {
+        paparazzi.snapshot {
+            FakeImageLoader.Resources.override {
+                Box(
+                    modifier = Modifier.background(Color.Black),
+                    contentAlignment = Alignment.Center
+                ) {
+                    SignedInConfirmationDialogContent(
+                        email = "maggie@example.com",
+                        avatarUri = android.R.drawable.sym_def_app_icon
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun signedInConfirmationDialogNoNameNoAvatar() {
+        paparazzi.snapshot {
+            Box(
+                modifier = Modifier.background(Color.Black),
+                contentAlignment = Alignment.Center
+            ) {
+                SignedInConfirmationDialogContent(
+                    email = "maggie@example.com"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun signedInConfirmationDialogNoEmail() {
+        paparazzi.snapshot {
+            FakeImageLoader.Resources.override {
+                Box(
+                    modifier = Modifier.background(Color.Black),
+                    contentAlignment = Alignment.Center
+                ) {
+                    SignedInConfirmationDialogContent(
+                        displayName = "Maggie",
+                        avatarUri = android.R.drawable.sym_def_app_icon
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun signedInConfirmationDialogNoInformation() {
+        paparazzi.snapshot {
+            Box(
+                modifier = Modifier.background(Color.Black),
+                contentAlignment = Alignment.Center
+            ) {
+                SignedInConfirmationDialogContent()
+            }
+        }
+    }
+
+    @Test
+    fun signedInConfirmationDialogTruncation() {
+        paparazzi.snapshot {
+            FakeImageLoader.Resources.override {
+                Box(
+                    modifier = Modifier.background(Color.Black),
+                    contentAlignment = Alignment.Center
+                ) {
+                    SignedInConfirmationDialogContent(
+                        displayName = "Wolfeschlegelsteinhausenbergerdorff",
+                        email = "wolfeschlegelsteinhausenbergerdorff@example.com",
+                        avatarUri = android.R.drawable.sym_def_app_icon
+                    )
+                }
+            }
+        }
+    }
+}

--- a/auth-composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialog.png
+++ b/auth-composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialog.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3999d6463ce834b225a561bd681bb3b16fb55c15f7a7ec79ecef1f195b88c9e
+size 110450

--- a/auth-composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogNoEmail.png
+++ b/auth-composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogNoEmail.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:300baf5971e026d7bf9aa04685a377fe6dd3398a5008f8fb4bcdb53460143c86
+size 79573

--- a/auth-composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogNoInformation.png
+++ b/auth-composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogNoInformation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58addcd1d1fdaca14cde3979514517ee678f78b00da1991754efc3288885c71d
+size 41327

--- a/auth-composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogNoName.png
+++ b/auth-composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogNoName.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5310752be2957f6c43efaeb9ced311c1ebd23b50af199fcaf3a92e6cd9ef6e77
+size 97744

--- a/auth-composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogNoNameNoAvatar.png
+++ b/auth-composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogNoNameNoAvatar.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d69441bf9e76c7626d471b1c47e7ecee11ec243c8064ad08fd43a46334488944
+size 72489

--- a/auth-composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogTruncation.png
+++ b/auth-composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogTruncation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ac2302fb841194f8b4b76a2688beaa83eab0edf2a200b3a09ddbaab83fdbbcb
+size 127551

--- a/sample/src/main/java/com/google/android/horologist/auth/googlesignin/GoogleSignInSampleScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/googlesignin/GoogleSignInSampleScreen.kt
@@ -39,8 +39,7 @@ fun GoogleSignInSampleScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
     when (state) {
-        AuthGoogleSignInScreenState.Idle,
-        AuthGoogleSignInScreenState.SelectAccount -> {
+        AuthGoogleSignInScreenState.Idle, AuthGoogleSignInScreenState.SelectAccount -> {
             GoogleSignInScreen(viewModel)
         }
 
@@ -52,29 +51,18 @@ fun GoogleSignInSampleScreen(
             var showDialog by rememberSaveable { mutableStateOf(true) }
             val successState = state as AuthGoogleSignInScreenState.Success
 
-            if (successState.displayName != null && successState.email != null) {
-                SignedInConfirmationDialog(
-                    displayName = successState.displayName!!,
-                    email = successState.email!!,
-                    showDialog = showDialog,
-                    onDismissOrTimeout = {
-                        showDialog = false
+            SignedInConfirmationDialog(
+                displayName = successState.displayName,
+                email = successState.email,
+                avatarUri = successState.photoUrl,
+                showDialog = showDialog,
+                onDismissOrTimeout = {
+                    showDialog = false
 
-                        onAuthSuccess()
-                    },
-                    modifier = modifier
-                )
-            } else {
-                SignedInConfirmationDialog(
-                    showDialog = showDialog,
-                    onDismissOrTimeout = {
-                        showDialog = false
-
-                        onAuthSuccess()
-                    },
-                    modifier = modifier
-                )
-            }
+                    onAuthSuccess()
+                },
+                modifier = modifier
+            )
         }
     }
 }

--- a/sample/src/main/java/com/google/android/horologist/auth/googlesignin/GoogleSignInSampleScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/googlesignin/GoogleSignInSampleScreen.kt
@@ -52,7 +52,7 @@ fun GoogleSignInSampleScreen(
             val successState = state as AuthGoogleSignInScreenState.Success
 
             SignedInConfirmationDialog(
-                displayName = successState.displayName,
+                name = successState.displayName,
                 email = successState.email,
                 avatarUri = successState.photoUrl,
                 showDialog = showDialog,


### PR DESCRIPTION
#### WHAT

Improve `SignedInConfirmationDialog`.

#### HOW

- Align with Figma redlines;
- Display photo;
- Handle scenarios when any of the information is not available;
- Improve a11y for timeout;
- Add previews;
- Add snapshot tests;


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
