### PR TITLE
Fix compose ui-tooling setup

### DIFF
--- a/audio-ui/build.gradle.kts
+++ b/audio-ui/build.gradle.kts
@@ -109,13 +109,13 @@ dependencies {
     implementation(libs.compose.material.iconscore)
     implementation(libs.compose.material.iconsext)
 
-    implementation(libs.compose.ui.tooling)
     implementation(libs.androidx.wear)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
 
     implementation(libs.lottie.compose)
 
-    debugImplementation(libs.compose.ui.toolingpreview)
+    implementation(libs.compose.ui.toolingpreview)
+    debugImplementation(libs.compose.ui.tooling)
     debugImplementation(projects.composeTools)
 
     testImplementation(libs.junit)

--- a/auth-composables/build.gradle.kts
+++ b/auth-composables/build.gradle.kts
@@ -109,7 +109,7 @@ dependencies {
     implementation(libs.wearcompose.foundation)
 
     debugImplementation(projects.composeTools)
-    debugImplementation(libs.compose.ui.toolingpreview)
+    implementation(libs.compose.ui.toolingpreview)
 
     testImplementation(projects.paparazzi)
     testImplementation(libs.androidx.test.ext.ktx)

--- a/auth-data/build.gradle.kts
+++ b/auth-data/build.gradle.kts
@@ -102,7 +102,7 @@ dependencies {
     ksp(libs.moshi.kotlin.codegen)
 
     debugImplementation(projects.composeTools)
-    debugImplementation(libs.compose.ui.toolingpreview)
+    implementation(libs.compose.ui.toolingpreview)
 
     testImplementation(libs.junit)
     testImplementation(libs.truth)

--- a/auth-sample-wear/build.gradle.kts
+++ b/auth-sample-wear/build.gradle.kts
@@ -92,12 +92,14 @@ dependencies {
     implementation(projects.baseUi)
     implementation(projects.composables)
     implementation(projects.composeLayout)
+    implementation(projects.composeTools)
 
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.wear)
     implementation(libs.compose.foundation.foundation)
+    implementation(libs.compose.ui.toolingpreview)
     implementation(libs.kotlin.stdlib)
     implementation(libs.wearcompose.material)
     implementation(libs.wearcompose.foundation)
@@ -109,8 +111,7 @@ dependencies {
     implementation(libs.moshi.kotlin)
     implementation(libs.playservices.auth)
 
-    debugImplementation(projects.composeTools)
-    debugImplementation(libs.compose.ui.toolingpreview)
+    debugImplementation(libs.compose.ui.tooling)
 }
 
 secrets {

--- a/auth-ui/build.gradle.kts
+++ b/auth-ui/build.gradle.kts
@@ -119,7 +119,7 @@ dependencies {
     implementation(libs.wearcompose.foundation)
 
     debugImplementation(projects.composeTools)
-    debugImplementation(libs.compose.ui.toolingpreview)
+    implementation(libs.compose.ui.toolingpreview)
 
     testImplementation(projects.composeTools)
     testImplementation(projects.paparazzi)

--- a/base-ui/build.gradle.kts
+++ b/base-ui/build.gradle.kts
@@ -97,7 +97,6 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime)
     implementation(libs.wearcompose.material)
     implementation(libs.wearcompose.foundation)
-    implementation(libs.compose.ui.tooling)
     implementation(libs.compose.material.iconscore)
     implementation(libs.compose.material.iconsext)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
@@ -105,13 +104,11 @@ dependencies {
     implementation(libs.coil)
     implementation(libs.androidx.palette.ktx)
 
-
+    implementation(libs.compose.ui.toolingpreview)
+    debugImplementation(libs.compose.ui.tooling)
     debugImplementation(projects.composeTools)
-    debugImplementation(libs.compose.ui.toolingpreview)
 
     debugImplementation(libs.compose.ui.test.manifest)
-    debugImplementation(libs.compose.ui.toolingpreview)
-    debugImplementation(projects.composeTools)
 
     testImplementation(libs.junit)
     testImplementation(libs.androidx.test.ext.ktx)

--- a/composables/build.gradle.kts
+++ b/composables/build.gradle.kts
@@ -98,13 +98,13 @@ dependencies {
     implementation(libs.androidx.wear)
     implementation(libs.wearcompose.material)
     implementation(libs.wearcompose.foundation)
-    implementation(libs.compose.ui.tooling)
     implementation(libs.compose.material.iconscore)
     implementation(libs.compose.material.iconsext)
     implementation(libs.androidx.corektx)
 
+    implementation(libs.compose.ui.toolingpreview)
+    debugImplementation(libs.compose.ui.tooling)
     debugImplementation(libs.compose.ui.test.manifest)
-    debugImplementation(libs.compose.ui.toolingpreview)
     debugImplementation(projects.composeTools)
 
     testImplementation(libs.junit)

--- a/compose-layout/build.gradle.kts
+++ b/compose-layout/build.gradle.kts
@@ -82,7 +82,6 @@ metalava {
 }
 
 dependencies {
-    implementation(libs.kotlin.stdlib)
 
     api(libs.wearcompose.material)
     api(libs.wearcompose.foundation)
@@ -90,24 +89,27 @@ dependencies {
 
     api(libs.accompanist.pager)
 
-    implementation(libs.compose.ui.tooling)
+    api(libs.androidx.lifecycle.runtime.compose)
+    api(libs.androidx.paging)
+
+    implementation(libs.kotlin.stdlib)
     implementation(libs.compose.ui.util)
     implementation(libs.androidx.wear)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
-    debugImplementation(projects.composeTools)
-    debugImplementation(libs.compose.ui.toolingpreview)
-    debugImplementation(libs.androidx.activity.compose)
-    api(libs.androidx.lifecycle.runtime.compose)
+    implementation(libs.compose.ui.toolingpreview)
 
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.navigation.ui.ktx)
 
-    api(libs.androidx.paging)
+    debugImplementation(libs.compose.ui.tooling)
+    debugImplementation(projects.composeTools)
+    debugImplementation(libs.androidx.activity.compose)
+    debugImplementation(libs.compose.ui.test.manifest)
 
     testImplementation(libs.junit)
     testImplementation(libs.truth)
+
     androidTestImplementation(libs.compose.ui.test.junit4)
-    debugImplementation(libs.compose.ui.test.manifest)
     androidTestImplementation(libs.espresso.core)
     androidTestImplementation(libs.truth)
     androidTestImplementation(libs.junit)

--- a/compose-tools/build.gradle.kts
+++ b/compose-tools/build.gradle.kts
@@ -96,8 +96,6 @@ dependencies {
 
     implementation(projects.tiles)
 
-    implementation(libs.compose.ui.tooling)
-
     implementation(libs.wearcompose.material)
     implementation(libs.wearcompose.foundation)
     implementation(libs.wearcompose.navigation)
@@ -106,10 +104,12 @@ dependencies {
     implementation(libs.androidx.wear.tiles.renderer)
     implementation(libs.coil)
 
-    compileOnly(projects.paparazzi)
+    implementation(libs.compose.ui.toolingpreview)
 
+    debugImplementation(libs.compose.ui.tooling)
     debugImplementation(libs.compose.ui.test.manifest)
-    debugImplementation(libs.compose.ui.toolingpreview)
+
+    compileOnly(projects.paparazzi)
 }
 
 apply(plugin = "com.vanniktech.maven.publish")

--- a/media-sample/build.gradle.kts
+++ b/media-sample/build.gradle.kts
@@ -168,7 +168,6 @@ dependencies {
         project.findProject(":media-lib-datasource-okhttp") ?: libs.androidx.media3.datasourceokhttp
     )
 
-    implementation(libs.compose.ui.tooling)
     implementation(libs.compose.ui.util)
 
     implementation(libs.compose.foundation.foundation)
@@ -209,8 +208,6 @@ dependencies {
     implementation(libs.kotlin.stdlib)
     implementation(libs.kotlinx.coroutines.guava)
 
-    debugImplementation(projects.composeTools)
-
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.complications.rendering)
 
@@ -230,6 +227,9 @@ dependencies {
     ksp(libs.room.compiler)
 
     implementation(libs.androidx.tracing.ktx)
+
+    debugImplementation(libs.compose.ui.tooling)
+    debugImplementation(projects.composeTools)
 
     testImplementation(libs.junit)
     testImplementation(libs.truth)

--- a/media-ui/build.gradle.kts
+++ b/media-ui/build.gradle.kts
@@ -118,7 +118,6 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodelktx)
     api(libs.wearcompose.material)
     api(libs.wearcompose.foundation)
-    implementation(libs.compose.ui.tooling)
     implementation(libs.compose.material.iconscore)
     implementation(libs.compose.material.iconsext)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
@@ -132,11 +131,11 @@ dependencies {
     implementation(libs.androidx.complications.datasource.ktx)
     implementation(libs.androidx.wear.tiles)
     implementation(libs.androidx.wear.tiles.material)
-    implementation(libs.compose.ui.tooling)
     implementation(libs.compose.ui.util)
+    implementation(libs.compose.ui.toolingpreview)
 
+    debugImplementation(libs.compose.ui.tooling)
     debugImplementation(libs.compose.ui.test.manifest)
-    debugImplementation(libs.compose.ui.toolingpreview)
     debugImplementation(projects.audioUi)
     debugImplementation(projects.composeTools)
 

--- a/network-awareness/build.gradle.kts
+++ b/network-awareness/build.gradle.kts
@@ -95,7 +95,6 @@ dependencies {
     implementation(libs.androidx.wear)
     implementation(libs.wearcompose.material)
     implementation(libs.wearcompose.foundation)
-    implementation(libs.compose.ui.tooling)
     implementation(libs.compose.material.iconscore)
     implementation(libs.compose.material.iconsext)
 
@@ -107,8 +106,10 @@ dependencies {
 
     implementation(libs.androidx.tracing.ktx)
 
+    implementation(libs.compose.ui.toolingpreview)
+
+    debugImplementation(libs.compose.ui.tooling)
     debugImplementation(libs.compose.ui.test.manifest)
-    debugImplementation(libs.compose.ui.toolingpreview)
 
     testImplementation(libs.junit)
     testImplementation(libs.truth)

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -151,7 +151,6 @@ dependencies {
     implementation(projects.composeTools)
     implementation(projects.datalayer)
 
-    implementation(libs.compose.ui.tooling)
     implementation(libs.compose.ui.util)
 
     implementation(libs.compose.foundation.foundation)
@@ -180,6 +179,9 @@ dependencies {
 
     implementation(libs.com.squareup.okhttp3.logging.interceptor)
 
+    implementation(libs.compose.ui.toolingpreview)
+
+    debugImplementation(libs.compose.ui.tooling)
     debugImplementation(projects.composeTools)
 
     androidTestImplementation(libs.compose.ui.test.junit4)


### PR DESCRIPTION
#### WHAT

Fix dependency on compose `ui-tooling`.

#### WHY

Our setup had it inverted according to the [docs](https://developer.android.com/jetpack/compose/tooling/studio): `ui-tooling` was set as `implementation` and `ui-toolingpreview` was set as `debugImplementation`.

This also fixes our nightly build for release builds.

#### HOW

Change `ui-tooling` to `debugImplementation` and `ui-toolingpreview` to `implementation`.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
