### PR TITLE
Increase timeout for builds to 40mins

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
 
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
#### WHAT

Increase timeout for builds to 40mins.

#### WHY

Loads of builds are being cancelled lately due to this limit.

#### HOW

Change value of `timeout-minutes`.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [N/A] Run tests
- [N/A] Update metalava's signature text files
