### PR TITLE
Convert media-sample-benchmark gradle file to Kotlin DSL

### DIFF
--- a/media-sample-benchmark/build.gradle.kts
+++ b/media-sample-benchmark/build.gradle.kts
@@ -43,11 +43,11 @@ android {
         // This benchmark buildType is used for benchmarking, and should function like your
         // release build (for example, with minification on). It's signed with a debug key
         // for easy local/CI testing.
-        benchmark {
-            debuggable = true
-            signingConfig = debug.signingConfig
+        create("benchmark") {
+            isDebuggable = true
+            signingConfig = getByName("debug").signingConfig
 
-            matchingFallbacks = ["release"]
+            matchingFallbacks.add("release")
         }
     }
 
@@ -63,11 +63,11 @@ dependencies {
     implementation(libs.espresso.core)
     implementation(libs.androidx.test.uiautomator)
     implementation(libs.kotlinx.coroutines.android)
-    implementation(projectOrDependency(":media-lib-session", libs.androidx.media3.session))
+    implementation(project.findProject(":media-lib-session") ?: libs.androidx.media3.session)
 }
 
 androidComponents {
     beforeVariants(selector().all()) {
-        enabled = buildType == "benchmark"
+        it.enabled = it.buildType == "benchmark"
     }
 }


### PR DESCRIPTION
#### WHAT
Convert the `:media-sample-benchmark` module' gradle file to Kotlin DSL.

#### WHY
Following up #846 relating to #833 .

#### HOW
Converting the file to `.kts` then converting the content and checking that It syncs correctly. Then running all the required gradle tasks and checking that it passes.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
