### PR TITLE
Fix order of columnState param

### DIFF
--- a/auth-ui/api/current.api
+++ b/auth-ui/api/current.api
@@ -12,7 +12,7 @@ package com.google.android.horologist.auth.ui.common.screens {
   }
 
   public final class SignInPromptScreenKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public static void SignInPromptScreen(String message, kotlin.jvm.functions.Function0<kotlin.Unit> onAlreadySignedIn, optional androidx.compose.ui.Modifier modifier, optional String title, optional com.google.android.horologist.auth.ui.common.screens.SignInPromptViewModel viewModel, com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, kotlin.jvm.functions.Function1<? super androidx.wear.compose.material.ScalingLazyListScope,kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public static void SignInPromptScreen(String message, kotlin.jvm.functions.Function0<kotlin.Unit> onAlreadySignedIn, com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, optional androidx.compose.ui.Modifier modifier, optional String title, optional com.google.android.horologist.auth.ui.common.screens.SignInPromptViewModel viewModel, kotlin.jvm.functions.Function1<? super androidx.wear.compose.material.ScalingLazyListScope,kotlin.Unit> content);
   }
 
   @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public abstract sealed class SignInPromptScreenState {

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/SignInPromptScreen.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/SignInPromptScreen.kt
@@ -41,10 +41,10 @@ import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 public fun SignInPromptScreen(
     message: String,
     onAlreadySignedIn: () -> Unit,
+    columnState: ScalingLazyColumnState,
     modifier: Modifier = Modifier,
     title: String = stringResource(id = R.string.horologist_signin_prompt_title),
     viewModel: SignInPromptViewModel = viewModel(),
-    columnState: ScalingLazyColumnState,
     content: ScalingLazyListScope.() -> Unit
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -76,8 +76,8 @@ public fun SignInPromptScreen(
 
         SignInPromptScreenState.SignedOut -> {
             ScalingLazyColumn(
-                modifier = modifier,
-                columnState = columnState
+                columnState = columnState,
+                modifier = modifier
             ) {
                 item { Title(text = title) }
                 item {

--- a/composables/src/main/java/com/google/android/horologist/composables/SectionedList.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/SectionedList.kt
@@ -62,9 +62,9 @@ public fun SectionedList(
     sections: List<Section<*>> = emptyList()
 ) {
     ScalingLazyColumn(
+        columnState = columnState,
         modifier = modifier
-            .fillMaxSize(),
-        columnState = columnState
+            .fillMaxSize()
     ) {
         sections.forEach { section ->
             section.display(this)

--- a/compose-layout/api/current.api
+++ b/compose-layout/api/current.api
@@ -92,7 +92,7 @@ package com.google.android.horologist.compose.layout {
   }
 
   public final class ScalingLazyColumnStateKt {
-    method @androidx.compose.runtime.Composable public static void ScalingLazyColumn(optional androidx.compose.ui.Modifier modifier, com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, kotlin.jvm.functions.Function1<? super androidx.wear.compose.material.ScalingLazyListScope,kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable public static void ScalingLazyColumn(com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, optional androidx.compose.ui.Modifier modifier, kotlin.jvm.functions.Function1<? super androidx.wear.compose.material.ScalingLazyListScope,kotlin.Unit> content);
   }
 
   public final class ScrollAwayKt {

--- a/compose-layout/src/androidTest/java/com/google/android/horologist/compose/navscaffold/NavScaffoldTest.kt
+++ b/compose-layout/src/androidTest/java/com/google/android/horologist/compose/navscaffold/NavScaffoldTest.kt
@@ -165,8 +165,8 @@ class NavScaffoldTest {
                     route = "a"
                 ) {
                     ScalingLazyColumn(
-                        modifier = Modifier.testTag("columna"),
-                        columnState = it.columnState
+                        columnState = it.columnState,
+                        modifier = Modifier.testTag("columna")
                     ) {
                         items(100) {
                             Text("Item $it")

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/layout/ScalingLazyColumnState.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/layout/ScalingLazyColumnState.kt
@@ -100,8 +100,8 @@ public class ScalingLazyColumnState(
 
 @Composable
 public fun ScalingLazyColumn(
-    modifier: Modifier = Modifier,
     columnState: ScalingLazyColumnState,
+    modifier: Modifier = Modifier,
     content: ScalingLazyListScope.() -> Unit
 ) {
     val focusRequester = rememberActiveFocusRequester()

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/debug/AudioDebugScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/debug/AudioDebugScreen.kt
@@ -45,9 +45,9 @@ fun AudioDebugScreen(
     val uiState by audioDebugScreenViewModel.uiState.collectAsStateWithLifecycle()
 
     ScalingLazyColumn(
+        columnState = columnState,
         modifier = modifier
-            .fillMaxSize(),
-        columnState = columnState
+            .fillMaxSize()
     ) {
         item {
             Text(

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/debug/SamplesScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/debug/SamplesScreen.kt
@@ -44,9 +44,9 @@ fun SamplesScreen(
     val uiState by samplesScreenViewModel.uiState.collectAsStateWithLifecycle()
 
     ScalingLazyColumn(
+        columnState = columnState,
         modifier = modifier
-            .fillMaxSize(),
-        columnState = columnState
+            .fillMaxSize()
     ) {
         item {
             Text(

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/settings/DeveloperOptionsScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/settings/DeveloperOptionsScreen.kt
@@ -48,9 +48,9 @@ fun DeveloperOptionsScreen(
     val uiState by developerOptionsScreenViewModel.uiState.collectAsStateWithLifecycle()
 
     ScalingLazyColumn(
+        columnState = columnState,
         modifier = modifier
-            .fillMaxSize(),
-        columnState = columnState
+            .fillMaxSize()
     ) {
         item {
             Text(

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/settings/UampSettingsScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/settings/UampSettingsScreen.kt
@@ -50,9 +50,9 @@ fun UampSettingsScreen(
     modifier: Modifier = Modifier
 ) {
     ScalingLazyColumn(
+        columnState = columnState,
         modifier = modifier
-            .fillMaxSize(),
-        columnState = columnState
+            .fillMaxSize()
     ) {
         item {
             Text(

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/EntityScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/EntityScreen.kt
@@ -40,9 +40,9 @@ public fun EntityScreen(
     content: (ScalingLazyListScope.() -> Unit)? = null
 ) {
     ScalingLazyColumn(
+        columnState = columnState,
         modifier = modifier
-            .fillMaxSize(),
-        columnState = columnState
+            .fillMaxSize()
     ) {
         item {
             headerContent()

--- a/sample/src/main/java/com/google/android/horologist/auth/googlesignin/prompt/GoogleSignInPromptSampleScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/googlesignin/prompt/GoogleSignInPromptSampleScreen.kt
@@ -44,9 +44,9 @@ fun GoogleSignInPromptSampleScreen(
     SignInPromptScreen(
         message = stringResource(id = R.string.google_sign_in_prompt_message),
         onAlreadySignedIn = { navController.popBackStack() },
+        columnState = columnState,
         modifier = modifier,
-        viewModel = viewModel,
-        columnState = columnState
+        viewModel = viewModel
     ) {
         item {
             SignInChip(

--- a/sample/src/main/java/com/google/android/horologist/auth/oauth/devicegrant/AuthDeviceGrantSignInPromptScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/oauth/devicegrant/AuthDeviceGrantSignInPromptScreen.kt
@@ -43,9 +43,9 @@ fun AuthDeviceGrantSignInPromptScreen(
     SignInPromptScreen(
         message = stringResource(id = R.string.auth_device_grant_sign_in_prompt_message),
         onAlreadySignedIn = { navController.popBackStack() },
+        columnState = columnState,
         modifier = modifier,
-        viewModel = viewModel,
-        columnState = columnState
+        viewModel = viewModel
     ) {
         item {
             SignInChip(

--- a/sample/src/main/java/com/google/android/horologist/auth/oauth/pkce/AuthPKCESignInPromptScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/oauth/pkce/AuthPKCESignInPromptScreen.kt
@@ -43,9 +43,9 @@ fun AuthPKCESignInPromptScreen(
     SignInPromptScreen(
         message = stringResource(id = R.string.auth_pkce_sign_in_prompt_message),
         onAlreadySignedIn = { navController.popBackStack() },
+        columnState = columnState,
         modifier = modifier,
-        viewModel = viewModel,
-        columnState = columnState
+        viewModel = viewModel
     ) {
         item {
             SignInChip(

--- a/sample/src/main/java/com/google/android/horologist/datalayer/DataLayerNodesScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/datalayer/DataLayerNodesScreen.kt
@@ -37,8 +37,8 @@ fun DataLayerNodesScreen(
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     ScalingLazyColumn(
-        modifier = modifier,
-        columnState = columnState
+        columnState = columnState,
+        modifier = modifier
     ) {
         item {
             ListHeader {

--- a/sample/src/main/java/com/google/android/horologist/networks/NetworkScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/networks/NetworkScreen.kt
@@ -38,8 +38,8 @@ fun NetworkScreen(
     val uiState by viewModel.state.collectAsStateWithLifecycle()
 
     ScalingLazyColumn(
-        modifier = Modifier.fillMaxSize(),
-        columnState = columnState
+        columnState = columnState,
+        modifier = Modifier.fillMaxSize()
     ) {
         item {
             Chip(

--- a/sample/src/main/java/com/google/android/horologist/paging/PagingScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/paging/PagingScreen.kt
@@ -75,8 +75,8 @@ fun PagingScreen(
     val lazyPagingItems = pager.flow.collectAsLazyPagingItems()
 
     ScalingLazyColumn(
-        modifier = modifier,
-        columnState = columnState
+        columnState = columnState,
+        modifier = modifier
     ) {
         if (lazyPagingItems.loadState.refresh == LoadState.Loading) {
             items(10) {

--- a/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
@@ -46,8 +46,8 @@ fun MenuScreen(
     columnState: ScalingLazyColumnState
 ) {
     ScalingLazyColumn(
-        modifier = modifier,
-        columnState = columnState
+        columnState = columnState,
+        modifier = modifier
     ) {
         item {
             ListHeader {


### PR DESCRIPTION
#### WHAT

Fix order of `columnState` param in composables.

#### WHY

> [Modifier](https://developer.android.com/reference/kotlin/androidx/compose/ui/Modifier) should appear as the first optional parameter in the parameter list; after all required parameters (except for trailing lambda parameters) but before any other parameters with default values.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
