### PR TITLE
Add AuthUser to onAlreadySignedIn callback

### DIFF
--- a/auth-ui/api/current.api
+++ b/auth-ui/api/current.api
@@ -16,7 +16,7 @@ package com.google.android.horologist.auth.ui.common.logging {
 package com.google.android.horologist.auth.ui.common.screens.prompt {
 
   public final class SignInPromptScreenKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public static void SignInPromptScreen(String message, kotlin.jvm.functions.Function0<kotlin.Unit> onAlreadySignedIn, com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, optional androidx.compose.ui.Modifier modifier, optional String title, optional com.google.android.horologist.auth.ui.common.screens.prompt.SignInPromptViewModel viewModel, kotlin.jvm.functions.Function1<? super androidx.wear.compose.foundation.lazy.ScalingLazyListScope,kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public static void SignInPromptScreen(String message, kotlin.jvm.functions.Function1<? super com.google.android.horologist.auth.data.common.model.AuthUser,kotlin.Unit> onAlreadySignedIn, com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, optional androidx.compose.ui.Modifier modifier, optional String title, optional com.google.android.horologist.auth.ui.common.screens.prompt.SignInPromptViewModel viewModel, kotlin.jvm.functions.Function1<? super androidx.wear.compose.foundation.lazy.ScalingLazyListScope,kotlin.Unit> content);
   }
 
   @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public abstract sealed class SignInPromptScreenState {
@@ -31,7 +31,11 @@ package com.google.android.horologist.auth.ui.common.screens.prompt {
   }
 
   public static final class SignInPromptScreenState.SignedIn extends com.google.android.horologist.auth.ui.common.screens.prompt.SignInPromptScreenState {
-    field public static final com.google.android.horologist.auth.ui.common.screens.prompt.SignInPromptScreenState.SignedIn INSTANCE;
+    ctor public SignInPromptScreenState.SignedIn(com.google.android.horologist.auth.data.common.model.AuthUser authUser);
+    method public com.google.android.horologist.auth.data.common.model.AuthUser component1();
+    method public com.google.android.horologist.auth.ui.common.screens.prompt.SignInPromptScreenState.SignedIn copy(com.google.android.horologist.auth.data.common.model.AuthUser authUser);
+    method public com.google.android.horologist.auth.data.common.model.AuthUser getAuthUser();
+    property public final com.google.android.horologist.auth.data.common.model.AuthUser authUser;
   }
 
   public static final class SignInPromptScreenState.SignedOut extends com.google.android.horologist.auth.ui.common.screens.prompt.SignInPromptScreenState {
@@ -50,7 +54,7 @@ package com.google.android.horologist.auth.ui.common.screens.prompt {
 package com.google.android.horologist.auth.ui.common.screens.streamline {
 
   public final class StreamlineSignInScreenKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public static void StreamlineSignInScreen(kotlin.jvm.functions.Function0<kotlin.Unit> onAlreadySignedIn, kotlin.jvm.functions.Function0<kotlin.Unit> onSignedOut, optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.auth.ui.common.screens.streamline.StreamlineSignInViewModel viewModel);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public static void StreamlineSignInScreen(kotlin.jvm.functions.Function1<? super com.google.android.horologist.auth.data.common.model.AuthUser,kotlin.Unit> onAlreadySignedIn, kotlin.jvm.functions.Function0<kotlin.Unit> onSignedOut, optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.auth.ui.common.screens.streamline.StreamlineSignInViewModel viewModel);
   }
 
   @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public abstract sealed class StreamlineSignInScreenState {
@@ -65,7 +69,11 @@ package com.google.android.horologist.auth.ui.common.screens.streamline {
   }
 
   public static final class StreamlineSignInScreenState.SignedIn extends com.google.android.horologist.auth.ui.common.screens.streamline.StreamlineSignInScreenState {
-    field public static final com.google.android.horologist.auth.ui.common.screens.streamline.StreamlineSignInScreenState.SignedIn INSTANCE;
+    ctor public StreamlineSignInScreenState.SignedIn(com.google.android.horologist.auth.data.common.model.AuthUser authUser);
+    method public com.google.android.horologist.auth.data.common.model.AuthUser component1();
+    method public com.google.android.horologist.auth.ui.common.screens.streamline.StreamlineSignInScreenState.SignedIn copy(com.google.android.horologist.auth.data.common.model.AuthUser authUser);
+    method public com.google.android.horologist.auth.data.common.model.AuthUser getAuthUser();
+    property public final com.google.android.horologist.auth.data.common.model.AuthUser authUser;
   }
 
   public static final class StreamlineSignInScreenState.SignedOut extends com.google.android.horologist.auth.ui.common.screens.streamline.StreamlineSignInScreenState {

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptScreen.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptScreen.kt
@@ -31,6 +31,7 @@ import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.auth.composables.R
 import com.google.android.horologist.auth.composables.screens.SignInPlaceholderScreen
+import com.google.android.horologist.auth.data.common.model.AuthUser
 import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
 import com.google.android.horologist.base.ui.components.Title
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
@@ -56,7 +57,7 @@ import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 @Composable
 public fun SignInPromptScreen(
     message: String,
-    onAlreadySignedIn: () -> Unit,
+    onAlreadySignedIn: (authUser: AuthUser) -> Unit,
     columnState: ScalingLazyColumnState,
     modifier: Modifier = Modifier,
     title: String = stringResource(id = R.string.horologist_signin_prompt_title),
@@ -84,7 +85,7 @@ internal fun SignInPromptScreen(
     title: String,
     message: String,
     onIdleStateObserved: () -> Unit,
-    onAlreadySignedIn: () -> Unit,
+    onAlreadySignedIn: (authUser: AuthUser) -> Unit,
     columnState: ScalingLazyColumnState,
     modifier: Modifier = Modifier,
     content: ScalingLazyListScope.() -> Unit
@@ -105,7 +106,7 @@ internal fun SignInPromptScreen(
         is SignInPromptScreenState.SignedIn -> {
             SignInPlaceholderScreen(modifier = modifier)
 
-            onAlreadySignedIn()
+            onAlreadySignedIn(state.authUser)
         }
 
         SignInPromptScreenState.SignedOut -> {

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptViewModel.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptViewModel.kt
@@ -18,6 +18,7 @@ package com.google.android.horologist.auth.ui.common.screens.prompt
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.android.horologist.auth.data.common.model.AuthUser
 import com.google.android.horologist.auth.data.common.repository.AuthUserRepository
 import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
 import com.google.android.horologist.auth.ui.ext.compareAndSet
@@ -49,9 +50,9 @@ public open class SignInPromptViewModel(
             update = SignInPromptScreenState.Loading
         ) {
             viewModelScope.launch {
-                if (authUserRepository.getAuthenticated() != null) {
-                    _uiState.value = SignInPromptScreenState.SignedIn
-                } else {
+                authUserRepository.getAuthenticated()?.let { authUser ->
+                    _uiState.value = SignInPromptScreenState.SignedIn(authUser)
+                } ?: run {
                     _uiState.value = SignInPromptScreenState.SignedOut
                 }
             }
@@ -69,7 +70,7 @@ public sealed class SignInPromptScreenState {
 
     public object Loading : SignInPromptScreenState()
 
-    public object SignedIn : SignInPromptScreenState()
+    public data class SignedIn(val authUser: AuthUser) : SignInPromptScreenState()
 
     public object SignedOut : SignInPromptScreenState()
 }

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInScreen.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.google.android.horologist.auth.composables.screens.SignInPlaceholderScreen
+import com.google.android.horologist.auth.data.common.model.AuthUser
 import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
 
 /**
@@ -39,7 +40,7 @@ import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
 @ExperimentalHorologistAuthUiApi
 @Composable
 public fun StreamlineSignInScreen(
-    onAlreadySignedIn: () -> Unit,
+    onAlreadySignedIn: (authUser: AuthUser) -> Unit,
     onSignedOut: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: StreamlineSignInViewModel = viewModel()
@@ -60,7 +61,7 @@ public fun StreamlineSignInScreen(
 internal fun StreamlineSignInScreen(
     state: StreamlineSignInScreenState,
     onIdleStateObserved: () -> Unit,
-    onAlreadySignedIn: () -> Unit,
+    onAlreadySignedIn: (authUser: AuthUser) -> Unit,
     onSignedOut: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -78,7 +79,7 @@ internal fun StreamlineSignInScreen(
         }
 
         is StreamlineSignInScreenState.SignedIn -> {
-            onAlreadySignedIn()
+            onAlreadySignedIn(state.authUser)
         }
 
         StreamlineSignInScreenState.SignedOut -> {

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInViewModel.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInViewModel.kt
@@ -18,6 +18,7 @@ package com.google.android.horologist.auth.ui.common.screens.streamline
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.android.horologist.auth.data.common.model.AuthUser
 import com.google.android.horologist.auth.data.common.repository.AuthUserRepository
 import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
 import com.google.android.horologist.auth.ui.ext.compareAndSet
@@ -36,7 +37,8 @@ public open class StreamlineSignInViewModel(
     private val authUserRepository: AuthUserRepository
 ) : ViewModel() {
 
-    private val _uiState = MutableStateFlow<StreamlineSignInScreenState>(StreamlineSignInScreenState.Idle)
+    private val _uiState =
+        MutableStateFlow<StreamlineSignInScreenState>(StreamlineSignInScreenState.Idle)
     public val uiState: StateFlow<StreamlineSignInScreenState> = _uiState
 
     /**
@@ -49,9 +51,9 @@ public open class StreamlineSignInViewModel(
             update = StreamlineSignInScreenState.Loading
         ) {
             viewModelScope.launch {
-                if (authUserRepository.getAuthenticated() != null) {
-                    _uiState.value = StreamlineSignInScreenState.SignedIn
-                } else {
+                authUserRepository.getAuthenticated()?.let { authUser ->
+                    _uiState.value = StreamlineSignInScreenState.SignedIn(authUser)
+                } ?: run {
                     _uiState.value = StreamlineSignInScreenState.SignedOut
                 }
             }
@@ -69,7 +71,7 @@ public sealed class StreamlineSignInScreenState {
 
     public object Loading : StreamlineSignInScreenState()
 
-    public object SignedIn : StreamlineSignInScreenState()
+    public data class SignedIn(val authUser: AuthUser) : StreamlineSignInScreenState()
 
     public object SignedOut : StreamlineSignInScreenState()
 }

--- a/auth-ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptScreenTest.kt
+++ b/auth-ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptScreenTest.kt
@@ -25,13 +25,14 @@ package com.google.android.horologist.auth.ui.common.screens.prompt
 import androidx.wear.compose.foundation.lazy.ScalingLazyListScope
 import com.google.android.horologist.auth.composables.chips.GuestModeChip
 import com.google.android.horologist.auth.composables.chips.SignInChip
+import com.google.android.horologist.auth.data.common.model.AuthUser
 import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
 import com.google.android.horologist.base.ui.components.StandardChipType
 import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
 import com.google.android.horologist.paparazzi.WearPaparazzi
-import com.google.android.horologist.test.toolbox.positionedState
+import com.google.android.horologist.test.toolbox.composables.positionedState
 import org.junit.Rule
 import org.junit.Test
 
@@ -76,7 +77,7 @@ class SignInPromptScreenTest {
     fun signedIn() {
         paparazzi.snapshotInABox {
             SignInPromptScreen(
-                state = SignInPromptScreenState.SignedIn,
+                state = SignInPromptScreenState.SignedIn(AuthUser()),
                 title = "Sign in",
                 message = "Send messages and create chat groups with your friends",
                 onIdleStateObserved = { },

--- a/auth-ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInScreenTest.kt
+++ b/auth-ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInScreenTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(
+    ExperimentalHorologistPaparazziApi::class,
+    ExperimentalHorologistComposeToolsApi::class,
+    ExperimentalHorologistAuthUiApi::class
+)
+
+package com.google.android.horologist.auth.ui.common.screens.streamline
+
+import com.google.android.horologist.auth.data.common.model.AuthUser
+import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
+import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
+import com.google.android.horologist.compose.tools.snapshotInABox
+import com.google.android.horologist.paparazzi.ExperimentalHorologistPaparazziApi
+import com.google.android.horologist.paparazzi.WearPaparazzi
+import org.junit.Rule
+import org.junit.Test
+
+class StreamlineSignInScreenTest {
+
+    @get:Rule
+    val paparazzi = WearPaparazzi()
+
+    @Test
+    fun idle() {
+        paparazzi.snapshotInABox {
+            StreamlineSignInScreen(
+                state = StreamlineSignInScreenState.Idle,
+                onIdleStateObserved = { },
+                onAlreadySignedIn = { },
+                onSignedOut = { }
+            )
+        }
+    }
+
+    @Test
+    fun loading() {
+        paparazzi.snapshotInABox {
+            StreamlineSignInScreen(
+                state = StreamlineSignInScreenState.Loading,
+                onIdleStateObserved = { },
+                onAlreadySignedIn = { },
+                onSignedOut = { }
+            )
+        }
+    }
+
+    @Test
+    fun signedIn() {
+        paparazzi.snapshotInABox {
+            StreamlineSignInScreen(
+                state = StreamlineSignInScreenState.SignedIn(AuthUser()),
+                onIdleStateObserved = { },
+                onAlreadySignedIn = { },
+                onSignedOut = { }
+            )
+        }
+    }
+
+    @Test
+    fun signedOut() {
+        paparazzi.snapshotInABox {
+            StreamlineSignInScreen(
+                state = StreamlineSignInScreenState.SignedOut,
+                onIdleStateObserved = { },
+                onAlreadySignedIn = { },
+                onSignedOut = { }
+            )
+        }
+    }
+}

--- a/auth-ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInViewModelTest.kt
+++ b/auth-ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInViewModelTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistAuthUiApi::class,
-    ExperimentalCoroutinesApi::class
-)
+@file:OptIn(ExperimentalHorologistAuthUiApi::class, ExperimentalCoroutinesApi::class)
 
-package com.google.android.horologist.auth.ui.common.screens.prompt
+package com.google.android.horologist.auth.ui.common.screens.streamline
 
 import app.cash.turbine.test
 import com.google.android.horologist.auth.data.common.model.AuthUser
@@ -33,18 +30,18 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
-class SignInPromptViewModelTest {
+class StreamlineSignInViewModelTest {
 
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
 
     private val fakeAuthUserRepository = AuthUserRepositoryStub()
 
-    private lateinit var sut: SignInPromptViewModel
+    private lateinit var sut: StreamlineSignInViewModel
 
     @Before
     fun setUp() {
-        sut = SignInPromptViewModel(fakeAuthUserRepository)
+        sut = StreamlineSignInViewModel(fakeAuthUserRepository)
     }
 
     @Test
@@ -53,7 +50,7 @@ class SignInPromptViewModelTest {
         val result = sut.uiState.value
 
         // then
-        assertThat(result).isEqualTo(SignInPromptScreenState.Idle)
+        assertThat(result).isEqualTo(StreamlineSignInScreenState.Idle)
     }
 
     @Test
@@ -67,7 +64,7 @@ class SignInPromptViewModelTest {
 
             whenBlock()
 
-            assertThat(awaitItem()).isEqualTo(SignInPromptScreenState.Loading)
+            assertThat(awaitItem()).isEqualTo(StreamlineSignInScreenState.Loading)
 
             skipItems(1)
         }
@@ -81,7 +78,7 @@ class SignInPromptViewModelTest {
 
         // then
         sut.uiState.test {
-            assertThat(awaitItem()).isNotEqualTo(SignInPromptScreenState.Idle)
+            assertThat(awaitItem()).isNotEqualTo(StreamlineSignInScreenState.Idle)
 
             whenBlock()
 
@@ -96,7 +93,7 @@ class SignInPromptViewModelTest {
 
         // then
         sut.uiState.test {
-            assertThat(awaitItem()).isEqualTo(SignInPromptScreenState.SignedOut)
+            assertThat(awaitItem()).isEqualTo(StreamlineSignInScreenState.SignedOut)
         }
     }
 
@@ -111,7 +108,7 @@ class SignInPromptViewModelTest {
 
         // then
         sut.uiState.test {
-            assertThat(awaitItem()).isEqualTo(SignInPromptScreenState.SignedIn(authUser))
+            assertThat(awaitItem()).isEqualTo(StreamlineSignInScreenState.SignedIn(authUser))
         }
     }
 }

--- a/auth-ui/src/test/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInViewModelTest.kt
+++ b/auth-ui/src/test/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInViewModelTest.kt
@@ -25,7 +25,7 @@ import app.cash.turbine.test
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
 import com.google.android.horologist.auth.data.googlesignin.GoogleSignInEventListener
 import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
-import com.google.android.horologist.test.toolbox.MainDispatcherRule
+import com.google.android.horologist.test.toolbox.rules.MainDispatcherRule
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest

--- a/auth-ui/src/test/java/com/google/android/horologist/test/toolbox/composables/PositionedState.kt
+++ b/auth-ui/src/test/java/com/google/android/horologist/test/toolbox/composables/PositionedState.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.test.toolbox
+package com.google.android.horologist.test.toolbox.composables
 
 import androidx.compose.runtime.Composable
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults

--- a/auth-ui/src/test/java/com/google/android/horologist/test/toolbox/rules/MainDispatcherRule.kt
+++ b/auth-ui/src/test/java/com/google/android/horologist/test/toolbox/rules/MainDispatcherRule.kt
@@ -16,7 +16,7 @@
 
 @file:OptIn(ExperimentalCoroutinesApi::class)
 
-package com.google.android.horologist.test.toolbox
+package com.google.android.horologist.test.toolbox.rules
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/auth-ui/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/AuthUserRepositoryStub.kt
+++ b/auth-ui/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/AuthUserRepositoryStub.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.test.toolbox.testdoubles
+
+import com.google.android.horologist.auth.data.common.model.AuthUser
+import com.google.android.horologist.auth.data.common.repository.AuthUserRepository
+class AuthUserRepositoryStub : AuthUserRepository {
+
+    var authUser: AuthUser? = null
+
+    override suspend fun getAuthenticated(): AuthUser? {
+        return authUser
+    }
+}

--- a/auth-ui/src/test/snapshots/images/com.google.android.horologist.auth.ui.common.screens.streamline_StreamlineSignInScreenTest_idle.png
+++ b/auth-ui/src/test/snapshots/images/com.google.android.horologist.auth.ui.common.screens.streamline_StreamlineSignInScreenTest_idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ff71829941db667d156cb1ea618457fc3b7b22840718a5103789f71bc88f686
+size 7254

--- a/auth-ui/src/test/snapshots/images/com.google.android.horologist.auth.ui.common.screens.streamline_StreamlineSignInScreenTest_loading.png
+++ b/auth-ui/src/test/snapshots/images/com.google.android.horologist.auth.ui.common.screens.streamline_StreamlineSignInScreenTest_loading.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ff71829941db667d156cb1ea618457fc3b7b22840718a5103789f71bc88f686
+size 7254

--- a/auth-ui/src/test/snapshots/images/com.google.android.horologist.auth.ui.common.screens.streamline_StreamlineSignInScreenTest_signedIn.png
+++ b/auth-ui/src/test/snapshots/images/com.google.android.horologist.auth.ui.common.screens.streamline_StreamlineSignInScreenTest_signedIn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ff71829941db667d156cb1ea618457fc3b7b22840718a5103789f71bc88f686
+size 7254

--- a/auth-ui/src/test/snapshots/images/com.google.android.horologist.auth.ui.common.screens.streamline_StreamlineSignInScreenTest_signedOut.png
+++ b/auth-ui/src/test/snapshots/images/com.google.android.horologist.auth.ui.common.screens.streamline_StreamlineSignInScreenTest_signedOut.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ff71829941db667d156cb1ea618457fc3b7b22840718a5103789f71bc88f686
+size 7254


### PR DESCRIPTION
#### WHAT

Add `AuthUser` to `onAlreadySignedIn` callback.

#### WHY

So it can be used to display information on the screen that is navigating to.

#### HOW

Add snapshot and unit tests;

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [ ] Update metalava's signature text files
