### PR TITLE
Fix benchmark build

### DIFF
--- a/media-sample/build.gradle.kts
+++ b/media-sample/build.gradle.kts
@@ -240,6 +240,7 @@ dependencies {
     debugImplementation(libs.compose.ui.tooling)
     debugImplementation(projects.composeTools)
     releaseCompileOnly(projects.composeTools)
+    add("benchmarkCompileOnly", projects.composeTools)
 
     testImplementation(libs.junit)
     testImplementation(libs.truth)


### PR DESCRIPTION
#### WHAT

Fix benchmark build

#### WHY

benchmark needs the same dependencies as release

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
