### PR TITLE
Improve package names for Google Sign In components

### DIFF
--- a/auth-ui/api/current.api
+++ b/auth-ui/api/current.api
@@ -61,43 +61,47 @@ package com.google.android.horologist.auth.ui.ext {
 
 }
 
-package com.google.android.horologist.auth.ui.googlesignin {
+package com.google.android.horologist.auth.ui.googlesignin.prompt {
 
   public final class GoogleSignInPromptViewModelFactoryKt {
     method public static androidx.lifecycle.ViewModelProvider.Factory getGoogleSignInPromptViewModelFactory();
     property public static final androidx.lifecycle.ViewModelProvider.Factory GoogleSignInPromptViewModelFactory;
   }
 
+}
+
+package com.google.android.horologist.auth.ui.googlesignin.signin {
+
   public final class GoogleSignInScreenKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public static void GoogleSignInScreen(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.auth.ui.googlesignin.GoogleSignInViewModel viewModel, kotlin.jvm.functions.Function0<kotlin.Unit> onAuthCancelled, kotlin.jvm.functions.Function0<kotlin.Unit> failedContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreenState.Success,kotlin.Unit> successContent);
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public static void GoogleSignInScreen(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.auth.ui.googlesignin.GoogleSignInViewModel viewModel, kotlin.jvm.functions.Function0<kotlin.Unit> onAuthCancelled, kotlin.jvm.functions.Function0<kotlin.Unit> onAuthSucceed);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public static void GoogleSignInScreen(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInViewModel viewModel, kotlin.jvm.functions.Function0<kotlin.Unit> onAuthCancelled, kotlin.jvm.functions.Function0<kotlin.Unit> failedContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreenState.Success,kotlin.Unit> successContent);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public static void GoogleSignInScreen(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInViewModel viewModel, kotlin.jvm.functions.Function0<kotlin.Unit> onAuthCancelled, kotlin.jvm.functions.Function0<kotlin.Unit> onAuthSucceed);
   }
 
   @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public abstract sealed class GoogleSignInScreenState {
   }
 
-  public static final class GoogleSignInScreenState.Cancelled extends com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreenState {
-    field public static final com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreenState.Cancelled INSTANCE;
+  public static final class GoogleSignInScreenState.Cancelled extends com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreenState {
+    field public static final com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreenState.Cancelled INSTANCE;
   }
 
-  public static final class GoogleSignInScreenState.Failed extends com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreenState {
-    field public static final com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreenState.Failed INSTANCE;
+  public static final class GoogleSignInScreenState.Failed extends com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreenState {
+    field public static final com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreenState.Failed INSTANCE;
   }
 
-  public static final class GoogleSignInScreenState.Idle extends com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreenState {
-    field public static final com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreenState.Idle INSTANCE;
+  public static final class GoogleSignInScreenState.Idle extends com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreenState {
+    field public static final com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreenState.Idle INSTANCE;
   }
 
-  public static final class GoogleSignInScreenState.SelectAccount extends com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreenState {
-    field public static final com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreenState.SelectAccount INSTANCE;
+  public static final class GoogleSignInScreenState.SelectAccount extends com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreenState {
+    field public static final com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreenState.SelectAccount INSTANCE;
   }
 
-  public static final class GoogleSignInScreenState.Success extends com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreenState {
+  public static final class GoogleSignInScreenState.Success extends com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreenState {
     ctor public GoogleSignInScreenState.Success(String? displayName, String? email, android.net.Uri? photoUrl);
     method public String? component1();
     method public String? component2();
     method public android.net.Uri? component3();
-    method public com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreenState.Success copy(String? displayName, String? email, android.net.Uri? photoUrl);
+    method public com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreenState.Success copy(String? displayName, String? email, android.net.Uri? photoUrl);
     method public String? getDisplayName();
     method public String? getEmail();
     method public android.net.Uri? getPhotoUrl();
@@ -108,12 +112,12 @@ package com.google.android.horologist.auth.ui.googlesignin {
 
   @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public class GoogleSignInViewModel extends androidx.lifecycle.ViewModel {
     ctor public GoogleSignInViewModel(optional com.google.android.horologist.auth.data.googlesignin.GoogleSignInEventListener googleSignInEventListener);
-    method public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreenState> getUiState();
+    method public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreenState> getUiState();
     method public final void onAccountSelected(com.google.android.gms.auth.api.signin.GoogleSignInAccount account);
     method public final void onAccountSelectionFailed();
     method public final void onAuthCancelled();
     method public final void onIdleStateObserved();
-    property public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreenState> uiState;
+    property public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreenState> uiState;
   }
 
 }

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/prompt/GoogleSignInPromptViewModelFactory.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/prompt/GoogleSignInPromptViewModelFactory.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.auth.ui.googlesignin
+package com.google.android.horologist.auth.ui.googlesignin.prompt
 
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInScreen.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInScreen.kt
@@ -16,7 +16,7 @@
 
 @file:OptIn(ExperimentalLifecycleComposeApi::class)
 
-package com.google.android.horologist.auth.ui.googlesignin
+package com.google.android.horologist.auth.ui.googlesignin.signin
 
 import android.app.Activity.RESULT_CANCELED
 import android.content.Context

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInViewModel.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInViewModel.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.auth.ui.googlesignin
+package com.google.android.horologist.auth.ui.googlesignin.signin
 
 import android.net.Uri
 import androidx.lifecycle.ViewModel

--- a/sample/src/main/java/com/google/android/horologist/auth/googlesignin/prompt/GoogleSignInPromptSampleScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/googlesignin/prompt/GoogleSignInPromptSampleScreen.kt
@@ -33,7 +33,7 @@ import com.google.android.horologist.auth.composables.chips.GuestModeChip
 import com.google.android.horologist.auth.composables.chips.SignInChip
 import com.google.android.horologist.auth.ui.common.screens.prompt.SignInPromptScreen
 import com.google.android.horologist.auth.ui.common.screens.prompt.SignInPromptViewModel
-import com.google.android.horologist.auth.ui.googlesignin.GoogleSignInPromptViewModelFactory
+import com.google.android.horologist.auth.ui.googlesignin.prompt.GoogleSignInPromptViewModelFactory
 import com.google.android.horologist.base.ui.components.ConfirmationDialog
 import com.google.android.horologist.base.ui.components.StandardChipType
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState

--- a/sample/src/main/java/com/google/android/horologist/auth/googlesignin/signin/GoogleSignInSampleViewModel.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/googlesignin/signin/GoogleSignInSampleViewModel.kt
@@ -19,7 +19,7 @@ package com.google.android.horologist.auth.googlesignin.signin
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import com.google.android.horologist.auth.ui.googlesignin.GoogleSignInViewModel
+import com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInViewModel
 
 object GoogleSignInSampleViewModel {
 

--- a/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
@@ -41,7 +41,7 @@ import com.google.android.horologist.auth.oauth.devicegrant.AuthDeviceGrantSampl
 import com.google.android.horologist.auth.oauth.devicegrant.AuthDeviceGrantSignInPromptScreen
 import com.google.android.horologist.auth.oauth.pkce.AuthPKCESampleViewModel
 import com.google.android.horologist.auth.oauth.pkce.AuthPKCESignInPromptScreen
-import com.google.android.horologist.auth.ui.googlesignin.GoogleSignInScreen
+import com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreen
 import com.google.android.horologist.auth.ui.oauth.devicegrant.AuthDeviceGrantScreen
 import com.google.android.horologist.auth.ui.oauth.pkce.AuthPKCEScreen
 import com.google.android.horologist.composables.DatePicker


### PR DESCRIPTION
#### WHAT

Improve package names for Google Sign In components in `auth-ui`.

#### WHY

In order to make it easier to see which screens the available classes should be used with.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
