### PR TITLE
Experiment with Wear Compose pager

### DIFF
--- a/compose-layout/build.gradle
+++ b/compose-layout/build.gradle
@@ -100,8 +100,6 @@ dependencies {
     api(libs.wearcompose.foundation)
     api(libs.wearcompose.navigation)
 
-    api(libs.accompanist.pager)
-
     implementation(libs.compose.ui.tooling)
     implementation(libs.compose.ui.util)
     implementation(libs.androidx.wear)

--- a/compose-layout/src/androidTest/java/com/google/android/horologist/compose/pager/PagerScreenTest.kt
+++ b/compose-layout/src/androidTest/java/com/google/android/horologist/compose/pager/PagerScreenTest.kt
@@ -15,16 +15,17 @@
  */
 
 @file:OptIn(
-    ExperimentalPagerApi::class,
     ExperimentalCoroutinesApi::class,
-    ExperimentalHorologistComposeLayoutApi::class
+    ExperimentalHorologistComposeLayoutApi::class, ExperimentalFoundationApi::class
 )
 
 package com.google.android.horologist.compose.pager
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.remember
@@ -40,8 +41,6 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onParent
 import androidx.test.filters.MediumTest
 import androidx.wear.compose.material.Text
-import com.google.accompanist.pager.ExperimentalPagerApi
-import com.google.accompanist.pager.PagerState
 import com.google.android.horologist.compose.focus.RequestFocusWhenActive
 import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 import com.google.android.horologist.compose.rotaryinput.rotaryWithFling
@@ -80,7 +79,7 @@ class PagerScreenTest {
         }
 
         assertThat(state.currentPage).isEqualTo(0)
-        assertThat(state.pageCount).isEqualTo(5)
+//        assertThat(state.pageCount).isEqualTo(5)
 
         val text0 = composeTestRule.onNodeWithTag("text0")
         val text1 = composeTestRule.onNodeWithTag("text1")

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/pager/PagerScreen.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/pager/PagerScreen.kt
@@ -14,14 +14,18 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalPagerApi::class)
+@file:OptIn(ExperimentalFoundationApi::class)
 
 package com.google.android.horologist.compose.pager
 
 import android.util.Log
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -36,11 +40,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.wear.compose.material.HorizontalPageIndicator
 import androidx.wear.compose.material.PageIndicatorState
-import com.google.accompanist.pager.ExperimentalPagerApi
-import com.google.accompanist.pager.HorizontalPager
-import com.google.accompanist.pager.PagerScope
-import com.google.accompanist.pager.PagerState
-import com.google.accompanist.pager.rememberPagerState
 import com.google.android.horologist.compose.focus.FocusControl
 import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 
@@ -56,14 +55,14 @@ public fun PagerScreen(
     count: Int,
     modifier: Modifier = Modifier,
     state: PagerState = rememberPagerState(),
-    content: @Composable (PagerScope.(Int) -> Unit)
+    content: @Composable ((Int) -> Unit)
 ) {
     val shape = if (LocalConfiguration.current.isScreenRound) CircleShape else null
 
     Box(
         modifier = Modifier.fillMaxSize()
     ) {
-        HorizontalPager(modifier = modifier, count = count, state = state) { page ->
+        HorizontalPager(modifier = modifier, pageCount = count, state = state) { page ->
             Box(
                 modifier = Modifier.fillMaxSize().run {
                     if (shape != null) {
@@ -79,7 +78,7 @@ public fun PagerScreen(
             }
         }
 
-        val pagerScreenState = remember { PageScreenIndicatorState(state) }
+        val pagerScreenState = remember { PageScreenIndicatorState(state, count) }
         HorizontalPageIndicator(
             modifier = Modifier.padding(6.dp),
             pageIndicatorState = pagerScreenState
@@ -94,12 +93,12 @@ public fun PagerScreen(
  * n.b. Currently fails for 0 pageCount, so enclose the HorizontalPageIndicator
  * in an if statement.
  */
-public class PageScreenIndicatorState(private val state: PagerState) : PageIndicatorState {
+public class PageScreenIndicatorState(
+    private val state: PagerState,
     override val pageCount: Int
-        get() = state.pageCount
-
+) : PageIndicatorState {
     override val pageOffset: Float
-        get() = state.currentPageOffset
+        get() = state.currentPageOffsetFraction.takeIf { it.isFinite() } ?: 0f
 
     override val selectedPage: Int
         get() = state.currentPage

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ app-cash-paparazzi = "1.1.0"
 benManes = "0.44.0"
 com-squareup-okhttp3 = "4.10.0"
 com-squareup-retrofit2 = "2.9.0"
-compose = "1.3.2"
+compose = "1.4.0-alpha03"
 compose-compiler = "1.3.2"
 composesnapshot = "-"
 dokka = "1.5.0"
@@ -46,10 +46,9 @@ room = "2.4.3"
 spotless = "6.12.0"
 truth = "1.1.3"
 versionCatalogUpdate = "0.7.0"
-wearcompose = "1.1.0"
+wearcompose = "1.2.0-alpha01"
 
 [libraries]
-accompanist-pager = "com.google.accompanist:accompanist-pager:0.28.0"
 affectedmoduledetector = { module = "com.dropbox.affectedmoduledetector:affectedmoduledetector", version.ref = "affectedmoduledetector" }
 android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "gradlePlugin" }
 android-tools-build-gradle = { module = "com.android.tools.build:gradle", version.ref = "gradlePlugin" }

--- a/media-sample/build.gradle
+++ b/media-sample/build.gradle
@@ -84,7 +84,6 @@ android {
         // Allow for widescale experimental APIs in Alpha libraries we build upon
         freeCompilerArgs += "-opt-in=androidx.compose.ui.ExperimentalComposeUiApi"
         freeCompilerArgs += "-opt-in=androidx.wear.compose.material.ExperimentalWearMaterialApi"
-        freeCompilerArgs += "-opt-in=com.google.accompanist.pager.ExperimentalPagerApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.audio.ExperimentalHorologistAudioApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.base.ui.ExperimentalHorologistBaseUiApi"

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
@@ -14,11 +14,15 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalFoundationApi::class)
+
 package com.google.android.horologist.mediasample.ui.app
 
 import android.content.Intent
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -29,7 +33,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavHostState
-import com.google.accompanist.pager.rememberPagerState
 import com.google.android.horologist.compose.navscaffold.scrollable
 import com.google.android.horologist.media.ui.navigation.MediaNavController.navigateToCollection
 import com.google.android.horologist.media.ui.navigation.MediaNavController.navigateToCollections

--- a/media-ui/build.gradle
+++ b/media-ui/build.gradle
@@ -44,7 +44,6 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
         freeCompilerArgs += "-opt-in=androidx.lifecycle.compose.ExperimentalLifecycleComposeApi"
-        freeCompilerArgs += "-opt-in=com.google.accompanist.pager.ExperimentalPagerApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.audio.ExperimentalHorologistAudioApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.base.ui.ExperimentalHorologistBaseUiApi"

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenPreview.kt
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistMediaUiApi::class, ExperimentalHorologistComposeToolsApi::class)
+@file:OptIn(ExperimentalHorologistMediaUiApi::class, ExperimentalHorologistComposeToolsApi::class,
+    ExperimentalFoundationApi::class
+)
 
 package com.google.android.horologist.media.ui.screens.player
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/navigation/MediaPlayerScaffold.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/navigation/MediaPlayerScaffold.kt
@@ -14,11 +14,16 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistAudioUiApi::class, ExperimentalPagerApi::class, ExperimentalLifecycleComposeApi::class)
+@file:OptIn(ExperimentalHorologistAudioUiApi::class, ExperimentalLifecycleComposeApi::class,
+    ExperimentalFoundationApi::class
+)
 
 package com.google.android.horologist.media.ui.navigation
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -29,9 +34,6 @@ import androidx.navigation.NavHostController
 import androidx.wear.compose.material.TimeText
 import androidx.wear.compose.navigation.SwipeDismissableNavHostState
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavHostState
-import com.google.accompanist.pager.ExperimentalPagerApi
-import com.google.accompanist.pager.PagerState
-import com.google.accompanist.pager.rememberPagerState
 import com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi
 import com.google.android.horologist.audio.ui.VolumeScreen
 import com.google.android.horologist.audio.ui.VolumeViewModel

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/playerlibrarypager/PlayerLibraryPagerScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/playerlibrarypager/PlayerLibraryPagerScreen.kt
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalPagerApi::class)
+@file:OptIn(ExperimentalFoundationApi::class)
 
 package com.google.android.horologist.media.ui.screens.playerlibrarypager
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.focusable
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
@@ -26,8 +28,6 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.navigation.NavBackStackEntry
 import androidx.wear.compose.material.PositionIndicator
 import androidx.wear.compose.material.Scaffold
-import com.google.accompanist.pager.ExperimentalPagerApi
-import com.google.accompanist.pager.PagerState
 import com.google.android.horologist.audio.VolumeState
 import com.google.android.horologist.audio.ui.VolumePositionIndicator
 import com.google.android.horologist.compose.focus.rememberActiveFocusRequester

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -67,7 +67,6 @@ android {
         freeCompilerArgs += "-opt-in=androidx.compose.ui.ExperimentalComposeUiApi"
         freeCompilerArgs += "-opt-in=androidx.lifecycle.compose.ExperimentalLifecycleComposeApi"
         freeCompilerArgs += "-opt-in=androidx.wear.compose.material.ExperimentalWearMaterialApi"
-        freeCompilerArgs += "-opt-in=com.google.accompanist.pager.ExperimentalPagerApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.audio.ExperimentalHorologistAudioApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.audio.ui.ExperimentalHorologistAudioUiApi"
         freeCompilerArgs += "-opt-in=com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi"

--- a/sample/src/main/java/com/google/android/horologist/navsample/NavWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/navsample/NavWearApp.kt
@@ -14,11 +14,15 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalFoundationApi::class)
+
 package com.google.android.horologist.navsample
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -34,7 +38,6 @@ import androidx.wear.compose.material.dialog.Alert
 import androidx.wear.compose.material.edgeSwipeToDismiss
 import androidx.wear.compose.material.rememberSwipeToDismissBoxState
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavHostState
-import com.google.accompanist.pager.rememberPagerState
 import com.google.android.horologist.audio.ui.VolumeScreen
 import com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel
 import com.google.android.horologist.compose.navscaffold.WearNavScaffold


### PR DESCRIPTION
#### WHAT

Experiment with Wear Compose pager

#### WHY

See what upgrade to Compose 1.4 and Wear Compose 1.2 would be like. 

#### HOW

Replace Accompanist pager with Compose foundation.

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
