### PR TITLE
Improve token sharing sample

### DIFF
--- a/auth-data-phone/api/current.api
+++ b/auth-data-phone/api/current.api
@@ -15,8 +15,8 @@ package com.google.android.horologist.auth.data.phone.common {
 
 package com.google.android.horologist.auth.data.phone.tokenshare {
 
-  @com.google.android.horologist.auth.data.phone.ExperimentalHorologistAuthDataPhoneApi public interface TokenBundleRepository<TokenBundle> {
-    method public suspend Object? update(TokenBundle? tokenBundle, kotlin.coroutines.Continuation<? super kotlin.Unit>);
+  @com.google.android.horologist.auth.data.phone.ExperimentalHorologistAuthDataPhoneApi public interface TokenBundleRepository<T> {
+    method public suspend Object? update(T? tokenBundle, kotlin.coroutines.Continuation<? super kotlin.Unit>);
   }
 
 }

--- a/auth-data/api/current.api
+++ b/auth-data/api/current.api
@@ -269,9 +269,9 @@ package com.google.android.horologist.auth.data.oauth.pkce.impl.google {
 
 package com.google.android.horologist.auth.data.tokenshare {
 
-  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public interface TokenBundleRepository<TokenBundle> {
-    method public kotlinx.coroutines.flow.Flow<TokenBundle> getFlow();
-    property public abstract kotlinx.coroutines.flow.Flow<TokenBundle> flow;
+  @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public interface TokenBundleRepository<T> {
+    method public kotlinx.coroutines.flow.Flow<T> getFlow();
+    property public abstract kotlinx.coroutines.flow.Flow<T> flow;
   }
 
   @com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi public final class TokenBundleRepositoryImpl<TokenBundle> implements com.google.android.horologist.auth.data.tokenshare.TokenBundleRepository<TokenBundle> {

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/tokenshare/TokenBundleRepository.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/tokenshare/TokenBundleRepository.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.flow.Flow
  * Repository of a bundle of information, related to auth tokens.
  */
 @ExperimentalHorologistAuthDataApi
-public interface TokenBundleRepository<TokenBundle> {
+public interface TokenBundleRepository<T> {
 
-    public val flow: Flow<TokenBundle>
+    public val flow: Flow<T>
 }

--- a/auth-sample-phone/src/main/res/values/strings.xml
+++ b/auth-sample-phone/src/main/res/values/strings.xml
@@ -16,4 +16,6 @@
 
 <resources>
     <string name="app_name">Horologist Auth Sample</string>
+    <string name="token_share_button_update_token_default">Update token - default key</string>
+    <string name="token_share_button_update_token_custom">Update token - custom key</string>
 </resources>

--- a/auth-sample-shared/build.gradle.kts
+++ b/auth-sample-shared/build.gradle.kts
@@ -21,7 +21,6 @@ import com.google.protobuf.gradle.*
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
     id("com.google.protobuf")
     kotlin("android")
 }
@@ -74,21 +73,6 @@ android {
     namespace = "com.google.android.horologist.auth.sample.shared"
 }
 
-project.tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-    // Workaround for https://youtrack.jetbrains.com/issue/KT-37652
-    if (!this.name.endsWith("TestKotlin") && !this.name.startsWith("compileDebug")) {
-        this.kotlinOptions {
-            freeCompilerArgs = freeCompilerArgs + "-Xexplicit-api=strict"
-        }
-    }
-}
-
-metalava {
-    sourcePaths.setFrom("src/main")
-    filename.set("api/current.api")
-    reportLintsAsErrors.set(true)
-}
-
 protobuf {
     protoc {
         artifact = "com.google.protobuf:protoc:3.21.4"
@@ -126,5 +110,3 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.robolectric)
 }
-
-apply(plugin = "com.vanniktech.maven.publish")

--- a/auth-sample-shared/build.gradle.kts
+++ b/auth-sample-shared/build.gradle.kts
@@ -16,10 +16,13 @@
 
 @file:Suppress("UnstableApiUsage")
 
+import com.google.protobuf.gradle.*
+
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
     id("me.tylerbwong.gradle.metalava")
+    id("com.google.protobuf")
     kotlin("android")
 }
 
@@ -86,12 +89,36 @@ metalava {
     reportLintsAsErrors.set(true)
 }
 
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:3.21.4"
+    }
+    plugins {
+        id("javalite") {
+            artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0"
+        }
+    }
+    generateProtoTasks {
+        all().forEach { task ->
+            task.builtins {
+                create("java") {
+                    option("lite")
+                }
+                create("kotlin") {
+                    option("lite")
+                }
+            }
+        }
+    }
+}
+
 dependencies {
 
     implementation(libs.androidx.corektx)
     implementation(libs.androidx.datastore)
     implementation(libs.kotlin.stdlib)
     implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.protobuf.kotlin.lite)
 
     testImplementation(libs.junit)
     testImplementation(libs.truth)

--- a/auth-sample-shared/src/main/java/com/google/android/horologist/auth/sample/shared/TokenBundleSerializer.kt
+++ b/auth-sample-shared/src/main/java/com/google/android/horologist/auth/sample/shared/TokenBundleSerializer.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.sample.shared
+
+import androidx.datastore.core.CorruptionException
+import androidx.datastore.core.Serializer
+import com.google.android.horologist.auth.sample.shared.model.TokenBundleProto.TokenBundle
+import com.google.protobuf.InvalidProtocolBufferException
+import java.io.InputStream
+import java.io.OutputStream
+
+public object TokenBundleSerializer : Serializer<TokenBundle?> {
+
+    override val defaultValue: TokenBundle? = null
+
+    override suspend fun readFrom(input: InputStream): TokenBundle? =
+        try {
+            TokenBundle.parseFrom(input)
+        } catch (exception: InvalidProtocolBufferException) {
+            throw CorruptionException("Cannot read proto.", exception)
+        }
+
+    override suspend fun writeTo(t: TokenBundle?, output: OutputStream) {
+        t?.writeTo(output)
+    }
+}

--- a/auth-sample-shared/src/main/java/com/google/android/horologist/auth/sample/shared/TokenSharingConstants.kt
+++ b/auth-sample-shared/src/main/java/com/google/android/horologist/auth/sample/shared/TokenSharingConstants.kt
@@ -16,22 +16,4 @@
 
 package com.google.android.horologist.auth.sample.shared
 
-import androidx.datastore.core.Serializer
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import java.io.InputStream
-import java.io.InputStreamReader
-import java.io.OutputStream
-
-public object TokenSerializer : Serializer<String> {
-    override val defaultValue: String = ""
-
-    override suspend fun readFrom(input: InputStream): String =
-        InputStreamReader(input).readText()
-
-    override suspend fun writeTo(t: String, output: OutputStream) {
-        withContext(Dispatchers.IO) {
-            output.write(t.toByteArray())
-        }
-    }
-}
+const val TOKEN_BUNDLE_CUSTOM_KEY = "token_bundle_custom_key"

--- a/auth-sample-shared/src/main/proto/token_bundle.proto
+++ b/auth-sample-shared/src/main/proto/token_bundle.proto
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.auth.data.phone.tokenshare
+syntax = "proto3";
 
-import com.google.android.horologist.auth.data.phone.ExperimentalHorologistAuthDataPhoneApi
+package com.google.android.horologist.auth.sample.shared.model;
 
-/**
- * Repository of a bundle of information, related to auth tokens.
- */
-@ExperimentalHorologistAuthDataPhoneApi
-public interface TokenBundleRepository<T> {
+option java_package = "com.google.android.horologist.auth.sample.shared.model";
+option java_outer_classname = "TokenBundleProto";
 
-    public suspend fun update(tokenBundle: T)
+message TokenBundle {
+  string access_token = 1;
+  string refresh_token = 2;
 }

--- a/auth-sample-wear/src/main/java/com/google/android/horologist/auth/sample/Screen.kt
+++ b/auth-sample-wear/src/main/java/com/google/android/horologist/auth/sample/Screen.kt
@@ -33,5 +33,6 @@ sealed class Screen(
     object GoogleSignInScreen : Screen("googleSignInScreen")
     object GoogleSignOutScreen : Screen("googleSignOutScreen")
 
-    object TokenShareScreen : Screen("tokenShareScreen")
+    object TokenShareDefaultKeyScreen : Screen("tokenShareDefaultKeyScreen")
+    object TokenShareCustomKeyScreen : Screen("tokenShareCustomKeyScreen")
 }

--- a/auth-sample-wear/src/main/java/com/google/android/horologist/auth/sample/WearApp.kt
+++ b/auth-sample-wear/src/main/java/com/google/android/horologist/auth/sample/WearApp.kt
@@ -37,7 +37,8 @@ import com.google.android.horologist.auth.sample.screens.oauth.devicegrant.signo
 import com.google.android.horologist.auth.sample.screens.oauth.pkce.prompt.PKCESignInPromptScreen
 import com.google.android.horologist.auth.sample.screens.oauth.pkce.signin.PKCESampleViewModelFactory
 import com.google.android.horologist.auth.sample.screens.oauth.pkce.signout.PKCESignOutScreen
-import com.google.android.horologist.auth.sample.screens.tokenshare.TokenShareScreen
+import com.google.android.horologist.auth.sample.screens.tokenshare.customkey.TokenShareCustomKeyScreen
+import com.google.android.horologist.auth.sample.screens.tokenshare.defaultkey.TokenShareDefaultKeyScreen
 import com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreen
 import com.google.android.horologist.auth.ui.oauth.devicegrant.signin.DeviceGrantSignInScreen
 import com.google.android.horologist.auth.ui.oauth.pkce.signin.PKCESignInScreen
@@ -113,8 +114,11 @@ fun WearApp() {
         composable(route = Screen.GoogleSignOutScreen.route) {
             GoogleSignOutScreen(navController = navController)
         }
-        scrollable(route = Screen.TokenShareScreen.route) {
-            TokenShareScreen(columnState = it.columnState)
+        scrollable(route = Screen.TokenShareDefaultKeyScreen.route) {
+            TokenShareDefaultKeyScreen(columnState = it.columnState)
+        }
+        scrollable(route = Screen.TokenShareCustomKeyScreen.route) {
+            TokenShareCustomKeyScreen(columnState = it.columnState)
         }
     }
 }

--- a/auth-sample-wear/src/main/java/com/google/android/horologist/auth/sample/screens/MainScreen.kt
+++ b/auth-sample-wear/src/main/java/com/google/android/horologist/auth/sample/screens/MainScreen.kt
@@ -135,8 +135,12 @@ private fun SectionedListScope.tokenShareSection(navigateToRoute: (String) -> Un
     section(
         listOf(
             Pair(
-                R.string.auth_menu_token_share_item,
-                Screen.TokenShareScreen.route
+                R.string.auth_menu_token_share_default_key_item,
+                Screen.TokenShareDefaultKeyScreen.route
+            ),
+            Pair(
+                R.string.auth_menu_token_share_custom_key_item,
+                Screen.TokenShareCustomKeyScreen.route
             )
         )
     ) {

--- a/auth-sample-wear/src/main/java/com/google/android/horologist/auth/sample/screens/tokenshare/customkey/TokenShareCustomKeyScreen.kt
+++ b/auth-sample-wear/src/main/java/com/google/android/horologist/auth/sample/screens/tokenshare/customkey/TokenShareCustomKeyScreen.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.sample.screens.tokenshare.customkey
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.wear.compose.foundation.lazy.items
+import androidx.wear.compose.material.Text
+import com.google.android.horologist.auth.sample.R
+import com.google.android.horologist.base.ui.components.StandardChip
+import com.google.android.horologist.base.ui.components.StandardChipType
+import com.google.android.horologist.base.ui.components.Title
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+
+@Composable
+fun TokenShareCustomKeyScreen(
+    columnState: ScalingLazyColumnState,
+    modifier: Modifier = Modifier,
+    viewModel: TokenShareCustomKeyViewModel = viewModel(factory = TokenShareCustomKeyViewModel.Factory)
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    ScalingLazyColumn(
+        columnState = columnState,
+        modifier = modifier.fillMaxSize()
+    ) {
+        item {
+            Title(textId = R.string.token_share_custom_key_title)
+        }
+        item {
+            Text(
+                text = stringResource(id = R.string.token_share_custom_key_message),
+                modifier = Modifier.padding(horizontal = 8.dp),
+                textAlign = TextAlign.Center
+            )
+        }
+        items(state) { tokenBundle ->
+            tokenBundle?.let {
+                StandardChip(
+                    label = tokenBundle.accessToken,
+                    onClick = { /* do nothing */ },
+                    chipType = StandardChipType.Secondary,
+                    enabled = false
+                )
+            }
+        }
+    }
+}

--- a/auth-sample-wear/src/main/java/com/google/android/horologist/auth/sample/screens/tokenshare/customkey/TokenShareCustomKeyViewModel.kt
+++ b/auth-sample-wear/src/main/java/com/google/android/horologist/auth/sample/screens/tokenshare/customkey/TokenShareCustomKeyViewModel.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.auth.sample.screens.tokenshare
+package com.google.android.horologist.auth.sample.screens.tokenshare.customkey
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -25,18 +25,20 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import com.google.android.horologist.auth.data.tokenshare.TokenBundleRepository
 import com.google.android.horologist.auth.data.tokenshare.TokenBundleRepositoryImpl
 import com.google.android.horologist.auth.sample.SampleApplication
-import com.google.android.horologist.auth.sample.shared.TokenSerializer
+import com.google.android.horologist.auth.sample.shared.TOKEN_BUNDLE_CUSTOM_KEY
+import com.google.android.horologist.auth.sample.shared.TokenBundleSerializer
+import com.google.android.horologist.auth.sample.shared.model.TokenBundleProto.TokenBundle
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.runningReduce
 import kotlinx.coroutines.flow.stateIn
 
-class TokenShareListenerViewModel(
-    tokenBundleRepository: TokenBundleRepository<String>
+class TokenShareCustomKeyViewModel(
+    tokenBundleRepository: TokenBundleRepository<TokenBundle?>
 ) : ViewModel() {
 
-    public val uiState: StateFlow<List<String>> =
+    public val uiState: StateFlow<List<TokenBundle?>> =
         tokenBundleRepository.flow
             .map { listOf(it) }
             .runningReduce { accumulator, value -> accumulator + value }
@@ -47,10 +49,11 @@ class TokenShareListenerViewModel(
             initializer {
                 val application = this[APPLICATION_KEY]!!
 
-                TokenShareListenerViewModel(
+                TokenShareCustomKeyViewModel(
                     TokenBundleRepositoryImpl.create(
                         registry = (application as SampleApplication).registry,
-                        serializer = TokenSerializer
+                        serializer = TokenBundleSerializer,
+                        key = TOKEN_BUNDLE_CUSTOM_KEY
                     )
                 )
             }

--- a/auth-sample-wear/src/main/java/com/google/android/horologist/auth/sample/screens/tokenshare/defaultkey/TokenShareDefaultKeyScreen.kt
+++ b/auth-sample-wear/src/main/java/com/google/android/horologist/auth/sample/screens/tokenshare/defaultkey/TokenShareDefaultKeyScreen.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.auth.sample.screens.tokenshare
+package com.google.android.horologist.auth.sample.screens.tokenshare.defaultkey
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -36,10 +36,10 @@ import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 
 @Composable
-fun TokenShareScreen(
+fun TokenShareDefaultKeyScreen(
     columnState: ScalingLazyColumnState,
     modifier: Modifier = Modifier,
-    viewModel: TokenShareListenerViewModel = viewModel(factory = TokenShareListenerViewModel.Factory)
+    viewModel: TokenShareDefaultKeyViewModel = viewModel(factory = TokenShareDefaultKeyViewModel.Factory)
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -48,22 +48,24 @@ fun TokenShareScreen(
         modifier = modifier.fillMaxSize()
     ) {
         item {
-            Title(textId = R.string.token_share_title)
+            Title(textId = R.string.token_share_default_key_title)
         }
         item {
             Text(
-                text = stringResource(id = R.string.token_share_message),
+                text = stringResource(id = R.string.token_share_default_key_message),
                 modifier = Modifier.padding(horizontal = 8.dp),
                 textAlign = TextAlign.Center
             )
         }
-        items(state) {
-            StandardChip(
-                label = it,
-                onClick = { /* do nothing */ },
-                chipType = StandardChipType.Secondary,
-                enabled = false
-            )
+        items(state) { tokenBundle ->
+            tokenBundle?.let {
+                StandardChip(
+                    label = tokenBundle.accessToken,
+                    onClick = { /* do nothing */ },
+                    chipType = StandardChipType.Secondary,
+                    enabled = false
+                )
+            }
         }
     }
 }

--- a/auth-sample-wear/src/main/java/com/google/android/horologist/auth/sample/screens/tokenshare/defaultkey/TokenShareDefaultKeyViewModel.kt
+++ b/auth-sample-wear/src/main/java/com/google/android/horologist/auth/sample/screens/tokenshare/defaultkey/TokenShareDefaultKeyViewModel.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.sample.screens.tokenshare.defaultkey
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.google.android.horologist.auth.data.tokenshare.TokenBundleRepository
+import com.google.android.horologist.auth.data.tokenshare.TokenBundleRepositoryImpl
+import com.google.android.horologist.auth.sample.SampleApplication
+import com.google.android.horologist.auth.sample.shared.TokenBundleSerializer
+import com.google.android.horologist.auth.sample.shared.model.TokenBundleProto.TokenBundle
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.runningReduce
+import kotlinx.coroutines.flow.stateIn
+
+class TokenShareDefaultKeyViewModel(
+    tokenBundleRepository: TokenBundleRepository<TokenBundle?>
+) : ViewModel() {
+
+    public val uiState: StateFlow<List<TokenBundle?>> =
+        tokenBundleRepository.flow
+            .map { listOf(it) }
+            .runningReduce { accumulator, value -> accumulator + value }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    companion object {
+        public val Factory: ViewModelProvider.Factory = viewModelFactory {
+            initializer {
+                val application = this[APPLICATION_KEY]!!
+
+                TokenShareDefaultKeyViewModel(
+                    TokenBundleRepositoryImpl.create(
+                        registry = (application as SampleApplication).registry,
+                        serializer = TokenBundleSerializer
+                    )
+                )
+            }
+        }
+    }
+}

--- a/auth-sample-wear/src/main/res/values/strings.xml
+++ b/auth-sample-wear/src/main/res/values/strings.xml
@@ -28,7 +28,8 @@
     <string name="auth_menu_google_streamline_sign_in_item">Streamline Sign-in</string>
     <string name="auth_menu_google_sign_out_item">Sign out</string>
     <string name="auth_menu_token_share_header">Token Sharing</string>
-    <string name="auth_menu_token_share_item">Sample</string>
+    <string name="auth_menu_token_share_default_key_item">Default Key</string>
+    <string name="auth_menu_token_share_custom_key_item">Custom Key</string>
     <string name="pkce_sign_in_prompt_message">Share workouts and compete with your friends and family</string>
     <string name="pkce_sign_in_prompt_already_signed_in_message">Already signed-in!</string>
     <string name="pkce_sign_out_success_message">Signed out successfully!</string>
@@ -39,6 +40,8 @@
     <string name="google_sign_out_success_message">Signed out successfully!</string>
     <string name="google_sign_in_prompt_already_signed_in_message">Already signed-in!</string>
     <string name="google_streamline_sign_in_already_signed_in_message">Already signed-in!</string>
-    <string name="token_share_title">Token Sharing</string>
-    <string name="token_share_message">Tokens emitted by the phone sample app while this is screen is visible will be displayed below:</string>
+    <string name="token_share_default_key_title">Token Sharing</string>
+    <string name="token_share_default_key_message">Tokens emitted by the phone sample app, with the default key, while this is screen is visible will be displayed below:</string>
+    <string name="token_share_custom_key_title">Token Sharing</string>
+    <string name="token_share_custom_key_message">Tokens emitted by the phone sample app, with a custom key, while this is screen is visible will be displayed below:</string>
 </resources>


### PR DESCRIPTION
#### WHAT

Improve token sharing sample.

#### WHY

- In order to have something more complex than just a simple string being shared between the devices;
- In order to demo the sharing of multiple token bundles;

#### HOW

Add `TokenBundle` proto definition in `auth-sample-shared` and update `TokenSerializer` to use it.


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
