### PR TITLE
Add unit tests for the ViewModels in auth-ui

### DIFF
--- a/auth-ui/build.gradle.kts
+++ b/auth-ui/build.gradle.kts
@@ -127,6 +127,7 @@ dependencies {
     testImplementation(libs.paparazzi)
     testImplementation(libs.robolectric)
     testImplementation(libs.truth)
+    testImplementation(libs.turbine)
 
     androidTestImplementation(libs.androidx.test.ext)
     androidTestImplementation(libs.androidx.test.ext.ktx)

--- a/auth-ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptViewModelTest.kt
+++ b/auth-ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptViewModelTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(
+    ExperimentalHorologistAuthUiApi::class,
+    ExperimentalCoroutinesApi::class
+)
+
+package com.google.android.horologist.auth.ui.common.screens.prompt
+
+import app.cash.turbine.test
+import com.google.android.horologist.auth.data.common.model.AuthUser
+import com.google.android.horologist.auth.data.common.repository.AuthUserRepository
+import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
+import com.google.android.horologist.test.toolbox.MainDispatcherRule
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class SignInPromptViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val fakeAuthUserRepository = AuthUserRepositoryStub()
+
+    private lateinit var sut: SignInPromptViewModel
+
+    @Before
+    fun setUp() {
+        sut = SignInPromptViewModel(fakeAuthUserRepository)
+    }
+
+    @Test
+    fun givenInitialState_thenStateIsIdle() {
+        // when
+        val result = sut.uiState.value
+
+        // then
+        assertThat(result).isEqualTo(SignInPromptScreenState.Idle)
+    }
+
+    @Test
+    fun givenInitialState_whenOnIdleStateObserved_thenStateIsLoading() = runTest {
+        // when
+        val whenBlock = { sut.onIdleStateObserved() }
+
+        // then
+        sut.uiState.test {
+            skipItems(1)
+
+            whenBlock()
+
+            assertThat(awaitItem()).isEqualTo(SignInPromptScreenState.Loading)
+
+            skipItems(1)
+        }
+    }
+
+    @Test
+    fun givenNonIdleState_whenOnIdleStateObserved_thenStateIsTheSame() = runTest {
+        // when
+        sut.onIdleStateObserved()
+        val whenBlock = { sut.onIdleStateObserved() }
+
+        // then
+        sut.uiState.test {
+            assertThat(awaitItem()).isNotEqualTo(SignInPromptScreenState.Idle)
+
+            whenBlock()
+
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun givenNoUserAuthenticated_whenOnIdleStateObserved_thenStateIsSignedOut() = runTest {
+        // when
+        sut.onIdleStateObserved()
+
+        // then
+        sut.uiState.test {
+            assertThat(awaitItem()).isEqualTo(SignInPromptScreenState.SignedOut)
+        }
+    }
+
+    @Test
+    fun givenUserAuthenticated_whenOnIdleStateObserved_thenStateIsSignedIn() = runTest {
+        // given
+        fakeAuthUserRepository.authUser = AuthUser()
+
+        // when
+        sut.onIdleStateObserved()
+
+        // then
+        sut.uiState.test {
+            assertThat(awaitItem()).isEqualTo(SignInPromptScreenState.SignedIn)
+        }
+    }
+
+    private class AuthUserRepositoryStub : AuthUserRepository {
+
+        var authUser: AuthUser? = null
+
+        override suspend fun getAuthenticated(): AuthUser? {
+            return authUser
+        }
+    }
+}

--- a/auth-ui/src/test/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInViewModelTest.kt
+++ b/auth-ui/src/test/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInViewModelTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(
+    ExperimentalHorologistAuthUiApi::class,
+    ExperimentalCoroutinesApi::class
+)
+
+package com.google.android.horologist.auth.ui.googlesignin.signin
+
+import app.cash.turbine.test
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import com.google.android.horologist.auth.data.googlesignin.GoogleSignInEventListener
+import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
+import com.google.android.horologist.test.toolbox.MainDispatcherRule
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class GoogleSignInViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val spyGoogleSignInEventListener = GoogleSignInEventListenerSpy()
+
+    private lateinit var sut: GoogleSignInViewModel
+
+    @Before
+    fun setUp() {
+        sut = GoogleSignInViewModel(spyGoogleSignInEventListener)
+    }
+
+    @Test
+    fun givenInitialState_thenStateIsIdle() = runTest {
+        // when
+        val result = sut.uiState.value
+
+        // then
+        assertThat(result).isEqualTo(GoogleSignInScreenState.Idle)
+    }
+
+    @Test
+    fun givenInitialState_whenOnIdleStateObserved_thenStateIsSelectAccount() = runTest {
+        // when
+        val whenBlock = { sut.onIdleStateObserved() }
+
+        // then
+        sut.uiState.test {
+            skipItems(1)
+
+            whenBlock()
+
+            assertThat(awaitItem()).isEqualTo(GoogleSignInScreenState.SelectAccount)
+        }
+    }
+
+    @Test
+    fun givenNonIdleState_whenOnIdleStateObserved_thenStateIsTheSame() = runTest {
+        // when
+        sut.onIdleStateObserved()
+        val whenBlock = { sut.onIdleStateObserved() }
+
+        // then
+        sut.uiState.test {
+            assertThat(awaitItem()).isNotEqualTo(GoogleSignInScreenState.Idle)
+
+            whenBlock()
+
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun whenOnAccountSelected_thenStateIsSuccess() = runTest {
+        // when
+        val account = GoogleSignInAccount.createDefault()
+        sut.onAccountSelected(account)
+
+        // then
+        sut.uiState.test {
+            assertThat(awaitItem()).isInstanceOf(GoogleSignInScreenState.Success::class.java)
+        }
+        assertThat(spyGoogleSignInEventListener.onSignedInAccount).isEqualTo(account)
+    }
+
+    @Test
+    fun whenOnAccountSelectionFailed_thenStateIsFailed() = runTest {
+        // when
+        sut.onAccountSelectionFailed()
+
+        // then
+        sut.uiState.test {
+            assertThat(awaitItem()).isEqualTo(GoogleSignInScreenState.Failed)
+        }
+    }
+
+    @Test
+    fun whenOnAuthCancelled_thenStateIsCancelled() = runTest {
+        // when
+        sut.onAuthCancelled()
+
+        // then
+        sut.uiState.test {
+            assertThat(awaitItem()).isEqualTo(GoogleSignInScreenState.Cancelled)
+        }
+    }
+
+    private class GoogleSignInEventListenerSpy : GoogleSignInEventListener {
+
+        var onSignedInAccount: GoogleSignInAccount? = null
+            private set
+
+        override suspend fun onSignedIn(account: GoogleSignInAccount) {
+            onSignedInAccount = account
+        }
+    }
+}

--- a/auth-ui/src/test/java/com/google/android/horologist/test/toolbox/MainDispatcherRule.kt
+++ b/auth-ui/src/test/java/com/google/android/horologist/test/toolbox/MainDispatcherRule.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.google.android.horologist.test.toolbox
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestRule
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+/**
+ * Reusable JUnit4 [TestRule] to override the [main][Dispatchers.Main] dispatcher.
+ */
+class MainDispatcherRule(
+    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
+) : TestWatcher() {
+
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ androidxWear = "1.3.0-alpha03"
 androidxWork = "2.7.1"
 androidxtiles = "1.1.0"
 app-cash-paparazzi = "1.1.0"
+app-cash-turbine = "0.12.1"
 benManes = "0.44.0"
 com-squareup-okhttp3 = "4.10.0"
 com-squareup-retrofit2 = "2.9.0"
@@ -152,6 +153,7 @@ room-common = { module = "androidx.room:room-common", version.ref = "room" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
+turbine = { module = "app.cash.turbine:turbine", version.ref = "app-cash-turbine" }
 wearcompose-foundation = { module = "androidx.wear.compose:compose-foundation", version.ref = "wearcompose" }
 wearcompose-material = { module = "androidx.wear.compose:compose-material", version.ref = "wearcompose" }
 wearcompose-navigation = { module = "androidx.wear.compose:compose-navigation", version.ref = "wearcompose" }


### PR DESCRIPTION
#### WHAT

Add unit tests for `GoogleSignInViewModel` and `SignInPromptViewModel`.

#### HOW

Add dependency on [turbine](https://github.com/cashapp/turbine) in order to make it easier to test emissions by StateFlow.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
