### PR TITLE
Check proto cache in CI

### DIFF
--- a/sample/src/main/java/com/google/android/horologist/datalayer/DataLayerNodesScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/datalayer/DataLayerNodesScreen.kt
@@ -49,6 +49,7 @@ fun DataLayerNodesScreen(
             Chip(
                 onClick = { },
                 label = {
+                    // REMOVEME: comment to check issues in CI
                     Text("${it.displayName}(${it.id}) ${if (it.isNearby) "NEAR" else ""}")
                 }
             )


### PR DESCRIPTION
#### WHAT

Empty commit to check proto cache in CI.

#### WHY

After merging https://github.com/google/horologist/pull/810 which changed the proto definition, builds are failing in CI with:

```
> Task :media-sample:kaptDebugKotlin
e: /home/runner/work/horologist/horologist/sample/src/main/java/com/google/android/horologist/datalayer/DataLayerNodesScreen.kt: (47, 15): Type mismatch: inferred type is List<Node> but Int was expected

e: /home/runner/work/horologist/horologist/sample/src/main/java/com/google/android/horologist/datalayer/DataLayerNodesScreen.kt: (51, 32): Unresolved reference: displayName
> Task :sample:compileDebugKotlin FAILED
e: /home/runner/work/horologist/horologist/sample/src/main/java/com/google/android/horologist/datalayer/DataLayerNodesScreen.kt: (51, 50): Unresolved reference: id
e: /home/runner/work/horologist/horologist/sample/src/main/java/com/google/android/horologist/datalayer/DataLayerNodesScreen.kt: (51, 64): Unresolved reference: isNearby
e: /home/runner/work/horologist/horologist/sample/src/main/java/com/google/android/horologist/datalayer/DataLayerNodesScreen.kt: (72, 15): Type mismatch: inferred type is List<Map.Entry<String, SampleProto.Data>> but Int was expected
e: /home/runner/work/horologist/horologist/sample/src/main/java/com/google/android/horologist/datalayer/DataLayerNodesScreen.kt: (72, 51): Destructuring declaration initializer of type Int must have a 'component1()' function
e: /home/runner/work/horologist/horologist/sample/src/main/java/com/google/android/horologist/datalayer/DataLayerNodesScreen.kt: (72, 55): Destructuring declaration initializer of type Int must have a 'component2()' function
```


#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [N/A] Run tests
- [N/A] Update metalava's signature text files
