### PR TITLE
Set media at a specific position

### DIFF
--- a/media-data/api/current.api
+++ b/media-data/api/current.api
@@ -329,6 +329,7 @@ package com.google.android.horologist.media.data.repository {
     method public void seekToDefaultPosition(int mediaIndex);
     method public void setMedia(com.google.android.horologist.media.model.Media media);
     method public void setMediaList(java.util.List<com.google.android.horologist.media.model.Media> mediaList);
+    method public void setMediaList(java.util.List<com.google.android.horologist.media.model.Media> mediaList, int index, kotlin.time.Duration? position);
     method public void setMediaListAndPlay(java.util.List<com.google.android.horologist.media.model.Media> mediaList, int index);
     method public void setPlaybackSpeed(float speed);
     method public void setShuffleModeEnabled(boolean shuffleModeEnabled);

--- a/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImpl.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImpl.kt
@@ -17,6 +17,7 @@
 package com.google.android.horologist.media.data.repository
 
 import android.util.Log
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
@@ -328,6 +329,19 @@ public class PlayerRepositoryImpl(
 
         player.value?.let {
             it.setMediaItems(mediaList.map(mediaItemMapper::map))
+            updatePosition()
+        }
+    }
+
+    /**
+     * This operation will stop the current [MediaItem] that is playing, if there is one, as per
+     * [Player.setMediaItems] and set the starting position to the position passed as parameter.
+     */
+    override fun setMediaList(mediaList: List<Media>, index: Int, position: Duration?) {
+        checkNotClosed()
+
+        player.value?.let {
+            it.setMediaItems(mediaList.map(mediaItemMapper::map), index, position?.inWholeMilliseconds ?: C.TIME_UNSET)
             updatePosition()
         }
     }

--- a/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplTest.kt
@@ -46,6 +46,8 @@ import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLooper
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)
@@ -559,6 +561,25 @@ class PlayerRepositoryImplTest {
         assertThat(sut.availableCommands.value).containsExactlyElementsIn(
             listOf(Command.PlayPause, Command.SkipToNextMedia, Command.SetShuffle)
         )
+    }
+
+    @Test
+    fun `given previous MediaList is set when setMediaList with position then position is correct`() {
+        // given
+        val player = TestExoPlayerBuilder(context).build()
+        sut.connect(player) {}
+        sut.setMediaList(listOf(getStubMedia("id1"), getStubMedia("id2")))
+
+        val media1 = getStubMedia("id3")
+        val media2 = getStubMedia("id4")
+        val mediaList = listOf(media1, media2)
+
+        // when
+        sut.setMediaList(mediaList, 0, 6000.toDuration(DurationUnit.MILLISECONDS))
+        runUntilPendingCommandsAreFullyHandled(player)
+
+        // then
+        assertThat(sut.player.value?.currentPosition).isEqualTo(6000)
     }
 
     @Ignore("Fix test once this issue is fixed: https://github.com/androidx/media/issues/85")

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/settings/SettingsSerializer.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/settings/SettingsSerializer.kt
@@ -36,6 +36,7 @@ object SettingsSerializer : Serializer<Settings> {
         this.offloadMode = SettingsProto.OffloadMode.BACKGROUND
         this.podcastControls = false
         this.showTimeTextInfo = false
+        this.currentPosition = 0
     }
 
     override suspend fun readFrom(input: InputStream): Settings {

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/MediaActivity.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/MediaActivity.kt
@@ -57,5 +57,6 @@ class MediaActivity : ComponentActivity() {
     companion object {
         const val CollectionKey = "collection"
         const val MediaIdKey = "mediaId"
+        const val PositionKey = "position"
     }
 }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
@@ -222,9 +222,14 @@ fun UampWearApp(
     LaunchedEffect(Unit) {
         val collectionId = intent.getAndRemoveKey(MediaActivity.CollectionKey)
         val mediaId = intent.getAndRemoveKey(MediaActivity.MediaIdKey)
+        val position = intent.getAndRemoveKey(MediaActivity.PositionKey)
 
         if (collectionId != null) {
-            appViewModel.playItems(mediaId, collectionId)
+            if (position != null) {
+                appViewModel.playItems(mediaId, collectionId, position.toLong())
+            } else {
+                appViewModel.playItems(mediaId, collectionId, 0)
+            }
         } else {
             appViewModel.startupSetup(navigateToLibrary = {
                 navController.navigateToLibrary()

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/player/MediaPlayerScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/player/MediaPlayerScreenViewModel.kt
@@ -18,6 +18,7 @@ package com.google.android.horologist.mediasample.ui.player
 
 import androidx.lifecycle.viewModelScope
 import com.google.android.horologist.media.data.repository.PlayerRepositoryImpl
+import com.google.android.horologist.media.model.MediaPosition
 import com.google.android.horologist.media.ui.state.PlayerViewModel
 import com.google.android.horologist.mediasample.domain.SettingsRepository
 import com.google.android.horologist.mediasample.domain.proto.SettingsProto.Settings
@@ -46,10 +47,17 @@ class MediaPlayerScreenViewModel @Inject constructor(
                 playerRepository.updatePosition()
 
                 // Write to currentMediaItemId in datastore.
-                playerRepository.currentMedia.value?.id?.let {
-                        id ->
+                playerRepository.currentMedia.value?.id?.let { id ->
                     settingsRepository.edit {
                         it.copy { currentMediaItemId = id }
+                    }
+                    val position = playerRepository.mediaPosition.value
+                    if (position is MediaPosition.KnownDuration) {
+                        settingsRepository.edit {
+                            it.copy {
+                                currentPosition = position.current.inWholeMilliseconds
+                            }
+                        }
                     }
                 }
             }

--- a/media-sample/src/main/proto/settings.proto
+++ b/media-sample/src/main/proto/settings.proto
@@ -36,5 +36,6 @@ message Settings {
   OffloadMode offload_mode = 6;
   string currentMediaListId = 7;
   string currentMediaItemId = 8;
-  bool streaming_mode = 9;
+  int64 currentPosition = 9;
+  bool streaming_mode = 10;
 }

--- a/media-ui/src/androidTest/java/com/google/android/horologist/test/toolbox/testdoubles/FakePlayerRepository.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/test/toolbox/testdoubles/FakePlayerRepository.kt
@@ -114,6 +114,13 @@ class FakePlayerRepository() : PlayerRepository {
         _currentMedia.value = mediaList[currentItemIndex]
     }
 
+    override fun setMediaList(mediaList: List<Media>, index: Int, position: Duration?) {
+        _mediaList = mediaList
+        currentItemIndex = 0
+        _currentMedia.value = mediaList[currentItemIndex]
+        _mediaPosition.value = position?.let { MediaPosition.create(it, 10.seconds) }
+    }
+
     override fun setMediaListAndPlay(mediaList: List<Media>, index: Int) {
         // do nothing
     }

--- a/media-ui/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/MockPlayerRepository.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/MockPlayerRepository.kt
@@ -110,6 +110,10 @@ class MockPlayerRepository(
         // do nothing
     }
 
+    override fun setMediaList(mediaList: List<Media>, index: Int, position: Duration?) {
+        // do nothing
+    }
+
     override fun setMediaListAndPlay(mediaList: List<Media>, index: Int) {
         // do nothing
     }

--- a/media/api/current.api
+++ b/media/api/current.api
@@ -201,6 +201,7 @@ package com.google.android.horologist.media.repository {
     method public void seekToDefaultPosition(int mediaIndex);
     method public void setMedia(com.google.android.horologist.media.model.Media media);
     method public void setMediaList(java.util.List<com.google.android.horologist.media.model.Media> mediaList);
+    method public void setMediaList(java.util.List<com.google.android.horologist.media.model.Media> mediaList, int index, optional kotlin.time.Duration? position);
     method public void setMediaListAndPlay(java.util.List<com.google.android.horologist.media.model.Media> mediaList, int index);
     method public void setPlaybackSpeed(float speed);
     method public void setShuffleModeEnabled(boolean shuffleModeEnabled);

--- a/media/src/main/java/com/google/android/horologist/media/repository/PlayerRepository.kt
+++ b/media/src/main/java/com/google/android/horologist/media/repository/PlayerRepository.kt
@@ -137,6 +137,17 @@ public interface PlayerRepository {
     public fun setMediaList(mediaList: List<Media>)
 
     /**
+     * Clears the playlist, adds the specified [Media] list and resets the position to
+     * the provided position.
+     *
+     * @param mediaList The new [Media] list.
+     * @param index The [Media] index to start playback from
+     * @param position The position to start playback from.
+     */
+
+    public fun setMediaList(mediaList: List<Media>, index: Int, position: Duration? = null)
+
+    /**
      * Clears the playlist, adds the specified [Media] list and plays the [Media] at the position of
      * the index passed as param.
      *


### PR DESCRIPTION
#### WHAT
Make it possible to set media at a specific position

#### WHY
Useful for podcasts where content can be often paused and should be resumed where left

#### HOW
Add a new method to PlayerRepository setMedia (media, position)

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
