### PR TITLE
Move GoogleSignInPromptViewModel to auth-ui

### DIFF
--- a/auth-ui/api/current.api
+++ b/auth-ui/api/current.api
@@ -62,6 +62,12 @@ package com.google.android.horologist.auth.ui.ext {
 
 package com.google.android.horologist.auth.ui.googlesignin {
 
+  @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public final class GoogleSignInPromptViewModel {
+    method public androidx.lifecycle.ViewModelProvider.Factory getFactory();
+    property public final androidx.lifecycle.ViewModelProvider.Factory Factory;
+    field public static final com.google.android.horologist.auth.ui.googlesignin.GoogleSignInPromptViewModel INSTANCE;
+  }
+
   public final class GoogleSignInScreenKt {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public static void GoogleSignInScreen(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.auth.ui.googlesignin.GoogleSignInViewModel viewModel, kotlin.jvm.functions.Function1<? super com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreenState.Success,kotlin.Unit> successContent, kotlin.jvm.functions.Function0<kotlin.Unit> failedContent);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public static void GoogleSignInScreen(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.auth.ui.googlesignin.GoogleSignInViewModel viewModel, kotlin.jvm.functions.Function0<kotlin.Unit> onAuthSucceed);

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/GoogleSignInPromptViewModel.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/GoogleSignInPromptViewModel.kt
@@ -14,26 +14,23 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.auth.googlesignin
+package com.google.android.horologist.auth.ui.googlesignin
 
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.google.android.horologist.auth.data.googlesignin.GoogleSignInAuthRepository
+import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
 import com.google.android.horologist.auth.ui.common.screens.SignInPromptViewModel
 
-class GoogleSignInPromptViewModel(
-    googleSignInAuthRepository: GoogleSignInAuthRepository
-) : SignInPromptViewModel(googleSignInAuthRepository) {
+@ExperimentalHorologistAuthUiApi
+public object GoogleSignInPromptViewModel {
+    public val Factory: ViewModelProvider.Factory = viewModelFactory {
+        initializer {
+            val application = this[APPLICATION_KEY]!!
 
-    companion object {
-        val Factory: ViewModelProvider.Factory = viewModelFactory {
-            initializer {
-                val application = this[APPLICATION_KEY]!!
-
-                GoogleSignInPromptViewModel(GoogleSignInAuthRepository(application))
-            }
+            SignInPromptViewModel(GoogleSignInAuthRepository(application))
         }
     }
 }

--- a/sample/src/main/java/com/google/android/horologist/auth/googlesignin/GoogleSignInPromptSampleScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/googlesignin/GoogleSignInPromptSampleScreen.kt
@@ -25,6 +25,8 @@ import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import com.google.android.horologist.auth.composables.chips.GuestModeChip
 import com.google.android.horologist.auth.composables.chips.SignInChip
 import com.google.android.horologist.auth.ui.common.screens.SignInPromptScreen
+import com.google.android.horologist.auth.ui.common.screens.SignInPromptViewModel
+import com.google.android.horologist.auth.ui.googlesignin.GoogleSignInPromptViewModel
 import com.google.android.horologist.base.ui.components.StandardChipType
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.layout.belowTimeTextPreview
@@ -37,7 +39,7 @@ fun GoogleSignInPromptSampleScreen(
     navController: NavHostController,
     columnState: ScalingLazyColumnState,
     modifier: Modifier = Modifier,
-    viewModel: GoogleSignInPromptViewModel = viewModel(factory = GoogleSignInPromptViewModel.Factory)
+    viewModel: SignInPromptViewModel = viewModel(factory = GoogleSignInPromptViewModel.Factory)
 ) {
     SignInPromptScreen(
         message = stringResource(id = R.string.google_sign_in_prompt_message),


### PR DESCRIPTION
#### WHAT

Move `GoogleSignInPromptViewModel` from sample project to `auth-ui` module.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
