### PR TITLE
Exposes playback speed method

### DIFF
--- a/media-data/api/current.api
+++ b/media-data/api/current.api
@@ -345,7 +345,7 @@ package com.google.android.horologist.media.data.repository {
     property public kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.media.model.Media> currentMedia;
     property public kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.media.model.PlayerState> currentState;
     property public kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.media.model.MediaPosition> mediaPosition;
-    property public final kotlinx.coroutines.flow.StateFlow<java.lang.Float> playbackSpeed;
+    property public kotlinx.coroutines.flow.StateFlow<java.lang.Float> playbackSpeed;
     property public final kotlinx.coroutines.flow.StateFlow<androidx.media3.common.Player> player;
     property public kotlinx.coroutines.flow.StateFlow<kotlin.time.Duration> seekBackIncrement;
     property public kotlinx.coroutines.flow.StateFlow<kotlin.time.Duration> seekForwardIncrement;

--- a/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImpl.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImpl.kt
@@ -86,7 +86,7 @@ public class PlayerRepositoryImpl(
      * The current playback speed relative to 1.0.
      */
     private var _playbackSpeed = MutableStateFlow(1f)
-    public val playbackSpeed: StateFlow<Float> get() = _playbackSpeed
+    override val playbackSpeed: StateFlow<Float> get() = _playbackSpeed
 
     private var _seekBackIncrement = MutableStateFlow<Duration?>(null)
     override val seekBackIncrement: StateFlow<Duration?> get() = _seekBackIncrement

--- a/media-sample/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/FakePlayerRepository.kt
+++ b/media-sample/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/FakePlayerRepository.kt
@@ -55,6 +55,9 @@ class FakePlayerRepository() : PlayerRepository {
     private var _seekForwardIncrement = MutableStateFlow<Duration?>(null)
     override val seekForwardIncrement: StateFlow<Duration?> = _seekForwardIncrement
 
+    private var _playbackSpeed = MutableStateFlow(1f)
+    override val playbackSpeed: StateFlow<Float> = _playbackSpeed
+
     private var _mediaList: List<Media>? = null
     private var currentItemIndex = -1
 

--- a/media-ui/src/androidTest/java/com/google/android/horologist/test/toolbox/testdoubles/FakePlayerRepository.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/test/toolbox/testdoubles/FakePlayerRepository.kt
@@ -55,6 +55,9 @@ class FakePlayerRepository() : PlayerRepository {
     private var _seekForwardIncrement = MutableStateFlow<Duration?>(null)
     override val seekForwardIncrement: StateFlow<Duration?> = _seekForwardIncrement
 
+    private var _playbackSpeed = MutableStateFlow(1f)
+    override val playbackSpeed: StateFlow<Float> = _playbackSpeed
+
     private var _mediaList: List<Media>? = null
     private var currentItemIndex = -1
 

--- a/media-ui/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/MockPlayerRepository.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/MockPlayerRepository.kt
@@ -35,7 +35,8 @@ class MockPlayerRepository(
     private val mediaPositionValue: MediaPosition? = null,
     private val shuffleModeEnabledValue: Boolean = false,
     private val seekBackIncrementValue: Duration? = null,
-    private val seekForwardIncrementValue: Duration? = null
+    private val seekForwardIncrementValue: Duration? = null,
+    private val playbackSpeedValue: Float = 1f
 ) : PlayerRepository {
 
     override val connected: StateFlow<Boolean>
@@ -61,6 +62,9 @@ class MockPlayerRepository(
 
     override val seekForwardIncrement: StateFlow<Duration?>
         get() = MutableStateFlow(seekForwardIncrementValue)
+
+    override val playbackSpeed: StateFlow<Float>
+        get() = MutableStateFlow(playbackSpeedValue)
 
     override fun prepare() {
         // do nothing

--- a/media/api/current.api
+++ b/media/api/current.api
@@ -190,6 +190,7 @@ package com.google.android.horologist.media.repository {
     method public com.google.android.horologist.media.model.Media? getMediaAt(int index);
     method public int getMediaCount();
     method public kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.media.model.MediaPosition> getMediaPosition();
+    method public kotlinx.coroutines.flow.StateFlow<java.lang.Float> getPlaybackSpeed();
     method public kotlinx.coroutines.flow.StateFlow<kotlin.time.Duration> getSeekBackIncrement();
     method public kotlinx.coroutines.flow.StateFlow<kotlin.time.Duration> getSeekForwardIncrement();
     method public kotlinx.coroutines.flow.StateFlow<java.lang.Boolean> getShuffleModeEnabled();
@@ -215,6 +216,7 @@ package com.google.android.horologist.media.repository {
     property public abstract kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.media.model.Media> currentMedia;
     property public abstract kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.media.model.PlayerState> currentState;
     property public abstract kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.media.model.MediaPosition> mediaPosition;
+    property public abstract kotlinx.coroutines.flow.StateFlow<java.lang.Float> playbackSpeed;
     property public abstract kotlinx.coroutines.flow.StateFlow<kotlin.time.Duration> seekBackIncrement;
     property public abstract kotlinx.coroutines.flow.StateFlow<kotlin.time.Duration> seekForwardIncrement;
     property public abstract kotlinx.coroutines.flow.StateFlow<java.lang.Boolean> shuffleModeEnabled;

--- a/media/src/main/java/com/google/android/horologist/media/repository/PlayerRepository.kt
+++ b/media/src/main/java/com/google/android/horologist/media/repository/PlayerRepository.kt
@@ -68,6 +68,11 @@ public interface PlayerRepository {
     public val seekForwardIncrement: StateFlow<Duration?>
 
     /**
+     * Returns the current [playbackSpeed].
+     */
+    public val playbackSpeed: StateFlow<Float>
+
+    /**
      * Prepares the player. E.g. player will start acquiring all the required resources to play.
      */
     public fun prepare()


### PR DESCRIPTION
#### WHAT
Currently playback speed can be set but cannot be read from using the interface

#### WHY
So that the playback speed can be read and the value can be represented in the UI

#### HOW
Add a get method to the interface

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
