### PR TITLE
Enable manual run of build & test github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - '**.md'
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
#### WHAT

Enable [manual run](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) of [build & test](https://github.com/google/horologist/blob/fd18cf42b6541a64df4708776a8d770b973c0418/.github/workflows/build.yml) github action.

#### WHY

For some reason one of my pull requests did not trigger the github action, so I'd like to trigger it manually.

Alternatively to this solution, I could push an empty commit.

#### HOW

Add [workflow_dispatch](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) event to build.yml.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [N/A] Run tests
- [N/A] Update metalava's signature text files
