### PR TITLE
Add sample usage of GoogleSignInAccountListener

### DIFF
--- a/sample/src/main/java/com/google/android/horologist/auth/googlesignin/prompt/GoogleSignInPromptSampleScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/googlesignin/prompt/GoogleSignInPromptSampleScreen.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.auth.googlesignin
+package com.google.android.horologist.auth.googlesignin.prompt
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier

--- a/sample/src/main/java/com/google/android/horologist/auth/googlesignin/signin/GoogleSignInAccountListenerSample.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/googlesignin/signin/GoogleSignInAccountListenerSample.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.googlesignin.signin
+
+import android.util.Log
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import com.google.android.horologist.auth.data.googlesignin.GoogleSignInAccountListener
+
+object GoogleSignInAccountListenerSample : GoogleSignInAccountListener {
+    private val TAG = this::class.java.simpleName
+
+    override suspend fun onAccountReceived(account: GoogleSignInAccount) {
+        // This class does not do anything and is only here for sample purposes.
+        Log.d(TAG, "Account received: ${account.displayName}")
+    }
+}

--- a/sample/src/main/java/com/google/android/horologist/auth/googlesignin/signin/GoogleSignInSampleViewModel.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/googlesignin/signin/GoogleSignInSampleViewModel.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.googlesignin.signin
+
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.google.android.horologist.auth.ui.googlesignin.GoogleSignInViewModel
+
+object GoogleSignInSampleViewModel {
+
+    val Factory: ViewModelProvider.Factory = viewModelFactory {
+        initializer {
+            GoogleSignInViewModel(GoogleSignInAccountListenerSample)
+        }
+    }
+}

--- a/sample/src/main/java/com/google/android/horologist/auth/googlesignin/signout/GoogleSignOutScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/googlesignin/signout/GoogleSignOutScreen.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.auth.googlesignin
+package com.google.android.horologist.auth.googlesignin.signout
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize

--- a/sample/src/main/java/com/google/android/horologist/auth/googlesignin/signout/GoogleSignOutViewModel.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/googlesignin/signout/GoogleSignOutViewModel.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.auth.googlesignin
+package com.google.android.horologist.auth.googlesignin.signout
 
 import android.util.Log
 import androidx.lifecycle.ViewModel

--- a/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
@@ -34,8 +34,9 @@ import com.google.android.horologist.auth.data.oauth.common.impl.google.api.Toke
 import com.google.android.horologist.auth.data.oauth.devicegrant.impl.AuthDeviceGrantDefaultConfig
 import com.google.android.horologist.auth.data.oauth.pkce.impl.AuthPKCEDefaultConfig
 import com.google.android.horologist.auth.data.oauth.pkce.impl.google.AuthPKCEOAuthCodeGooglePayload
-import com.google.android.horologist.auth.googlesignin.GoogleSignInPromptSampleScreen
-import com.google.android.horologist.auth.googlesignin.GoogleSignOutScreen
+import com.google.android.horologist.auth.googlesignin.prompt.GoogleSignInPromptSampleScreen
+import com.google.android.horologist.auth.googlesignin.signin.GoogleSignInSampleViewModel
+import com.google.android.horologist.auth.googlesignin.signout.GoogleSignOutScreen
 import com.google.android.horologist.auth.oauth.devicegrant.AuthDeviceGrantSampleViewModel
 import com.google.android.horologist.auth.oauth.devicegrant.AuthDeviceGrantSignInPromptScreen
 import com.google.android.horologist.auth.oauth.pkce.AuthPKCESampleViewModel
@@ -266,7 +267,9 @@ fun SampleWearApp() {
             )
         }
         composable(route = Screen.GoogleSignInScreen.route) {
-            GoogleSignInScreen { navController.popBackStack() }
+            GoogleSignInScreen(viewModel = viewModel(factory = GoogleSignInSampleViewModel.Factory)) {
+                navController.popBackStack()
+            }
         }
         composable(route = Screen.GoogleSignOutScreen.route) {
             GoogleSignOutScreen(navController = navController)


### PR DESCRIPTION
#### WHAT

Add sample usage of `GoogleSignInAccountListener`.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
