### PR TITLE
Start preparation phase to convert audio domains gradle from Groovy  DSL to Kotlin DSL

### DIFF
--- a/audio-ui/build.gradle
+++ b/audio-ui/build.gradle
@@ -15,30 +15,30 @@
  */
 
 plugins {
-    id 'com.android.library'
-    id 'kotlin-android'
-    id 'org.jetbrains.dokka'
-    id "org.jetbrains.kotlin.kapt"
-    id 'dev.chrisbanes.paparazzi'
+    id("com.android.library")
+    id("kotlin-android")
+    id("org.jetbrains.dokka")
+    id("org.jetbrains.kotlin.kapt")
+    id("dev.chrisbanes.paparazzi")
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion = 33
 
     defaultConfig {
-        minSdk 25
-        targetSdk 30
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        minSdk = 25
+        targetSdk = 30
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     buildFeatures {
-        buildConfig false
-        compose true
+        buildConfig = false
+        compose = true
     }
 
     kotlinOptions {
@@ -46,48 +46,47 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion libs.versions.compose.compiler.get()
+        kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
     }
     packagingOptions {
         resources {
             excludes += [
-                '/META-INF/AL2.0',
-                '/META-INF/LGPL2.1'
+                "/META-INF/AL2.0",
+                "/META-INF/LGPL2.1"
             ]
         }
     }
-
 
     testOptions {
         unitTests {
             includeAndroidResources = true
         }
-        animationsDisabled true
+        animationsDisabled = true
     }
 
     sourceSets {
         main {
-            assets.srcDirs = ['src/main/assets']
+            assets.srcDirs = ["src/main/assets"]
         }
         test {
-            java.srcDirs += 'src/sharedTest/kotlin'
-            res.srcDirs += 'src/sharedTest/res'
+            java.srcDirs += "src/sharedTest/kotlin"
+            res.srcDirs += "src/sharedTest/res"
         }
         androidTest {
-            java.srcDirs += 'src/sharedTest/kotlin'
-            res.srcDirs += 'src/sharedTest/res'
+            java.srcDirs += "src/sharedTest/kotlin"
+            res.srcDirs += "src/sharedTest/res"
         }
     }
     lint {
-        checkReleaseBuilds false
-        textReport true
-        disable 'MissingTranslation', 'ExtraTranslation'
+        checkReleaseBuilds = false
+        textReport = true
+        disable "MissingTranslation", "ExtraTranslation"
     }
-    namespace 'com.google.android.horologist.audio.ui'
+    namespace = "com.google.android.horologist.audio.ui"
 }
 
 kapt {
-    correctErrorTypes true
+    correctErrorTypes = true
 }
 
 project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile.class).configureEach { task ->
@@ -97,7 +96,7 @@ project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile.class).co
     }
 }
 
-apply plugin: 'me.tylerbwong.gradle.metalava'
+apply plugin: "me.tylerbwong.gradle.metalava"
 
 metalava {
     sourcePaths = ["src/main"]
@@ -106,35 +105,35 @@ metalava {
 }
 
 dependencies {
-    api projects.audio
-    api libs.kotlin.stdlib
-    implementation projects.composeLayout
+    api(projects.audio)
+    api(libs.kotlin.stdlib)
+    implementation(projects.composeLayout)
 
-    api libs.wearcompose.material
-    api libs.wearcompose.foundation
-    implementation libs.androidx.corektx
+    api(libs.wearcompose.material)
+    api(libs.wearcompose.foundation)
+    implementation(libs.androidx.corektx)
 
-    implementation libs.compose.material.iconscore
-    implementation libs.compose.material.iconsext
+    implementation(libs.compose.material.iconscore)
+    implementation(libs.compose.material.iconsext)
 
-    implementation libs.compose.ui.tooling
-    implementation libs.androidx.wear
-    implementation libs.androidx.lifecycle.viewmodel.compose
+    implementation(libs.compose.ui.tooling)
+    implementation(libs.androidx.wear)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
 
-    implementation libs.lottie.compose
+    implementation(libs.lottie.compose)
 
-    debugImplementation libs.compose.ui.toolingpreview
-    debugImplementation projects.composeTools
+    debugImplementation(libs.compose.ui.toolingpreview)
+    debugImplementation(projects.composeTools)
 
-    testImplementation libs.junit
-    testImplementation projects.paparazzi
-    testImplementation libs.paparazzi
+    testImplementation(libs.junit)
+    testImplementation(projects.paparazzi)
+    testImplementation(libs.paparazzi)
 
-    androidTestImplementation libs.compose.ui.test.junit4
-    debugImplementation libs.compose.ui.test.manifest
-    androidTestImplementation libs.espresso.core
-    androidTestImplementation libs.junit
-    androidTestImplementation libs.truth
+    androidTestImplementation(libs.compose.ui.test.junit4)
+    debugImplementation(libs.compose.ui.test.manifest)
+    androidTestImplementation(libs.espresso.core)
+    androidTestImplementation(libs.junit)
+    androidTestImplementation(libs.truth)
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/audio/build.gradle
+++ b/audio/build.gradle
@@ -15,28 +15,28 @@
  */
 
 plugins {
-    id 'com.android.library'
-    id 'kotlin-android'
-    id 'org.jetbrains.dokka'
-    id "org.jetbrains.kotlin.kapt"
+    id("com.android.library")
+    id("kotlin-android")
+    id("org.jetbrains.dokka")
+    id("org.jetbrains.kotlin.kapt")
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion = 33
 
     defaultConfig {
-        minSdk 25
-        targetSdk 30
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        minSdk = 25
+        targetSdk = 30
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     buildFeatures {
-        buildConfig false
+        buildConfig = false
     }
 
     kotlinOptions {
@@ -44,13 +44,13 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion libs.versions.compose.compiler.get()
+        kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
     }
     packagingOptions {
         resources {
             excludes += [
-                '/META-INF/AL2.0',
-                '/META-INF/LGPL2.1'
+                "/META-INF/AL2.0",
+                "/META-INF/LGPL2.1"
             ]
         }
     }
@@ -60,28 +60,28 @@ android {
         unitTests {
             includeAndroidResources = true
         }
-        animationsDisabled true
+        animationsDisabled = true
     }
 
     sourceSets {
         test {
-            java.srcDirs += 'src/sharedTest/kotlin'
-            res.srcDirs += 'src/sharedTest/res'
+            java.srcDirs += "src/sharedTest/kotlin"
+            res.srcDirs += "src/sharedTest/res"
         }
         androidTest {
-            java.srcDirs += 'src/sharedTest/kotlin'
-            res.srcDirs += 'src/sharedTest/res'
+            java.srcDirs += "src/sharedTest/kotlin"
+            res.srcDirs += "src/sharedTest/res"
         }
     }
     lint {
-        checkReleaseBuilds false
-        textReport true
+        checkReleaseBuilds = false
+        textReport = true
     }
-    namespace 'com.google.android.horologist.audio'
+    namespace = "com.google.android.horologist.audio"
 }
 
 kapt {
-    correctErrorTypes true
+    correctErrorTypes = true
 }
 
 project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile.class).configureEach { task ->
@@ -91,7 +91,7 @@ project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile.class).co
     }
 }
 
-apply plugin: 'me.tylerbwong.gradle.metalava'
+apply plugin: "me.tylerbwong.gradle.metalava"
 
 metalava {
     sourcePaths = ["src/main"]
@@ -100,20 +100,20 @@ metalava {
 }
 
 dependencies {
-    implementation libs.kotlin.stdlib
+    implementation(libs.kotlin.stdlib)
 
-    implementation libs.androidx.mediarouter
-    implementation libs.androidx.wear
-    implementation libs.androidx.lifecycle.runtime
-    implementation libs.kotlinx.coroutines.android
+    implementation(libs.androidx.mediarouter)
+    implementation(libs.androidx.wear)
+    implementation(libs.androidx.lifecycle.runtime)
+    implementation(libs.kotlinx.coroutines.android)
 
-    androidTestImplementation libs.androidx.lifecycle.testing
-    androidTestImplementation libs.androidx.test.rules
-    androidTestImplementation libs.truth
-    androidTestImplementation libs.compose.ui.test.junit4
-    debugImplementation libs.compose.ui.test.manifest
-    androidTestImplementation libs.espresso.core
-    androidTestImplementation libs.junit
+    androidTestImplementation(libs.androidx.lifecycle.testing)
+    androidTestImplementation(libs.androidx.test.rules)
+    androidTestImplementation(libs.truth)
+    androidTestImplementation(libs.compose.ui.test.junit4)
+    debugImplementation(libs.compose.ui.test.manifest)
+    androidTestImplementation(libs.espresso.core)
+    androidTestImplementation(libs.junit)
 }
 
 apply plugin: "com.vanniktech.maven.publish"


### PR DESCRIPTION
#### WHAT
Starting the preparation phase for converting the gradle files in the audio domain from Groovy DSL to Kotlin DSL.

#### WHY

See #833 

#### HOW

My plan here is to start with each domain and go through the preparation phases from: https://docs.gradle.org/current/userguide/migrating_from_groovy_to_kotlin_dsl.html#prepare_your_groovy_scripts

On this step, I will separate the gradle files in each domain by commits, so that if you want to review it gradle file by gradle file, you can do so by reviewing commit by commit.

(By domain here I mean audio is one domain, auth is one domain etc.)

Then step 2 is to actually convert each gradle module to Kotlin DSL and rename the files to start using it. For this step I will make a PR for each module.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
