### PR TITLE
Add setPaybackSpeed to PlayerRepository

### DIFF
--- a/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImpl.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImpl.kt
@@ -398,7 +398,7 @@ public class PlayerRepositoryImpl(
         _mediaPosition.value = MediaPositionMapper.map(player.value)
     }
 
-    public fun setPlaybackSpeed(speed: Float) {
+    override fun setPlaybackSpeed(speed: Float) {
         player.value?.setPlaybackSpeed(speed)
     }
 

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -554,6 +554,7 @@ package com.google.android.horologist.media.ui.state {
     method public void play();
     method public void seekBack();
     method public void seekForward();
+    method public void setPlaybackSpeed(float speed);
     method public void skipToNextMedia();
     method public void skipToPreviousMedia();
   }

--- a/media-ui/src/androidTest/java/com/google/android/horologist/test/toolbox/testdoubles/FakePlayerRepository.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/test/toolbox/testdoubles/FakePlayerRepository.kt
@@ -144,6 +144,10 @@ class FakePlayerRepository() : PlayerRepository {
         _connected.value = false
     }
 
+    override fun setPlaybackSpeed(speed: Float) {
+        // do nothing
+    }
+
     fun updatePosition() {
         _mediaPosition.value = _mediaPosition.value?.let {
             val newCurrent = (it as MediaPosition.KnownDuration).current + 1.seconds

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/PlayerUiController.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/PlayerUiController.kt
@@ -50,4 +50,8 @@ public class PlayerUiController(private val playerRepository: PlayerRepository) 
     public fun seekForward() {
         playerRepository.seekForward()
     }
+
+    public fun setPlaybackSpeed(speed: Float) {
+        playerRepository.setPlaybackSpeed(speed)
+    }
 }

--- a/media-ui/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/MockPlayerRepository.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/MockPlayerRepository.kt
@@ -139,4 +139,8 @@ class MockPlayerRepository(
     override fun release() {
         // do nothing
     }
+
+    override fun setPlaybackSpeed(speed: Float) {
+        // do nothing
+    }
 }

--- a/media/api/current.api
+++ b/media/api/current.api
@@ -202,6 +202,7 @@ package com.google.android.horologist.media.repository {
     method public void setMedia(com.google.android.horologist.media.model.Media media);
     method public void setMediaList(java.util.List<com.google.android.horologist.media.model.Media> mediaList);
     method public void setMediaListAndPlay(java.util.List<com.google.android.horologist.media.model.Media> mediaList, int index);
+    method public void setPlaybackSpeed(float speed);
     method public void setShuffleModeEnabled(boolean shuffleModeEnabled);
     method public void skipToNextMedia();
     method public void skipToPreviousMedia();

--- a/media/src/main/java/com/google/android/horologist/media/repository/PlayerRepository.kt
+++ b/media/src/main/java/com/google/android/horologist/media/repository/PlayerRepository.kt
@@ -191,4 +191,9 @@ public interface PlayerRepository {
      * player must not be used after calling this method.
      */
     public fun release()
+
+    /**
+     * Set the playback speed.
+     */
+    public fun setPlaybackSpeed(speed: Float)
 }


### PR DESCRIPTION
#### WHAT
Add setPlaybackSpeed to PlayerRepository

#### WHY
So that the method can be mapped from the UI via the PlayerUIController

#### HOW
Add the method to the interface and add the mapping in the PlayerUIController

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
