### PR TITLE
Bump paparazzi to version 1.2

### DIFF
--- a/audio-ui/build.gradle.kts
+++ b/audio-ui/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("kotlin-android")
     id("org.jetbrains.dokka")
     id("org.jetbrains.kotlin.kapt")
-    id("dev.chrisbanes.paparazzi")
+    id("app.cash.paparazzi")
     id("me.tylerbwong.gradle.metalava")
 }
 

--- a/auth-composables/build.gradle.kts
+++ b/auth-composables/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("org.jetbrains.dokka")
-    id("dev.chrisbanes.paparazzi")
+    id("app.cash.paparazzi")
     id("me.tylerbwong.gradle.metalava")
 }
 

--- a/auth-ui/build.gradle.kts
+++ b/auth-ui/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("org.jetbrains.dokka")
-    id("dev.chrisbanes.paparazzi")
+    id("app.cash.paparazzi")
     id("me.tylerbwong.gradle.metalava")
 }
 

--- a/base-ui/build.gradle.kts
+++ b/base-ui/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("org.jetbrains.dokka")
-    id("dev.chrisbanes.paparazzi")
+    id("app.cash.paparazzi")
     id("me.tylerbwong.gradle.metalava")
 }
 

--- a/composables/build.gradle.kts
+++ b/composables/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("org.jetbrains.dokka")
-    id("dev.chrisbanes.paparazzi")
+    id("app.cash.paparazzi")
     id("me.tylerbwong.gradle.metalava")
 }
 

--- a/compose-tools/build.gradle.kts
+++ b/compose-tools/build.gradle.kts
@@ -93,7 +93,7 @@ metalava {
 
 dependencies {
     implementation(libs.kotlin.stdlib)
-
+    implementation(libs.kotlin.reflect)
     implementation(projects.tiles)
 
     implementation(libs.compose.ui.tooling)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ androidxTracing = "1.1.0"
 androidxWear = "1.3.0-alpha03"
 androidxWork = "2.7.1"
 androidxtiles = "1.1.0"
-app-cash-paparazzi = "1.1.0"
+app-cash-paparazzi = "1.2.0"
 app-cash-turbine = "0.12.1"
 benManes = "0.44.0"
 com-squareup-okhttp3 = "4.10.0"
@@ -130,6 +130,7 @@ hilt-ext-work = { module = "androidx.hilt:hilt-work", version.ref = "androidx-hi
 hilt-navigationcompose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "androidx-hilt" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-stdlib = "org.jetbrains.kotlin:kotlin-stdlib:1.7.20"
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutine" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutine" }
@@ -142,7 +143,7 @@ moshi-adapters = { module = "com.squareup.moshi:moshi-adapters", version.ref = "
 moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
 moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
 paparazzi = { module = "app.cash.paparazzi:paparazzi", version.ref = "app-cash-paparazzi" }
-paparazziPlugin = "dev.chrisbanes.paparazzi:paparazzi-gradle-plugin:1.1.0-sdk33-alpha02"
+paparazziPlugin = { module = "app.cash.paparazzi:paparazzi-gradle-plugin", version.ref = "app-cash-paparazzi"}
 playservices-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "playServicesAuth" }
 playservices-wearable = "com.google.android.gms:play-services-wearable:18.0.0"
 protobuf-kotlin-lite = "com.google.protobuf:protobuf-kotlin-lite:3.21.9"

--- a/media-ui/build.gradle.kts
+++ b/media-ui/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("org.jetbrains.dokka")
-    id("dev.chrisbanes.paparazzi")
+    id("app.cash.paparazzi")
     id("me.tylerbwong.gradle.metalava")
 }
 


### PR DESCRIPTION
#### WHAT

Making a draft PR on Bumping paparazzi to 1.2 and using the artefact from app.cash


#### WHY
Resolves #932 

#### HOW
Bumping the dependencies

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
