### PR TITLE
Fix ActiveDurationText API

### DIFF
--- a/health-composables/api/current.api
+++ b/health-composables/api/current.api
@@ -16,7 +16,7 @@ package com.google.android.horologist.health.composables {
   }
 
   public final class ActiveDurationTextKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.health.composables.ExperimentalHorologistHealthComposablesApi public static void ActiveDurationText(androidx.health.services.client.data.ExerciseUpdate.ActiveDurationCheckpoint checkpoint, androidx.health.services.client.data.ExerciseState state, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function1<? super java.time.Duration,kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.health.composables.ExperimentalHorologistHealthComposablesApi public static void ActiveDurationText(androidx.health.services.client.data.ExerciseUpdate.ActiveDurationCheckpoint checkpoint, androidx.health.services.client.data.ExerciseState state, optional kotlin.jvm.functions.Function1<? super java.time.Duration,kotlin.Unit> content);
     method @androidx.compose.runtime.Composable public static void FormattedDurationText(java.time.Duration duration, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function1<? super java.time.Duration,java.lang.String> formatter, optional long color, optional androidx.compose.ui.text.style.TextAlign? textAlign, optional androidx.compose.ui.text.TextStyle style);
     method public static kotlin.jvm.functions.Function1<java.time.Duration,java.lang.String> patternFormatter(optional String format);
   }

--- a/health-composables/src/main/java/com/google/android/horologist/health/composables/ActiveDurationText.kt
+++ b/health-composables/src/main/java/com/google/android/horologist/health/composables/ActiveDurationText.kt
@@ -66,9 +66,8 @@ import java.time.Instant
 public fun ActiveDurationText(
     checkpoint: ExerciseUpdate.ActiveDurationCheckpoint,
     state: ExerciseState,
-    modifier: Modifier = Modifier,
     content: @Composable (Duration) -> Unit = {
-        FormattedDurationText(modifier = modifier, duration = it)
+        FormattedDurationText(duration = it)
     }
 ) {
     var activeSeconds by remember {
@@ -202,12 +201,16 @@ internal fun ActiveDurationTextPreview() {
         )
     }
     ActiveDurationText(
-        modifier = Modifier.clickable {
-            state = state.flip()
-        },
         checkpoint = checkpoint,
         state = state
-    )
+    ) {
+        FormattedDurationText(
+            modifier = Modifier.clickable {
+                state = state.flip()
+            },
+            duration = it
+        )
+    }
 }
 
 private fun ExerciseState.flip(): ExerciseState {
@@ -229,13 +232,16 @@ internal fun ActiveDurationTextCustomSeparatorPreview() {
         )
     }
     ActiveDurationText(
-        modifier = Modifier.clickable {
-            state = state.flip()
-        },
         checkpoint = checkpoint,
         state = state
     ) {
         val formatter = remember { patternFormatter("%1\$02dh%2\$02dm%3\$02ds") }
-        FormattedDurationText(duration = it, formatter = formatter)
+        FormattedDurationText(
+            modifier = Modifier.clickable {
+                state = state.flip()
+            },
+            duration = it,
+            formatter = formatter
+        )
     }
 }


### PR DESCRIPTION
#### WHAT

Fix ActiveDurationText API

#### WHY

Garan seeing

```
        androidx.compose.runtime.ComposeRuntimeError: Compose Runtime internal error. Unexpected or incorrect use of the Compose internal runtime API (Unexpected anchor value, expected a negative anchor). Please report to Google or use https://goo.gle/compose-feedback
            at androidx.compose.runtime.ComposerKt.composeRuntimeError(Composer.kt:4383)
            at 
```

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
