### PR TITLE
Add ExperimentalHorologistComposeToolsApi to snapshotInABox extension function

### DIFF
--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonTest.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonTest.kt
@@ -14,11 +14,15 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistPaparazziApi::class)
+@file:OptIn(
+    ExperimentalHorologistPaparazziApi::class,
+    ExperimentalHorologistComposeToolsApi::class
+)
 
 package com.google.android.horologist.audio.ui.components.actions
 
 import com.google.android.horologist.audio.VolumeState
+import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/CreateAccountChipTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/CreateAccountChipTest.kt
@@ -16,13 +16,15 @@
 
 @file:OptIn(
     ExperimentalHorologistPaparazziApi::class,
-    ExperimentalHorologistAuthComposablesApi::class
+    ExperimentalHorologistAuthComposablesApi::class,
+    ExperimentalHorologistComposeToolsApi::class
 )
 
 package com.google.android.horologist.auth.composables.chips
 
 import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
 import com.google.android.horologist.base.ui.components.StandardChipType
+import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/GuestModeChipTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/GuestModeChipTest.kt
@@ -16,13 +16,15 @@
 
 @file:OptIn(
     ExperimentalHorologistPaparazziApi::class,
-    ExperimentalHorologistAuthComposablesApi::class
+    ExperimentalHorologistAuthComposablesApi::class,
+    ExperimentalHorologistComposeToolsApi::class
 )
 
 package com.google.android.horologist.auth.composables.chips
 
 import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
 import com.google.android.horologist.base.ui.components.StandardChipType
+import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/OtherOptionsChipTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/OtherOptionsChipTest.kt
@@ -16,13 +16,15 @@
 
 @file:OptIn(
     ExperimentalHorologistPaparazziApi::class,
-    ExperimentalHorologistAuthComposablesApi::class
+    ExperimentalHorologistAuthComposablesApi::class,
+    ExperimentalHorologistComposeToolsApi::class
 )
 
 package com.google.android.horologist.auth.composables.chips
 
 import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
 import com.google.android.horologist.base.ui.components.StandardChipType
+import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/SignInChipTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/SignInChipTest.kt
@@ -16,13 +16,15 @@
 
 @file:OptIn(
     ExperimentalHorologistPaparazziApi::class,
-    ExperimentalHorologistAuthComposablesApi::class
+    ExperimentalHorologistAuthComposablesApi::class,
+    ExperimentalHorologistComposeToolsApi::class
 )
 
 package com.google.android.horologist.auth.composables.chips
 
 import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
 import com.google.android.horologist.base.ui.components.StandardChipType
+import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogTest.kt
@@ -16,7 +16,8 @@
 
 @file:OptIn(
     ExperimentalHorologistPaparazziApi::class,
-    ExperimentalHorologistAuthComposablesApi::class
+    ExperimentalHorologistAuthComposablesApi::class,
+    ExperimentalHorologistComposeToolsApi::class
 )
 
 package com.google.android.horologist.auth.composables.dialogs
@@ -27,6 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
+import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/screens/AuthErrorScreenTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/screens/AuthErrorScreenTest.kt
@@ -16,12 +16,14 @@
 
 @file:OptIn(
     ExperimentalHorologistPaparazziApi::class,
-    ExperimentalHorologistAuthComposablesApi::class
+    ExperimentalHorologistAuthComposablesApi::class,
+    ExperimentalHorologistComposeToolsApi::class
 )
 
 package com.google.android.horologist.auth.composables.screens
 
 import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
+import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/screens/SelectAccountScreenTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/screens/SelectAccountScreenTest.kt
@@ -16,7 +16,8 @@
 
 @file:OptIn(
     ExperimentalHorologistPaparazziApi::class,
-    ExperimentalHorologistAuthComposablesApi::class
+    ExperimentalHorologistAuthComposablesApi::class,
+    ExperimentalHorologistComposeToolsApi::class
 )
 
 package com.google.android.horologist.auth.composables.screens
@@ -25,6 +26,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Face
 import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
 import com.google.android.horologist.auth.composables.model.AccountUiModel
+import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/screens/SignInPlaceholderScreenTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/screens/SignInPlaceholderScreenTest.kt
@@ -16,12 +16,14 @@
 
 @file:OptIn(
     ExperimentalHorologistPaparazziApi::class,
-    ExperimentalHorologistAuthComposablesApi::class
+    ExperimentalHorologistAuthComposablesApi::class,
+    ExperimentalHorologistComposeToolsApi::class
 )
 
 package com.google.android.horologist.auth.composables.screens
 
 import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
+import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi

--- a/base-ui/src/test/java/com/google/android/horologist/base/ui/components/PrimaryChipTest.kt
+++ b/base-ui/src/test/java/com/google/android/horologist/base/ui/components/PrimaryChipTest.kt
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistPaparazziApi::class, ExperimentalHorologistBaseUiApi::class)
+@file:OptIn(
+    ExperimentalHorologistPaparazziApi::class,
+    ExperimentalHorologistBaseUiApi::class,
+    ExperimentalHorologistComposeToolsApi::class
+)
 
 package com.google.android.horologist.base.ui.components
 
@@ -28,6 +32,7 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.dp
 import com.google.android.horologist.base.ui.ExperimentalHorologistBaseUiApi
 import com.google.android.horologist.base.ui.util.rememberVectorPainter
+import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi

--- a/base-ui/src/test/java/com/google/android/horologist/base/ui/components/SecondaryChipTest.kt
+++ b/base-ui/src/test/java/com/google/android/horologist/base/ui/components/SecondaryChipTest.kt
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistPaparazziApi::class, ExperimentalHorologistBaseUiApi::class)
+@file:OptIn(
+    ExperimentalHorologistPaparazziApi::class,
+    ExperimentalHorologistBaseUiApi::class,
+    ExperimentalHorologistComposeToolsApi::class
+)
 
 package com.google.android.horologist.base.ui.components
 
@@ -32,6 +36,7 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.dp
 import com.google.android.horologist.base.ui.ExperimentalHorologistBaseUiApi
 import com.google.android.horologist.base.ui.util.rememberVectorPainter
+import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi

--- a/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardButtonTest.kt
+++ b/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardButtonTest.kt
@@ -14,13 +14,18 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistPaparazziApi::class, ExperimentalHorologistBaseUiApi::class)
+@file:OptIn(
+    ExperimentalHorologistPaparazziApi::class,
+    ExperimentalHorologistBaseUiApi::class,
+    ExperimentalHorologistComposeToolsApi::class
+)
 
 package com.google.android.horologist.base.ui.components
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import com.google.android.horologist.base.ui.ExperimentalHorologistBaseUiApi
+import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi

--- a/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardChipIconWithProgressTest.kt
+++ b/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardChipIconWithProgressTest.kt
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistPaparazziApi::class, ExperimentalHorologistBaseUiApi::class)
+@file:OptIn(
+    ExperimentalHorologistPaparazziApi::class,
+    ExperimentalHorologistBaseUiApi::class,
+    ExperimentalHorologistComposeToolsApi::class
+)
 
 package com.google.android.horologist.base.ui.components
 
@@ -22,6 +26,7 @@ import androidx.compose.material.icons.materialPath
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import com.google.android.horologist.base.ui.ExperimentalHorologistBaseUiApi
+import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi

--- a/base-ui/src/test/java/com/google/android/horologist/base/ui/components/TitleTest.kt
+++ b/base-ui/src/test/java/com/google/android/horologist/base/ui/components/TitleTest.kt
@@ -14,11 +14,16 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistPaparazziApi::class, ExperimentalHorologistBaseUiApi::class)
+@file:OptIn(
+    ExperimentalHorologistPaparazziApi::class,
+    ExperimentalHorologistBaseUiApi::class,
+    ExperimentalHorologistComposeToolsApi::class
+)
 
 package com.google.android.horologist.base.ui.components
 
 import com.google.android.horologist.base.ui.ExperimentalHorologistBaseUiApi
+import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/PlaceholderChipTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/PlaceholderChipTest.kt
@@ -14,11 +14,16 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistPaparazziApi::class, ExperimentalHorologistComposablesApi::class)
+@file:OptIn(
+    ExperimentalHorologistPaparazziApi::class,
+    ExperimentalHorologistComposablesApi::class,
+    ExperimentalHorologistComposeToolsApi::class
+)
 
 package com.google.android.horologist.composables
 
 import androidx.wear.compose.material.ChipDefaults
+import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi

--- a/compose-tools/api/current.api
+++ b/compose-tools/api/current.api
@@ -17,7 +17,7 @@ package com.google.android.horologist.compose.tools {
   }
 
   public final class SnapshotInABoxKt {
-    method public static void snapshotInABox(app.cash.paparazzi.Paparazzi, optional androidx.compose.ui.Modifier boxModifier, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.BoxScope,kotlin.Unit> content);
+    method @com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi public static void snapshotInABox(app.cash.paparazzi.Paparazzi, optional androidx.compose.ui.Modifier boxModifier, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.BoxScope,kotlin.Unit> content);
   }
 
   public final class ThemeValues {

--- a/compose-tools/src/main/java/com/google/android/horologist/compose/tools/SnapshotInABox.kt
+++ b/compose-tools/src/main/java/com/google/android/horologist/compose/tools/SnapshotInABox.kt
@@ -35,6 +35,7 @@ import app.cash.paparazzi.Paparazzi
  * @param boxModifier Modifier for the box that the snapshot is wrapped in.
  * @param content Composable content that we want to snapshot.
  */
+@ExperimentalHorologistComposeToolsApi
 public fun Paparazzi.snapshotInABox(
     boxModifier: Modifier = Modifier,
     content: @Composable BoxScope.() -> Unit

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/MediaChipTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/MediaChipTest.kt
@@ -14,13 +14,18 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistMediaUiApi::class, ExperimentalHorologistPaparazziApi::class)
+@file:OptIn(
+    ExperimentalHorologistMediaUiApi::class,
+    ExperimentalHorologistPaparazziApi::class,
+    ExperimentalHorologistComposeToolsApi::class
+)
 
 package com.google.android.horologist.media.ui.components
 
 import androidx.compose.foundation.layout.height
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChipTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChipTest.kt
@@ -14,10 +14,15 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistMediaUiApi::class, ExperimentalHorologistPaparazziApi::class)
+@file:OptIn(
+    ExperimentalHorologistMediaUiApi::class,
+    ExperimentalHorologistPaparazziApi::class,
+    ExperimentalHorologistComposeToolsApi::class
+)
 
 package com.google.android.horologist.media.ui.components.actions
 
+import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/SeekBackButtonTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/SeekBackButtonTest.kt
@@ -14,10 +14,15 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistPaparazziApi::class, ExperimentalHorologistMediaUiApi::class)
+@file:OptIn(
+    ExperimentalHorologistPaparazziApi::class,
+    ExperimentalHorologistMediaUiApi::class,
+    ExperimentalHorologistComposeToolsApi::class
+)
 
 package com.google.android.horologist.media.ui.controls
 
+import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.components.controls.SeekBackButton

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/SeekForwardButtonTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/SeekForwardButtonTest.kt
@@ -16,11 +16,13 @@
 
 @file:OptIn(
     ExperimentalHorologistPaparazziApi::class,
-    ExperimentalHorologistMediaUiApi::class
+    ExperimentalHorologistMediaUiApi::class,
+    ExperimentalHorologistComposeToolsApi::class
 )
 
 package com.google.android.horologist.media.ui.controls
 
+import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/ShuffleToggleButtonTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/ShuffleToggleButtonTest.kt
@@ -14,10 +14,15 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistPaparazziApi::class, ExperimentalHorologistMediaUiApi::class)
+@file:OptIn(
+    ExperimentalHorologistPaparazziApi::class,
+    ExperimentalHorologistMediaUiApi::class,
+    ExperimentalHorologistComposeToolsApi::class
+)
 
 package com.google.android.horologist.media.ui.controls
 
+import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.components.controls.ShuffleToggleButton
@@ -31,7 +36,6 @@ class ShuffleToggleButtonTest {
     @get:Rule
     val paparazzi = WearPaparazzi()
 
-    @OptIn(ExperimentalHorologistMediaUiApi::class)
     @Test
     fun givenShuffleIsOn_thenIconIsShuffleOn() {
         paparazzi.snapshotInABox {
@@ -42,6 +46,7 @@ class ShuffleToggleButtonTest {
         }
     }
 
+    @OptIn(ExperimentalHorologistComposeToolsApi::class)
     @Test
     fun givenShuffleIsOff_thenIconIsShuffle() {
         paparazzi.snapshotInABox {


### PR DESCRIPTION
#### WHAT
Adding the `ExperimentalHorologistComposeToolsApi` annotation to the `snapshotInABox` paparazzi extension function. 

#### WHY
Reference (https://github.com/google/horologist/pull/890#discussion_r1058827209)

#### HOW
Add annotation and optIn on call site.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
