### PR TITLE
Makes predictive progress easier to test

### DIFF
--- a/media-data/api/current.api
+++ b/media-data/api/current.api
@@ -269,7 +269,7 @@ package com.google.android.horologist.media.data.mapper {
   }
 
   @com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi public final class PlaybackStateMapper {
-    ctor public PlaybackStateMapper(optional kotlin.jvm.functions.Function0<java.lang.Long> timestampProvider);
+    ctor public PlaybackStateMapper(optional com.google.android.horologist.media.model.TimestampProvider timestampProvider);
     method public com.google.android.horologist.media.model.PlaybackStateEvent createEvent(androidx.media3.common.Player? player, com.google.android.horologist.media.model.PlaybackStateEvent.Cause cause);
   }
 

--- a/media-data/src/main/java/com/google/android/horologist/media/data/mapper/PlaybackStateMapper.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/mapper/PlaybackStateMapper.kt
@@ -23,18 +23,19 @@ import com.google.android.horologist.media.data.ExperimentalHorologistMediaDataA
 import com.google.android.horologist.media.model.PlaybackState
 import com.google.android.horologist.media.model.PlaybackStateEvent
 import com.google.android.horologist.media.model.PlayerState
+import com.google.android.horologist.media.model.TimestampProvider
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Maps a [Media3 player][Player] position into a [PlaybackState].
  */
 @ExperimentalHorologistMediaDataApi
-public class PlaybackStateMapper(private val timestampProvider: () -> Long = { SystemClock.elapsedRealtime() }) {
+public class PlaybackStateMapper(private val timestampProvider: TimestampProvider = TimestampProvider { SystemClock.elapsedRealtime() }) {
     public fun createEvent(player: Player?, cause: PlaybackStateEvent.Cause): PlaybackStateEvent =
         PlaybackStateEvent(
             playbackState = map(player),
             cause = cause,
-            timestamp = timestampProvider().milliseconds
+            timestamp = timestampProvider.getTimestamp().milliseconds
         )
 
     // should only be mapped as an event

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -546,6 +546,11 @@ package com.google.android.horologist.media.ui.snackbar {
 
 package com.google.android.horologist.media.ui.state {
 
+  public final class LocalTimestampProviderKt {
+    method public static androidx.compose.runtime.ProvidableCompositionLocal<com.google.android.horologist.media.model.TimestampProvider> getLocalTimestampProvider();
+    property public static final androidx.compose.runtime.ProvidableCompositionLocal<com.google.android.horologist.media.model.TimestampProvider> LocalTimestampProvider;
+  }
+
   @androidx.compose.runtime.Stable public final class PlayerUiController {
     ctor public PlayerUiController(com.google.android.horologist.media.repository.PlayerRepository playerRepository);
     method public com.google.android.horologist.media.ui.state.PlayerUiController copy(com.google.android.horologist.media.repository.PlayerRepository playerRepository);

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/ProgressStateHolderTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/ProgressStateHolderTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistMediaUiApi::class)
+
+package com.google.android.horologist.media.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.google.android.horologist.media.model.MediaPositionPredictor
+import com.google.android.horologist.media.model.TimestampProvider
+import com.google.android.horologist.media.ui.state.LocalTimestampProvider
+import com.google.android.horologist.media.ui.state.ProgressStateHolder
+import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+class ProgressStateHolderTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun givenPredictiveProgress_usesTimestampForInitialValue() = runTest {
+        // given
+        val predictor = MediaPositionPredictor(
+            eventTimestamp = 500,
+            durationMs = 1000,
+            currentPositionMs = 100,
+            positionSpeed = 1f
+        )
+        val trackPositionUiModel = TrackPositionUiModel.Predictive(predictor)
+        val timestamp = 600L
+        val progressStateHolder = setContentWithResult({ timestamp }) {
+            ProgressStateHolder.fromTrackPositionUiModel(trackPositionUiModel = trackPositionUiModel)
+        }
+
+        // then
+        assertThat(progressStateHolder.value).isEqualTo(0.2f)
+    }
+
+    @Test
+    fun givenPredictiveProgress_predictsProgress() = runTest {
+        // given
+        val timestampProvider = TimestampProvider { composeTestRule.mainClock.currentTime }
+        val predictor = MediaPositionPredictor(
+            eventTimestamp = timestampProvider.getTimestamp(),
+            durationMs = 1000,
+            currentPositionMs = 100,
+            positionSpeed = 1f
+        )
+        val trackPositionUiModel = TrackPositionUiModel.Predictive(predictor)
+        composeTestRule.mainClock.autoAdvance = false
+        val progressStateHolder = setContentWithResult(timestampProvider) {
+            ProgressStateHolder.fromTrackPositionUiModel(trackPositionUiModel = trackPositionUiModel)
+        }
+
+        // then
+        assertThat(progressStateHolder.value).isEqualTo(0.1f)
+        composeTestRule.mainClock.advanceTimeBy(200, ignoreFrameDuration = false)
+        // check range because clock is not fully precise
+        assertThat(progressStateHolder.value).isGreaterThan(0.29f)
+        assertThat(progressStateHolder.value).isAtMost(0.3f)
+    }
+
+    private suspend fun <T> setContentWithResult(
+        timestampProvider: TimestampProvider,
+        block: @Composable () -> T
+    ): T {
+        val result = CompletableDeferred<T>()
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalTimestampProvider provides timestampProvider) {
+                result.complete(block())
+            }
+        }
+        return result.await()
+    }
+}

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/LocalTimestampProvider.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/LocalTimestampProvider.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.state
+
+import android.os.SystemClock
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.staticCompositionLocalOf
+import com.google.android.horologist.media.model.TimestampProvider
+
+/**
+ * [TimestampProvider] used to generate timestamps for predicting progress. The timestamps must
+ * match those used to create [com.google.android.horologist.media.model.MediaPositionPredictor] and
+ * [com.google.android.horologist.media.model.LiveMediaPositionPredictor] instances.
+ */
+public val LocalTimestampProvider: ProvidableCompositionLocal<TimestampProvider> =
+    staticCompositionLocalOf { TimestampProvider { SystemClock.elapsedRealtime() } }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/ProgressStateHolder.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/ProgressStateHolder.kt
@@ -16,16 +16,16 @@
 
 package com.google.android.horologist.media.ui.state
 
-import android.os.SystemClock
 import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.withInfiniteAnimationFrameMillis
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.withFrameMillis
 import androidx.wear.compose.material.ProgressIndicatorDefaults
+import com.google.android.horologist.media.model.TimestampProvider
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
 import kotlinx.coroutines.NonCancellable
@@ -39,7 +39,10 @@ import kotlin.math.abs
  * animating progress.
  */
 @ExperimentalHorologistMediaUiApi
-internal class ProgressStateHolder(initial: Float) {
+internal class ProgressStateHolder(
+    initial: Float,
+    private val timestampProvider: TimestampProvider
+) {
     private val actual = mutableStateOf(initial)
     private val animatable = Animatable(0f)
     val state = derivedStateOf { actual.value + animatable.value - animatable.targetValue }
@@ -57,12 +60,12 @@ internal class ProgressStateHolder(initial: Float) {
     }
 
     suspend fun predictProgress(predictor: (Long) -> Float) = coroutineScope {
-        val elapsedRealtime = getElapsedRealtime()
-        val initialFrameTime = withInfiniteAnimationFrameMillis { it }
+        val timestamp = timestampProvider.getTimestamp()
+        val initialFrameTime = withFrameMillis { it }
         do {
-            withInfiniteAnimationFrameMillis {
+            withFrameMillis {
                 val frameTimeOffset = it - initialFrameTime
-                actual.value = predictor(elapsedRealtime + frameTimeOffset)
+                actual.value = predictor(timestamp + frameTimeOffset)
             }
         } while (isActive)
     }
@@ -73,9 +76,11 @@ internal class ProgressStateHolder(initial: Float) {
 
         @Composable
         fun fromTrackPositionUiModel(trackPositionUiModel: TrackPositionUiModel): State<Float> {
-            val stateHolder = remember { ProgressStateHolder(trackPositionUiModel.percent) }
+            val timestampProvider = LocalTimestampProvider.current
+            val percent = trackPositionUiModel.getCurrentPercent(timestampProvider.getTimestamp())
+            val stateHolder = remember { ProgressStateHolder(percent, timestampProvider) }
             LaunchedEffect(trackPositionUiModel) {
-                stateHolder.setProgress(trackPositionUiModel.percent, trackPositionUiModel.shouldAnimate)
+                stateHolder.setProgress(percent, trackPositionUiModel.shouldAnimate)
                 if (trackPositionUiModel is TrackPositionUiModel.Predictive) {
                     stateHolder.predictProgress(trackPositionUiModel.predictor::predictPercent)
                 }
@@ -83,13 +88,10 @@ internal class ProgressStateHolder(initial: Float) {
             return stateHolder.state
         }
 
-        private val TrackPositionUiModel.percent: Float
-            get() = when (this) {
-                is TrackPositionUiModel.Actual -> percent
-                is TrackPositionUiModel.Predictive -> predictor.predictPercent(getElapsedRealtime())
-                else -> 0f
-            }
-
-        private fun getElapsedRealtime() = SystemClock.elapsedRealtime()
+        private fun TrackPositionUiModel.getCurrentPercent(timestamp: Long) = when (this) {
+            is TrackPositionUiModel.Actual -> percent
+            is TrackPositionUiModel.Predictive -> predictor.predictPercent(timestamp)
+            else -> 0f
+        }
     }
 }

--- a/media/api/current.api
+++ b/media/api/current.api
@@ -235,6 +235,10 @@ package com.google.android.horologist.media.model {
     method public long predictPosition(long timestamp);
   }
 
+  public fun interface TimestampProvider {
+    method public long getTimestamp();
+  }
+
 }
 
 package com.google.android.horologist.media.repository {

--- a/media/src/main/java/com/google/android/horologist/media/model/TimestampProvider.kt
+++ b/media/src/main/java/com/google/android/horologist/media/model/TimestampProvider.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.model
+
+public fun interface TimestampProvider {
+    public fun getTimestamp(): Long
+}


### PR DESCRIPTION
#### WHAT
Defines a `TimestampProvider` in the media package and uses it throughout progress prediction.

#### WHY
To make it easier to test and not rely on `SystemClock`.

#### HOW
Creates new `TimestampProvider` interface and a `LocalTimestampProvider` for use in composables.

#### Checklist :clipboard:
- [X] Add explicit visibility modifier and explicit return types for public declarations
- [X] Run spotless check
- [X] Run tests
- [X] Update metalava's signature text files
