### PR TITLE
Remove ExperimentalHorologisComposableApi optin from TimePrickerTest

### DIFF
--- a/composables/src/test/kotlin/com/google/android/horologist/composables/TimePickerTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/TimePickerTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistComposablesApi::class, ExperimentalHorologistPaparazziApi::class)
+@file:OptIn(ExperimentalHorologistPaparazziApi::class)
 
 package com.google.android.horologist.composables
 


### PR DESCRIPTION
#### WHAT
Remove the optin for ExperimentalHorologistComposableApi  in the TimePickerTest file.

#### WHY
As far as I can see, the TimePicker composable is not marked with ExperimentalHorologistComposableApi annotation anymore, making the optin in the test redundant.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
