### PR TITLE
Convert compose-layout module gradle file to Kotlin DSL

### DIFF
--- a/compose-layout/build.gradle.kts
+++ b/compose-layout/build.gradle.kts
@@ -19,10 +19,11 @@ plugins {
     id("kotlin-android")
     id("org.jetbrains.dokka")
     id("org.jetbrains.kotlin.kapt")
+    id("me.tylerbwong.gradle.metalava")
 }
 
 android {
-    compileSdkVersion = 33
+    compileSdk = 33
 
     defaultConfig {
         minSdk = 25
@@ -49,31 +50,20 @@ android {
     }
     packagingOptions {
         resources {
-            excludes += [
+            excludes += listOf(
                 "/META-INF/AL2.0",
                 "/META-INF/LGPL2.1"
-            ]
+            )
         }
     }
 
-
     testOptions {
         unitTests {
-            includeAndroidResources = true
+            isIncludeAndroidResources = true
         }
         animationsDisabled = true
     }
 
-    sourceSets {
-        test {
-            java.srcDirs += "src/sharedTest/kotlin"
-            res.srcDirs += "src/sharedTest/res"
-        }
-        androidTest {
-            java.srcDirs += "src/sharedTest/kotlin"
-            res.srcDirs += "src/sharedTest/res"
-        }
-    }
     lint {
         checkReleaseBuilds = false
         textReport = true
@@ -85,10 +75,8 @@ kapt {
     correctErrorTypes = true
 }
 
-apply plugin: "me.tylerbwong.gradle.metalava"
-
 metalava {
-    sourcePaths = ["src/main"]
+    sourcePaths = mutableSetOf("src/main")
     filename = "api/current.api"
     reportLintsAsErrors = true
 }
@@ -125,4 +113,4 @@ dependencies {
     androidTestImplementation(libs.junit)
 }
 
-apply plugin: "com.vanniktech.maven.publish"
+apply(plugin = "com.vanniktech.maven.publish")


### PR DESCRIPTION
#### WHAT
Convert the `:compose-layout` gradle file to Kotlin DSL

#### WHY
Following up #846  relating to #833 

#### HOW
Converting the filetype to `.kts` then converting the content. Then further, checking that it syncs correctly and that the required gradle tasks are passing.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
