### PR TITLE
Convert the media module gradle file to Kotlin DSL

### DIFF
--- a/media/build.gradle.kts
+++ b/media/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     id("java-library")
     id("org.jetbrains.kotlin.jvm")
     id("org.jetbrains.dokka")
+    id("me.tylerbwong.gradle.metalava")
 }
 
 java {
@@ -25,10 +26,8 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-apply plugin: "me.tylerbwong.gradle.metalava"
-
 metalava {
-    sourcePaths = ["src/main"]
+    sourcePaths = mutableSetOf("src/main")
     filename = "api/current.api"
     reportLintsAsErrors = true
 }
@@ -40,4 +39,4 @@ dependencies {
     testImplementation(libs.truth)
 }
 
-apply plugin: "com.vanniktech.maven.publish"
+apply(plugin = "com.vanniktech.maven.publish")


### PR DESCRIPTION
#### WHAT
Convert the `:media` module' gradle file to Kotlin DSL.

#### WHY
Following up #846 relating to #833 

#### HOW
Converting the file type to `.kts` then converting the content. Then checking that it syncs and that the required gradle tasks are passing.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
