### PR TITLE
Address lint warnings

### DIFF
--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/oauth/devicegrant/impl/google/AuthDeviceGrantTokenRepositoryGoogleImpl.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/oauth/devicegrant/impl/google/AuthDeviceGrantTokenRepositoryGoogleImpl.kt
@@ -42,16 +42,14 @@ public class AuthDeviceGrantTokenRepositoryGoogleImpl(
         config: AuthDeviceGrantDefaultConfig,
         verificationInfoPayload: DeviceCodeResponse
     ): Result<String> {
-        val future = RemoteActivityHelper(application).startRemoteActivity(
-            targetIntent = Intent(Intent.ACTION_VIEW).apply {
-                addCategory(Intent.CATEGORY_BROWSABLE)
-                data = Uri.parse(verificationInfoPayload.verificationUri)
-            },
-            targetNodeId = null
-        )
-
         try {
-            future.await()
+            RemoteActivityHelper(application).startRemoteActivity(
+                targetIntent = Intent(Intent.ACTION_VIEW).apply {
+                    addCategory(Intent.CATEGORY_BROWSABLE)
+                    data = Uri.parse(verificationInfoPayload.verificationUri)
+                },
+                targetNodeId = null
+            ).await()
         } catch (e: RemoteActivityHelper.RemoteIntentException) {
             Log.e(TAG, "Error starting remote activity", e)
             // It should return `Result.failure(e)` here, however, as described in b/263238683,


### PR DESCRIPTION
#### WHAT

Address lint warning regarding ListenableFuture not "linked" to the CoroutineScope.

#### HOW

Move code inside try/catch instead of storing `ListenableFuture` in a variable, as it would make sense anyway to wrap any exception in a `Result.failure`.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
