### PR TITLE
Avoid StrictMode violation from reading on main thread

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/auth/GoogleSignInAuthUserRepository.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/auth/GoogleSignInAuthUserRepository.kt
@@ -25,11 +25,13 @@ import com.google.android.horologist.auth.data.common.model.AuthUser
 import com.google.android.horologist.auth.data.common.repository.AuthUserRepository
 import com.google.android.horologist.auth.data.googlesignin.AuthUserMapper
 import com.google.android.horologist.auth.data.googlesignin.GoogleSignInEventListener
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
 
 /**
  * An implementation of [AuthUserRepository] for the Google Sign-In authentication method.
@@ -44,8 +46,8 @@ public class GoogleSignInAuthUserRepository(
 
     public val authState: Flow<AuthUser?> = _authTrigger.map { getAuthenticated() }
 
-    override suspend fun getAuthenticated(): AuthUser? {
-        return AuthUserMapper.map(GoogleSignIn.getLastSignedInAccount(applicationContext))
+    override suspend fun getAuthenticated(): AuthUser? = withContext(Dispatchers.Default) {
+        AuthUserMapper.map(GoogleSignIn.getLastSignedInAccount(applicationContext))
     }
 
     override suspend fun onSignedIn(account: GoogleSignInAccount) {
@@ -55,9 +57,6 @@ public class GoogleSignInAuthUserRepository(
     public fun onSignedOut() {
         _authTrigger.update { it + 1 }
     }
-
-    public fun getAuthenticatedGoogleSignInAccount(): GoogleSignInAccount? =
-        GoogleSignIn.getLastSignedInAccount(applicationContext)
 
     public suspend fun signOut() {
         googleSignInClient.signOut().await()

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/auth/GoogleSignInAuthUserRepository.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/auth/GoogleSignInAuthUserRepository.kt
@@ -46,7 +46,7 @@ public class GoogleSignInAuthUserRepository(
 
     public val authState: Flow<AuthUser?> = _authTrigger.map { getAuthenticated() }
 
-    override suspend fun getAuthenticated(): AuthUser? = withContext(Dispatchers.Default) {
+    override suspend fun getAuthenticated(): AuthUser? = withContext(Dispatchers.IO) {
         AuthUserMapper.map(GoogleSignIn.getLastSignedInAccount(applicationContext))
     }
 


### PR DESCRIPTION
#### WHAT

Avoid StrictMode violation from reading on main thread

#### WHY

GoogleSignIn.getLastSignedInAccount is not main thread safe.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
