### PR TITLE
Update jvmTarget to 11

### DIFF
--- a/audio-ui/build.gradle.kts
+++ b/audio-ui/build.gradle.kts
@@ -43,7 +43,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     composeOptions {

--- a/audio/build.gradle.kts
+++ b/audio/build.gradle.kts
@@ -41,7 +41,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     composeOptions {

--- a/auth-composables/build.gradle.kts
+++ b/auth-composables/build.gradle.kts
@@ -43,7 +43,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
         freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn"
         freeCompilerArgs = freeCompilerArgs + "-opt-in=com.google.android.horologist.base.ui.ExperimentalHorologistBaseUiApi"
         freeCompilerArgs = freeCompilerArgs + "-opt-in=com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi"

--- a/auth-data/build.gradle.kts
+++ b/auth-data/build.gradle.kts
@@ -42,7 +42,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
         freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn"
     }
 

--- a/auth-sample-wear/build.gradle.kts
+++ b/auth-sample-wear/build.gradle.kts
@@ -64,7 +64,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
 
         // Allow for widescale experimental APIs in Alpha libraries we build upon
         freeCompilerArgs = freeCompilerArgs + listOf(

--- a/auth-ui/build.gradle.kts
+++ b/auth-ui/build.gradle.kts
@@ -43,7 +43,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
         freeCompilerArgs = listOf(
             "-opt-in=androidx.lifecycle.compose.ExperimentalLifecycleComposeApi",
             "-opt-in=com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi",

--- a/base-ui/build.gradle.kts
+++ b/base-ui/build.gradle.kts
@@ -43,7 +43,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     composeOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -153,7 +153,7 @@ subprojects {
                 allWarningsAsErrors = true
             }
             // Set JVM target to 1.8
-            jvmTarget = "1.8"
+            jvmTarget = "11"
             freeCompilerArgs = freeCompilerArgs + listOf(
                 // Allow use of @OptIn
                 "-opt-in=kotlin.RequiresOptIn",

--- a/composables/build.gradle.kts
+++ b/composables/build.gradle.kts
@@ -43,7 +43,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
         freeCompilerArgs = freeCompilerArgs + listOf(
             "-opt-in=kotlin.RequiresOptIn",
             "-opt-in=com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi"

--- a/compose-layout/build.gradle.kts
+++ b/compose-layout/build.gradle.kts
@@ -42,7 +42,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     composeOptions {

--- a/compose-tools/build.gradle.kts
+++ b/compose-tools/build.gradle.kts
@@ -42,7 +42,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     composeOptions {

--- a/datalayer/build.gradle.kts
+++ b/datalayer/build.gradle.kts
@@ -41,7 +41,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
         freeCompilerArgs = freeCompilerArgs + listOf(
             "-opt-in=kotlin.RequiresOptIn",
             "-opt-in=com.google.android.horologist.data.ExperimentalHorologistDataLayerApi"

--- a/media-benchmark/build.gradle.kts
+++ b/media-benchmark/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
         freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn"
     }
 

--- a/media-data/build.gradle.kts
+++ b/media-data/build.gradle.kts
@@ -42,7 +42,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
         freeCompilerArgs = freeCompilerArgs + listOf(
             "-opt-in=com.google.android.horologist.media.ExperimentalHorologistMediaApi",
             "-opt-in=kotlin.RequiresOptIn"

--- a/media-sample-benchmark/build.gradle.kts
+++ b/media-sample-benchmark/build.gradle.kts
@@ -29,7 +29,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     defaultConfig {

--- a/media-sample/build.gradle.kts
+++ b/media-sample/build.gradle.kts
@@ -91,7 +91,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
         // Allow for widescale experimental APIs in Alpha libraries we build upon
         freeCompilerArgs = freeCompilerArgs + listOf(
             "-opt-in=androidx.compose.ui.ExperimentalComposeUiApi",

--- a/media-sync/build.gradle.kts
+++ b/media-sync/build.gradle.kts
@@ -42,7 +42,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
     packagingOptions {
         resources {

--- a/media-ui/build.gradle.kts
+++ b/media-ui/build.gradle.kts
@@ -43,7 +43,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
         freeCompilerArgs = freeCompilerArgs + listOf(
             "-opt-in=androidx.lifecycle.compose.ExperimentalLifecycleComposeApi",
             "-opt-in=com.google.accompanist.pager.ExperimentalPagerApi",

--- a/media3-backend/build.gradle.kts
+++ b/media3-backend/build.gradle.kts
@@ -41,7 +41,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
         freeCompilerArgs = freeCompilerArgs + listOf(
             "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
             "-opt-in=com.google.android.horologist.audio.ExperimentalHorologistAudioApi",

--- a/network-awareness/build.gradle.kts
+++ b/network-awareness/build.gradle.kts
@@ -44,7 +44,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
         freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn"
     }
 

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -66,7 +66,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
         // Allow for widescale experimental APIs in Alpha libraries we build upon
         freeCompilerArgs = freeCompilerArgs + listOf(
             "-opt-in=androidx.compose.ui.ExperimentalComposeUiApi",

--- a/tiles/build.gradle.kts
+++ b/tiles/build.gradle.kts
@@ -44,7 +44,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     composeOptions {


### PR DESCRIPTION
#### WHAT

Update [jvmTarget attribute](https://kotlinlang.org/docs/gradle-compiler-options.html#attributes-specific-to-jvm) in the kotlin extension to 11.

#### WHY

In order to avoid cause JVM target incompatibility. 
```
> Task :auth-ui:compileDebugKotlin
'compileDebugJavaWithJavac' task (current target is 11) and 'compileDebugKotlin' task (current target is 1.8) jvm target compatibility should be set to the same Java version.
```

Missed in https://github.com/google/horologist/pull/928.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
