### PR TITLE
Add auth-composables to the auto translation pipeline

### DIFF
--- a/localization.bzl
+++ b/localization.bzl
@@ -1,6 +1,7 @@
 # List of files that are part of the automated translation pipeline
 localized_files = [
+    "audio-ui/src/main/res/values/strings.xml",
+    "auth-composables/src/main/res/values/strings.xml",
     "composables/src/main/res/values/strings.xml",
     "media-ui/src/main/res/values/strings.xml",
-    "audio-ui/src/main/res/values/strings.xml",
 ]


### PR DESCRIPTION
#### WHAT

Add `auth-composables` to the auto translation pipeline.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
