### PR TITLE
Convert datalayer module gradle file to Kotlin DSL

### DIFF
--- a/datalayer/build.gradle.kts
+++ b/datalayer/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion = 33
+    compileSdk = 33
 
     defaultConfig {
         minSdk = 21
@@ -47,25 +47,25 @@ android {
     }
     packagingOptions {
         resources {
-            excludes += [
+            excludes += listOf(
                 "/META-INF/AL2.0",
                 "/META-INF/LGPL2.1"
-            ]
+            )
         }
     }
-
 
     testOptions {
         unitTests {
-            includeAndroidResources = true
+            isIncludeAndroidResources = true
         }
     }
+
     lint {
         checkReleaseBuilds = false
         textReport = true
-
-        baseline(file("quality/lint/lint-baseline.xml"))
+        baseline = file("quality/lint/lint-baseline.xml")
     }
+
     namespace = "com.google.android.horologist.datalayer"
 }
 
@@ -91,4 +91,4 @@ dependencies {
     androidTestImplementation(libs.truth)
 }
 
-apply plugin: "com.vanniktech.maven.publish"
+apply(plugin = "com.vanniktech.maven.publish")

--- a/datalayer/quality/lint/lint-baseline.xml
+++ b/datalayer/quality/lint/lint-baseline.xml
@@ -7,7 +7,7 @@
         errorLine1="        targetSdk 30"
         errorLine2="        ~~~~~~~~~~~~">
         <location
-            file="build.gradle"
+            file="build.gradle.kts"
             line="28"
             column="9"/>
     </issue>


### PR DESCRIPTION
#### WHAT
Convert the `:datalayer` module' gradle file to Kotlin DSL

#### WHY
Following up #846 relating to #833 

#### HOW
Converting the file to `.kts` then converting the content. Then checking that the project syncs and that the required gradle tasks passes.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
