### PR TITLE
Refactors metadata display and handling

### DIFF
--- a/media-data/api/current.api
+++ b/media-data/api/current.api
@@ -266,7 +266,7 @@ package com.google.android.horologist.media.data.mapper {
 
   @com.google.android.horologist.media.data.ExperimentalHorologistMediaDataApi public final class MediaMapper {
     ctor public MediaMapper(com.google.android.horologist.media.data.mapper.MediaExtrasMapper mediaExtrasMapper);
-    method public com.google.android.horologist.media.model.Media map(androidx.media3.common.MediaItem mediaItem, androidx.media3.common.MediaMetadata? mediaMetadata, optional String defaultArtist);
+    method public com.google.android.horologist.media.model.Media map(androidx.media3.common.MediaItem mediaItem, androidx.media3.common.MediaMetadata mediaMetadata);
     method public com.google.android.horologist.media.model.Media map(com.google.android.horologist.media.data.database.model.MediaEntity media);
   }
 

--- a/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaMapper.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaMapper.kt
@@ -29,9 +29,7 @@ import com.google.android.horologist.media.model.Media
  * Functions to map models from other layers and / or packages into a [Media].
  */
 @ExperimentalHorologistMediaDataApi
-public class MediaMapper(
-    private val mediaExtrasMapper: MediaExtrasMapper
-) {
+public class MediaMapper(private val mediaExtrasMapper: MediaExtrasMapper) {
 
     /**
      * Maps from a [MediaItem].
@@ -41,21 +39,16 @@ public class MediaMapper(
      */
     public fun map(
         mediaItem: MediaItem,
-        mediaMetadata: MediaMetadata?,
-        defaultArtist: String = ""
+        mediaMetadata: MediaMetadata
     ): Media = Media(
         id = mediaItem.mediaId,
         uri = mediaItem.localConfiguration?.uri?.toString() ?: "",
-        title = mediaMetadata?.title?.toString()
-            ?: mediaItem.mediaMetadata.displayTitle?.toString()
-            ?: mediaItem.mediaMetadata.title?.toString()
+        title = mediaMetadata.title?.toString() ?: "",
+        artist = mediaMetadata.artist?.toString()
+            ?: mediaMetadata.albumArtist?.toString()
+            ?: mediaMetadata.subtitle?.toString()
             ?: "",
-        artist = mediaMetadata?.artist?.toString()
-            ?: mediaItem.mediaMetadata.artist?.toString()
-            ?: mediaItem.mediaMetadata.albumArtist?.toString()
-            ?: defaultArtist,
-        artworkUri = mediaMetadata?.artworkUri?.toString()
-            ?: mediaItem.mediaMetadata.artworkUri?.toString(),
+        artworkUri = mediaMetadata.artworkUri?.toString(),
         extras = mediaExtrasMapper.map(mediaItem, mediaMetadata)
     )
 

--- a/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImpl.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImpl.kt
@@ -319,7 +319,7 @@ public class PlayerRepositoryImpl(
     override fun getMediaAt(index: Int): Media? {
         checkNotClosed()
 
-        return player.value?.getMediaItemAt(index)?.let { mediaMapper.map(it, null) }
+        return player.value?.getMediaItemAt(index)?.let { mediaMapper.map(it, it.mediaMetadata) }
     }
 
     override fun getCurrentMediaIndex(): Int {

--- a/media-data/src/test/java/com/google/android/horologist/media/data/mapper/MediaMapperTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/mapper/MediaMapperTest.kt
@@ -47,7 +47,6 @@ class MediaMapperTest {
         val id = "id"
         val uri = "uri"
         val title = "title"
-        val displayTitle = "displayTitle"
         val artist = "artist"
         val albumArtist = "albumArtist"
         val artworkUri = "artworkUri"
@@ -58,7 +57,6 @@ class MediaMapperTest {
             .setMediaMetadata(
                 MediaMetadata.Builder()
                     .setTitle(title)
-                    .setDisplayTitle(displayTitle)
                     .setArtist(artist)
                     .setAlbumArtist(albumArtist)
                     .setArtworkUri(Uri.parse(artworkUri))
@@ -67,12 +65,12 @@ class MediaMapperTest {
             .build()
 
         // when
-        val result = sut.map(mediaItem, null)
+        val result = sut.map(mediaItem, mediaItem.mediaMetadata)
 
         // then
         assertThat(result.id).isEqualTo(id)
         assertThat(result.uri).isEqualTo(uri)
-        assertThat(result.title).isEqualTo(displayTitle)
+        assertThat(result.title).isEqualTo(title)
         assertThat(result.artist).isEqualTo(artist)
         assertThat(result.artworkUri).isEqualTo(artworkUri)
     }
@@ -95,7 +93,7 @@ class MediaMapperTest {
             .build()
 
         // when
-        val result = sut.map(mediaItem, null)
+        val result = sut.map(mediaItem, mediaItem.mediaMetadata)
 
         // then
         assertThat(result.id).isEqualTo(id)
@@ -125,7 +123,7 @@ class MediaMapperTest {
             .build()
 
         // when
-        val result = sut.map(mediaItem, null)
+        val result = sut.map(mediaItem, mediaItem.mediaMetadata)
 
         // then
         assertThat(result.id).isEqualTo(id)
@@ -136,16 +134,16 @@ class MediaMapperTest {
     }
 
     @Test
-    fun `given MediaItem currentArtist is null and defaultArtist is passed then maps correctly`() {
+    fun `given no title and artist, uses empty string`() {
         // given
-        val defaultArtist = "defaultArtist"
         val mediaItem = MediaItem.Builder().build()
 
         // when
-        val result = sut.map(mediaItem, null, defaultArtist)
+        val result = sut.map(mediaItem, mediaItem.mediaMetadata)
 
         // then
-        assertThat(result.artist).isEqualTo(defaultArtist)
+        assertThat(result.title).isEqualTo("")
+        assertThat(result.artist).isEqualTo("")
     }
 
     @Test
@@ -208,7 +206,7 @@ class MediaMapperTest {
         })
 
         // when
-        val result = sut.map(mediaItem, null)
+        val result = sut.map(mediaItem, mediaItem.mediaMetadata)
 
         // then
         assertThat(result.extras[id]).isEqualTo(id)

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/DataModule.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/DataModule.kt
@@ -171,8 +171,7 @@ class DataModule {
     fun mediaExtrasMapper(): MediaExtrasMapper = MediaExtrasMapperNoopImpl
 
     @Provides
-    fun mediaMapper(mediaExtrasMapper: MediaExtrasMapper): MediaMapper =
-        MediaMapper(mediaExtrasMapper)
+    fun mediaMapper(mediaExtrasMapper: MediaExtrasMapper): MediaMapper = MediaMapper(mediaExtrasMapper)
 
     @Provides
     fun playlistMapper(mediaMapper: MediaMapper): PlaylistMapper = PlaylistMapper(mediaMapper)

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/player/UampMediaPlayerScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/player/UampMediaPlayerScreen.kt
@@ -25,10 +25,10 @@ import androidx.wear.compose.material.MaterialTheme
 import com.google.android.horologist.audio.ui.VolumeViewModel
 import com.google.android.horologist.media.ui.components.PodcastControlButtons
 import com.google.android.horologist.media.ui.components.animated.AnimatedMediaControlButtons
-import com.google.android.horologist.media.ui.components.animated.AnimatedPlayerScreenMediaDisplay
+import com.google.android.horologist.media.ui.components.animated.AnimatedMediaInfoDisplay
 import com.google.android.horologist.media.ui.components.background.ArtworkColorBackground
+import com.google.android.horologist.media.ui.screens.player.DefaultMediaInfoDisplay
 import com.google.android.horologist.media.ui.screens.player.DefaultPlayerScreenControlButtons
-import com.google.android.horologist.media.ui.screens.player.DefaultPlayerScreenMediaDisplay
 import com.google.android.horologist.media.ui.screens.player.PlayerScreen
 import com.google.android.horologist.media.ui.state.PlayerUiController
 import com.google.android.horologist.media.ui.state.PlayerUiState
@@ -51,9 +51,13 @@ fun UampMediaPlayerScreen(
         volumeViewModel = volumeViewModel,
         mediaDisplay = { playerUiState ->
             if (settingsState.animated) {
-                AnimatedPlayerScreenMediaDisplay(playerUiState.media, loading = !playerUiState.connected)
+                AnimatedMediaInfoDisplay(
+                    media = playerUiState.media,
+                    loading = !playerUiState.connected || playerUiState.media?.loading == true,
+                    modifier = modifier
+                )
             } else {
-                DefaultPlayerScreenMediaDisplay(playerUiState.media, loading = !playerUiState.connected)
+                DefaultMediaInfoDisplay(playerUiState)
             }
         },
         buttons = {

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -47,20 +47,8 @@ package com.google.android.horologist.media.ui.components {
     method @androidx.compose.runtime.Composable public static void ControlButtonLayout(kotlin.jvm.functions.Function0<kotlin.Unit> leftButton, kotlin.jvm.functions.Function0<kotlin.Unit> middleButton, kotlin.jvm.functions.Function0<kotlin.Unit> rightButton, optional androidx.compose.ui.Modifier modifier);
   }
 
-  public final class DefaultMediaDisplayKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void DefaultMediaDisplay(com.google.android.horologist.media.ui.state.model.MediaUiModel? media, optional androidx.compose.ui.Modifier modifier);
-  }
-
   public final class EntityButtonKt {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void EntityButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, androidx.compose.ui.graphics.vector.ImageVector icon, String contentDescription, optional androidx.compose.ui.Modifier modifier, optional boolean enabled);
-  }
-
-  public final class InfoMediaDisplayKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void InfoMediaDisplay(optional androidx.compose.ui.Modifier modifier, optional String? message);
-  }
-
-  public final class LoadingMediaDisplayKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void LoadingMediaDisplay(optional androidx.compose.ui.Modifier modifier);
   }
 
   public final class MediaArtworkKt {
@@ -78,6 +66,10 @@ package com.google.android.horologist.media.ui.components {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void MediaControlButtons(kotlin.jvm.functions.Function0<kotlin.Unit> onPlayButtonClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPauseButtonClick, boolean playPauseButtonEnabled, boolean playing, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekToPreviousButtonClick, boolean seekToPreviousButtonEnabled, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekToNextButtonClick, boolean seekToNextButtonEnabled, optional androidx.compose.ui.Modifier modifier, com.google.android.horologist.media.ui.state.model.TrackPositionUiModel trackPositionUiModel, optional androidx.wear.compose.material.ButtonColors colors);
   }
 
+  public final class MediaInfoDisplayKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void MediaInfoDisplay(com.google.android.horologist.media.ui.state.model.MediaUiModel? media, boolean loading, optional androidx.compose.ui.Modifier modifier);
+  }
+
   public final class PlayPauseButtonKt {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PlayPauseButton(kotlin.jvm.functions.Function0<kotlin.Unit> onPlayClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPauseClick, boolean playing, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional androidx.wear.compose.material.ButtonColors colors, optional float iconSize, optional long tapTargetSize, optional kotlin.jvm.functions.Function0<kotlin.Unit> progress);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PlayPauseProgressButton(kotlin.jvm.functions.Function0<kotlin.Unit> onPlayClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPauseClick, boolean playing, com.google.android.horologist.media.ui.state.model.TrackPositionUiModel trackPositionUiModel, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional androidx.wear.compose.material.ButtonColors colors, optional float iconSize, optional long tapTargetSize, optional long progressColour, optional long trackColor, optional long backgroundColor);
@@ -87,10 +79,6 @@ package com.google.android.horologist.media.ui.components {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PodcastControlButtons(com.google.android.horologist.media.ui.state.PlayerUiController playerController, com.google.android.horologist.media.ui.state.PlayerUiState playerUiState, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PodcastControlButtons(kotlin.jvm.functions.Function0<kotlin.Unit> onPlayButtonClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPauseButtonClick, boolean playPauseButtonEnabled, boolean playing, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekBackButtonClick, boolean seekBackButtonEnabled, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekForwardButtonClick, boolean seekForwardButtonEnabled, optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement seekBackButtonIncrement, optional com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement seekForwardButtonIncrement, optional androidx.wear.compose.material.ButtonColors colors);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PodcastControlButtons(kotlin.jvm.functions.Function0<kotlin.Unit> onPlayButtonClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPauseButtonClick, boolean playPauseButtonEnabled, boolean playing, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekBackButtonClick, boolean seekBackButtonEnabled, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekForwardButtonClick, boolean seekForwardButtonEnabled, com.google.android.horologist.media.ui.state.model.TrackPositionUiModel trackPositionUiModel, optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement seekBackButtonIncrement, optional com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement seekForwardButtonIncrement, optional androidx.wear.compose.material.ButtonColors colors);
-  }
-
-  public final class TextMediaDisplayKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void TextMediaDisplay(optional androidx.compose.ui.Modifier modifier, optional String? title, optional String? subtitle);
   }
 
 }
@@ -113,13 +101,13 @@ package com.google.android.horologist.media.ui.components.animated {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void AnimatedMediaControlButtons(kotlin.jvm.functions.Function0<kotlin.Unit> onPlayButtonClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPauseButtonClick, boolean playPauseButtonEnabled, boolean playing, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekToPreviousButtonClick, boolean seekToPreviousButtonEnabled, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekToNextButtonClick, boolean seekToNextButtonEnabled, optional androidx.compose.ui.Modifier modifier, com.google.android.horologist.media.ui.state.model.TrackPositionUiModel trackPositionUiModel, optional androidx.wear.compose.material.ButtonColors colors);
   }
 
+  public final class AnimatedMediaInfoDisplayKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void AnimatedMediaInfoDisplay(com.google.android.horologist.media.ui.state.model.MediaUiModel? media, boolean loading, optional androidx.compose.ui.Modifier modifier);
+  }
+
   public final class AnimatedPlayPauseButtonKt {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void AnimatedPlayPauseButton(kotlin.jvm.functions.Function0<kotlin.Unit> onPlayClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPauseClick, boolean playing, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional androidx.wear.compose.material.ButtonColors colors, optional float iconSize, optional long tapTargetSize, optional kotlin.jvm.functions.Function0<kotlin.Unit> progress);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void AnimatedPlayPauseProgressButton(kotlin.jvm.functions.Function0<kotlin.Unit> onPlayClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPauseClick, boolean playing, float percent, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional androidx.wear.compose.material.ButtonColors colors, optional float iconSize, optional long tapTargetSize, optional long progressColour, optional long trackColor, optional long backgroundColor);
-  }
-
-  public final class AnimatedPlayerScreenMediaDisplayKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void AnimatedPlayerScreenMediaDisplay(com.google.android.horologist.media.ui.state.model.MediaUiModel? media, boolean loading, optional androidx.compose.ui.Modifier modifier);
   }
 
   public final class AnimatedSeekToNextButtonKt {
@@ -215,6 +203,30 @@ package com.google.android.horologist.media.ui.components.controls {
 
   public final class ShuffleToggleButtonKt {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void ShuffleToggleButton(boolean shuffleOn, kotlin.jvm.functions.Function1<? super java.lang.Boolean,kotlin.Unit> onToggle, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional androidx.wear.compose.material.ToggleButtonColors colors);
+  }
+
+}
+
+package com.google.android.horologist.media.ui.components.display {
+
+  public final class LoadingMediaDisplayKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void LoadingMediaDisplay(optional androidx.compose.ui.Modifier modifier);
+  }
+
+  public final class MessageMediaDisplayKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void MessageMediaDisplay(optional androidx.compose.ui.Modifier modifier, optional String? message);
+  }
+
+  public final class NothingPlayingDisplayKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void NothingPlayingDisplay(androidx.compose.ui.Modifier modifier);
+  }
+
+  public final class TextMediaDisplayKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void TextMediaDisplay(optional androidx.compose.ui.Modifier modifier, optional String? title, optional String? subtitle);
+  }
+
+  public final class TrackMediaDisplayKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void TrackMediaDisplay(com.google.android.horologist.media.ui.state.model.MediaUiModel? media, optional androidx.compose.ui.Modifier modifier);
   }
 
 }
@@ -448,8 +460,8 @@ package com.google.android.horologist.media.ui.screens.entity {
 package com.google.android.horologist.media.ui.screens.player {
 
   public final class PlayerScreenKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void DefaultMediaInfoDisplay(com.google.android.horologist.media.ui.state.PlayerUiState playerUiState, optional androidx.compose.ui.Modifier modifier);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void DefaultPlayerScreenControlButtons(com.google.android.horologist.media.ui.state.PlayerUiController playerController, com.google.android.horologist.media.ui.state.PlayerUiState playerUiState);
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void DefaultPlayerScreenMediaDisplay(com.google.android.horologist.media.ui.state.model.MediaUiModel? media, boolean loading, optional androidx.compose.ui.Modifier modifier);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PlayerScreen(com.google.android.horologist.media.ui.state.PlayerViewModel playerViewModel, com.google.android.horologist.audio.ui.VolumeViewModel volumeViewModel, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function2<? super androidx.compose.foundation.layout.ColumnScope,? super com.google.android.horologist.media.ui.state.PlayerUiState,kotlin.Unit> mediaDisplay, optional kotlin.jvm.functions.Function3<? super androidx.compose.foundation.layout.RowScope,? super com.google.android.horologist.media.ui.state.PlayerUiController,? super com.google.android.horologist.media.ui.state.PlayerUiState,kotlin.Unit> controlButtons, optional kotlin.jvm.functions.Function2<? super androidx.compose.foundation.layout.RowScope,? super com.google.android.horologist.media.ui.state.PlayerUiState,kotlin.Unit> buttons, optional kotlin.jvm.functions.Function2<? super androidx.compose.foundation.layout.BoxScope,? super com.google.android.horologist.media.ui.state.PlayerUiState,kotlin.Unit> background);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PlayerScreen(kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.ColumnScope,kotlin.Unit> mediaDisplay, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.RowScope,kotlin.Unit> controlButtons, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.RowScope,kotlin.Unit> buttons, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.BoxScope,kotlin.Unit> background, kotlin.jvm.functions.Function1<? super java.lang.Float,kotlin.Unit> onVolumeChangeByScroll);
   }
@@ -645,7 +657,7 @@ package com.google.android.horologist.media.ui.state.mapper {
   }
 
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public final class MediaUiModelMapper {
-    method public com.google.android.horologist.media.ui.state.model.MediaUiModel map(com.google.android.horologist.media.model.Media media);
+    method public com.google.android.horologist.media.ui.state.model.MediaUiModel map(com.google.android.horologist.media.model.Media media, optional String defaultTitle, optional String defaultArtist);
     field public static final com.google.android.horologist.media.ui.state.mapper.MediaUiModelMapper INSTANCE;
   }
 
@@ -758,23 +770,25 @@ package com.google.android.horologist.media.ui.state.model {
   }
 
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public final class MediaUiModel {
-    ctor public MediaUiModel(String id, optional String? title, optional String? subtitle, optional String? artworkUri, optional androidx.compose.ui.graphics.Color? artworkColor);
+    ctor public MediaUiModel(String id, String title, optional String subtitle, optional String? artworkUri, optional androidx.compose.ui.graphics.Color? artworkColor);
     method public String component1();
-    method public String? component2();
-    method public String? component3();
+    method public String component2();
+    method public String component3();
     method public String? component4();
     method public androidx.compose.ui.graphics.Color? component5-QN2ZGVo();
-    method public com.google.android.horologist.media.ui.state.model.MediaUiModel copy-6nskv5g(String id, String? title, String? subtitle, String? artworkUri, androidx.compose.ui.graphics.Color? artworkColor);
+    method public com.google.android.horologist.media.ui.state.model.MediaUiModel copy-6nskv5g(String id, String title, String subtitle, String? artworkUri, androidx.compose.ui.graphics.Color? artworkColor);
     method public androidx.compose.ui.graphics.Color? getArtworkColor();
     method public String? getArtworkUri();
     method public String getId();
-    method public String? getSubtitle();
-    method public String? getTitle();
+    method public boolean getLoading();
+    method public String getSubtitle();
+    method public String getTitle();
     property public final androidx.compose.ui.graphics.Color? artworkColor;
     property public final String? artworkUri;
     property public final String id;
-    property public final String? subtitle;
-    property public final String? title;
+    property public final boolean loading;
+    property public final String subtitle;
+    property public final String title;
   }
 
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public abstract sealed class PlaylistDownloadUiModel {

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/MediaChipPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/MediaChipPreview.kt
@@ -70,7 +70,7 @@ fun MediaChipPreviewNoArtwork() {
 @Composable
 fun MediaChipPreviewNoTitle() {
     MediaChip(
-        media = MediaUiModel(id = "id", artworkUri = "artworkUri"),
+        media = MediaUiModel(id = "id", title = "title", artworkUri = "artworkUri"),
         onClick = {},
         defaultTitle = "No title",
         placeholder = rememberVectorPainter(

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/display/TextMediaDisplayPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/display/TextMediaDisplayPreview.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalHorologistMediaUiApi::class)
+
+package com.google.android.horologist.media.ui.components.display
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.google.android.horologist.compose.tools.WearPreview
+import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
+
+@WearPreview
+@Composable
+fun TextMediaDisplayPreview() {
+    TextMediaDisplay(
+        title = "Song title",
+        subtitle = "Artist name"
+    )
+}
+
+@Preview(
+    "With long text",
+    backgroundColor = 0xff000000,
+    showBackground = true
+)
+@Composable
+fun TextMediaDisplayPreviewLongText() {
+    TextMediaDisplay(
+        title = "I Predict That You Look Good In A Riot",
+        subtitle = "Arctic Monkeys feat Kaiser Chiefs"
+    )
+}

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/display/TrackMediaDisplayPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/display/TrackMediaDisplayPreview.kt
@@ -16,19 +16,23 @@
 
 @file:OptIn(ExperimentalHorologistMediaUiApi::class)
 
-package com.google.android.horologist.media.ui.components
+package com.google.android.horologist.media.ui.components.display
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import com.google.android.horologist.compose.tools.WearPreview
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
+import com.google.android.horologist.media.ui.state.model.MediaUiModel
 
 @WearPreview
 @Composable
-fun TextMediaDisplayPreview() {
-    TextMediaDisplay(
-        title = "Song title",
-        subtitle = "Artist name"
+fun TrackMediaDisplayPreview() {
+    TrackMediaDisplay(
+        media = MediaUiModel(
+            id = "id",
+            title = "Song title",
+            subtitle = "Artist name"
+        )
     )
 }
 
@@ -38,9 +42,12 @@ fun TextMediaDisplayPreview() {
     showBackground = true
 )
 @Composable
-fun TextMediaDisplayPreviewLongText() {
-    TextMediaDisplay(
-        title = "I Predict That You Look Good In A Riot",
-        subtitle = "Arctic Monkeys feat Kaiser Chiefs"
+fun TrackMediaDisplayPreviewLongText() {
+    TrackMediaDisplay(
+        media = MediaUiModel(
+            id = "id",
+            title = "I Predict That You Look Good In A Riot",
+            subtitle = "Arctic Monkeys feat Kaiser Chiefs"
+        )
     )
 }

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenPreview.kt
@@ -16,7 +16,6 @@
 
 @file:OptIn(
     ExperimentalHorologistMediaUiApi::class,
-    ExperimentalHorologistComposeToolsApi::class,
     ExperimentalFoundationApi::class
 )
 
@@ -44,7 +43,6 @@ import com.google.android.horologist.audio.VolumeState
 import com.google.android.horologist.audio.ui.components.SettingsButtons
 import com.google.android.horologist.audio.ui.components.SettingsButtonsDefaults
 import com.google.android.horologist.compose.pager.PagerScreen
-import com.google.android.horologist.compose.tools.ExperimentalHorologistComposeToolsApi
 import com.google.android.horologist.compose.tools.ThemeValues
 import com.google.android.horologist.compose.tools.WearLargeRoundDevicePreview
 import com.google.android.horologist.compose.tools.WearPreviewDevices
@@ -53,8 +51,8 @@ import com.google.android.horologist.compose.tools.WearPreviewThemes
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.R
 import com.google.android.horologist.media.ui.components.MediaControlButtons
-import com.google.android.horologist.media.ui.components.TextMediaDisplay
 import com.google.android.horologist.media.ui.components.background.RadialBackground
+import com.google.android.horologist.media.ui.components.display.TextMediaDisplay
 import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
 import com.google.android.horologist.media.ui.uamp.UampTheme
 import kotlin.time.Duration.Companion.seconds

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/MediaChip.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/MediaChip.kt
@@ -55,7 +55,7 @@ public fun MediaChip(
     val title = media.title
 
     MediaChip(
-        title = title ?: defaultTitle,
+        title = title.takeIf { it.isNotEmpty() } ?: defaultTitle,
         artworkUri = artworkUri,
         onClick = onClick,
         modifier = modifier,

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/MediaInfoDisplay.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/MediaInfoDisplay.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,23 +14,22 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.media.ui.components.animated
+package com.google.android.horologist.media.ui.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
-import com.google.android.horologist.media.ui.R
-import com.google.android.horologist.media.ui.components.InfoMediaDisplay
-import com.google.android.horologist.media.ui.components.LoadingMediaDisplay
+import com.google.android.horologist.media.ui.components.display.LoadingMediaDisplay
+import com.google.android.horologist.media.ui.components.display.NothingPlayingDisplay
+import com.google.android.horologist.media.ui.components.display.TrackMediaDisplay
 import com.google.android.horologist.media.ui.state.model.MediaUiModel
 
 /**
- * Animated [MediaDisplay] implementation for [PlayerScreen] including player status.
+ * A display implementation that shows the track information, loading or nothing playing.
  */
 @ExperimentalHorologistMediaUiApi
 @Composable
-public fun AnimatedPlayerScreenMediaDisplay(
+public fun MediaInfoDisplay(
     media: MediaUiModel?,
     loading: Boolean,
     modifier: Modifier = Modifier
@@ -38,15 +37,11 @@ public fun AnimatedPlayerScreenMediaDisplay(
     if (loading) {
         LoadingMediaDisplay(modifier)
     } else if (media != null) {
-        MarqueeTextMediaDisplay(
-            modifier = modifier,
-            title = media.title,
-            artist = media.subtitle
-        )
-    } else {
-        InfoMediaDisplay(
-            message = stringResource(R.string.horologist_nothing_playing),
+        TrackMediaDisplay(
+            media = media,
             modifier = modifier
         )
+    } else {
+        NothingPlayingDisplay(modifier)
     }
 }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/animated/AnimatedMediaInfoDisplay.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/animated/AnimatedMediaInfoDisplay.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.components.animated
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
+import com.google.android.horologist.media.ui.components.display.LoadingMediaDisplay
+import com.google.android.horologist.media.ui.components.display.NothingPlayingDisplay
+import com.google.android.horologist.media.ui.state.model.MediaUiModel
+
+/**
+ * Animated [MediaDisplay] implementation for [PlayerScreen] including player status.
+ */
+@ExperimentalHorologistMediaUiApi
+@Composable
+public fun AnimatedMediaInfoDisplay(
+    media: MediaUiModel?,
+    loading: Boolean,
+    modifier: Modifier = Modifier
+) {
+    if (loading) {
+        LoadingMediaDisplay(modifier)
+    } else if (media != null) {
+        MarqueeTextMediaDisplay(
+            modifier = modifier,
+            title = media.title,
+            artist = media.subtitle
+        )
+    } else {
+        NothingPlayingDisplay(modifier)
+    }
+}

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/display/LoadingMediaDisplay.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/display/LoadingMediaDisplay.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.media.ui.components
+package com.google.android.horologist.media.ui.components.display
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/display/MessageMediaDisplay.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/display/MessageMediaDisplay.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.media.ui.components
+package com.google.android.horologist.media.ui.components.display
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -28,11 +28,11 @@ import androidx.wear.compose.material.Text
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 
 /**
- * A simple text only display showing status information.
+ * A simple text-only display showing status information or a message.
  */
 @ExperimentalHorologistMediaUiApi
 @Composable
-public fun InfoMediaDisplay(
+public fun MessageMediaDisplay(
     modifier: Modifier = Modifier,
     message: String? = null
 ) {

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/display/NothingPlayingDisplay.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/display/NothingPlayingDisplay.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,22 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.media.ui.components
+package com.google.android.horologist.media.ui.components.display
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
-import com.google.android.horologist.media.ui.state.model.MediaUiModel
+import com.google.android.horologist.media.ui.R
 
 /**
- * A simple text only display of [MediaUiModel] showing artist and title in two separated rows.
+ * A media display indicating nothing is playing.
  */
 @ExperimentalHorologistMediaUiApi
 @Composable
-public fun DefaultMediaDisplay(
-    media: MediaUiModel?,
-    modifier: Modifier = Modifier
-) {
-    TextMediaDisplay(
-        modifier = modifier,
-        title = media?.title,
-        subtitle = media?.subtitle
+public fun NothingPlayingDisplay(modifier: Modifier) {
+    MessageMediaDisplay(
+        message = stringResource(R.string.horologist_nothing_playing),
+        modifier = modifier
     )
 }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/display/TextMediaDisplay.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/display/TextMediaDisplay.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.media.ui.components
+package com.google.android.horologist.media.ui.components.display
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/display/TrackMediaDisplay.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/display/TrackMediaDisplay.kt
@@ -14,40 +14,25 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistMediaUiApi::class)
-
-package com.google.android.horologist.media.ui.components
+package com.google.android.horologist.media.ui.components.display
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.compose.tools.WearPreview
+import androidx.compose.ui.Modifier
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.state.model.MediaUiModel
 
-@WearPreview
+/**
+ * A simple text only display of [MediaUiModel] showing artist and title in two separated rows.
+ */
+@ExperimentalHorologistMediaUiApi
 @Composable
-fun DefaultMediaDisplayPreview() {
-    DefaultMediaDisplay(
-        media = MediaUiModel(
-            id = "id",
-            title = "Song title",
-            subtitle = "Artist name"
-        )
-    )
-}
-
-@Preview(
-    "With long text",
-    backgroundColor = 0xff000000,
-    showBackground = true
-)
-@Composable
-fun DefaultMediaDisplayPreviewLongText() {
-    DefaultMediaDisplay(
-        media = MediaUiModel(
-            id = "id",
-            title = "I Predict That You Look Good In A Riot",
-            subtitle = "Arctic Monkeys feat Kaiser Chiefs"
-        )
+public fun TrackMediaDisplay(
+    media: MediaUiModel?,
+    modifier: Modifier = Modifier
+) {
+    TextMediaDisplay(
+        modifier = modifier,
+        title = media?.title,
+        subtitle = media?.subtitle
     )
 }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/player/PlayerScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/player/PlayerScreen.kt
@@ -38,22 +38,17 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.wear.compose.foundation.rememberActiveFocusRequester
 import com.google.android.horologist.audio.ui.VolumeViewModel
 import com.google.android.horologist.compose.rotaryinput.onRotaryInputAccumulated
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
-import com.google.android.horologist.media.ui.R
-import com.google.android.horologist.media.ui.components.DefaultMediaDisplay
-import com.google.android.horologist.media.ui.components.InfoMediaDisplay
-import com.google.android.horologist.media.ui.components.LoadingMediaDisplay
 import com.google.android.horologist.media.ui.components.MediaControlButtons
+import com.google.android.horologist.media.ui.components.MediaInfoDisplay
 import com.google.android.horologist.media.ui.state.PlayerUiController
 import com.google.android.horologist.media.ui.state.PlayerUiState
 import com.google.android.horologist.media.ui.state.PlayerViewModel
-import com.google.android.horologist.media.ui.state.model.MediaUiModel
 
 public typealias MediaDisplay = @Composable ColumnScope.(playerUiState: PlayerUiState) -> Unit
 
@@ -75,7 +70,7 @@ public fun PlayerScreen(
     volumeViewModel: VolumeViewModel,
     modifier: Modifier = Modifier,
     mediaDisplay: MediaDisplay = { playerUiState ->
-        DefaultPlayerScreenMediaDisplay(playerUiState.media, loading = !playerUiState.connected)
+        DefaultMediaInfoDisplay(playerUiState)
     },
     controlButtons: ControlButtons = { playerUiController, playerUiState ->
         DefaultPlayerScreenControlButtons(playerUiController, playerUiState)
@@ -102,24 +97,15 @@ public fun PlayerScreen(
  */
 @ExperimentalHorologistMediaUiApi
 @Composable
-public fun DefaultPlayerScreenMediaDisplay(
-    media: MediaUiModel?,
-    loading: Boolean,
+public fun DefaultMediaInfoDisplay(
+    playerUiState: PlayerUiState,
     modifier: Modifier = Modifier
 ) {
-    if (loading) {
-        LoadingMediaDisplay(modifier)
-    } else if (media != null) {
-        DefaultMediaDisplay(
-            media = media,
-            modifier = modifier
-        )
-    } else {
-        InfoMediaDisplay(
-            message = stringResource(R.string.horologist_nothing_playing),
-            modifier = modifier
-        )
-    }
+    MediaInfoDisplay(
+        media = playerUiState.media,
+        loading = !playerUiState.connected || playerUiState.media?.loading == true,
+        modifier = modifier
+    )
 }
 
 /**

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/MediaUiModelMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/MediaUiModelMapper.kt
@@ -30,11 +30,19 @@ import com.google.android.horologist.media.ui.state.model.MediaUiModel
 @ExperimentalHorologistMediaUiApi
 public object MediaUiModelMapper {
 
-    public fun map(media: Media): MediaUiModel = MediaUiModel(
-        id = media.id,
-        title = media.title,
-        subtitle = media.artist,
-        artworkUri = media.artworkUri,
-        artworkColor = media.artworkColor?.let { Color(it) }
-    )
+    public fun map(media: Media, defaultTitle: String = "", defaultArtist: String = ""): MediaUiModel {
+        var title = media.title
+        var artist = media.artist
+        if (title.isEmpty() && artist.isEmpty()) {
+            title = defaultTitle
+            artist = defaultArtist
+        }
+        return MediaUiModel(
+            id = media.id,
+            title = title,
+            subtitle = artist,
+            artworkUri = media.artworkUri,
+            artworkColor = media.artworkColor?.let { Color(it) }
+        )
+    }
 }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/MediaUiModel.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/MediaUiModel.kt
@@ -22,8 +22,11 @@ import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 @ExperimentalHorologistMediaUiApi
 public data class MediaUiModel(
     val id: String,
-    val title: String? = null,
-    val subtitle: String? = null,
+    val title: String,
+    val subtitle: String = "",
     val artworkUri: String? = null,
     val artworkColor: Color? = null
-)
+) {
+    // Consider making this a field
+    val loading: Boolean get() = title.isEmpty() && subtitle.isEmpty()
+}

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerTestCase.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerTestCase.kt
@@ -44,7 +44,7 @@ import com.google.android.horologist.compose.pager.PagerScreen
 import com.google.android.horologist.compose.tools.RoundPreview
 import com.google.android.horologist.media.ui.components.MediaControlButtons
 import com.google.android.horologist.media.ui.components.background.RadialBackground
-import com.google.android.horologist.media.ui.screens.player.DefaultPlayerScreenMediaDisplay
+import com.google.android.horologist.media.ui.screens.player.DefaultMediaInfoDisplay
 import com.google.android.horologist.media.ui.screens.player.PlayerScreen
 import com.google.android.horologist.media.ui.state.PlayerUiState
 
@@ -52,7 +52,7 @@ import com.google.android.horologist.media.ui.state.PlayerUiState
 fun MediaPlayerTestCase(
     playerUiState: PlayerUiState,
     mediaDisplay: @Composable ColumnScope.() -> Unit = {
-        DefaultPlayerScreenMediaDisplay(playerUiState.media, loading = !playerUiState.connected)
+        DefaultMediaInfoDisplay(playerUiState)
     },
     controlButtons: @Composable RowScope.() -> Unit = {
         MediaControlButtons(

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/MediaChipTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/MediaChipTest.kt
@@ -86,6 +86,7 @@ class MediaChipTest {
                 MediaChip(
                     media = MediaUiModel(
                         id = "id",
+                        title = "",
                         artworkUri = FakeImageLoader.TestIconResourceUri
                     ),
                     onClick = {},


### PR DESCRIPTION
#### WHAT
- Moves display-related components into new `components.display` package
- Moves default title and artist to mapper constructor
- Changes how metadata is determined to be more in line with media3 apps
- Makes determining loading state more explicit (but currently relies on empty metadata)

#### WHY
Simplifies customization of metadata extraction and makes displaying it more robust, especially when a loading state is needed.


#### Checklist :clipboard:
- [X] Add explicit visibility modifier and explicit return types for public declarations
- [X] Run spotless check
- [X] Run tests
- [X] Update metalava's signature text files
