### PR TITLE
Fix VolumeViewModel creation

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
@@ -182,7 +182,7 @@ fun UampWearApp(
             navHostState = navHostState,
             pagerState = pagerState,
             snackbarViewModel = hiltViewModel<SnackbarViewModel>(),
-            volumeViewModel = hiltViewModel<VolumeViewModel>(),
+            volumeViewModel = volumeViewModel,
             timeText = timeText,
             deepLinkPrefix = appViewModel.deepLinkPrefix,
             navController = navController,

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/navigation/MediaPlayerScaffold.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/navigation/MediaPlayerScaffold.kt
@@ -79,7 +79,7 @@ public fun MediaPlayerScaffold(
     navController: NavHostController,
     modifier: Modifier = Modifier,
     volumeScreen: @Composable () -> Unit = {
-        VolumeScreen()
+        VolumeScreen(volumeViewModel = volumeViewModel)
     },
     timeText: @Composable (Modifier) -> Unit = {
         TimeText(modifier = it)


### PR DESCRIPTION
#### WHAT

Fix VolumeViewModel creation

#### WHY

The library methods like VolumeScreen, are super tolerant, creating the ViewModel with viewModel and a factor on the fly.  Instead we should use our ViewModel created from hilt in case it has different configuration.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
