### PR TITLE
Improve handling of scenario when account selection is cancelled

### DIFF
--- a/auth-ui/api/current.api
+++ b/auth-ui/api/current.api
@@ -69,11 +69,15 @@ package com.google.android.horologist.auth.ui.googlesignin {
   }
 
   public final class GoogleSignInScreenKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public static void GoogleSignInScreen(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.auth.ui.googlesignin.GoogleSignInViewModel viewModel, kotlin.jvm.functions.Function1<? super com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreenState.Success,kotlin.Unit> successContent, kotlin.jvm.functions.Function0<kotlin.Unit> failedContent);
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public static void GoogleSignInScreen(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.auth.ui.googlesignin.GoogleSignInViewModel viewModel, kotlin.jvm.functions.Function0<kotlin.Unit> onAuthSucceed);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public static void GoogleSignInScreen(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.auth.ui.googlesignin.GoogleSignInViewModel viewModel, kotlin.jvm.functions.Function0<kotlin.Unit> onAuthCancelled, kotlin.jvm.functions.Function0<kotlin.Unit> failedContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreenState.Success,kotlin.Unit> successContent);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public static void GoogleSignInScreen(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.auth.ui.googlesignin.GoogleSignInViewModel viewModel, kotlin.jvm.functions.Function0<kotlin.Unit> onAuthCancelled, kotlin.jvm.functions.Function0<kotlin.Unit> onAuthSucceed);
   }
 
   @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public abstract sealed class GoogleSignInScreenState {
+  }
+
+  public static final class GoogleSignInScreenState.Cancelled extends com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreenState {
+    field public static final com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreenState.Cancelled INSTANCE;
   }
 
   public static final class GoogleSignInScreenState.Failed extends com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreenState {
@@ -107,6 +111,7 @@ package com.google.android.horologist.auth.ui.googlesignin {
     method public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreenState> getUiState();
     method public final void onAccountSelected(com.google.android.gms.auth.api.signin.GoogleSignInAccount account);
     method public final void onAccountSelectionFailed();
+    method public final void onAuthCancelled();
     method public final void startAuthFlow();
     property public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreenState> uiState;
   }

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/GoogleSignInViewModel.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/GoogleSignInViewModel.kt
@@ -26,6 +26,7 @@ import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -36,7 +37,8 @@ public open class GoogleSignInViewModel(
 
     private val _uiState =
         MutableStateFlow<GoogleSignInScreenState>(GoogleSignInScreenState.Idle)
-    public val uiState: StateFlow<GoogleSignInScreenState> = _uiState.stateIn(
+    public val uiState: StateFlow<GoogleSignInScreenState> = _uiState.onEach {
+    }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
         initialValue = GoogleSignInScreenState.Idle
@@ -64,6 +66,10 @@ public open class GoogleSignInViewModel(
     public fun onAccountSelectionFailed() {
         _uiState.value = GoogleSignInScreenState.Failed
     }
+
+    public fun onAuthCancelled() {
+        _uiState.value = GoogleSignInScreenState.Cancelled
+    }
 }
 
 @ExperimentalHorologistAuthUiApi
@@ -79,4 +85,6 @@ public sealed class GoogleSignInScreenState {
     ) : GoogleSignInScreenState()
 
     public object Failed : GoogleSignInScreenState()
+
+    public object Cancelled : GoogleSignInScreenState()
 }

--- a/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
@@ -267,7 +267,10 @@ fun SampleWearApp() {
             )
         }
         composable(route = Screen.GoogleSignInScreen.route) {
-            GoogleSignInScreen(viewModel = viewModel(factory = GoogleSignInSampleViewModel.Factory)) {
+            GoogleSignInScreen(
+                viewModel = viewModel(factory = GoogleSignInSampleViewModel.Factory),
+                onAuthCancelled = { navController.popBackStack() }
+            ) {
                 navController.popBackStack()
             }
         }


### PR DESCRIPTION
#### WHAT

Improve handling of scenario when account selection is cancelled when using `GoogleSignInScreen` component.

#### HOW

Add `onAuthCancelled` callback.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
