### PR TITLE
Do not display SignedInConfirmationDialog when already signed in.

### DIFF
--- a/auth-ui/api/current.api
+++ b/auth-ui/api/current.api
@@ -27,17 +27,7 @@ package com.google.android.horologist.auth.ui.common.screens {
   }
 
   public static final class SignInPromptScreenState.SignedIn extends com.google.android.horologist.auth.ui.common.screens.SignInPromptScreenState {
-    ctor public SignInPromptScreenState.SignedIn(optional String? displayName, optional String? email, optional Object? avatar);
-    method public String? component1();
-    method public String? component2();
-    method public Object? component3();
-    method public com.google.android.horologist.auth.ui.common.screens.SignInPromptScreenState.SignedIn copy(String? displayName, String? email, Object? avatar);
-    method public Object? getAvatar();
-    method public String? getDisplayName();
-    method public String? getEmail();
-    property public final Object? avatar;
-    property public final String? displayName;
-    property public final String? email;
+    field public static final com.google.android.horologist.auth.ui.common.screens.SignInPromptScreenState.SignedIn INSTANCE;
   }
 
   public static final class SignInPromptScreenState.SignedOut extends com.google.android.horologist.auth.ui.common.screens.SignInPromptScreenState {

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/SignInPromptScreen.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/SignInPromptScreen.kt
@@ -33,7 +33,7 @@ import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.ScalingLazyListScope
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.auth.composables.R
-import com.google.android.horologist.auth.composables.dialogs.SignedInConfirmationDialog
+import com.google.android.horologist.auth.composables.screens.SignInPlaceholderScreen
 import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
 import com.google.android.horologist.base.ui.components.Title
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
@@ -58,23 +58,17 @@ public fun SignInPromptScreen(
                 viewModel.startFlow()
             }
 
-            LoadingView(modifier = modifier)
+            SignInPlaceholderScreen(modifier = modifier)
         }
 
         SignInPromptScreenState.Loading -> {
-            LoadingView(modifier = modifier)
+            SignInPlaceholderScreen(modifier = modifier)
         }
 
         is SignInPromptScreenState.SignedIn -> {
-            val signedInState = state as SignInPromptScreenState.SignedIn
+            SignInPlaceholderScreen(modifier = modifier)
 
-            SignedInConfirmationDialog(
-                name = signedInState.displayName,
-                email = signedInState.email,
-                avatar = signedInState.avatar
-            ) {
-                onAlreadySignedIn()
-            }
+            onAlreadySignedIn()
         }
 
         SignInPromptScreenState.SignedOut -> {

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/SignInPromptViewModel.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/SignInPromptViewModel.kt
@@ -46,13 +46,9 @@ public open class SignInPromptViewModel(
             update = SignInPromptScreenState.Loading
         ) {
             viewModelScope.launch {
-                authRepository.getAuthUser()?.let { authUser ->
-                    _uiState.value = SignInPromptScreenState.SignedIn(
-                        displayName = authUser.displayName,
-                        email = authUser.email,
-                        avatar = authUser.avatarUri
-                    )
-                } ?: run {
+                if (authRepository.getAuthUser() != null) {
+                    _uiState.value = SignInPromptScreenState.SignedIn
+                } else {
                     _uiState.value = SignInPromptScreenState.SignedOut
                 }
             }
@@ -67,11 +63,7 @@ public sealed class SignInPromptScreenState {
 
     public object Loading : SignInPromptScreenState()
 
-    public data class SignedIn(
-        val displayName: String? = null,
-        val email: String? = null,
-        val avatar: Any? = null
-    ) : SignInPromptScreenState()
+    public object SignedIn : SignInPromptScreenState()
 
     public object SignedOut : SignInPromptScreenState()
 }

--- a/sample/src/main/java/com/google/android/horologist/auth/googlesignin/prompt/GoogleSignInPromptSampleScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/googlesignin/prompt/GoogleSignInPromptSampleScreen.kt
@@ -17,16 +17,24 @@
 package com.google.android.horologist.auth.googlesignin.prompt
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
+import androidx.wear.compose.material.Text
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import com.google.android.horologist.auth.composables.chips.GuestModeChip
 import com.google.android.horologist.auth.composables.chips.SignInChip
 import com.google.android.horologist.auth.ui.common.screens.SignInPromptScreen
 import com.google.android.horologist.auth.ui.common.screens.SignInPromptViewModel
 import com.google.android.horologist.auth.ui.googlesignin.GoogleSignInPromptViewModel
+import com.google.android.horologist.base.ui.components.ConfirmationDialog
 import com.google.android.horologist.base.ui.components.StandardChipType
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.layout.belowTimeTextPreview
@@ -41,9 +49,13 @@ fun GoogleSignInPromptSampleScreen(
     modifier: Modifier = Modifier,
     viewModel: SignInPromptViewModel = viewModel(factory = GoogleSignInPromptViewModel.Factory)
 ) {
+    var showAlreadySignedInDialog by rememberSaveable { mutableStateOf(false) }
+
     SignInPromptScreen(
         message = stringResource(id = R.string.google_sign_in_prompt_message),
-        onAlreadySignedIn = { navController.popBackStack() },
+        onAlreadySignedIn = {
+            showAlreadySignedInDialog = true
+        },
         columnState = columnState,
         modifier = modifier,
         viewModel = viewModel
@@ -62,6 +74,21 @@ fun GoogleSignInPromptSampleScreen(
             GuestModeChip(
                 onClick = { navController.popBackStack() },
                 chipType = StandardChipType.Secondary
+            )
+        }
+    }
+
+    if (showAlreadySignedInDialog) {
+        ConfirmationDialog(
+            onTimeout = {
+                showAlreadySignedInDialog = false
+                navController.popBackStack()
+            }
+        ) {
+            Text(
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                textAlign = TextAlign.Center,
+                text = stringResource(id = R.string.google_sign_in_prompt_already_signed_in_message)
             )
         }
     }

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="auth_device_grant_sign_in_prompt_message">Sign in to download and stream music</string>
     <string name="google_sign_in_prompt_message">Send messages and create chat groups with your friends</string>
     <string name="google_sign_out_success_message">Signed out successfully!</string>
+    <string name="google_sign_in_prompt_already_signed_in_message">Already signed-in!</string>
 
     <string name="rotarymenu_scroll">Scroll</string>
     <string name="rotarymenu_scroll_list">Scroll list</string>


### PR DESCRIPTION
#### WHAT

Change `SignInPromptScreen` to not display `SignedInConfirmationDialog` when already signed in.

Also change it to display `SignInPlaceholderScreen` when in idle/loading state.

#### WHY

UX feedback.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
