### PR TITLE
Adds ActiveDurationText to health-composables

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ androidx-benchmark = "1.2.0-alpha09"
 androidx-compose-material = "1.4.0-alpha05"
 androidx-concurrent = "1.1.0"
 androidx-datastore = "1.0.0"
+androidx-health-services = "1.0.0-beta02"
 androidx-hilt = "1.0.0"
 androidx-media3 = "1.0.0-beta03"
 androidx-test = "1.5.0-beta01"
@@ -66,6 +67,7 @@ androidx-corektx = { module = "androidx.core:core-ktx", version.ref = "androidxC
 androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "androidx-datastore" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidx-datastore" }
 androidx-fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "androidxFragment" }
+androidx-health-services = { module = "androidx.health:health-services-client", version.ref = "androidx-health-services" }
 androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidxLifecycle" }
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
 androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidxLifecycle" }

--- a/health-composables/README.md
+++ b/health-composables/README.md
@@ -1,0 +1,17 @@
+# Health Composables library
+
+[![Maven Central](https://img.shields.io/maven-central/v/com.google.android.horologist/horologist-health-composables)](https://search.maven.org/search?q=g:com.google.android.horologist)
+
+Composables for Health use-cases, principally [Health Services](https://developer.android.com/training/wearables/health-services).
+
+## Download
+
+```groovy
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation "com.google.android.horologist:horologist-health-composables:<version>"
+}
+```

--- a/health-composables/api/current.api
+++ b/health-composables/api/current.api
@@ -1,0 +1,26 @@
+// Signature format: 4.0
+package com.google.android.horologist.health.composables {
+
+  public final class ActiveDurationDefaults {
+    ctor public ActiveDurationDefaults();
+    field public static final com.google.android.horologist.health.composables.ActiveDurationDefaults.Companion Companion;
+    field public static final String HH_MM = "%1$02d:%2$02d";
+    field public static final String HH_MM_SS = "%1$02d:%2$02d:%3$02d";
+    field public static final String H_MM = "%1$01d:%2$02d";
+    field public static final String H_MM_SS = "%1$01d:%2$02d:%3$02d";
+    field public static final String MM_SS = "%2$02d:%3$02d";
+    field public static final String M_SS = "%2$01d:%3$02d";
+  }
+
+  public static final class ActiveDurationDefaults.Companion {
+  }
+
+  public final class ActiveDurationTextKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.health.composables.ExperimentalHorologistHealthComposablesApi public static void ActiveDurationText(androidx.health.services.client.data.ExerciseUpdate.ActiveDurationCheckpoint checkpoint, androidx.health.services.client.data.ExerciseState state, optional androidx.compose.ui.Modifier modifier, optional String formatTemplate, optional long color, optional androidx.compose.ui.text.style.TextAlign? textAlign, optional androidx.compose.ui.text.TextStyle style, optional androidx.lifecycle.LifecycleOwner lifecycleOwner);
+  }
+
+  @kotlin.RequiresOptIn(message="Horologist Health Composables is experimental. The API may be changed in the future.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.BINARY) public @interface ExperimentalHorologistHealthComposablesApi {
+  }
+
+}
+

--- a/health-composables/build.gradle.kts
+++ b/health-composables/build.gradle.kts
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UnstableApiUsage")
+
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.dokka")
+    id("app.cash.paparazzi")
+    id("me.tylerbwong.gradle.metalava")
+    kotlin("android")
+}
+
+android {
+    compileSdk = 33
+
+    defaultConfig {
+        minSdk = 30
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    buildFeatures {
+        buildConfig = false
+        compose = true
+    }
+
+    kotlinOptions {
+        jvmTarget = "11"
+        freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn"
+        freeCompilerArgs = freeCompilerArgs + "-opt-in=com.google.android.horologist.base.ui.ExperimentalHorologistBaseUiApi"
+        freeCompilerArgs = freeCompilerArgs + "-opt-in=com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi"
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
+    }
+
+    packagingOptions {
+        resources {
+            excludes += listOf(
+                "/META-INF/AL2.0",
+                "/META-INF/LGPL2.1"
+            )
+        }
+    }
+
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+        animationsDisabled = true
+    }
+
+    lint {
+        checkReleaseBuilds = false
+        disable += listOf("MissingTranslation", "ExtraTranslation")
+        textReport = true
+    }
+
+    resourcePrefix = "horologist_"
+
+    namespace = "com.google.android.horologist.health.composables"
+}
+
+project.tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    // Workaround for https://youtrack.jetbrains.com/issue/KT-37652
+    if (!this.name.endsWith("TestKotlin") && !this.name.startsWith("compileDebug")) {
+        this.kotlinOptions {
+            freeCompilerArgs = freeCompilerArgs + "-Xexplicit-api=strict"
+        }
+    }
+}
+
+metalava {
+    sourcePaths.setFrom("src/main")
+    filename.set("api/current.api")
+    reportLintsAsErrors.set(true)
+}
+
+dependencies {
+
+    implementation(projects.baseUi)
+    implementation(projects.composeLayout)
+
+    implementation(libs.androidx.wear)
+    implementation(libs.androidx.health.services)
+    implementation(libs.kotlin.stdlib)
+    implementation(libs.wearcompose.material)
+    implementation(libs.wearcompose.foundation)
+
+    debugImplementation(projects.composeTools)
+    implementation(libs.compose.ui.toolingpreview)
+
+    testImplementation(projects.paparazzi)
+    testImplementation(libs.androidx.test.ext.ktx)
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.paparazzi)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.truth)
+
+    androidTestImplementation(libs.androidx.test.ext)
+    androidTestImplementation(libs.androidx.test.ext.ktx)
+    androidTestImplementation(libs.compose.ui.test.junit4)
+    androidTestImplementation(libs.espresso.core)
+    androidTestImplementation(libs.junit)
+    androidTestImplementation(libs.truth)
+}
+
+apply(plugin = "com.vanniktech.maven.publish")

--- a/health-composables/gradle.properties
+++ b/health-composables/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=horologist-health-composables
+POM_NAME=Horologist Health Composables library
+POM_PACKAGING=aar

--- a/health-composables/src/debug/java/com/google/android/horologist/health/composables/ActiveDurationTextPreview.kt
+++ b/health-composables/src/debug/java/com/google/android/horologist/health/composables/ActiveDurationTextPreview.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistHealthComposablesApi::class)
+
+package com.google.android.horologist.health.composables
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.health.services.client.data.ExerciseState
+import androidx.health.services.client.data.ExerciseUpdate.ActiveDurationCheckpoint
+import java.time.Duration
+import java.time.Instant
+
+@Preview(
+    backgroundColor = 0xff000000,
+    showBackground = true
+)
+@Composable
+fun ActiveDurationTextPreview() {
+    val state = ExerciseState.ACTIVE
+    val checkpoint = ActiveDurationCheckpoint(
+        time = Instant.now(),
+        activeDuration = Duration.ZERO
+    )
+    ActiveDurationText(
+        checkpoint = checkpoint,
+        state = state
+    )
+}
+
+@Preview(
+    backgroundColor = 0xff000000,
+    showBackground = true
+)
+@Composable
+fun ActiveDurationTextCustomSeparatorPreview() {
+    val state = ExerciseState.ACTIVE
+    val checkpoint = ActiveDurationCheckpoint(
+        time = Instant.now(),
+        activeDuration = Duration.ZERO
+    )
+    ActiveDurationText(
+        checkpoint = checkpoint,
+        state = state,
+        formatTemplate = "%1\$02dh%2\$02dm%3\$02ds"
+    )
+}

--- a/health-composables/src/main/AndroidManifest.xml
+++ b/health-composables/src/main/AndroidManifest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2023 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.google.android.horologist.health.composables">
+
+    <uses-feature android:name="android.hardware.type.watch" />
+
+    <uses-sdk android:minSdkVersion="30" tools:ignore="GradleOverrides" />
+</manifest>

--- a/health-composables/src/main/java/com/google/android/horologist/health/composables/ActiveDurationDefaults.kt
+++ b/health-composables/src/main/java/com/google/android/horologist/health/composables/ActiveDurationDefaults.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.health.composables
+public class ActiveDurationDefaults {
+    public companion object {
+        public const val HH_MM_SS: String = "%1\$02d:%2\$02d:%3\$02d"
+        public const val H_MM_SS: String = "%1\$01d:%2\$02d:%3\$02d"
+        public const val MM_SS: String = "%2\$02d:%3\$02d"
+        public const val M_SS: String = "%2\$01d:%3\$02d"
+        public const val HH_MM: String = "%1\$02d:%2\$02d"
+        public const val H_MM: String = "%1\$01d:%2\$02d"
+    }
+}

--- a/health-composables/src/main/java/com/google/android/horologist/health/composables/ActiveDurationText.kt
+++ b/health-composables/src/main/java/com/google/android/horologist/health/composables/ActiveDurationText.kt
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.health.composables
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.health.services.client.data.ExerciseState
+import androidx.health.services.client.data.ExerciseUpdate
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.wear.compose.material.LocalTextStyle
+import androidx.wear.compose.material.Text
+import kotlinx.coroutines.delay
+
+/**
+ * Composable to make it easier to create a chronometer from Health Services exercise data.
+ *
+ * [ActiveDurationText] provides a text-based chronometer, which can be styled using the same means
+ * as a [Text] component, and which should only recompose once-per second as the chronometer ticks.
+ *
+ * Things to note that [ActiveDurationText] aims to workaround:
+ *
+ * 1.  Health Services does not guarantee [ExerciseUpdate] messages every second, so these must not
+ *     be used to drive a ticker.
+ * 2.  The ActiveDuration delivered in an [ExerciseUpdate] will not fall on a second-boundary, so
+ *     the delivery time of these messages cannot be used to determine when to update any content
+ *     on the screen through a ticker.
+ *
+ * @param checkpoint The checkpoint from the most recent state change. This is supplied in the
+ *     [ExerciseUpdate] messages from [ExerciseClient].
+ * @param state The current state of the exercise. This is supplied in the [ExerciseUpdate] messages
+ *     from [ExerciseClient].
+ * @param modifier Compose modifier.
+ * @param formatTemplate A string representing the format for the active duration. A collection of
+ *     useful defaults are available in [ActiveDurationDefaults], but a custom value can be
+ *     specified to handle specific scenarios or locales. See [ActiveDurationDefaults] for examples.
+ * @param color The text color.
+ * @param textAlign Horizontal text alignment.
+ * @param style The text styling.
+ * @param lifecycleOwner lifecycle owner.
+ */
+
+@ExperimentalHorologistHealthComposablesApi
+@Composable
+public fun ActiveDurationText(
+    checkpoint: ExerciseUpdate.ActiveDurationCheckpoint,
+    state: ExerciseState,
+    modifier: Modifier = Modifier,
+    formatTemplate: String = ActiveDurationDefaults.HH_MM_SS,
+    color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
+    style: TextStyle = LocalTextStyle.current,
+    lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current
+) {
+    var lifecycleEnabled by remember { mutableStateOf(true) }
+    var activeSeconds by remember {
+        mutableStateOf(
+            calculateDurationSeconds(
+                checkpoint,
+                state
+            )
+        )
+    }
+    val formattedActiveDuration by remember {
+        derivedStateOf {
+            val hours = activeSeconds / 3600
+            val minutes = (activeSeconds % 3600) / 60
+            val seconds = activeSeconds % 60
+            formatTemplate.format(hours, minutes, seconds)
+        }
+    }
+
+    // When the component is not visible, then the ticker should stop, and only resume when the UI
+    // component becomes visible again.
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                lifecycleEnabled = true
+            } else if (event == Lifecycle.Event.ON_PAUSE) {
+                lifecycleEnabled = false
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
+    /**
+     * The starting and stopping of the ticker depends on two things: (1) Whether or not the
+     * exercise is in the ACTIVE state, and (2) whether the component is visible. The app should
+     * handle any ambient behaviour separately.
+     */
+    LaunchedEffect(state, lifecycleEnabled) {
+        if (state == ExerciseState.ACTIVE && lifecycleEnabled) {
+            val absoluteOffset = absoluteTimeOffsetMillis(checkpoint)
+            while (true) {
+                val now = System.currentTimeMillis()
+                // Delay until the next active duration second boundary
+                val delayInterval = nextTimeForOffset(now, absoluteOffset) - now
+                // Delay should delay for _at least_ the interval specified.
+                delay(delayInterval)
+                activeSeconds = calculateDurationSeconds(checkpoint, state)
+            }
+        }
+    }
+
+    Text(
+        modifier = modifier,
+        text = formattedActiveDuration,
+        color = color,
+        textAlign = textAlign,
+        style = style
+    )
+}
+
+/**
+ * Returns the offset within physical time, in milliseconds (so 0-999) where the ActiveDuration
+ * second boundary falls.
+ *
+ * For example, if WHS reports at 10:23:15.2 that the active duration is 11.4 seconds, then the
+ * active duration second boundary is 800ms (e.g. The active duration will advance a second at
+ * 10:23:15.8, 10:23:16.8, 10:23:17.8, ...
+ *
+ * This is useful because the component should recalculate the active duration each time that
+ * boundary is passed. (This assumes the state is active).
+ *
+ * @param checkpoint An active duration checkpoint.
+ * @return The offset, in milliseconds.
+ */
+private fun absoluteTimeOffsetMillis(checkpoint: ExerciseUpdate.ActiveDurationCheckpoint) =
+    (checkpoint.time.toEpochMilli() - checkpoint.activeDuration.toMillis()) % 1000
+
+/**
+ * Calculates the next physical time when the active duration second boundary will be passed, given
+ * a point in time.
+ *
+ * For example, if the active duration offset is 800ms, as per the example above, then the following
+ * should be returned:
+ *
+ * 10:23:15.2 -> returns 10:23:15.8
+ * 10:23:15.9 -> returns 10:23:16.8
+ *
+ * @param timeMillis The physical time after which to find the next active duration second boundary.
+ * @param offsetMillis The offset in physical time, between 0-999 where the active duration second
+ *     ticks over.
+ * @return The next physical time where the active duration boundary is crossed.
+ */
+private fun nextTimeForOffset(timeMillis: Long, offsetMillis: Long) =
+    ((timeMillis - offsetMillis) / 1000) * 1000 + 1000 + offsetMillis
+
+/**
+ * Calculates the active duration, taking into account any elapsed time since the
+ * [ExerciseUpdate.ActiveDurationCheckpoint] was delivered from Health Services.
+ *
+ * @param checkpoint The checkpoint from the most recent state change.
+ * @param state The current state of the exercise.
+ * @return The current active duration, in seconds since epoch.
+ */
+private fun calculateDurationSeconds(
+    checkpoint: ExerciseUpdate.ActiveDurationCheckpoint,
+    state: ExerciseState
+): Long {
+    val delta = if (state == ExerciseState.ACTIVE) {
+        System.currentTimeMillis() - checkpoint.time.toEpochMilli()
+    } else {
+        0L
+    }
+    return checkpoint.activeDuration.plusMillis(delta).seconds
+}

--- a/health-composables/src/main/java/com/google/android/horologist/health/composables/ExperimentalHorologistHealthComposablesApi.kt
+++ b/health-composables/src/main/java/com/google/android/horologist/health/composables/ExperimentalHorologistHealthComposablesApi.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.health.composables
+
+@RequiresOptIn(
+    message = "Horologist Health Composables is experimental. The API may be changed in the future."
+)
+@Retention(AnnotationRetention.BINARY)
+public annotation class ExperimentalHorologistHealthComposablesApi

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -54,6 +54,7 @@ include(":compose-tools")
 include(":paparazzi")
 include(":network-awareness")
 include(":datalayer")
+include("health-composables")
 
 // Enable Gradle's version catalog support
 // https://docs.gradle.org/current/userguide/platforms.html


### PR DESCRIPTION
#### WHAT

Adds the first Composable to `health-composables`. This is the `ActiveDurationText` composable to make it easier to show a chronometer in an exercise.

#### WHY

When using `ExerciseClient` from Health Services, creating a chronometer that ticks correctly can be time consuming.

#### HOW

Creates a Composable that takes values from `ExerciseUpdate` to display a chronometer for active duration.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
