### PR TITLE
Rotary

### DIFF
--- a/compose-layout/api/current.api
+++ b/compose-layout/api/current.api
@@ -346,6 +346,14 @@ package com.google.android.horologist.compose.rotaryinput {
     property public final int ScrollTick;
   }
 
+  public final class RotaryInputConfigDefaults {
+    field public static final long DEFAULT_EVENT_ACCUMULATION_THRESHOLD_MS = 200L; // 0xc8L
+    field public static final float DEFAULT_MIN_VALUE_CHANGE_DISTANCE_PX = 48.0f;
+    field public static final long DEFAULT_RATE_LIMIT_COOL_DOWN_MS = 300L; // 0x12cL
+    field public static final com.google.android.horologist.compose.rotaryinput.RotaryInputConfigDefaults INSTANCE;
+    field public static final long RATE_LIMITING_DISABLED = -1L; // 0xffffffffffffffffL
+  }
+
   public final class RotaryKt {
     method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public static kotlinx.coroutines.flow.Flow<com.google.android.horologist.compose.rotaryinput.TimestampedDelta> batchRequestsWithinTimeframe(kotlinx.coroutines.flow.Flow<com.google.android.horologist.compose.rotaryinput.TimestampedDelta>, long timeframe);
     method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public static androidx.compose.ui.Modifier rotaryHandler(androidx.compose.ui.Modifier, com.google.android.horologist.compose.rotaryinput.RotaryScrollHandler rotaryScrollHandler, optional long batchTimeframe, com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback rotaryHaptics);

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/AccumulatedRotaryInputModifier.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/AccumulatedRotaryInputModifier.kt
@@ -58,8 +58,8 @@ internal fun RotaryInputAccumulator.onRotaryScrollEvent(event: RotaryScrollEvent
 }
 
 public object RotaryInputConfigDefaults {
-    const val DEFAULT_EVENT_ACCUMULATION_THRESHOLD_MS: Long = 200L
-    const val DEFAULT_MIN_VALUE_CHANGE_DISTANCE_PX: Float = 48f
-    const val DEFAULT_RATE_LIMIT_COOL_DOWN_MS: Long = 300L
-    const val RATE_LIMITING_DISABLED: Long = -1L
+    public const val DEFAULT_EVENT_ACCUMULATION_THRESHOLD_MS: Long = 200L
+    public const val DEFAULT_MIN_VALUE_CHANGE_DISTANCE_PX: Float = 48f
+    public const val DEFAULT_RATE_LIMIT_COOL_DOWN_MS: Long = 300L
+    public const val RATE_LIMITING_DISABLED: Long = -1L
 }

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/AccumulatedRotaryInputModifier.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/AccumulatedRotaryInputModifier.kt
@@ -32,9 +32,9 @@ import androidx.compose.ui.input.rotary.onRotaryScrollEvent
  */
 @OptIn(ExperimentalComposeUiApi::class)
 public fun Modifier.onRotaryInputAccumulated(
-    eventAccumulationThresholdMs: Long = RotaryInputAccumulator.DEFAULT_EVENT_ACCUMULATION_THRESHOLD_MS,
-    minValueChangeDistancePx: Float = RotaryInputAccumulator.DEFAULT_MIN_VALUE_CHANGE_DISTANCE_PX,
-    rateLimitCoolDownMs: Long = RotaryInputAccumulator.DEFAULT_RATE_LIMIT_COOL_DOWN_MS,
+    eventAccumulationThresholdMs: Long = RotaryInputConfigDefaults.DEFAULT_EVENT_ACCUMULATION_THRESHOLD_MS,
+    minValueChangeDistancePx: Float = RotaryInputConfigDefaults.DEFAULT_MIN_VALUE_CHANGE_DISTANCE_PX,
+    rateLimitCoolDownMs: Long = RotaryInputConfigDefaults.DEFAULT_RATE_LIMIT_COOL_DOWN_MS,
     onValueChange: (change: Float) -> Unit
 ): Modifier {
     val rotaryInputAccumulator = RotaryInputAccumulator(
@@ -55,4 +55,11 @@ public fun Modifier.onRotaryInputAccumulated(
 internal fun RotaryInputAccumulator.onRotaryScrollEvent(event: RotaryScrollEvent): Boolean {
     onRotaryScroll(event.verticalScrollPixels, event.uptimeMillis)
     return true
+}
+
+public object RotaryInputConfigDefaults {
+    const val DEFAULT_EVENT_ACCUMULATION_THRESHOLD_MS: Long = 200L
+    const val DEFAULT_MIN_VALUE_CHANGE_DISTANCE_PX: Float = 48f
+    const val DEFAULT_RATE_LIMIT_COOL_DOWN_MS: Long = 300L
+    const val RATE_LIMITING_DISABLED: Long = -1L
 }

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/GenericMotionRotaryInputAccumulator.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/GenericMotionRotaryInputAccumulator.kt
@@ -31,9 +31,9 @@ import androidx.core.view.ViewConfigurationCompat
 public class GenericMotionRotaryInputAccumulator(
     context: Context,
     onValueChange: (change: Float) -> Unit,
-    eventAccumulationThresholdMs: Long = RotaryInputAccumulator.DEFAULT_EVENT_ACCUMULATION_THRESHOLD_MS,
-    minValueChangeDistancePx: Float = RotaryInputAccumulator.DEFAULT_MIN_VALUE_CHANGE_DISTANCE_PX,
-    rateLimitCoolDownMs: Long = RotaryInputAccumulator.DEFAULT_RATE_LIMIT_COOL_DOWN_MS
+    eventAccumulationThresholdMs: Long = RotaryInputConfigDefaults.DEFAULT_EVENT_ACCUMULATION_THRESHOLD_MS,
+    minValueChangeDistancePx: Float = RotaryInputConfigDefaults.DEFAULT_MIN_VALUE_CHANGE_DISTANCE_PX,
+    rateLimitCoolDownMs: Long = RotaryInputConfigDefaults.DEFAULT_RATE_LIMIT_COOL_DOWN_MS
 ) {
 
     private val rotaryInputEventReader: RotaryInputEventReader = RotaryInputEventReader(context)

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/RotaryInputAccumulator.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/RotaryInputAccumulator.kt
@@ -19,7 +19,7 @@ package com.google.android.horologist.compose.rotaryinput
 import kotlin.math.abs
 
 /** Accumulator to trigger callbacks based on rotary input event. */
-internal class RotaryInputAccumulator(
+class RotaryInputAccumulator(
     private val eventAccumulationThresholdMs: Long,
     private val minValueChangeDistancePx: Float,
     private val rateLimitCoolDownMs: Long,
@@ -55,12 +55,5 @@ internal class RotaryInputAccumulator(
         onValueChange(accumulatedDistance)
         lastUpdateTimeMs = eventTimeMs
         accumulatedDistance = 0f
-    }
-
-    companion object {
-        const val DEFAULT_EVENT_ACCUMULATION_THRESHOLD_MS = 200L
-        const val DEFAULT_MIN_VALUE_CHANGE_DISTANCE_PX = 48f
-        const val DEFAULT_RATE_LIMIT_COOL_DOWN_MS = 300L
-        const val RATE_LIMITING_DISABLED = -1L
     }
 }

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/RotaryInputAccumulator.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/RotaryInputAccumulator.kt
@@ -19,7 +19,7 @@ package com.google.android.horologist.compose.rotaryinput
 import kotlin.math.abs
 
 /** Accumulator to trigger callbacks based on rotary input event. */
-class RotaryInputAccumulator(
+internal class RotaryInputAccumulator(
     private val eventAccumulationThresholdMs: Long,
     private val minValueChangeDistancePx: Float,
     private val rateLimitCoolDownMs: Long,

--- a/compose-layout/src/test/java/com/google/android/horologist/compose/rotaryinput/RotaryInputAccumulatorTest.kt
+++ b/compose-layout/src/test/java/com/google/android/horologist/compose/rotaryinput/RotaryInputAccumulatorTest.kt
@@ -32,7 +32,7 @@ class RotaryInputAccumulatorTest {
         RotaryInputAccumulator(
             eventAccumulationThresholdMs = accumulationThreshold,
             minValueChangeDistancePx = minChangePx,
-            rateLimitCoolDownMs = RotaryInputAccumulator.RATE_LIMITING_DISABLED
+            rateLimitCoolDownMs = RotaryInputConfigDefaults.RATE_LIMITING_DISABLED
         ) {
             latestValue.set(it)
             valueChangedTimes.incrementAndGet()


### PR DESCRIPTION
#### WHAT
Move the RotaryInputAccumulator default values to modifier

#### WHY
So these configs can be accessible in modifiers outside of the package

#### HOW


#### Checklist :clipboard:
- [X] Add explicit visibility modifier and explicit return types for public declarations
- [X] Run spotless check
- [X] Run tests
- [X] Update metalava's signature text files
