### PR TITLE
Convert auth-data module gradle file to Kotlin DSL

### DIFF
--- a/auth-data/build.gradle.kts
+++ b/auth-data/build.gradle.kts
@@ -15,14 +15,15 @@
  */
 
 plugins {
-    id ("com.android.library")
-    id ("kotlin-android")
-    id ("org.jetbrains.dokka")
-    id ("com.google.devtools.ksp")
+    id("com.android.library")
+    id("kotlin-android")
+    id("org.jetbrains.dokka")
+    id("com.google.devtools.ksp")
+    id("me.tylerbwong.gradle.metalava")
 }
 
 android {
-    compileSdkVersion = 33
+    compileSdk = 33
 
     defaultConfig {
         minSdk = 26
@@ -47,16 +48,16 @@ android {
 
     packagingOptions {
         resources {
-            excludes += [
+            excludes += listOf(
                 "/META-INF/AL2.0",
                 "/META-INF/LGPL2.1"
-            ]
+            )
         }
     }
 
     testOptions {
         unitTests {
-            includeAndroidResources = true
+            isIncludeAndroidResources = true
         }
         animationsDisabled = true
     }
@@ -69,17 +70,17 @@ android {
     namespace = "com.google.android.horologist.auth.data"
 }
 
-project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile.class).configureEach { task ->
+project.tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
     // Workaround for https://youtrack.jetbrains.com/issue/KT-37652
-    if (!task.name.endsWith("TestKotlin") && !task.name.startsWith("compileDebug")) {
-        task.kotlinOptions.freeCompilerArgs.add("-Xexplicit-api=strict")
+    if (!this.name.endsWith("TestKotlin") && !this.name.startsWith("compileDebug")) {
+        this.kotlinOptions {
+            freeCompilerArgs = freeCompilerArgs + "-Xexplicit-api=strict"
+        }
     }
 }
 
-apply plugin: "me.tylerbwong.gradle.metalava"
-
 metalava {
-    sourcePaths = ["src/main"]
+    sourcePaths = mutableSetOf("src/main")
     filename = "api/current.api"
     reportLintsAsErrors = true
 }
@@ -109,4 +110,4 @@ dependencies {
 }
 
 // Not publishing it until it's ready
-//apply plugin: "com.vanniktech.maven.publish"
+//apply(plugin = "com.vanniktech.maven.publish")


### PR DESCRIPTION
#### WHAT
Convert the `:auth-data` module' gradle file to Kotlin DSL.

#### WHY
Following up #846 relating to #833 

#### HOW
Converting the file to`.kts` then converting the content. Making sure that it syncs properly and that the required gradle tasks pass.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
