### PR TITLE
Bump memory for releases

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ android.useAndroidX=true
 android.disableAutomaticComponentCreation=true
 
 # Increase memory
-org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1596m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=2596m -XX:+HeapDumpOnOutOfMemoryError
 
 # Required to publish to Nexus (see https://github.com/gradle/gradle/issues/11308)
 systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
#### WHAT

Bump memory for releases

#### WHY

```
* What went wrong:
Execution failed for task ':media-data:javaDocReleaseGeneration'.
> A failure occurred while executing com.android.build.gradle.tasks.JavaDocGenerationTask$DokkaWorkAction
   > java.lang.reflect.InvocationTargetException (no error message)
...
Caused by: java.lang.OutOfMemoryError: Metaspace
        at com.fasterxml.jackson.databind.ObjectMapper.<init>(ObjectMapper.java:636)
        at com.fasterxml.jackson.databind.ObjectMapper.<init>(ObjectMapper.java:539)
        at com.fasterxml.jackson.module.kotlin.ExtensionsKt.jacksonObjectMapper(Extensions.kt:15)
        at org.jetbrains.dokka.utilities.JsonKt.<clinit>(json.kt:17)
        at org.jetbrains.dokka.ConfigurationKt.DokkaConfigurationImpl(configuration.kt:194)
        at org.jetbrains.dokka.DokkaBootstrapImpl.configure(DokkaBootstrapImpl.kt:75)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at com.android.build.gradle.tasks.JavaDocGenerationTask$DokkaWorkAction.execute(JavaDocGenerationTask.kt:137)
        at org.gradle.workers.internal.DefaultWorkerServer.execute(DefaultWorkerServer.java:63)

```

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
