### PR TITLE
Remove double experimental annotation from SectionedList

### DIFF
--- a/composables/api/current.api
+++ b/composables/api/current.api
@@ -105,8 +105,8 @@ package com.google.android.horologist.composables {
   }
 
   public final class SectionedListKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public static void SectionedList(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionedListScope,kotlin.Unit> content);
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public static void SectionedList(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, optional java.util.List<? extends com.google.android.horologist.composables.Section<?>> sections);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public static void SectionedList(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionedListScope,kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public static void SectionedList(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, optional java.util.List<? extends com.google.android.horologist.composables.Section<?>> sections);
   }
 
   @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public final class SectionedListScope {

--- a/composables/build.gradle
+++ b/composables/build.gradle
@@ -44,6 +44,7 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
         freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
+        freeCompilerArgs += "-opt-in=com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi"
     }
 
     composeOptions {

--- a/composables/src/debug/java/com/google/android/horologist/composables/SectionedListPreview.kt
+++ b/composables/src/debug/java/com/google/android/horologist/composables/SectionedListPreview.kt
@@ -15,8 +15,7 @@
  */
 
 @file:OptIn(
-    ExperimentalHorologistComposablesApi::class,
-    ExperimentalHorologistComposeLayoutApi::class
+    ExperimentalHorologistComposablesApi::class
 )
 
 package com.google.android.horologist.composables
@@ -39,13 +38,12 @@ import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
-import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 
 @WearPreviewDevices
 @Composable
 fun SectionedListPreviewLoadingSection() {
-    SectionedList() {
+    SectionedList {
         downloadsSection(state = Section.State.Loading())
 
         favouritesSection(state = Section.State.Empty())
@@ -55,7 +53,7 @@ fun SectionedListPreviewLoadingSection() {
 @WearPreviewDevices
 @Composable
 fun SectionedListPreviewLoadedSection() {
-    SectionedList() {
+    SectionedList {
         downloadsSection(state = Section.State.Loaded(downloads))
 
         favouritesSection(state = Section.State.Failed())
@@ -65,7 +63,7 @@ fun SectionedListPreviewLoadedSection() {
 @WearPreviewDevices
 @Composable
 fun SectionedListPreviewFailedSection() {
-    SectionedList() {
+    SectionedList {
         downloadsSection(state = Section.State.Failed())
 
         favouritesSection(state = Section.State.Loaded(favourites))
@@ -75,7 +73,7 @@ fun SectionedListPreviewFailedSection() {
 @WearPreviewDevices
 @Composable
 fun SectionedListPreviewEmptySection() {
-    SectionedList() {
+    SectionedList {
         downloadsSection(state = Section.State.Empty())
 
         favouritesSection(state = Section.State.Loading())

--- a/composables/src/main/java/com/google/android/horologist/composables/SectionedList.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/SectionedList.kt
@@ -28,13 +28,11 @@ import com.google.android.horologist.composables.Section.Companion.DEFAULT_LOADI
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
-import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 
 /**
  * A list component that is split into [sections][Section].
  * Each [Section] has its own [state][Section.State] controlled individually.
  */
-@ExperimentalHorologistComposeLayoutApi
 @ExperimentalHorologistComposablesApi
 @Composable
 public fun SectionedList(
@@ -53,7 +51,6 @@ public fun SectionedList(
  * A list component that is split into [sections][Section].
  * Each [Section] has its own [state][Section.State] controlled individually.
  */
-@ExperimentalHorologistComposeLayoutApi
 @ExperimentalHorologistComposablesApi
 @Composable
 public fun SectionedList(

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/SectionedListTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/SectionedListTest.kt
@@ -17,8 +17,7 @@
 @file:Suppress("TestFunctionName" /* incorrectly flagging composable functions */)
 @file:OptIn(
     ExperimentalHorologistPaparazziApi::class,
-    ExperimentalHorologistComposablesApi::class,
-    ExperimentalHorologistComposeLayoutApi::class
+    ExperimentalHorologistComposablesApi::class
 )
 
 package com.google.android.horologist.composables
@@ -49,7 +48,6 @@ import androidx.wear.compose.material.ScalingLazyListState
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
-import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 import com.google.android.horologist.compose.tools.RoundPreview
 import com.google.android.horologist.compose.tools.a11y.forceState
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi


### PR DESCRIPTION
#### WHAT

Remove double experimental annotation from `SectionedList`.

#### WHY

Using this component shouldn't require to opt in to two different experimental annotations.

#### HOW

Remove annotation and opt in via build.gradle for the whole module.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
