### PR TITLE
Update SignedInConfirmationDialog to use ConfirmationDialog

### DIFF
--- a/auth-composables/api/current.api
+++ b/auth-composables/api/current.api
@@ -29,7 +29,7 @@ package com.google.android.horologist.auth.composables.chips {
 package com.google.android.horologist.auth.composables.dialogs {
 
   public final class SignedInConfirmationDialogKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi public static void SignedInConfirmationDialog(boolean showDialog, kotlin.jvm.functions.Function0<kotlin.Unit> onDismissOrTimeout, optional androidx.compose.ui.Modifier modifier, optional String? name, optional String? email, optional Object? avatarUri, optional java.time.Duration duration);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi public static void SignedInConfirmationDialog(kotlin.jvm.functions.Function0<kotlin.Unit> onDismissOrTimeout, optional androidx.compose.ui.Modifier modifier, optional String? name, optional String? email, optional Object? avatarUri, optional java.time.Duration duration);
   }
 
 }

--- a/auth-composables/src/main/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialog.kt
+++ b/auth-composables/src/main/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialog.kt
@@ -27,16 +27,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalAccessibilityManager
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -45,13 +40,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
-import androidx.wear.compose.material.dialog.Dialog
 import androidx.wear.compose.material.dialog.DialogDefaults
 import coil.compose.rememberAsyncImagePainter
 import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
 import com.google.android.horologist.auth.composables.R
+import com.google.android.horologist.base.ui.components.ConfirmationDialog
 import com.google.android.horologist.base.ui.util.DECORATIVE_ELEMENT_CONTENT_DESCRIPTION
-import kotlinx.coroutines.delay
 import java.time.Duration
 
 private const val AVATAR_BACKGROUND_COLOR = 0xFF4ECDE6
@@ -65,7 +59,6 @@ private const val HORIZONTAL_PADDING_SCREEN_PERCENTAGE = 0.094
 @ExperimentalHorologistAuthComposablesApi
 @Composable
 public fun SignedInConfirmationDialog(
-    showDialog: Boolean,
     onDismissOrTimeout: () -> Unit,
     modifier: Modifier = Modifier,
     name: String? = null,
@@ -73,27 +66,10 @@ public fun SignedInConfirmationDialog(
     avatarUri: Any? = null,
     duration: Duration = Duration.ofMillis(DialogDefaults.ShortDurationMillis)
 ) {
-    val currentOnDismissOrTimeout by rememberUpdatedState(onDismissOrTimeout)
-
-    val accessibilityManager = LocalAccessibilityManager.current
-    val durationMillis = remember(duration) {
-        accessibilityManager?.calculateRecommendedTimeoutMillis(
-            originalTimeoutMillis = duration.toMillis(),
-            containsIcons = false,
-            containsText = true,
-            containsControls = false
-        ) ?: duration.toMillis()
-    }
-
-    LaunchedEffect(durationMillis) {
-        delay(durationMillis)
-        currentOnDismissOrTimeout()
-    }
-
-    Dialog(
-        showDialog = showDialog,
-        onDismissRequest = currentOnDismissOrTimeout,
-        modifier = modifier
+    ConfirmationDialog(
+        onTimeout = onDismissOrTimeout,
+        modifier = modifier,
+        durationMillis = duration.toMillis()
     ) {
         SignedInConfirmationDialogContent(
             modifier = modifier,

--- a/sample/src/main/java/com/google/android/horologist/auth/googlesignin/GoogleSignInSampleScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/googlesignin/GoogleSignInSampleScreen.kt
@@ -18,8 +18,6 @@ package com.google.android.horologist.auth.googlesignin
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -48,17 +46,13 @@ fun GoogleSignInSampleScreen(
         }
 
         is AuthGoogleSignInScreenState.Success -> {
-            var showDialog by rememberSaveable { mutableStateOf(true) }
             val successState = state as AuthGoogleSignInScreenState.Success
 
             SignedInConfirmationDialog(
                 name = successState.displayName,
                 email = successState.email,
                 avatarUri = successState.photoUrl,
-                showDialog = showDialog,
                 onDismissOrTimeout = {
-                    showDialog = false
-
                     onAuthSuccess()
                 },
                 modifier = modifier

--- a/sample/src/main/java/com/google/android/horologist/auth/googlesignin/GoogleSignOutScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/googlesignin/GoogleSignOutScreen.kt
@@ -27,7 +27,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.wear.compose.material.Text
-import androidx.wear.compose.material.dialog.Confirmation
+import com.google.android.horologist.base.ui.components.ConfirmationDialog
 import com.google.android.horologist.sample.R
 
 @Composable
@@ -43,7 +43,7 @@ fun GoogleSignOutScreen(
         }
 
         GoogleSignOutScreenState.Success -> {
-            Confirmation(
+            ConfirmationDialog(
                 onTimeout = { navController.popBackStack() }
             ) {
                 Text(

--- a/sample/src/main/java/com/google/android/horologist/auth/oauth/devicegrant/AuthDeviceGrantSampleScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/oauth/devicegrant/AuthDeviceGrantSampleScreen.kt
@@ -18,9 +18,6 @@ package com.google.android.horologist.auth.oauth.devicegrant
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -49,13 +46,8 @@ fun AuthDeviceGrantSampleScreen(
         }
 
         AuthDeviceGrantScreenState.Success -> {
-            var showDialog by rememberSaveable { mutableStateOf(true) }
-
             SignedInConfirmationDialog(
-                showDialog = showDialog,
                 onDismissOrTimeout = {
-                    showDialog = false
-
                     onAuthSuccess()
                 },
                 modifier = modifier

--- a/sample/src/main/java/com/google/android/horologist/auth/oauth/pkce/AuthPKCESampleScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/oauth/pkce/AuthPKCESampleScreen.kt
@@ -18,9 +18,6 @@ package com.google.android.horologist.auth.oauth.pkce
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -49,13 +46,8 @@ fun AuthPKCESampleScreen(
         }
 
         AuthPKCEScreenState.Success -> {
-            var showDialog by rememberSaveable { mutableStateOf(true) }
-
             SignedInConfirmationDialog(
-                showDialog = showDialog,
                 onDismissOrTimeout = {
-                    showDialog = false
-
                     onAuthSuccess()
                 },
                 modifier = modifier


### PR DESCRIPTION
#### WHAT

Update `SignedInConfirmationDialog` to use `ConfirmationDialog`

#### WHY

So it doesn't need to make the A11y calculations itself.

#### HOW

Update component and samples.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
