### PR TITLE
Remove unnecessary stateIn calls

### DIFF
--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptViewModel.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptViewModel.kt
@@ -22,9 +22,7 @@ import com.google.android.horologist.auth.data.common.repository.AuthUserReposit
 import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
 import com.google.android.horologist.auth.ui.ext.compareAndSet
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 /**
@@ -38,13 +36,8 @@ public open class SignInPromptViewModel(
     private val authUserRepository: AuthUserRepository
 ) : ViewModel() {
 
-    private val _uiState =
-        MutableStateFlow<SignInPromptScreenState>(SignInPromptScreenState.Idle)
-    public val uiState: StateFlow<SignInPromptScreenState> = _uiState.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
-        initialValue = SignInPromptScreenState.Idle
-    )
+    private val _uiState = MutableStateFlow<SignInPromptScreenState>(SignInPromptScreenState.Idle)
+    public val uiState: StateFlow<SignInPromptScreenState> = _uiState
 
     /**
      * Indicate that the screen has observed the [idle][SignInPromptScreenState.Idle] state and that

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInViewModel.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInViewModel.kt
@@ -24,10 +24,7 @@ import com.google.android.horologist.auth.data.googlesignin.GoogleSignInEventLis
 import com.google.android.horologist.auth.data.googlesignin.GoogleSignInEventListenerNoOpImpl
 import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 /**
@@ -38,14 +35,8 @@ public open class GoogleSignInViewModel(
     private val googleSignInEventListener: GoogleSignInEventListener = GoogleSignInEventListenerNoOpImpl
 ) : ViewModel() {
 
-    private val _uiState =
-        MutableStateFlow<GoogleSignInScreenState>(GoogleSignInScreenState.Idle)
-    public val uiState: StateFlow<GoogleSignInScreenState> = _uiState.onEach {
-    }.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
-        initialValue = GoogleSignInScreenState.Idle
-    )
+    private val _uiState = MutableStateFlow<GoogleSignInScreenState>(GoogleSignInScreenState.Idle)
+    public val uiState: StateFlow<GoogleSignInScreenState> = _uiState
 
     /**
      * Indicate that the screen has observed the [idle][GoogleSignInScreenState.Idle] state and that

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/oauth/devicegrant/AuthDeviceGrantViewModel.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/oauth/devicegrant/AuthDeviceGrantViewModel.kt
@@ -26,9 +26,7 @@ import com.google.android.horologist.auth.data.oauth.devicegrant.AuthDeviceGrant
 import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
 import com.google.android.horologist.auth.ui.ext.compareAndSet
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 @ExperimentalHorologistAuthUiApi
@@ -42,11 +40,7 @@ public open class AuthDeviceGrantViewModel<AuthDeviceGrantConfig, VerificationIn
 
     private val _uiState =
         MutableStateFlow<AuthDeviceGrantScreenState>(AuthDeviceGrantScreenState.Idle)
-    public val uiState: StateFlow<AuthDeviceGrantScreenState> = _uiState.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
-        initialValue = AuthDeviceGrantScreenState.Idle
-    )
+    public val uiState: StateFlow<AuthDeviceGrantScreenState> = _uiState
 
     public fun startAuthFlow() {
         _uiState.compareAndSet(

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/oauth/pkce/AuthPKCEViewModel.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/oauth/pkce/AuthPKCEViewModel.kt
@@ -27,9 +27,7 @@ import com.google.android.horologist.auth.data.oauth.pkce.AuthPKCETokenRepositor
 import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
 import com.google.android.horologist.auth.ui.ext.compareAndSet
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 @ExperimentalHorologistAuthUiApi
@@ -41,11 +39,7 @@ public open class AuthPKCEViewModel<AuthPKCEConfig, OAuthCodePayload, TokenPaylo
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<AuthPKCEScreenState>(AuthPKCEScreenState.Idle)
-    public val uiState: StateFlow<AuthPKCEScreenState> = _uiState.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
-        initialValue = AuthPKCEScreenState.Idle
-    )
+    public val uiState: StateFlow<AuthPKCEScreenState> = _uiState
 
     public fun startAuthFlow() {
         _uiState.compareAndSet(

--- a/sample/src/main/java/com/google/android/horologist/auth/googlesignin/signout/GoogleSignOutViewModel.kt
+++ b/sample/src/main/java/com/google/android/horologist/auth/googlesignin/signout/GoogleSignOutViewModel.kt
@@ -27,9 +27,7 @@ import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.common.api.ApiException
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 
@@ -38,11 +36,7 @@ class GoogleSignOutViewModel(
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(GoogleSignOutScreenState.Idle)
-    public val uiState: StateFlow<GoogleSignOutScreenState> = _uiState.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
-        initialValue = GoogleSignOutScreenState.Idle
-    )
+    public val uiState: StateFlow<GoogleSignOutScreenState> = _uiState
 
     fun startFlow() {
         if (_uiState.compareAndSet(


### PR DESCRIPTION
#### WHAT

Remove `stateIn` calls in properties that are already a `StateFlow`.

#### WHY

https://github.com/google/horologist/pull/765#discussion_r1029168249

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
