### PR TITLE
Use Horizontal Pager Defaults

### DIFF
--- a/compose-layout/src/main/java/com/google/android/horologist/compose/pager/HorizontalPagerDefaults.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/pager/HorizontalPagerDefaults.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.compose.pager
+
+import androidx.compose.animation.core.SpringSpec
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.snapping.SnapFlingBehavior
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerDefaults
+import androidx.compose.foundation.pager.PagerSnapDistance
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.runtime.Composable
+
+/**
+ * Contains the default fling values used by [HorizontalPager].
+ *
+ * This exists only until available in androidx.wear.compose.foundation.pager.
+ */
+public object HorizontalPagerDefaults {
+    /**
+     * Creates [flingParams] that represents fling properties for [HorizontalPager].
+     * See [HorizontalPagerSample] for usage.
+     *
+     * @param pagerState the state to control this pager
+     */
+    @Composable
+    @OptIn(ExperimentalFoundationApi::class)
+    fun flingParams(
+        pagerState: PagerState
+    ): SnapFlingBehavior {
+        return PagerDefaults.flingBehavior(
+            state = pagerState,
+            pagerSnapDistance = PagerSnapDistance.atMost(0),
+            snapAnimationSpec = SpringSpec(dampingRatio = 1f, stiffness = 200f)
+        )
+    }
+}

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/pager/PagerScreen.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/pager/PagerScreen.kt
@@ -64,7 +64,12 @@ public fun PagerScreen(
     Box(
         modifier = Modifier.fillMaxSize()
     ) {
-        HorizontalPager(modifier = modifier, pageCount = count, state = state) { page ->
+        HorizontalPager(
+            modifier = modifier,
+            pageCount = count,
+            state = state,
+            flingBehavior = HorizontalPagerDefaults.flingParams(state)
+        ) { page ->
             Box(
                 modifier = Modifier.fillMaxSize().run {
                     if (shape != null) {

--- a/sample/src/main/java/com/google/android/horologist/pager/PagerScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/pager/PagerScreen.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalFoundationApi::class)
+
+package com.google.android.horologist.pager
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.navigation.NavController
+import androidx.paging.LoadState
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import androidx.paging.compose.collectAsLazyPagingItems
+import androidx.wear.compose.material.CardDefaults
+import androidx.wear.compose.material.PlaceholderDefaults
+import androidx.wear.compose.material.Text
+import androidx.wear.compose.material.TitleCard
+import androidx.wear.compose.material.placeholder
+import androidx.wear.compose.material.placeholderShimmer
+import androidx.wear.compose.material.rememberPlaceholderState
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.layout.fillMaxRectangle
+import com.google.android.horologist.compose.pager.PagerScreen
+import com.google.android.horologist.compose.paging.items
+import com.google.android.horologist.compose.tools.WearSquareDevicePreview
+import com.google.android.horologist.sample.R
+import kotlinx.coroutines.delay
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+import kotlin.math.ceil
+import kotlin.time.Duration.Companion.seconds
+
+@Composable
+fun SamplePagerScreen(
+) {
+    PagerScreen(count = 10) {
+        PagerItemScreen(item = "item $it")
+    }
+}
+
+@Composable
+private fun PagerItemScreen(
+    item: String,
+) {
+    Box(modifier = Modifier
+        .fillMaxSize()
+        .background(Color.DarkGray)) {
+        Text(text = item, modifier = Modifier.align(Alignment.Center))
+    }
+}

--- a/sample/src/main/java/com/google/android/horologist/sample/MenuChips.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/MenuChips.kt
@@ -23,6 +23,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Pages
+import androidx.compose.material.icons.filled.Panorama
+import androidx.compose.material.icons.filled.ReceiptLong
+import androidx.compose.material.icons.filled.ViewCarousel
 import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -230,8 +233,24 @@ fun PagingChip(
         label = stringResource(R.string.paging_chip_label),
         content = {
             Icon(
-                imageVector = Icons.Default.Pages,
+                imageVector = Icons.Default.ReceiptLong,
                 contentDescription = stringResource(R.string.paging_chip_content_description)
+            )
+        }
+    )
+}
+
+@Composable
+fun PagerScreenChip(
+    navigateToRoute: () -> Unit
+) {
+    SampleChip(
+        onClick = { navigateToRoute() },
+        label = stringResource(R.string.pager_screen_chip_label),
+        content = {
+            Icon(
+                imageVector = Icons.Default.ViewCarousel,
+                contentDescription = stringResource(R.string.pager_screen_chip_content_description)
             )
         }
     )

--- a/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
@@ -123,6 +123,9 @@ fun MenuScreen(
         item {
             PagingChip { navigateToRoute(Screen.Paging.route) }
         }
+        item {
+            PagerScreenChip { navigateToRoute(Screen.PagerScreen.route) }
+        }
     }
 }
 

--- a/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
@@ -39,6 +39,7 @@ import com.google.android.horologist.compose.navscaffold.scrollable
 import com.google.android.horologist.datalayer.DataLayerNodesScreen
 import com.google.android.horologist.datalayer.DataLayerNodesViewModel
 import com.google.android.horologist.networks.NetworkScreen
+import com.google.android.horologist.pager.SamplePagerScreen
 import com.google.android.horologist.paging.PagingItemScreen
 import com.google.android.horologist.paging.PagingScreen
 import com.google.android.horologist.rotary.RotaryMenuScreen
@@ -213,6 +214,9 @@ fun SampleWearApp() {
             )
         ) {
             PagingItemScreen(it.arguments!!.getInt("id"))
+        }
+        composable(route = Screen.PagerScreen.route) {
+            SamplePagerScreen()
         }
     }
 }

--- a/sample/src/main/java/com/google/android/horologist/sample/Screen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/Screen.kt
@@ -46,4 +46,6 @@ sealed class Screen(
 
     object Paging : Screen("paging")
     object PagingItem : Screen("pagingItem?id={id}")
+
+    object PagerScreen : Screen("pagerScreen")
 }

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -64,4 +64,6 @@
     <string name="paging_items_waiting_message">Waiting for items to load from the backend</string>
     <string name="paging_chip_content_description">Paging</string>
     <string name="paging_chip_label">Paging</string>
+    <string name="pager_screen_chip_label">Pager Screen</string>
+    <string name="pager_screen_chip_content_description">Pager Screen</string>
 </resources>


### PR DESCRIPTION
#### WHAT

Use Horizontal Pager Defaults.

#### WHY

There are defaults coming in Wear Compose 1.3 for Horizontal Pager.  User them now.

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
