### PR TITLE
Replaces forEach uses with for loops where possible

### DIFF
--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/impl/google/PKCEConfigRepositoryGoogleImpl.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/impl/google/PKCEConfigRepositoryGoogleImpl.kt
@@ -36,7 +36,7 @@ public class PKCEConfigRepositoryGoogleImpl(
         val uri = Uri.Builder()
             .encodedPath(encodedPath)
             .also { builder ->
-                queryParameters.forEach { (key, value) ->
+                for ((key, value) in queryParameters) {
                     builder.appendQueryParameter(key, value)
                 }
             }

--- a/composables/src/main/java/com/google/android/horologist/composables/SectionedList.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/SectionedList.kt
@@ -63,7 +63,7 @@ public fun SectionedList(
         modifier = modifier
             .fillMaxSize()
     ) {
-        sections.forEach { section ->
+        for (section in sections) {
             section.display(this)
         }
     }

--- a/composables/src/main/java/com/google/android/horologist/composables/SegmentedProgressIndicator.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/SegmentedProgressIndicator.kt
@@ -145,7 +145,7 @@ public fun SegmentedProgressIndicator(
         var currentStartAngle = startAngle + paddingAngle / 2
         var remainingProgress = progress.coerceIn(0.0f, 1.0f) * segmentableAngle
 
-        trackSegments.forEach { segment ->
+        for (segment in trackSegments) {
             val segmentAngle = (segment.weight * segmentableAngle) / totalWeight
             val currentEndAngle = currentStartAngle + segmentAngle - endDelta
             val startAngleWithDelta = currentStartAngle + endDelta

--- a/composables/src/main/java/com/google/android/horologist/composables/SquareSegmentedProgressIndicator.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/SquareSegmentedProgressIndicator.kt
@@ -111,10 +111,10 @@ public fun SquareSegmentedProgressIndicator(
                 .fillMaxSize()
                 .progressSemantics(progress)
         ) {
-            calculatedSegments.forEach { segmentGroups ->
+            for (segmentGroups in calculatedSegments) {
                 drawPath(
                     path = Path().apply {
-                        segmentGroups.calculatedSegments.forEach {
+                        for (it in segmentGroups.calculatedSegments) {
                             it.drawIncomplete(this, progress)
                         }
                     },
@@ -123,7 +123,7 @@ public fun SquareSegmentedProgressIndicator(
                 )
                 drawPath(
                     path = Path().apply {
-                        segmentGroups.calculatedSegments.forEach {
+                        for (it in segmentGroups.calculatedSegments) {
                             it.drawCompleted(this, progress)
                         }
                     },

--- a/compose-tools/src/main/java/com/google/android/horologist/compose/tools/WidthConstrainedBox.kt
+++ b/compose-tools/src/main/java/com/google/android/horologist/compose/tools/WidthConstrainedBox.kt
@@ -47,7 +47,7 @@ public fun WidthConstrainedBox(
             .height(widths.size * comfortableHeight)
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
-            widths.forEach { width ->
+            for (width in widths) {
                 Text(width.toString(), style = MaterialTheme.typography.caption3)
                 Column(
                     modifier = Modifier

--- a/compose-tools/src/main/java/com/google/android/horologist/compose/tools/a11y/ComposeA11yExtension.kt
+++ b/compose-tools/src/main/java/com/google/android/horologist/compose/tools/a11y/ComposeA11yExtension.kt
@@ -100,7 +100,7 @@ public class ComposeA11yExtension : RenderExtension {
             )
         }
 
-        p0.children.forEach {
+        for (it in p0.children) {
             processAccessibleChildren(it, fn)
         }
     }

--- a/datalayer/src/main/java/com/google/android/horologist/data/WearDataLayerRegistry.kt
+++ b/datalayer/src/main/java/com/google/android/horologist/data/WearDataLayerRegistry.kt
@@ -122,7 +122,7 @@ public class WearDataLayerRegistry(
 
     fun onDataChanged(dataEvents: List<DataEvent>) {
         runBlocking {
-            dataEvents.forEach { dataEvent ->
+            for (dataEvent in dataEvents) {
                 val listeners = protoDataListeners.filter { it.path == dataEvent.dataItem.uri.path }
 
                 if (listeners.isNotEmpty()) {
@@ -140,12 +140,12 @@ public class WearDataLayerRegistry(
         val path = dataEvent.dataItem.uri.path!!
         if (dataEvent.type == DataEvent.TYPE_CHANGED) {
             val data = dataEvent.dataItem.data!!
-            listeners.forEach {
-                it.dataAdded(nodeId, path, data)
+            for (listener in listeners) {
+                listener.dataAdded(nodeId, path, data)
             }
         } else {
-            listeners.forEach {
-                it.dataDeleted(nodeId, path)
+            for (listener in listeners) {
+                listener.dataDeleted(nodeId, path)
             }
         }
     }

--- a/datalayer/src/main/java/com/google/android/horologist/data/store/prefs/PreferencesSerializer.kt
+++ b/datalayer/src/main/java/com/google/android/horologist/data/store/prefs/PreferencesSerializer.kt
@@ -60,7 +60,7 @@ internal object PreferencesSerializer : Serializer<Preferences> {
 
         val mutablePreferences = mutablePreferencesOf()
 
-        preferencesProto.preferencesMap.forEach { (name, value) ->
+        for ((name, value) in preferencesProto.preferencesMap) {
             addProtoEntryToPreferences(name, value, mutablePreferences)
         }
 

--- a/media-data/src/main/java/com/google/android/horologist/media/data/datasource/PlaylistLocalDataSource.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/datasource/PlaylistLocalDataSource.kt
@@ -39,7 +39,7 @@ public class PlaylistLocalDataSource(
 ) {
 
     public suspend fun upsert(playlists: List<Playlist>) {
-        playlists.forEach { playlist ->
+        for (playlist in playlists) {
             playlistDao.upsert(
                 PlaylistEntityMapper.map(playlist),
                 playlist.mediaList.map(MediaEntityMapper::map),

--- a/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlaylistDownloadRepositoryImpl.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/repository/PlaylistDownloadRepositoryImpl.kt
@@ -62,7 +62,7 @@ public class PlaylistDownloadRepositoryImpl(
 
     override fun download(playlist: Playlist) {
         coroutineScope.launch {
-            playlist.mediaList.forEach { media ->
+            for (media in playlist.mediaList) {
                 mediaDownloadLocalDataSource.add(mediaId = media.id)
 
                 media3DownloadDataSource.download(media.id, media.uri.toUri())
@@ -71,7 +71,7 @@ public class PlaylistDownloadRepositoryImpl(
     }
 
     override fun remove(playlist: Playlist) {
-        playlist.mediaList.forEach { media ->
+        for (media in playlist.mediaList) {
             media3DownloadDataSource.removeDownload(media.id)
         }
     }

--- a/media-data/src/main/java/com/google/android/horologist/media/data/service/download/DownloadProgressMonitor.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/service/download/DownloadProgressMonitor.kt
@@ -56,7 +56,7 @@ public class DownloadProgressMonitor(
             val downloads = mediaDownloadLocalDataSource.getAllDownloading()
 
             if (downloads.isNotEmpty()) {
-                downloads.forEach {
+                for (it in downloads) {
                     downloadManager.downloadIndex.getDownload(it.mediaId)?.let { download ->
                         mediaDownloadLocalDataSource.updateProgress(
                             mediaId = download.request.id,

--- a/media-data/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/FakeStatePlayer.kt
+++ b/media-data/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/FakeStatePlayer.kt
@@ -97,7 +97,7 @@ class FakeStatePlayer(
         _duration = duration
         _currentMediaItem = currentMediaItem
 
-        listeners.forEach {
+        for (it in listeners) {
             it.onEvents(
                 this,
                 Player.Events(
@@ -115,7 +115,7 @@ class FakeStatePlayer(
         playbackSpeed: Float
     ) {
         _playbackSpeed = playbackSpeed
-        listeners.forEach {
+        for (it in listeners) {
             it.onEvents(
                 this,
                 Player.Events(FlagSet.Builder().add(EVENT_PLAYBACK_PARAMETERS_CHANGED).build())
@@ -131,7 +131,7 @@ class FakeStatePlayer(
         _playbackState = playbackState
         _playWhenReady = playWhenReady
 
-        listeners.forEach {
+        for (it in listeners) {
             it.onEvents(
                 this,
                 Player.Events(

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/data/api/NetworkChangeListService.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/data/api/NetworkChangeListService.kt
@@ -47,7 +47,7 @@ class NetworkChangeListService {
             )
         }
 
-        remotePlaylistsSet.forEach { playlist ->
+        for (playlist in remotePlaylistsSet) {
             add(
                 NetworkChangeList(
                     id = playlist.id,
@@ -75,7 +75,7 @@ class NetworkChangeListService {
             )
         }
 
-        remoteMediaSet.forEach { playlist ->
+        for (playlist in remoteMediaSet) {
             add(
                 NetworkChangeList(
                     id = playlist.id,

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/di/AudioOffloadListenerList.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/di/AudioOffloadListenerList.kt
@@ -37,7 +37,7 @@ class AudioOffloadListenerList : AudioOffloadListener {
 
     override fun onExperimentalOffloadSchedulingEnabledChanged(offloadSchedulingEnabled: Boolean) {
         synchronized(audioOffloadListeners) {
-            audioOffloadListeners.forEach {
+            for (it in audioOffloadListeners) {
                 it.onExperimentalOffloadSchedulingEnabledChanged(offloadSchedulingEnabled)
             }
         }
@@ -45,7 +45,7 @@ class AudioOffloadListenerList : AudioOffloadListener {
 
     override fun onExperimentalSleepingForOffloadChanged(sleepingForOffload: Boolean) {
         synchronized(audioOffloadListeners) {
-            audioOffloadListeners.forEach {
+            for (it in audioOffloadListeners) {
                 it.onExperimentalSleepingForOffloadChanged(sleepingForOffload)
             }
         }
@@ -56,7 +56,7 @@ class AudioOffloadListenerList : AudioOffloadListener {
     // For now requires `media3.checkout=false` in local.properties
 //    override fun onExperimentalOffloadedPlayback(offloadedPlayback: Boolean) {
 //        synchronized(audioOffloadListeners) {
-//            audioOffloadListeners.forEach {
+//            for (it in audioOffloadListeners) {
 //                it.onExperimentalOffloadedPlayback(offloadedPlayback)
 //            }
 //        }

--- a/media-sync/src/main/java/com/google/android/horologist/media/sync/api/SyncUtilities.kt
+++ b/media-sync/src/main/java/com/google/android/horologist/media/sync/api/SyncUtilities.kt
@@ -101,7 +101,7 @@ public suspend fun Synchronizer.changeListSync(
     modelDeleter: suspend (model: String, ids: List<String>) -> Unit,
     modelUpdater: suspend (model: String, ids: List<String>) -> Unit
 ): Boolean = suspendRunCatching {
-    models.forEach { model ->
+    for (model in models) {
         // Fetch the change list since last sync (akin to a git fetch)
         val currentVersion = getChangeListVersions(model)
         val changeList = changeListFetcher(model, currentVersion)

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
@@ -466,7 +466,7 @@ public fun createPlaylistDownloadScreenStateLoaded(
         var downloading = false
 
         var downloadedCount = 0
-        downloadMediaList.forEach {
+        for (it in downloadMediaList) {
             if (it is DownloadMediaUiModel.Downloaded) {
                 downloadedCount++
                 none = false

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/tiles/MediaCollectionsTileRenderer.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/tiles/MediaCollectionsTileRenderer.kt
@@ -116,7 +116,7 @@ public class MediaCollectionsTileRenderer(
         deviceParameters: DeviceParameters,
         resourceIds: MutableList<String>
     ) {
-        resourceState.images.forEach { (image, imageResource) ->
+        for ((image, imageResource) in resourceState.images) {
             if (imageResource != null) {
                 addIdToImageMapping(image, imageResource)
             }

--- a/media3-backend/src/main/java/com/google/android/horologist/media3/WearConfiguredPlayer.kt
+++ b/media3-backend/src/main/java/com/google/android/horologist/media3/WearConfiguredPlayer.kt
@@ -98,7 +98,7 @@ public class WearConfiguredPlayer(
             // Flush our still not playing state, relevant since a MediaController
             // May assume play is successful if we don't error
             withContext(Dispatchers.Main) {
-                listeners.forEach {
+                for (it in listeners) {
                     it.onPlayWhenReadyChanged(false, PLAY_WHEN_READY_CHANGE_REASON_AUDIO_BECOMING_NOISY)
                     it.onIsPlayingChanged(false)
                 }

--- a/network-awareness/src/main/java/com/google/android/horologist/networks/db/DBDataRequestRepository.kt
+++ b/network-awareness/src/main/java/com/google/android/horologist/networks/db/DBDataRequestRepository.kt
@@ -66,7 +66,7 @@ public class DBDataRequestRepository(
             var wifi = 0L
             var unknown = 0L
 
-            list.forEach {
+            for (it in list) {
                 when (it.networkType) {
                     "ble" -> ble += it.bytesTotal
                     "cell" -> cell += it.bytesTotal

--- a/network-awareness/src/main/java/com/google/android/horologist/networks/status/NetworkRepositoryImpl.kt
+++ b/network-awareness/src/main/java/com/google/android/horologist/networks/status/NetworkRepositoryImpl.kt
@@ -100,7 +100,7 @@ public class NetworkRepositoryImpl(
         ) {
             getOrBuild(network).apply {
                 linkProperties = networkLinkProperties
-                networkLinkProperties.linkAddresses.forEach {
+                for (it in networkLinkProperties.linkAddresses) {
                     linkAddresses[it.address] = network.id
                 }
             }
@@ -124,7 +124,7 @@ public class NetworkRepositoryImpl(
 
     init {
         @Suppress("DEPRECATION")
-        connectivityManager.allNetworks.forEach { network ->
+        for (network in connectivityManager.allNetworks) {
             getOrBuild(network).apply {
                 connectivityManager.getNetworkCapabilities(network)?.let {
                     this.networkCapabilities = it

--- a/network-awareness/src/main/java/com/google/android/horologist/networks/ui/DataUsage.kt
+++ b/network-awareness/src/main/java/com/google/android/horologist/networks/ui/DataUsage.kt
@@ -58,7 +58,7 @@ public fun CurvedScope.curveDataUsage(
 
     val networks = networkStatus.networks
     val types = networks.map { it.networkInfo.type }
-    networks.forEach {
+    for (it in networks) {
         curvedComposable(radialAlignment = CurvedAlignment.Radial.Outer) {
             if (pinnedNetworks.contains(it.networkInfo.type)) {
                 Icon(
@@ -86,7 +86,7 @@ public fun CurvedScope.curveDataUsage(
     if (networkUsage?.dataByType != null) {
         val keys = networkUsage.dataByType.keys
         val missingTypes = keys - types.toSet()
-        missingTypes.forEach {
+        for (it in missingTypes) {
             val usage = networkUsage.dataByType[it]
             if (usage != null && usage > 0) {
                 curvedComposable(radialAlignment = CurvedAlignment.Radial.Outer) {

--- a/paparazzi/src/main/java/com/google/android/horologist/paparazzi/a11y/A11ySnapshotHandler.kt
+++ b/paparazzi/src/main/java/com/google/android/horologist/paparazzi/a11y/A11ySnapshotHandler.kt
@@ -209,8 +209,8 @@ public class A11ySnapshotHandler(
                         drawItem("Progress \"${it.progress}\"")
                     }
                     if (it.customActions != null) {
-                        it.customActions.forEach {
-                            drawItem("Custom Action \"${it.label}\"")
+                        for (action in it.customActions) {
+                            drawItem("Custom Action \"${action.label}\"")
                         }
                     }
                     val end = index


### PR DESCRIPTION
To follow [Kotlin coding conventions﻿](https://kotlinlang.org/docs/coding-conventions.html#loops):

> Prefer using higher-order functions (`filter`, `map` etc.) to loops. Exception: `forEach` (**prefer using a regular `for` loop instead**, unless the receiver of `forEach` is nullable or `forEach` is used as part of a longer call chain).