### PR TITLE
Convert audio-ui module gradle file from Groovy DSL to Kotlin DSL

### DIFF
--- a/audio-ui/build.gradle.kts
+++ b/audio-ui/build.gradle.kts
@@ -20,10 +20,11 @@ plugins {
     id("org.jetbrains.dokka")
     id("org.jetbrains.kotlin.kapt")
     id("dev.chrisbanes.paparazzi")
+    id("me.tylerbwong.gradle.metalava")
 }
 
 android {
-    compileSdkVersion = 33
+    compileSdk = 33
 
     defaultConfig {
         minSdk = 25
@@ -50,38 +51,30 @@ android {
     }
     packagingOptions {
         resources {
-            excludes += [
+            excludes += listOf(
                 "/META-INF/AL2.0",
                 "/META-INF/LGPL2.1"
-            ]
+            )
         }
     }
 
     testOptions {
         unitTests {
-            includeAndroidResources = true
+            isIncludeAndroidResources = true
         }
         animationsDisabled = true
     }
 
-    sourceSets {
-        main {
-            assets.srcDirs = ["src/main/assets"]
-        }
-        test {
-            java.srcDirs += "src/sharedTest/kotlin"
-            res.srcDirs += "src/sharedTest/res"
-        }
-        androidTest {
-            java.srcDirs += "src/sharedTest/kotlin"
-            res.srcDirs += "src/sharedTest/res"
-        }
+    sourceSets.getByName("main") {
+        assets.srcDir("src/main/assets")
     }
+
     lint {
+        disable.addAll(listOf("MissingTranslation", "ExtraTranslation"))
         checkReleaseBuilds = false
         textReport = true
-        disable "MissingTranslation", "ExtraTranslation"
     }
+
     namespace = "com.google.android.horologist.audio.ui"
 }
 
@@ -89,17 +82,19 @@ kapt {
     correctErrorTypes = true
 }
 
-project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile.class).configureEach { task ->
+project.tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
     // Workaround for https://youtrack.jetbrains.com/issue/KT-37652
-    if (!task.name.endsWith("TestKotlin") && !task.name.startsWith("compileDebug")) {
-        task.kotlinOptions.freeCompilerArgs.add("-Xexplicit-api=strict")
+    if (!this.name.endsWith("TestKotlin") && !this.name.startsWith("compileDebug")) {
+        this.kotlinOptions {
+            freeCompilerArgs = freeCompilerArgs + "-Xexplicit-api=strict"
+        }
     }
 }
 
-apply plugin: "me.tylerbwong.gradle.metalava"
+apply(plugin = "me.tylerbwong.gradle.metalava")
 
 metalava {
-    sourcePaths = ["src/main"]
+    sourcePaths = mutableSetOf("src/main")
     filename = "api/current.api"
     reportLintsAsErrors = true
 }
@@ -136,4 +131,4 @@ dependencies {
     androidTestImplementation(libs.truth)
 }
 
-apply plugin: "com.vanniktech.maven.publish"
+apply(plugin = "com.vanniktech.maven.publish")


### PR DESCRIPTION
#### WHAT
Convert the `:audio-ui` module' gradle file to Kotlin DSL from Groovy DSL.

#### WHY
Following up #846 relating to #833 

#### HOW
Converting the file by changing the filename to use `.kts` then converting the content. Then syncing and running all the required gradle tasks. 

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
