### PR TITLE
Convert media-benchmark module gradle file to Kotlin DSL

### DIFF
--- a/media-benchmark/build.gradle.kts
+++ b/media-benchmark/build.gradle.kts
@@ -17,10 +17,11 @@
 plugins {
     id("com.android.library")
     id("kotlin-android")
+    id("me.tylerbwong.gradle.metalava")
 }
 
 android {
-    compileSdkVersion = 33
+    compileSdk = 33
 
     defaultConfig {
         minSdk = 28
@@ -41,16 +42,16 @@ android {
 
     packagingOptions {
         resources {
-            excludes += [
+            excludes += listOf(
                 "/META-INF/AL2.0",
                 "/META-INF/LGPL2.1"
-            ]
+            )
         }
     }
 
     testOptions {
         unitTests {
-            includeAndroidResources = true
+            isIncludeAndroidResources = true
         }
         animationsDisabled = true
     }
@@ -58,29 +59,35 @@ android {
     lint {
         checkReleaseBuilds = false
         textReport = true
-        disable("MissingTranslation", "ExtraTranslation")
+        disable.addAll(listOf("MissingTranslation", "ExtraTranslation"))
     }
 
     namespace = "com.google.android.horologist.media.benchmark"
 }
 
-project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile.class).configureEach { task ->
+project.tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
     // Workaround for https://youtrack.jetbrains.com/issue/KT-37652
-    if (!task.name.endsWith("TestKotlin") && !task.name.startsWith("compileDebug")) {
-        task.kotlinOptions.freeCompilerArgs.add("-Xexplicit-api=strict")
+    if (!this.name.endsWith("TestKotlin") && !this.name.startsWith("compileDebug")) {
+        this.kotlinOptions {
+            freeCompilerArgs = freeCompilerArgs + "-Xexplicit-api=strict"
+        }
     }
 }
 
-apply plugin: "me.tylerbwong.gradle.metalava"
-
 metalava {
-    sourcePaths = ["src/main"]
+    sourcePaths = mutableSetOf("src/main")
     filename = "api/current.api"
     reportLintsAsErrors = true
 }
 
 dependencies {
-    api(projectOrDependency(":media-lib-session", libs.androidx.media3.session))
+
+    if (project.findProject(":media-lib-session") != null) {
+        api(project(":media-lib-session"))
+    } else {
+        api(libs.androidx.media3.session)
+    }
+
     api(libs.espresso.core)
     implementation(libs.androidx.test.ext.ktx)
     api(libs.androidx.test.uiautomator)
@@ -92,4 +99,4 @@ dependencies {
 }
 
 // Not publishing it until it's ready
-//apply plugin: "com.vanniktech.maven.publish"
+//apply(plugin = "com.vanniktech.maven.publish")


### PR DESCRIPTION
#### WHAT
Convert the `:media-benchmark` module gradle file to Kotlin DSL.

#### WHY
Following up #846 relating to #833 

#### HOW
Converting the file to `.kts` then converting the content and checking that it syncs and that the required gradle tasks are passing.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
