### PR TITLE
Add maven publish plugin to auth modules

### DIFF
--- a/auth-composables/build.gradle.kts
+++ b/auth-composables/build.gradle.kts
@@ -75,6 +75,8 @@ android {
         textReport = true
     }
 
+    resourcePrefix = "horologist_"
+
     namespace = "com.google.android.horologist.auth.composables"
 }
 
@@ -127,5 +129,4 @@ dependencies {
     androidTestImplementation(libs.truth)
 }
 
-// Not publishing it until it's ready
-//apply(plugin = "com.vanniktech.maven.publish")
+apply(plugin = "com.vanniktech.maven.publish")

--- a/auth-data/build.gradle.kts
+++ b/auth-data/build.gradle.kts
@@ -67,6 +67,8 @@ android {
         textReport = true
     }
 
+    resourcePrefix = "horologist_"
+
     namespace = "com.google.android.horologist.auth.data"
 }
 
@@ -109,5 +111,4 @@ dependencies {
     testImplementation(libs.robolectric)
 }
 
-// Not publishing it until it's ready
-//apply(plugin = "com.vanniktech.maven.publish")
+apply(plugin = "com.vanniktech.maven.publish")

--- a/auth-data/gradle.properties
+++ b/auth-data/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=horologist-auth-data
+POM_NAME=Horologist Auth Data library
+POM_PACKAGING=aar

--- a/auth-ui/build.gradle.kts
+++ b/auth-ui/build.gradle.kts
@@ -78,6 +78,8 @@ android {
         disable.addAll(listOf("MissingTranslation", "ExtraTranslation"))
     }
 
+    resourcePrefix = "horologist_"
+
     namespace = "com.google.android.horologist.auth.ui"
 }
 
@@ -133,5 +135,4 @@ dependencies {
     androidTestImplementation(libs.truth)
 }
 
-// Not publishing it until it's ready
-//apply(plugin = "com.vanniktech.maven.publish")
+apply(plugin = "com.vanniktech.maven.publish")


### PR DESCRIPTION
#### WHAT

Add maven publish plugin to auth modules.

#### WHY

So they are published to maven in the next release for early API feedback.

#### HOW

- Uncomment line to apply maven publish plugin;
- Add missing configuration files;
- Unrelated: add [resourcePrefix](https://github.com/google/horologist/issues/892);

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
