### PR TITLE
Add paparazzi extension function to wrap snapshot in a box

### DIFF
--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonTest.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonTest.kt
@@ -18,12 +18,8 @@
 
 package com.google.android.horologist.audio.ui.components.actions
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import com.google.android.horologist.audio.VolumeState
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi
 import org.junit.Rule
@@ -38,13 +34,11 @@ class SetVolumeButtonTest {
     fun givenCurrentVolumeIsNotMaxAndNotMin_thenIconIsVolumeDown() {
         val currentVolume = 5
 
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                SetVolumeButton(
-                    onVolumeClick = {},
-                    volumeState = VolumeState(current = currentVolume, max = 10)
-                )
-            }
+        paparazzi.snapshotInABox {
+            SetVolumeButton(
+                onVolumeClick = {},
+                volumeState = VolumeState(current = currentVolume, max = 10)
+            )
         }
     }
 
@@ -52,26 +46,22 @@ class SetVolumeButtonTest {
     fun givenCurrentVolumeIsMinimum_thenIconIsVolumeMute() {
         val currentVolume = 0
 
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                SetVolumeButton(
-                    onVolumeClick = {},
-                    volumeState = VolumeState(current = currentVolume, max = 10)
-                )
-            }
+        paparazzi.snapshotInABox {
+            SetVolumeButton(
+                onVolumeClick = {},
+                volumeState = VolumeState(current = currentVolume, max = 10)
+            )
         }
     }
 
     @Test
     fun givenCurrentVolumeIsMaximum_thenIconIsVolumeUp() {
         val currentVolume = 10
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                SetVolumeButton(
-                    onVolumeClick = {},
-                    volumeState = VolumeState(current = currentVolume, max = currentVolume)
-                )
-            }
+        paparazzi.snapshotInABox {
+            SetVolumeButton(
+                onVolumeClick = {},
+                volumeState = VolumeState(current = currentVolume, max = currentVolume)
+            )
         }
     }
 }

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/CreateAccountChipTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/CreateAccountChipTest.kt
@@ -21,13 +21,9 @@
 
 package com.google.android.horologist.auth.composables.chips
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
 import com.google.android.horologist.base.ui.components.StandardChipType
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi
 import org.junit.Rule
@@ -40,59 +36,39 @@ class CreateAccountChipTest {
 
     @Test
     fun default() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                CreateAccountChip(onClick = {})
-            }
+        paparazzi.snapshotInABox {
+            CreateAccountChip(onClick = {})
         }
     }
 
     @Test
     fun disabled() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                CreateAccountChip(
-                    onClick = {},
-                    enabled = false
-                )
-            }
+        paparazzi.snapshotInABox {
+            CreateAccountChip(
+                onClick = {},
+                enabled = false
+            )
         }
     }
 
     @Test
     fun withSecondaryChipType() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                CreateAccountChip(
-                    onClick = {},
-                    chipType = StandardChipType.Secondary
-                )
-            }
+        paparazzi.snapshotInABox {
+            CreateAccountChip(
+                onClick = {},
+                chipType = StandardChipType.Secondary
+            )
         }
     }
 
     @Test
     fun withSecondaryChipTypeDisabled() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                CreateAccountChip(
-                    onClick = {},
-                    chipType = StandardChipType.Secondary,
-                    enabled = false
-                )
-            }
+        paparazzi.snapshotInABox {
+            CreateAccountChip(
+                onClick = {},
+                chipType = StandardChipType.Secondary,
+                enabled = false
+            )
         }
     }
 }

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/GuestModeChipTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/GuestModeChipTest.kt
@@ -21,13 +21,9 @@
 
 package com.google.android.horologist.auth.composables.chips
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
 import com.google.android.horologist.base.ui.components.StandardChipType
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi
 import org.junit.Rule
@@ -40,59 +36,39 @@ class GuestModeChipTest {
 
     @Test
     fun default() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                GuestModeChip(onClick = {})
-            }
+        paparazzi.snapshotInABox {
+            GuestModeChip(onClick = {})
         }
     }
 
     @Test
     fun disabled() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                GuestModeChip(
-                    onClick = {},
-                    enabled = false
-                )
-            }
+        paparazzi.snapshotInABox {
+            GuestModeChip(
+                onClick = {},
+                enabled = false
+            )
         }
     }
 
     @Test
     fun withSecondaryChipType() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                GuestModeChip(
-                    onClick = {},
-                    chipType = StandardChipType.Secondary
-                )
-            }
+        paparazzi.snapshotInABox {
+            GuestModeChip(
+                onClick = {},
+                chipType = StandardChipType.Secondary
+            )
         }
     }
 
     @Test
     fun withSecondaryChipTypeDisabled() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                GuestModeChip(
-                    onClick = {},
-                    chipType = StandardChipType.Secondary,
-                    enabled = false
-                )
-            }
+        paparazzi.snapshotInABox {
+            GuestModeChip(
+                onClick = {},
+                chipType = StandardChipType.Secondary,
+                enabled = false
+            )
         }
     }
 }

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/OtherOptionsChipTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/OtherOptionsChipTest.kt
@@ -21,13 +21,9 @@
 
 package com.google.android.horologist.auth.composables.chips
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
 import com.google.android.horologist.base.ui.components.StandardChipType
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi
 import org.junit.Rule
@@ -40,59 +36,39 @@ class OtherOptionsChipTest {
 
     @Test
     fun default() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                OtherOptionsChip(onClick = {})
-            }
+        paparazzi.snapshotInABox {
+            OtherOptionsChip(onClick = {})
         }
     }
 
     @Test
     fun disabled() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                OtherOptionsChip(
-                    onClick = {},
-                    enabled = false
-                )
-            }
+        paparazzi.snapshotInABox {
+            OtherOptionsChip(
+                onClick = {},
+                enabled = false
+            )
         }
     }
 
     @Test
     fun withSecondaryChipType() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                OtherOptionsChip(
-                    onClick = {},
-                    chipType = StandardChipType.Secondary
-                )
-            }
+        paparazzi.snapshotInABox {
+            OtherOptionsChip(
+                onClick = {},
+                chipType = StandardChipType.Secondary
+            )
         }
     }
 
     @Test
     fun withSecondaryChipTypeDisabled() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                OtherOptionsChip(
-                    onClick = {},
-                    chipType = StandardChipType.Secondary,
-                    enabled = false
-                )
-            }
+        paparazzi.snapshotInABox {
+            OtherOptionsChip(
+                onClick = {},
+                chipType = StandardChipType.Secondary,
+                enabled = false
+            )
         }
     }
 }

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/SignInChipTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/SignInChipTest.kt
@@ -21,13 +21,9 @@
 
 package com.google.android.horologist.auth.composables.chips
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
 import com.google.android.horologist.base.ui.components.StandardChipType
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi
 import org.junit.Rule
@@ -40,59 +36,39 @@ class SignInChipTest {
 
     @Test
     fun default() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                SignInChip(onClick = {})
-            }
+        paparazzi.snapshotInABox {
+            SignInChip(onClick = {})
         }
     }
 
     @Test
     fun disabled() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                SignInChip(
-                    onClick = {},
-                    enabled = false
-                )
-            }
+        paparazzi.snapshotInABox {
+            SignInChip(
+                onClick = {},
+                enabled = false
+            )
         }
     }
 
     @Test
     fun withSecondaryChipType() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                SignInChip(
-                    onClick = {},
-                    chipType = StandardChipType.Secondary
-                )
-            }
+        paparazzi.snapshotInABox {
+            SignInChip(
+                onClick = {},
+                chipType = StandardChipType.Secondary
+            )
         }
     }
 
     @Test
     fun withSecondaryChipTypeDisabled() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                SignInChip(
-                    onClick = {},
-                    chipType = StandardChipType.Secondary,
-                    enabled = false
-                )
-            }
+        paparazzi.snapshotInABox {
+            SignInChip(
+                onClick = {},
+                chipType = StandardChipType.Secondary,
+                enabled = false
+            )
         }
     }
 }

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogTest.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi
 import org.junit.Rule
@@ -58,78 +59,53 @@ class SignedInConfirmationDialogTest {
 
     @Test
     fun signedInConfirmationDialogNoName() {
-        paparazzi.snapshot {
+        paparazzi.snapshotInABox {
             FakeImageLoader.Resources.override {
-                Box(
-                    modifier = Modifier.background(Color.Black),
-                    contentAlignment = Alignment.Center
-                ) {
-                    SignedInConfirmationDialogContent(
-                        email = "maggie@example.com",
-                        avatar = android.R.drawable.sym_def_app_icon
-                    )
-                }
-            }
-        }
-    }
-
-    @Test
-    fun signedInConfirmationDialogNoNameNoAvatar() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
                 SignedInConfirmationDialogContent(
-                    email = "maggie@example.com"
+                    email = "maggie@example.com",
+                    avatar = android.R.drawable.sym_def_app_icon
                 )
             }
         }
     }
 
     @Test
+    fun signedInConfirmationDialogNoNameNoAvatar() {
+        paparazzi.snapshotInABox {
+            SignedInConfirmationDialogContent(
+                email = "maggie@example.com"
+            )
+        }
+    }
+
+    @Test
     fun signedInConfirmationDialogNoEmail() {
-        paparazzi.snapshot {
+        paparazzi.snapshotInABox {
             FakeImageLoader.Resources.override {
-                Box(
-                    modifier = Modifier.background(Color.Black),
-                    contentAlignment = Alignment.Center
-                ) {
-                    SignedInConfirmationDialogContent(
-                        displayName = "Maggie",
-                        avatar = android.R.drawable.sym_def_app_icon
-                    )
-                }
+                SignedInConfirmationDialogContent(
+                    displayName = "Maggie",
+                    avatar = android.R.drawable.sym_def_app_icon
+                )
             }
         }
     }
 
     @Test
     fun signedInConfirmationDialogNoInformation() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                SignedInConfirmationDialogContent()
-            }
+        paparazzi.snapshotInABox {
+            SignedInConfirmationDialogContent()
         }
     }
 
     @Test
     fun signedInConfirmationDialogTruncation() {
-        paparazzi.snapshot {
+        paparazzi.snapshotInABox {
             FakeImageLoader.Resources.override {
-                Box(
-                    modifier = Modifier.background(Color.Black),
-                    contentAlignment = Alignment.Center
-                ) {
-                    SignedInConfirmationDialogContent(
-                        displayName = "Wolfeschlegelsteinhausenbergerdorff",
-                        email = "wolfeschlegelsteinhausenbergerdorff@example.com",
-                        avatar = android.R.drawable.sym_def_app_icon
-                    )
-                }
+                SignedInConfirmationDialogContent(
+                    displayName = "Wolfeschlegelsteinhausenbergerdorff",
+                    email = "wolfeschlegelsteinhausenbergerdorff@example.com",
+                    avatar = android.R.drawable.sym_def_app_icon
+                )
             }
         }
     }

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/screens/AuthErrorScreenTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/screens/AuthErrorScreenTest.kt
@@ -21,12 +21,8 @@
 
 package com.google.android.horologist.auth.composables.screens
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi
 import org.junit.Rule
@@ -39,13 +35,8 @@ class AuthErrorScreenTest {
 
     @Test
     fun authErrorScreen() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                AuthErrorScreen()
-            }
+        paparazzi.snapshotInABox {
+            AuthErrorScreen()
         }
     }
 }

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/screens/SelectAccountScreenTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/screens/SelectAccountScreenTest.kt
@@ -21,15 +21,11 @@
 
 package com.google.android.horologist.auth.composables.screens
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Face
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
 import com.google.android.horologist.auth.composables.model.AccountUiModel
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi
 import com.google.android.horologist.test.toolbox.positionedState
@@ -43,43 +39,33 @@ class SelectAccountScreenTest {
 
     @Test
     fun selectAccountScreen() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                SelectAccountScreen(
-                    accounts = listOf(
-                        AccountUiModel(
-                            email = "maggie@example.com",
-                            avatar = Icons.Default.Face
-                        ),
-                        AccountUiModel(email = "thisisaverylongemail@example.com")
+        paparazzi.snapshotInABox {
+            SelectAccountScreen(
+                accounts = listOf(
+                    AccountUiModel(
+                        email = "maggie@example.com",
+                        avatar = Icons.Default.Face
                     ),
-                    onAccountClicked = { _, _ -> },
-                    columnState = positionedState(0, 0)
-                )
-            }
+                    AccountUiModel(email = "thisisaverylongemail@example.com")
+                ),
+                onAccountClicked = { _, _ -> },
+                columnState = positionedState(0, 0)
+            )
         }
     }
 
     @Test
     fun selectAccountScreenNoAvatar() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                SelectAccountScreen(
-                    accounts = listOf(
-                        AccountUiModel(email = "maggie@example.com"),
-                        AccountUiModel(email = "thisisaverylongemailaccountsample@example.com")
-                    ),
-                    onAccountClicked = { _, _ -> },
-                    columnState = positionedState(0, 0),
-                    defaultAvatar = null
-                )
-            }
+        paparazzi.snapshotInABox {
+            SelectAccountScreen(
+                accounts = listOf(
+                    AccountUiModel(email = "maggie@example.com"),
+                    AccountUiModel(email = "thisisaverylongemailaccountsample@example.com")
+                ),
+                onAccountClicked = { _, _ -> },
+                columnState = positionedState(0, 0),
+                defaultAvatar = null
+            )
         }
     }
 }

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/screens/SignInPlaceholderScreenTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/screens/SignInPlaceholderScreenTest.kt
@@ -21,12 +21,8 @@
 
 package com.google.android.horologist.auth.composables.screens
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi
 import org.junit.Rule
@@ -39,13 +35,8 @@ class SignInPlaceholderScreenTest {
 
     @Test
     fun signInPlaceholderScreen() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                SignInPlaceholderScreen()
-            }
+        paparazzi.snapshotInABox {
+            SignInPlaceholderScreen()
         }
     }
 }

--- a/base-ui/src/test/java/com/google/android/horologist/base/ui/components/PrimaryChipTest.kt
+++ b/base-ui/src/test/java/com/google/android/horologist/base/ui/components/PrimaryChipTest.kt
@@ -18,14 +18,10 @@
 
 package com.google.android.horologist.base.ui.components
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.materialPath
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalInspectionMode
@@ -33,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import com.google.android.horologist.base.ui.ExperimentalHorologistBaseUiApi
 import com.google.android.horologist.base.ui.util.rememberVectorPainter
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi
 import org.junit.Rule
@@ -45,215 +42,182 @@ class PrimaryChipTest {
 
     @Test
     fun default() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { }
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { }
+            )
         }
     }
 
     @Test
     fun withSecondaryLabel() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    secondaryLabel = "Secondary label"
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                secondaryLabel = "Secondary label"
+            )
         }
     }
 
     @Test
     fun withIcon() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    icon = Icons.Default.Image
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                icon = Icons.Default.Image
+            )
         }
     }
 
     @Test
     fun withLargeIcon() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    icon = Icon32dp,
-                    largeIcon = true
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                icon = Icon32dp,
+                largeIcon = true
+            )
         }
     }
 
     @Test
     fun withSecondaryLabelAndIcon() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    secondaryLabel = "Secondary label",
-                    icon = Icons.Default.Image
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                secondaryLabel = "Secondary label",
+                icon = Icons.Default.Image
+            )
         }
     }
 
     @Test
     fun withSecondaryLabelAndLargeIcon() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    secondaryLabel = "Secondary label",
-                    icon = Icon32dp,
-                    largeIcon = true
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                secondaryLabel = "Secondary label",
+                icon = Icon32dp,
+                largeIcon = true
+            )
         }
     }
 
     @Test
     fun disabled() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    secondaryLabel = "Secondary label",
-                    icon = Icons.Default.Image,
-                    enabled = false
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                secondaryLabel = "Secondary label",
+                icon = Icons.Default.Image,
+                enabled = false
+            )
         }
     }
 
     @Test
     fun withLongText() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label very very very very very very very very very very very very very very very very very long text",
-                    onClick = { }
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label very very very very very very very very very very very very very very very very very long text",
+                onClick = { }
+            )
         }
     }
 
     @Test
     fun withSecondaryLabelAndLongText() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label very very very very very very very very long text",
-                    onClick = { },
-                    secondaryLabel = "Secondary label very very very very very very very very very long text",
-                    icon = Icons.Default.Image
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label very very very very very very very very long text",
+                onClick = { },
+                secondaryLabel = "Secondary label very very very very very very very very very long text",
+                icon = Icons.Default.Image
+            )
         }
     }
 
     @Test
     fun usingSmallIcon() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    icon = Icon12dp
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                icon = Icon12dp
+            )
         }
     }
 
     @Test
     fun withLargeIconUsingSmallIcon() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    icon = Icon12dp,
-                    largeIcon = true
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                icon = Icon12dp,
+                largeIcon = true
+            )
         }
     }
 
     @Test
     fun usingExtraLargeIcon() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    icon = Icon48dp
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                icon = Icon48dp
+            )
         }
     }
 
     @Test
     fun withLargeIconUsingExtraLargeIcon() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    icon = Icon48dp,
-                    largeIcon = true
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                icon = Icon48dp,
+                largeIcon = true
+            )
         }
     }
 
     @Test
     fun withPlaceholderIcon() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    icon = Icons.Default.Image
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                icon = Icons.Default.Image
+            )
         }
     }
 
     @Test
     fun disabledWithIconPlaceholder() {
-        paparazzi.snapshot {
+        paparazzi.snapshotInABox {
             FakeImageLoader.Never.override {
                 // In inspection mode will jump to placeholder
                 CompositionLocalProvider(LocalInspectionMode.provides(true)) {
-                    Box(
-                        modifier = Modifier.background(Color.Black),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        StandardChip(
-                            label = "Primary label",
-                            onClick = { },
-                            secondaryLabel = "Secondary label",
-                            icon = "iconUri",
-                            placeholder = rememberVectorPainter(
-                                image = Icons.Default.Image,
-                                tintColor = Color.Black
-                            ),
-                            enabled = false
-                        )
-                    }
+                    StandardChip(
+                        label = "Primary label",
+                        onClick = { },
+                        secondaryLabel = "Secondary label",
+                        icon = "iconUri",
+                        placeholder = rememberVectorPainter(
+                            image = Icons.Default.Image,
+                            tintColor = Color.Black
+                        ),
+                        enabled = false
+                    )
                 }
             }
         }

--- a/base-ui/src/test/java/com/google/android/horologist/base/ui/components/SecondaryChipTest.kt
+++ b/base-ui/src/test/java/com/google/android/horologist/base/ui/components/SecondaryChipTest.kt
@@ -25,7 +25,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.materialPath
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -34,6 +33,7 @@ import androidx.compose.ui.unit.dp
 import com.google.android.horologist.base.ui.ExperimentalHorologistBaseUiApi
 import com.google.android.horologist.base.ui.util.rememberVectorPainter
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi
 import org.junit.Rule
@@ -46,272 +46,235 @@ class SecondaryChipTest {
 
     @Test
     fun default() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    chipType = StandardChipType.Secondary
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                chipType = StandardChipType.Secondary
+            )
         }
     }
 
     @Test
     fun withSecondaryLabel() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    secondaryLabel = "Secondary label",
-                    chipType = StandardChipType.Secondary
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                secondaryLabel = "Secondary label",
+                chipType = StandardChipType.Secondary
+            )
         }
     }
 
     @Test
     fun withIcon() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    icon = Icons.Default.Image,
-                    chipType = StandardChipType.Secondary
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                icon = Icons.Default.Image,
+                chipType = StandardChipType.Secondary
+            )
         }
     }
 
     @Test
     fun withLargeIcon() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    icon = Icon32dp,
-                    largeIcon = true,
-                    chipType = StandardChipType.Secondary
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                icon = Icon32dp,
+                largeIcon = true,
+                chipType = StandardChipType.Secondary
+            )
         }
     }
 
     @Test
     fun withSecondaryLabelAndIcon() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    secondaryLabel = "Secondary label",
-                    icon = Icons.Default.Image,
-                    chipType = StandardChipType.Secondary
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                secondaryLabel = "Secondary label",
+                icon = Icons.Default.Image,
+                chipType = StandardChipType.Secondary
+            )
         }
     }
 
     @Test
     fun withSecondaryLabelAndLargeIcon() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    secondaryLabel = "Secondary label",
-                    icon = Icon32dp,
-                    largeIcon = true,
-                    chipType = StandardChipType.Secondary
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                secondaryLabel = "Secondary label",
+                icon = Icon32dp,
+                largeIcon = true,
+                chipType = StandardChipType.Secondary
+            )
         }
     }
 
     @Test
     fun disabled() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    secondaryLabel = "Secondary label",
-                    icon = Icons.Default.Image,
-                    chipType = StandardChipType.Secondary,
-                    enabled = false
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                secondaryLabel = "Secondary label",
+                icon = Icons.Default.Image,
+                chipType = StandardChipType.Secondary,
+                enabled = false
+            )
         }
     }
 
     @Test
     fun withLongText() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label very very very very very very very very very very very very very very very very very long text",
-                    onClick = { },
-                    chipType = StandardChipType.Secondary
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label very very very very very very very very very very very very very very very very very long text",
+                onClick = { },
+                chipType = StandardChipType.Secondary
+            )
         }
     }
 
     @Test
     fun withSecondaryLabelAndLongText() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label very very very very very very very very long text",
-                    onClick = { },
-                    secondaryLabel = "Secondary label very very very very very very very very very long text",
-                    icon = Icons.Default.Image,
-                    chipType = StandardChipType.Secondary
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label very very very very very very very very long text",
+                onClick = { },
+                secondaryLabel = "Secondary label very very very very very very very very very long text",
+                icon = Icons.Default.Image,
+                chipType = StandardChipType.Secondary
+            )
         }
     }
 
     @Test
     fun usingSmallIcon() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    icon = Icon12dp,
-                    chipType = StandardChipType.Secondary
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                icon = Icon12dp,
+                chipType = StandardChipType.Secondary
+            )
         }
     }
 
     @Test
     fun withLargeIconUsingSmallIcon() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    icon = Icon12dp,
-                    largeIcon = true,
-                    chipType = StandardChipType.Secondary
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                icon = Icon12dp,
+                largeIcon = true,
+                chipType = StandardChipType.Secondary
+            )
         }
     }
 
     @Test
     fun usingExtraLargeIcon() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    icon = Icon48dp,
-                    chipType = StandardChipType.Secondary
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                icon = Icon48dp,
+                chipType = StandardChipType.Secondary
+            )
         }
     }
 
     @Test
     fun withLargeIconUsingExtraLargeIcon() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    icon = Icon48dp,
-                    largeIcon = true,
-                    chipType = StandardChipType.Secondary
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                icon = Icon48dp,
+                largeIcon = true,
+                chipType = StandardChipType.Secondary
+            )
         }
     }
 
     @Test
     fun withPlaceholderIcon() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    icon = Icons.Default.Image,
-                    chipType = StandardChipType.Secondary
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                icon = Icons.Default.Image,
+                chipType = StandardChipType.Secondary
+            )
         }
     }
 
     @Test
     fun withProgressIcon() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    icon = {
-                        StandardChipIconWithProgress(
-                            progress = 75f,
-                            icon = Icon48dp,
-                            largeIcon = true
-                        )
-                    },
-                    chipType = StandardChipType.Secondary
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                icon = {
+                    StandardChipIconWithProgress(
+                        progress = 75f,
+                        icon = Icon48dp,
+                        largeIcon = true
+                    )
+                },
+                chipType = StandardChipType.Secondary
+            )
         }
     }
 
     @Test
     fun withSquareIcon() {
-        paparazzi.snapshot {
+        paparazzi.snapshotInABox {
             // This was made to showcase that the icon can be any composable in this version of
             // StandardChip.
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChip(
-                    label = "Primary label",
-                    onClick = { },
-                    icon = {
-                        Box(
-                            Modifier
-                                .size(32.dp)
-                                .background(Color.White)
-                        )
-                    },
-                    chipType = StandardChipType.Secondary
-                )
-            }
+            StandardChip(
+                label = "Primary label",
+                onClick = { },
+                icon = {
+                    Box(
+                        Modifier
+                            .size(32.dp)
+                            .background(Color.White)
+                    )
+                },
+                chipType = StandardChipType.Secondary
+            )
         }
     }
 
     @Test
     fun disabledWithIconPlaceholder() {
-        paparazzi.snapshot {
+        paparazzi.snapshotInABox {
             FakeImageLoader.Never.override {
                 // In inspection mode will jump to placeholder
                 CompositionLocalProvider(LocalInspectionMode.provides(true)) {
-                    Box(
-                        modifier = Modifier.background(Color.Black),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        StandardChip(
-                            label = "Primary label",
-                            onClick = { },
-                            secondaryLabel = "Secondary label",
-                            icon = "iconUri",
-                            placeholder = rememberVectorPainter(
-                                image = Icons.Default.Image,
-                                tintColor = Color.Black
-                            ),
-                            chipType = StandardChipType.Secondary,
-                            enabled = false
-                        )
-                    }
+                    StandardChip(
+                        label = "Primary label",
+                        onClick = { },
+                        secondaryLabel = "Secondary label",
+                        icon = "iconUri",
+                        placeholder = rememberVectorPainter(
+                            image = Icons.Default.Image,
+                            tintColor = Color.Black
+                        ),
+                        chipType = StandardChipType.Secondary,
+                        enabled = false
+                    )
                 }
             }
         }

--- a/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardButtonTest.kt
+++ b/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardButtonTest.kt
@@ -18,14 +18,10 @@
 
 package com.google.android.horologist.base.ui.components
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import com.google.android.horologist.base.ui.ExperimentalHorologistBaseUiApi
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi
 import org.junit.Rule
@@ -49,17 +45,15 @@ internal class StandardButtonTest(
 
     @Test
     fun variants() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardButton(
-                    imageVector = Icons.Default.Check,
-                    contentDescription = "contentDescription",
-                    onClick = { },
-                    buttonType = buttonType,
-                    buttonSize = buttonSize,
-                    enabled = enabled
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardButton(
+                imageVector = Icons.Default.Check,
+                contentDescription = "contentDescription",
+                onClick = { },
+                buttonType = buttonType,
+                buttonSize = buttonSize,
+                enabled = enabled
+            )
         }
     }
 

--- a/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardChipIconWithProgressTest.kt
+++ b/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardChipIconWithProgressTest.kt
@@ -18,16 +18,12 @@
 
 package com.google.android.horologist.base.ui.components
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.material.icons.materialPath
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import com.google.android.horologist.base.ui.ExperimentalHorologistBaseUiApi
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi
 import org.junit.Rule
@@ -42,43 +38,35 @@ class StandardChipIconWithProgressTest {
 
     @Test
     fun default() {
-        paparazzi.snapshot {
+        paparazzi.snapshotInABox {
             FakeImageLoader.NotFound.override {
-                Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                    StandardChipIconWithProgress(progress = 75f)
-                }
+                StandardChipIconWithProgress(progress = 75f)
             }
         }
     }
 
     @Test
     fun withProgressSmallIcon() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChipIconWithProgress(progress = 75f, icon = Icon12dp)
-            }
+        paparazzi.snapshotInABox {
+            StandardChipIconWithProgress(progress = 75f, icon = Icon12dp)
         }
     }
 
     @Test
     fun withProgressMediumIcon() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChipIconWithProgress(progress = 75f, icon = Icon32dp)
-            }
+        paparazzi.snapshotInABox {
+            StandardChipIconWithProgress(progress = 75f, icon = Icon32dp)
         }
     }
 
     @Test
     fun withProgressLargeIcon() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                StandardChipIconWithProgress(
-                    progress = 75f,
-                    icon = Icon48dp,
-                    largeIcon = true
-                )
-            }
+        paparazzi.snapshotInABox {
+            StandardChipIconWithProgress(
+                progress = 75f,
+                icon = Icon48dp,
+                largeIcon = true
+            )
         }
     }
 

--- a/base-ui/src/test/java/com/google/android/horologist/base/ui/components/TitleTest.kt
+++ b/base-ui/src/test/java/com/google/android/horologist/base/ui/components/TitleTest.kt
@@ -18,12 +18,8 @@
 
 package com.google.android.horologist.base.ui.components
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import com.google.android.horologist.base.ui.ExperimentalHorologistBaseUiApi
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi
 import org.junit.Rule
@@ -38,19 +34,15 @@ class TitleTest {
 
     @Test
     fun default() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                Title("Title")
-            }
+        paparazzi.snapshotInABox {
+            Title("Title")
         }
     }
 
     @Test
     fun withVeryLongText() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                Title("Title with a very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very long text")
-            }
+        paparazzi.snapshotInABox {
+            Title("Title with a very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very long text")
         }
     }
 }

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/PlaceholderChipTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/PlaceholderChipTest.kt
@@ -18,12 +18,8 @@
 
 package com.google.android.horologist.composables
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.wear.compose.material.ChipDefaults
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi
 import org.junit.Rule
@@ -35,19 +31,15 @@ class PlaceholderChipTest {
 
     @Test
     fun default() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                PlaceholderChip()
-            }
+        paparazzi.snapshotInABox {
+            PlaceholderChip()
         }
     }
 
     @Test
     fun secondaryColors() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                PlaceholderChip(colors = ChipDefaults.secondaryChipColors())
-            }
+        paparazzi.snapshotInABox {
+            PlaceholderChip(colors = ChipDefaults.secondaryChipColors())
         }
     }
 }

--- a/compose-tools/api/current.api
+++ b/compose-tools/api/current.api
@@ -16,6 +16,10 @@ package com.google.android.horologist.compose.tools {
     method @androidx.compose.runtime.Composable public static void RoundPreview(optional boolean round, kotlin.jvm.functions.Function0<kotlin.Unit> content);
   }
 
+  public final class SnapshotInABoxKt {
+    method public static void snapshotInABox(app.cash.paparazzi.Paparazzi, optional androidx.compose.ui.Modifier boxModifier, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.BoxScope,kotlin.Unit> content);
+  }
+
   public final class ThemeValues {
     ctor public ThemeValues(String name, int index, androidx.wear.compose.material.Colors colors);
     method public String component1();

--- a/compose-tools/src/main/java/com/google/android/horologist/compose/tools/SnapshotInABox.kt
+++ b/compose-tools/src/main/java/com/google/android/horologist/compose/tools/SnapshotInABox.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.compose.tools
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import app.cash.paparazzi.Paparazzi
+
+/**
+ * Paparazzi extension function to default wrap our snapshots in a box
+ * with black background.
+ *
+ * If you need to change up how the box is rendered with the composable, a modifier for the
+ * box is exposed.
+ *
+ * @param boxModifier Modifier for the box that the snapshot is wrapped in.
+ * @param content Composable content that we want to snapshot.
+ */
+public fun Paparazzi.snapshotInABox(
+    boxModifier: Modifier = Modifier,
+    content: @Composable BoxScope.() -> Unit
+) {
+    this.snapshot {
+        Box(
+            modifier = boxModifier.background(Color.Black),
+            contentAlignment = Alignment.Center,
+            content = content
+        )
+    }
+}

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerDeviceScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerDeviceScreenTest.kt
@@ -22,12 +22,9 @@
 
 package com.google.android.horologist.media.ui
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import app.cash.paparazzi.DeviceConfig
 import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.media.ui.state.PlayerUiState
 import com.google.android.horologist.media.ui.state.model.MediaUiModel
 import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
@@ -64,18 +61,21 @@ class MediaPlayerDeviceScreenTest(
                 title = "Weather with You",
                 subtitle = "Crowded House"
             ),
-            trackPosition = TrackPositionUiModel(current = 30, duration = 225, percent = 0.133f, showProgress = true),
+            trackPosition = TrackPositionUiModel(
+                current = 30,
+                duration = 225,
+                percent = 0.133f,
+                showProgress = true
+            ),
             connected = true
         )
 
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black)) {
-                MediaPlayerTestCase(
-                    colors = UampColors,
-                    playerUiState = playerUiState,
-                    round = device != DeviceConfig.WEAR_OS_SQUARE
-                )
-            }
+        paparazzi.snapshotInABox {
+            MediaPlayerTestCase(
+                colors = UampColors,
+                playerUiState = playerUiState,
+                round = device != DeviceConfig.WEAR_OS_SQUARE
+            )
         }
     }
 

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/MediaArtworkA11yTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/MediaArtworkA11yTest.kt
@@ -22,17 +22,13 @@
 
 package com.google.android.horologist.media.ui.components
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Album
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.a11y.ComposeA11yExtension
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.state.model.MediaUiModel
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
@@ -63,21 +59,16 @@ class MediaArtworkA11yTest {
 
     @Test
     fun a11y() {
-        paparazzi.snapshot {
+        paparazzi.snapshotInABox {
             FakeImageLoader.Resources.override {
-                Box(
-                    modifier = Modifier.background(Color.Black),
-                    contentAlignment = Alignment.Center
-                ) {
-                    MediaArtwork(
-                        media = MediaUiModel(
-                            id = "id",
-                            title = "title",
-                            artworkUri = FakeImageLoader.TestIconResourceUri
-                        ),
-                        placeholder = rememberVectorPainter(image = Icons.Default.Album)
-                    )
-                }
+                MediaArtwork(
+                    media = MediaUiModel(
+                        id = "id",
+                        title = "title",
+                        artworkUri = FakeImageLoader.TestIconResourceUri
+                    ),
+                    placeholder = rememberVectorPainter(image = Icons.Default.Album)
+                )
             }
         }
     }

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/MediaChipA11yTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/MediaChipA11yTest.kt
@@ -22,14 +22,10 @@
 
 package com.google.android.horologist.media.ui.components
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.a11y.ComposeA11yExtension
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.state.model.MediaUiModel
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
@@ -60,21 +56,16 @@ class MediaChipA11yTest {
 
     @Test
     fun a11y() {
-        paparazzi.snapshot {
+        paparazzi.snapshotInABox {
             FakeImageLoader.Resources.override {
-                Box(
-                    modifier = Modifier.background(Color.Black),
-                    contentAlignment = Alignment.Center
-                ) {
-                    MediaChip(
-                        media = MediaUiModel(
-                            id = "id",
-                            title = "Red Hot Chilli Peppers",
-                            artworkUri = FakeImageLoader.TestIconResourceUri
-                        ),
-                        onClick = {}
-                    )
-                }
+                MediaChip(
+                    media = MediaUiModel(
+                        id = "id",
+                        title = "Red Hot Chilli Peppers",
+                        artworkUri = FakeImageLoader.TestIconResourceUri
+                    ),
+                    onClick = {}
+                )
             }
         }
     }

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/MediaChipTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/MediaChipTest.kt
@@ -18,14 +18,11 @@
 
 package com.google.android.horologist.media.ui.components
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.R
 import com.google.android.horologist.media.ui.state.model.MediaUiModel
@@ -40,95 +37,73 @@ class MediaChipTest {
 
     @Test
     fun givenMediaWithArtwork_thenDisplaysArtwork() {
-        paparazzi.snapshot {
+        paparazzi.snapshotInABox {
             FakeImageLoader.Resources.override {
-                Box(
-                    modifier = Modifier.background(Color.Black),
-                    contentAlignment = Alignment.Center
-                ) {
-                    MediaChip(
-                        title = "Red Hot Chilli Peppers",
-                        artworkUri = R.drawable.ic_uamp,
-                        onClick = {}
-                    )
-                }
+                MediaChip(
+                    title = "Red Hot Chilli Peppers",
+                    artworkUri = R.drawable.ic_uamp,
+                    onClick = {}
+                )
             }
         }
     }
 
     @Test
     fun givenMediaWithNOArtwork_thenDoesNOTDisplayArtwork() {
-        paparazzi.snapshot {
+        paparazzi.snapshotInABox {
             FakeImageLoader.Resources.override {
-                Box(
-                    modifier = Modifier.background(Color.Black),
-                    contentAlignment = Alignment.Center
-                ) {
-                    MediaChip(
-                        title = "Red Hot Chilli Peppers",
-                        artworkUri = null,
-                        onClick = {}
-                    )
-                }
+                MediaChip(
+                    title = "Red Hot Chilli Peppers",
+                    artworkUri = null,
+                    onClick = {}
+                )
             }
         }
     }
 
     @Test
     fun givenVeryLongTitle_thenEllipsizeAt2ndLine() {
-        paparazzi.snapshot {
+        paparazzi.snapshotInABox {
             FakeImageLoader.Resources.override {
-                Box(
-                    modifier = Modifier.background(Color.Black),
-                    contentAlignment = Alignment.Center
-                ) {
-                    MediaChip(
-                        title = "Very very very very very very very very very very very long title",
-                        artworkUri = R.drawable.ic_uamp,
-                        onClick = {}
-                    )
-                }
+                MediaChip(
+                    title = "Very very very very very very very very very very very long title",
+                    artworkUri = R.drawable.ic_uamp,
+                    onClick = {}
+                )
             }
         }
     }
 
     @Test
     fun givenNOTitle_thenDisplaysDefaultTitle() {
-        paparazzi.snapshot {
+        paparazzi.snapshotInABox {
             FakeImageLoader.Resources.override {
-                Box(
-                    modifier = Modifier.background(Color.Black),
-                    contentAlignment = Alignment.Center
-                ) {
-                    MediaChip(
-                        media = MediaUiModel(id = "id", artworkUri = FakeImageLoader.TestIconResourceUri),
-                        onClick = {},
-                        defaultTitle = "No title"
-                    )
-                }
+                MediaChip(
+                    media = MediaUiModel(
+                        id = "id",
+                        artworkUri = FakeImageLoader.TestIconResourceUri
+                    ),
+                    onClick = {},
+                    defaultTitle = "No title"
+                )
             }
         }
     }
 
     @Test
     fun givenModifier_thenAppliesModifierCorrectly() {
-        paparazzi.snapshot {
+        paparazzi.snapshotInABox {
             FakeImageLoader.Resources.override {
-                Box(
-                    modifier = Modifier.background(Color.Black),
-                    contentAlignment = Alignment.Center
-                ) {
-                    MediaChip(
-                        media = MediaUiModel(
-                            id = "id",
-                            title = "Red Hot Chilli Peppers",
-                            artworkUri = FakeImageLoader.TestIconResourceUri
-                        ),
-                        onClick = {},
-                        modifier = Modifier
-                            .height(120.dp)
-                    )
-                }
+                MediaChip(
+                    media = MediaUiModel(
+                        id = "id",
+                        title = "Red Hot Chilli Peppers",
+                        artworkUri = FakeImageLoader.TestIconResourceUri
+                    ),
+                    onClick = {},
+                    modifier = Modifier
+                        .height(120.dp)
+                )
             }
         }
     }

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChipA11yTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChipA11yTest.kt
@@ -22,14 +22,10 @@
 
 package com.google.android.horologist.media.ui.components.actions
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.a11y.ComposeA11yExtension
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.R
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
@@ -60,18 +56,13 @@ class ShowPlaylistChipA11yTest {
 
     @Test
     fun a11y() {
-        paparazzi.snapshot {
+        paparazzi.snapshotInABox {
             FakeImageLoader.Resources.override {
-                Box(
-                    modifier = Modifier.background(Color.Black),
-                    contentAlignment = Alignment.Center
-                ) {
-                    ShowPlaylistChip(
-                        artworkUri = R.drawable.ic_uamp,
-                        name = "Playlists",
-                        onClick = {}
-                    )
-                }
+                ShowPlaylistChip(
+                    artworkUri = R.drawable.ic_uamp,
+                    name = "Playlists",
+                    onClick = {}
+                )
             }
         }
     }

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChipTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChipTest.kt
@@ -18,12 +18,8 @@
 
 package com.google.android.horologist.media.ui.components.actions
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.R
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
@@ -40,72 +36,52 @@ class ShowPlaylistChipTest {
 
     @Test
     fun givenArtwork_thenDisplaysArtwork() {
-        paparazzi.snapshot {
+        paparazzi.snapshotInABox {
             FakeImageLoader.Resources.override {
-                Box(
-                    modifier = Modifier.background(Color.Black),
-                    contentAlignment = Alignment.Center
-                ) {
-                    ShowPlaylistChip(
-                        artworkUri = R.drawable.ic_uamp,
-                        name = "Playlists",
-                        onClick = {}
-                    )
-                }
+                ShowPlaylistChip(
+                    artworkUri = R.drawable.ic_uamp,
+                    name = "Playlists",
+                    onClick = {}
+                )
             }
         }
     }
 
     @Test
     fun givenNOArtwork_thenDoesNOTDisplayArtwork() {
-        paparazzi.snapshot {
+        paparazzi.snapshotInABox {
             FakeImageLoader.Resources.override {
-                Box(
-                    modifier = Modifier.background(Color.Black),
-                    contentAlignment = Alignment.Center
-                ) {
-                    ShowPlaylistChip(
-                        artworkUri = null,
-                        name = "Playlists",
-                        onClick = {}
-                    )
-                }
+                ShowPlaylistChip(
+                    artworkUri = null,
+                    name = "Playlists",
+                    onClick = {}
+                )
             }
         }
     }
 
     @Test
     fun givenNOName_thenDoesDisplayArtwork() {
-        paparazzi.snapshot {
+        paparazzi.snapshotInABox {
             FakeImageLoader.Resources.override {
-                Box(
-                    modifier = Modifier.background(Color.Black),
-                    contentAlignment = Alignment.Center
-                ) {
-                    ShowPlaylistChip(
-                        artworkUri = R.drawable.ic_uamp,
-                        name = null,
-                        onClick = {}
-                    )
-                }
+                ShowPlaylistChip(
+                    artworkUri = R.drawable.ic_uamp,
+                    name = null,
+                    onClick = {}
+                )
             }
         }
     }
 
     @Test
     fun givenVeryLongTitle_thenEllipsizeAt2ndLine() {
-        paparazzi.snapshot {
+        paparazzi.snapshotInABox {
             FakeImageLoader.Resources.override {
-                Box(
-                    modifier = Modifier.background(Color.Black),
-                    contentAlignment = Alignment.Center
-                ) {
-                    ShowPlaylistChip(
-                        artworkUri = R.drawable.ic_uamp,
-                        name = "Very very very very very very very very very very very very very very very very very very very long title",
-                        onClick = {}
-                    )
-                }
+                ShowPlaylistChip(
+                    artworkUri = R.drawable.ic_uamp,
+                    name = "Very very very very very very very very very very very very very very very very very very very long title",
+                    onClick = {}
+                )
             }
         }
     }

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/SeekBackButtonA11yTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/SeekBackButtonA11yTest.kt
@@ -22,13 +22,9 @@
 
 package com.google.android.horologist.media.ui.controls
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.a11y.ComposeA11yExtension
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.components.controls.SeekBackButton
 import com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement
@@ -61,76 +57,51 @@ class SeekBackButtonA11yTest {
 
     @Test
     fun incrementIsFive() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                SeekBackButton(
-                    onClick = {},
-                    seekButtonIncrement = SeekButtonIncrement.Five
-                )
-            }
+        paparazzi.snapshotInABox {
+            SeekBackButton(
+                onClick = {},
+                seekButtonIncrement = SeekButtonIncrement.Five
+            )
         }
     }
 
     @Test
     fun incrementIsTen() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                SeekBackButton(
-                    onClick = {},
-                    seekButtonIncrement = SeekButtonIncrement.Ten
-                )
-            }
+        paparazzi.snapshotInABox {
+            SeekBackButton(
+                onClick = {},
+                seekButtonIncrement = SeekButtonIncrement.Ten
+            )
         }
     }
 
     @Test
     fun incrementIsThirty() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                SeekBackButton(
-                    onClick = {},
-                    seekButtonIncrement = SeekButtonIncrement.Thirty
-                )
-            }
+        paparazzi.snapshotInABox {
+            SeekBackButton(
+                onClick = {},
+                seekButtonIncrement = SeekButtonIncrement.Thirty
+            )
         }
     }
 
     @Test
     fun incrementIsOther() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                SeekBackButton(
-                    onClick = {},
-                    seekButtonIncrement = SeekButtonIncrement.Known(15)
-                )
-            }
+        paparazzi.snapshotInABox {
+            SeekBackButton(
+                onClick = {},
+                seekButtonIncrement = SeekButtonIncrement.Known(15)
+            )
         }
     }
 
     @Test
     fun incrementIsUnknown() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                SeekBackButton(
-                    onClick = {},
-                    seekButtonIncrement = SeekButtonIncrement.Unknown
-                )
-            }
+        paparazzi.snapshotInABox {
+            SeekBackButton(
+                onClick = {},
+                seekButtonIncrement = SeekButtonIncrement.Unknown
+            )
         }
     }
 }

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/SeekBackButtonTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/SeekBackButtonTest.kt
@@ -18,11 +18,7 @@
 
 package com.google.android.horologist.media.ui.controls
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.components.controls.SeekBackButton
 import com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement
@@ -38,61 +34,51 @@ class SeekBackButtonTest {
 
     @Test
     fun givenIncrementIsFive_thenIconIsFive() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                SeekBackButton(
-                    onClick = {},
-                    seekButtonIncrement = SeekButtonIncrement.Five
-                )
-            }
+        paparazzi.snapshotInABox {
+            SeekBackButton(
+                onClick = {},
+                seekButtonIncrement = SeekButtonIncrement.Five
+            )
         }
     }
 
     @Test
     fun givenIncrementIsTen_thenIconIsTen() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                SeekBackButton(
-                    onClick = {},
-                    seekButtonIncrement = SeekButtonIncrement.Ten
-                )
-            }
+        paparazzi.snapshotInABox {
+            SeekBackButton(
+                onClick = {},
+                seekButtonIncrement = SeekButtonIncrement.Ten
+            )
         }
     }
 
     @Test
     fun givenIncrementIsThirty_thenIconIsThirty() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                SeekBackButton(
-                    onClick = {},
-                    seekButtonIncrement = SeekButtonIncrement.Thirty
-                )
-            }
+        paparazzi.snapshotInABox {
+            SeekBackButton(
+                onClick = {},
+                seekButtonIncrement = SeekButtonIncrement.Thirty
+            )
         }
     }
 
     @Test
     fun givenIncrementIsOtherValue_thenIconIsDefault() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                SeekBackButton(
-                    onClick = {},
-                    seekButtonIncrement = SeekButtonIncrement.Known(15)
-                )
-            }
+        paparazzi.snapshotInABox {
+            SeekBackButton(
+                onClick = {},
+                seekButtonIncrement = SeekButtonIncrement.Known(15)
+            )
         }
     }
 
     @Test
     fun givenIncrementIsUnknown_thenIconIsDefault() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                SeekBackButton(
-                    onClick = {},
-                    seekButtonIncrement = SeekButtonIncrement.Unknown
-                )
-            }
+        paparazzi.snapshotInABox {
+            SeekBackButton(
+                onClick = {},
+                seekButtonIncrement = SeekButtonIncrement.Unknown
+            )
         }
     }
 }

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/SeekForwardButtonA11yTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/SeekForwardButtonA11yTest.kt
@@ -22,13 +22,9 @@
 
 package com.google.android.horologist.media.ui.controls
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.a11y.ComposeA11yExtension
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement
 import com.google.android.horologist.media.ui.components.controls.SeekForwardButton
@@ -61,76 +57,51 @@ class SeekForwardButtonA11yTest {
 
     @Test
     fun incrementIsFive() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                SeekForwardButton(
-                    onClick = {},
-                    seekButtonIncrement = SeekButtonIncrement.Five
-                )
-            }
+        paparazzi.snapshotInABox {
+            SeekForwardButton(
+                onClick = {},
+                seekButtonIncrement = SeekButtonIncrement.Five
+            )
         }
     }
 
     @Test
     fun incrementIsTen() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                SeekForwardButton(
-                    onClick = {},
-                    seekButtonIncrement = SeekButtonIncrement.Ten
-                )
-            }
+        paparazzi.snapshotInABox {
+            SeekForwardButton(
+                onClick = {},
+                seekButtonIncrement = SeekButtonIncrement.Ten
+            )
         }
     }
 
     @Test
     fun incrementIsThirty() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                SeekForwardButton(
-                    onClick = {},
-                    seekButtonIncrement = SeekButtonIncrement.Thirty
-                )
-            }
+        paparazzi.snapshotInABox {
+            SeekForwardButton(
+                onClick = {},
+                seekButtonIncrement = SeekButtonIncrement.Thirty
+            )
         }
     }
 
     @Test
     fun incrementIsOther() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                SeekForwardButton(
-                    onClick = {},
-                    seekButtonIncrement = SeekButtonIncrement.Known(15)
-                )
-            }
+        paparazzi.snapshotInABox {
+            SeekForwardButton(
+                onClick = {},
+                seekButtonIncrement = SeekButtonIncrement.Known(15)
+            )
         }
     }
 
     @Test
     fun incrementIsUnknown() {
-        paparazzi.snapshot {
-            Box(
-                modifier = Modifier.background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                SeekForwardButton(
-                    onClick = {},
-                    seekButtonIncrement = SeekButtonIncrement.Unknown
-                )
-            }
+        paparazzi.snapshotInABox {
+            SeekForwardButton(
+                onClick = {},
+                seekButtonIncrement = SeekButtonIncrement.Unknown
+            )
         }
     }
 }

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/SeekForwardButtonTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/SeekForwardButtonTest.kt
@@ -21,11 +21,7 @@
 
 package com.google.android.horologist.media.ui.controls
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement
 import com.google.android.horologist.media.ui.components.controls.SeekForwardButton
@@ -41,61 +37,51 @@ class SeekForwardButtonTest {
 
     @Test
     fun givenIncrementIsFive_thenIconIsFive() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                SeekForwardButton(
-                    onClick = {},
-                    seekButtonIncrement = SeekButtonIncrement.Five
-                )
-            }
+        paparazzi.snapshotInABox {
+            SeekForwardButton(
+                onClick = {},
+                seekButtonIncrement = SeekButtonIncrement.Five
+            )
         }
     }
 
     @Test
     fun givenIncrementIsTen_thenIconIsTen() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                SeekForwardButton(
-                    onClick = {},
-                    seekButtonIncrement = SeekButtonIncrement.Ten
-                )
-            }
+        paparazzi.snapshotInABox {
+            SeekForwardButton(
+                onClick = {},
+                seekButtonIncrement = SeekButtonIncrement.Ten
+            )
         }
     }
 
     @Test
     fun givenIncrementIsThirty_thenIconIsThirty() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                SeekForwardButton(
-                    onClick = {},
-                    seekButtonIncrement = SeekButtonIncrement.Thirty
-                )
-            }
+        paparazzi.snapshotInABox {
+            SeekForwardButton(
+                onClick = {},
+                seekButtonIncrement = SeekButtonIncrement.Thirty
+            )
         }
     }
 
     @Test
     fun givenIncrementIsOtherValue_thenIconIsDefault() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                SeekForwardButton(
-                    onClick = {},
-                    seekButtonIncrement = SeekButtonIncrement.Known(15)
-                )
-            }
+        paparazzi.snapshotInABox {
+            SeekForwardButton(
+                onClick = {},
+                seekButtonIncrement = SeekButtonIncrement.Known(15)
+            )
         }
     }
 
     @Test
     fun givenIncrementIsUnknown_thenIconIsDefault() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                SeekForwardButton(
-                    onClick = {},
-                    seekButtonIncrement = SeekButtonIncrement.Unknown
-                )
-            }
+        paparazzi.snapshotInABox {
+            SeekForwardButton(
+                onClick = {},
+                seekButtonIncrement = SeekButtonIncrement.Unknown
+            )
         }
     }
 }

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/ShuffleToggleButtonTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/ShuffleToggleButtonTest.kt
@@ -18,11 +18,7 @@
 
 package com.google.android.horologist.media.ui.controls
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.components.controls.ShuffleToggleButton
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
@@ -38,25 +34,21 @@ class ShuffleToggleButtonTest {
     @OptIn(ExperimentalHorologistMediaUiApi::class)
     @Test
     fun givenShuffleIsOn_thenIconIsShuffleOn() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                ShuffleToggleButton(
-                    onToggle = {},
-                    shuffleOn = true
-                )
-            }
+        paparazzi.snapshotInABox {
+            ShuffleToggleButton(
+                onToggle = {},
+                shuffleOn = true
+            )
         }
     }
 
     @Test
     fun givenShuffleIsOff_thenIconIsShuffle() {
-        paparazzi.snapshot {
-            Box(modifier = Modifier.background(Color.Black), contentAlignment = Alignment.Center) {
-                ShuffleToggleButton(
-                    onToggle = {},
-                    shuffleOn = false
-                )
-            }
+        paparazzi.snapshotInABox {
+            ShuffleToggleButton(
+                onToggle = {},
+                shuffleOn = false
+            )
         }
     }
 }


### PR DESCRIPTION
#### WHAT
Add an extension function on paparazzi to wrap our snapshots in a box. 

#### WHY
This is because we mostly have tests that are wrapped in a box with a black background. We want to not have to write this boilerplate code every time we make a snapshot test. 
resolves #886 

Ran through and changed everywhere we have used snapshot with a black centered aligned box and changed it out with this extension.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
