### PR TITLE
Add SelectAccountScreen

### DIFF
--- a/auth-composables/api/current.api
+++ b/auth-composables/api/current.api
@@ -29,12 +29,23 @@ package com.google.android.horologist.auth.composables.chips {
 package com.google.android.horologist.auth.composables.dialogs {
 
   public final class SignedInConfirmationDialogKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi public static void SignedInConfirmationDialog(optional androidx.compose.ui.Modifier modifier, optional String? name, optional String? email, optional Object? avatarUri, optional java.time.Duration duration, kotlin.jvm.functions.Function0<kotlin.Unit> onDismissOrTimeout);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi public static void SignedInConfirmationDialog(optional androidx.compose.ui.Modifier modifier, optional String? name, optional String? email, optional Object? avatar, optional java.time.Duration duration, kotlin.jvm.functions.Function0<kotlin.Unit> onDismissOrTimeout);
   }
 
 }
 
 package com.google.android.horologist.auth.composables.screens {
+
+  @com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi public final class AccountUiModel {
+    ctor public AccountUiModel(String email, optional Object? avatar);
+    method public String component1();
+    method public Object? component2();
+    method public com.google.android.horologist.auth.composables.screens.AccountUiModel copy(String email, Object? avatar);
+    method public Object? getAvatar();
+    method public String getEmail();
+    property public final Object? avatar;
+    property public final String email;
+  }
 
   public final class AuthErrorScreenKt {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi public static void AuthErrorScreen(optional androidx.compose.ui.Modifier modifier);
@@ -43,6 +54,10 @@ package com.google.android.horologist.auth.composables.screens {
   public final class CheckYourPhoneScreenKt {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi public static void CheckYourPhoneScreen(optional androidx.compose.ui.Modifier modifier);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi public static void CheckYourPhoneScreen(optional androidx.compose.ui.Modifier modifier, String message);
+  }
+
+  public final class SelectAccountScreenKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi public static void SelectAccountScreen(java.util.List<com.google.android.horologist.auth.composables.screens.AccountUiModel> accounts, kotlin.jvm.functions.Function2<? super java.lang.Integer,? super com.google.android.horologist.auth.composables.screens.AccountUiModel,kotlin.Unit> onAccountClicked, com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, optional androidx.compose.ui.Modifier modifier, optional String title, optional Object? defaultAvatar);
   }
 
 }

--- a/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/screens/SelectAccountScreenPreview.kt
+++ b/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/screens/SelectAccountScreenPreview.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistAuthComposablesApi::class)
+
+package com.google.android.horologist.auth.composables.screens
+
+import androidx.compose.runtime.Composable
+import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
+import com.google.android.horologist.compose.layout.belowTimeTextPreview
+import com.google.android.horologist.compose.tools.WearPreviewDevices
+
+@WearPreviewDevices
+@Composable
+fun SelectAccountScreenPreview() {
+    SelectAccountScreen(
+        accounts = listOf(
+            AccountUiModel(email = "maggie@example.com"),
+            AccountUiModel(email = "thisisaverylongemail@example.com")
+        ),
+        onAccountClicked = { _, _ -> },
+        columnState = belowTimeTextPreview()
+    )
+}
+
+@WearPreviewDevices
+@Composable
+fun SelectAccountScreenPreviewNoAvatar() {
+    SelectAccountScreen(
+        accounts = listOf(
+            AccountUiModel(email = "maggie@example.com"),
+            AccountUiModel(email = "thisisaverylongemailaccountsample@example.com")
+        ),
+        onAccountClicked = { _, _ -> },
+        columnState = belowTimeTextPreview(),
+        defaultAvatar = null
+    )
+}

--- a/auth-composables/src/main/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialog.kt
+++ b/auth-composables/src/main/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialog.kt
@@ -62,7 +62,7 @@ public fun SignedInConfirmationDialog(
     modifier: Modifier = Modifier,
     name: String? = null,
     email: String? = null,
-    avatarUri: Any? = null,
+    avatar: Any? = null,
     duration: Duration = Duration.ofMillis(DialogDefaults.ShortDurationMillis),
     onDismissOrTimeout: () -> Unit
 ) {
@@ -75,7 +75,7 @@ public fun SignedInConfirmationDialog(
             modifier = modifier,
             displayName = name,
             email = email,
-            avatarUri = avatarUri
+            avatar = avatar
         )
     }
 }
@@ -86,7 +86,7 @@ internal fun SignedInConfirmationDialogContent(
     modifier: Modifier = Modifier,
     displayName: String? = null,
     email: String? = null,
-    avatarUri: Any? = null
+    avatar: Any? = null
 ) {
     val configuration = LocalConfiguration.current
     val horizontalPadding = (configuration.screenWidthDp * HORIZONTAL_PADDING_SCREEN_PERCENTAGE).dp
@@ -101,7 +101,7 @@ internal fun SignedInConfirmationDialogContent(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         val hasName = displayName != null
-        val hasAvatar = avatarUri != null
+        val hasAvatar = avatar != null
 
         Box(
             modifier = Modifier
@@ -112,7 +112,7 @@ internal fun SignedInConfirmationDialogContent(
             if (hasAvatar) {
                 Image(
                     modifier = Modifier.clip(CircleShape),
-                    painter = rememberAsyncImagePainter(model = avatarUri),
+                    painter = rememberAsyncImagePainter(model = avatar),
                     contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
                     contentScale = ContentScale.Fit
                 )

--- a/auth-composables/src/main/java/com/google/android/horologist/auth/composables/screens/SelectAccountScreen.kt
+++ b/auth-composables/src/main/java/com/google/android/horologist/auth/composables/screens/SelectAccountScreen.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.composables.screens
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
+import com.google.android.horologist.auth.composables.R
+import com.google.android.horologist.base.ui.components.StandardChip
+import com.google.android.horologist.base.ui.components.StandardChipType
+import com.google.android.horologist.base.ui.components.Title
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+
+private const val HORIZONTAL_PADDING_SCREEN_PERCENTAGE = 0.052
+
+@ExperimentalHorologistAuthComposablesApi
+@Composable
+public fun SelectAccountScreen(
+    accounts: List<AccountUiModel>,
+    onAccountClicked: (index: Int, account: AccountUiModel) -> Unit,
+    columnState: ScalingLazyColumnState,
+    modifier: Modifier = Modifier,
+    title: String = stringResource(id = R.string.horologist_select_account_title),
+    defaultAvatar: Any? = Icons.Default.AccountCircle
+) {
+    val configuration = LocalConfiguration.current
+    val horizontalPadding = (configuration.screenWidthDp * HORIZONTAL_PADDING_SCREEN_PERCENTAGE).dp
+
+    ScalingLazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = horizontalPadding),
+        columnState = columnState
+    ) {
+        item { Title(text = title, modifier = Modifier.padding(bottom = 8.dp)) }
+
+        items(accounts.size) { index ->
+            val account = accounts[index]
+
+            StandardChip(
+                label = account.email,
+                icon = account.avatar ?: defaultAvatar,
+                largeIcon = true,
+                onClick = { onAccountClicked(index, account) },
+                chipType = StandardChipType.Secondary
+            )
+        }
+    }
+}
+
+@ExperimentalHorologistAuthComposablesApi
+public data class AccountUiModel(
+    val email: String,
+    val avatar: Any? = null
+)

--- a/auth-composables/src/main/res/values/strings.xml
+++ b/auth-composables/src/main/res/values/strings.xml
@@ -24,4 +24,5 @@
     <string name="horologist_guest_mode_chip_label">Use without account</string>
     <string name="horologist_other_options_chip_label">Other options</string>
     <string name="horologist_create_account_chip_label">Create account</string>
+    <string name="horologist_select_account_title">Select account</string>
 </resources>

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogTest.kt
@@ -49,7 +49,7 @@ class SignedInConfirmationDialogTest {
                     SignedInConfirmationDialogContent(
                         displayName = "Maggie",
                         email = "maggie@example.com",
-                        avatarUri = android.R.drawable.sym_def_app_icon
+                        avatar = android.R.drawable.sym_def_app_icon
                     )
                 }
             }
@@ -66,7 +66,7 @@ class SignedInConfirmationDialogTest {
                 ) {
                     SignedInConfirmationDialogContent(
                         email = "maggie@example.com",
-                        avatarUri = android.R.drawable.sym_def_app_icon
+                        avatar = android.R.drawable.sym_def_app_icon
                     )
                 }
             }
@@ -97,7 +97,7 @@ class SignedInConfirmationDialogTest {
                 ) {
                     SignedInConfirmationDialogContent(
                         displayName = "Maggie",
-                        avatarUri = android.R.drawable.sym_def_app_icon
+                        avatar = android.R.drawable.sym_def_app_icon
                     )
                 }
             }
@@ -127,7 +127,7 @@ class SignedInConfirmationDialogTest {
                     SignedInConfirmationDialogContent(
                         displayName = "Wolfeschlegelsteinhausenbergerdorff",
                         email = "wolfeschlegelsteinhausenbergerdorff@example.com",
-                        avatarUri = android.R.drawable.sym_def_app_icon
+                        avatar = android.R.drawable.sym_def_app_icon
                     )
                 }
             }

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/screens/SelectAccountScreenTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/screens/SelectAccountScreenTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(
+    ExperimentalHorologistPaparazziApi::class,
+    ExperimentalHorologistAuthComposablesApi::class
+)
+
+package com.google.android.horologist.auth.composables.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Face
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
+import com.google.android.horologist.compose.tools.coil.FakeImageLoader
+import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
+import com.google.android.horologist.paparazzi.WearPaparazzi
+import com.google.android.horologist.test.toolbox.positionedState
+import org.junit.Rule
+import org.junit.Test
+
+class SelectAccountScreenTest {
+
+    @get:Rule
+    val paparazzi = WearPaparazzi()
+
+    @Test
+    fun selectAccountScreen() {
+        paparazzi.snapshot {
+            FakeImageLoader.Resources.override {
+                Box(
+                    modifier = Modifier.background(Color.Black),
+                    contentAlignment = Alignment.Center
+                ) {
+                    SelectAccountScreen(
+                        accounts = listOf(
+                            AccountUiModel(
+                                email = "maggie@example.com",
+                                avatar = Icons.Default.Face
+                            ),
+                            AccountUiModel(email = "thisisaverylongemail@example.com")
+                        ),
+                        onAccountClicked = { _, _ -> },
+                        columnState = positionedState(0, 0)
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun selectAccountScreenNoAvatar() {
+        paparazzi.snapshot {
+            FakeImageLoader.Resources.override {
+                Box(
+                    modifier = Modifier.background(Color.Black),
+                    contentAlignment = Alignment.Center
+                ) {
+                    SelectAccountScreen(
+                        accounts = listOf(
+                            AccountUiModel(email = "maggie@example.com"),
+                            AccountUiModel(email = "thisisaverylongemailaccountsample@example.com")
+                        ),
+                        onAccountClicked = { _, _ -> },
+                        columnState = positionedState(0, 0),
+                        defaultAvatar = null
+                    )
+                }
+            }
+        }
+    }
+}

--- a/auth-composables/src/test/java/com/google/android/horologist/test/toolbox/PositionedState.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/test/toolbox/PositionedState.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.test.toolbox
+
+import androidx.compose.runtime.Composable
+import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
+import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.tools.a11y.forceState
+
+@Composable
+fun positionedState(
+    topIndex: Int,
+    topScrollOffset: Int
+): ScalingLazyColumnState {
+    return ScalingLazyColumnDefaults.belowTimeText().create().apply {
+        state.forceState(topIndex, topScrollOffset)
+    }
+}

--- a/auth-composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.screens_SelectAccountScreenTest_selectAccountScreen.png
+++ b/auth-composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.screens_SelectAccountScreenTest_selectAccountScreen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5714b3109867ff94167e27a232b90a03f272bf0e8632a6c50efdd5a9c48487d6
+size 162385

--- a/auth-composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.screens_SelectAccountScreenTest_selectAccountScreenNoAvatar.png
+++ b/auth-composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.screens_SelectAccountScreenTest_selectAccountScreenNoAvatar.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a3427fc2c2451e818003cac3b549e1a70306b6b0e33197241e4938fdb455ea8
+size 156148

--- a/auth-ui/api/current.api
+++ b/auth-ui/api/current.api
@@ -27,15 +27,15 @@ package com.google.android.horologist.auth.ui.common.screens {
   }
 
   public static final class SignInPromptScreenState.SignedIn extends com.google.android.horologist.auth.ui.common.screens.SignInPromptScreenState {
-    ctor public SignInPromptScreenState.SignedIn(optional String? displayName, optional String? email, optional Object? avatarUri);
+    ctor public SignInPromptScreenState.SignedIn(optional String? displayName, optional String? email, optional Object? avatar);
     method public String? component1();
     method public String? component2();
     method public Object? component3();
-    method public com.google.android.horologist.auth.ui.common.screens.SignInPromptScreenState.SignedIn copy(String? displayName, String? email, Object? avatarUri);
-    method public Object? getAvatarUri();
+    method public com.google.android.horologist.auth.ui.common.screens.SignInPromptScreenState.SignedIn copy(String? displayName, String? email, Object? avatar);
+    method public Object? getAvatar();
     method public String? getDisplayName();
     method public String? getEmail();
-    property public final Object? avatarUri;
+    property public final Object? avatar;
     property public final String? displayName;
     property public final String? email;
   }

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/SignInPromptScreen.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/SignInPromptScreen.kt
@@ -68,7 +68,7 @@ public fun SignInPromptScreen(
             SignedInConfirmationDialog(
                 name = signedInState.displayName,
                 email = signedInState.email,
-                avatarUri = signedInState.avatarUri
+                avatar = signedInState.avatar
             ) {
                 onAlreadySignedIn()
             }

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/SignInPromptViewModel.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/SignInPromptViewModel.kt
@@ -50,7 +50,7 @@ public open class SignInPromptViewModel(
                     _uiState.value = SignInPromptScreenState.SignedIn(
                         displayName = authUser.displayName,
                         email = authUser.email,
-                        avatarUri = authUser.avatarUri
+                        avatar = authUser.avatarUri
                     )
                 } ?: run {
                     _uiState.value = SignInPromptScreenState.SignedOut
@@ -70,7 +70,7 @@ public sealed class SignInPromptScreenState {
     public data class SignedIn(
         val displayName: String? = null,
         val email: String? = null,
-        val avatarUri: Any? = null
+        val avatar: Any? = null
     ) : SignInPromptScreenState()
 
     public object SignedOut : SignInPromptScreenState()

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/GoogleSignInScreen.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/GoogleSignInScreen.kt
@@ -123,7 +123,7 @@ public fun GoogleSignInScreen(
                 modifier = modifier,
                 name = successState.displayName,
                 email = successState.email,
-                avatarUri = successState.photoUrl
+                avatar = successState.photoUrl
             ) {
                 onAuthSucceed()
             }


### PR DESCRIPTION
#### WHAT

Add `SelectAccountScreen`.

#### WHY

In order to provide common auth screens.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
