### PR TITLE
Add min sdk version to AndroidManifest

### DIFF
--- a/auth-composables/src/main/AndroidManifest.xml
+++ b/auth-composables/src/main/AndroidManifest.xml
@@ -16,8 +16,10 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.google.android.horologist.auth.composables">
 
     <uses-feature android:name="android.hardware.type.watch" />
 
+    <uses-sdk android:minSdkVersion="26" tools:ignore="GradleOverrides" />
 </manifest>

--- a/auth-data/src/main/AndroidManifest.xml
+++ b/auth-data/src/main/AndroidManifest.xml
@@ -16,8 +16,10 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.google.android.horologist.auth.data">
 
     <uses-feature android:name="android.hardware.type.watch" />
 
+    <uses-sdk android:minSdkVersion="26" tools:ignore="GradleOverrides" />
 </manifest>

--- a/auth-ui/src/main/AndroidManifest.xml
+++ b/auth-ui/src/main/AndroidManifest.xml
@@ -16,8 +16,10 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.google.android.horologist.auth.ui">
 
     <uses-feature android:name="android.hardware.type.watch" />
 
+    <uses-sdk android:minSdkVersion="26" tools:ignore="GradleOverrides" />
 </manifest>


### PR DESCRIPTION
#### WHAT

Add min sdk version to AndroidManifest.

#### WHY

To be picked up when using build systems other than gradle.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
