### PR TITLE
Improve StreamlineSignInDefaultScreen callback

### DIFF
--- a/auth-sample-wear/src/main/java/com/google/android/horologist/auth/sample/screens/common/streamline/StreamlineSignInSampleScreen.kt
+++ b/auth-sample-wear/src/main/java/com/google/android/horologist/auth/sample/screens/common/streamline/StreamlineSignInSampleScreen.kt
@@ -49,11 +49,11 @@ fun StreamlineSignInSampleScreen(
     modifier: Modifier = Modifier,
     viewModel: StreamlineSignInDefaultViewModel = viewModel(factory = StreamlineSignInSampleViewModelFactory)
 ) {
-    var showSignedInConfirmationDialog by rememberSaveable { mutableStateOf(false) }
+    var showNoAccountsAvailableDialog by rememberSaveable { mutableStateOf(false) }
 
     StreamlineSignInDefaultScreen(
-        onSignedInConfirmationDialogDismissOrTimeout = navController::popBackStack,
-        onNoAccountsAvailable = { showSignedInConfirmationDialog = true },
+        onSignedInConfirmationDialogDismissOrTimeout = { navController.popBackStack() },
+        onNoAccountsAvailable = { showNoAccountsAvailableDialog = true },
         columnState = columnState,
         viewModel = viewModel
     ) {
@@ -69,7 +69,7 @@ fun StreamlineSignInSampleScreen(
         }
     }
 
-    if (showSignedInConfirmationDialog) {
+    if (showNoAccountsAvailableDialog) {
         ConfirmationDialog(
             onTimeout = navController::popBackStack
         ) {

--- a/auth-sample-wear/src/main/java/com/google/android/horologist/auth/sample/screens/googlesignin/signin/GoogleSignInSampleViewModel.kt
+++ b/auth-sample-wear/src/main/java/com/google/android/horologist/auth/sample/screens/googlesignin/signin/GoogleSignInSampleViewModel.kt
@@ -17,6 +17,7 @@
 package com.google.android.horologist.auth.sample.screens.googlesignin.signin
 
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.google.android.gms.auth.api.signin.GoogleSignIn
@@ -25,7 +26,7 @@ import com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInVie
 
 val GoogleSignInSampleViewModelFactory: ViewModelProvider.Factory = viewModelFactory {
     initializer {
-        val application = this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY]!!
+        val application = this[APPLICATION_KEY]!!
 
         val googleSignInClient = GoogleSignIn.getClient(
             application,

--- a/auth-sample-wear/src/main/java/com/google/android/horologist/auth/sample/screens/googlesignin/signout/GoogleSignOutViewModel.kt
+++ b/auth-sample-wear/src/main/java/com/google/android/horologist/auth/sample/screens/googlesignin/signout/GoogleSignOutViewModel.kt
@@ -19,6 +19,7 @@ package com.google.android.horologist.auth.sample.screens.googlesignin.signout
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
@@ -62,7 +63,7 @@ class GoogleSignOutViewModel(
 
         val Factory: ViewModelProvider.Factory = viewModelFactory {
             initializer {
-                val application = this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY]!!
+                val application = this[APPLICATION_KEY]!!
 
                 val googleSignInClient = GoogleSignIn.getClient(
                     application,

--- a/auth-ui/api/current.api
+++ b/auth-ui/api/current.api
@@ -54,7 +54,7 @@ package com.google.android.horologist.auth.ui.common.screens.prompt {
 package com.google.android.horologist.auth.ui.common.screens.streamline {
 
   public final class StreamlineSignInDefaultScreenKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public static void StreamlineSignInDefaultScreen(kotlin.jvm.functions.Function0<kotlin.Unit> onSignedInConfirmationDialogDismissOrTimeout, kotlin.jvm.functions.Function0<kotlin.Unit> onNoAccountsAvailable, com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, com.google.android.horologist.auth.ui.common.screens.streamline.StreamlineSignInDefaultViewModel viewModel, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public static void StreamlineSignInDefaultScreen(kotlin.jvm.functions.Function1<? super com.google.android.horologist.auth.composables.model.AccountUiModel,kotlin.Unit> onSignedInConfirmationDialogDismissOrTimeout, kotlin.jvm.functions.Function0<kotlin.Unit> onNoAccountsAvailable, com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, com.google.android.horologist.auth.ui.common.screens.streamline.StreamlineSignInDefaultViewModel viewModel, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit> content);
   }
 
   @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public abstract sealed class StreamlineSignInDefaultScreenState {

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInDefaultScreen.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInDefaultScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.android.horologist.auth.composables.dialogs.SignedInConfirmationDialog
+import com.google.android.horologist.auth.composables.model.AccountUiModel
 import com.google.android.horologist.auth.composables.screens.SelectAccountScreen
 import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
@@ -39,7 +40,7 @@ import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 @ExperimentalHorologistAuthUiApi
 @Composable
 public fun StreamlineSignInDefaultScreen(
-    onSignedInConfirmationDialogDismissOrTimeout: () -> Unit,
+    onSignedInConfirmationDialogDismissOrTimeout: (account: AccountUiModel) -> Unit,
     onNoAccountsAvailable: () -> Unit,
     columnState: ScalingLazyColumnState,
     viewModel: StreamlineSignInDefaultViewModel,
@@ -62,7 +63,7 @@ public fun StreamlineSignInDefaultScreen(
         is StreamlineSignInDefaultScreenState.SignedIn -> {
             val account = (state as StreamlineSignInDefaultScreenState.SignedIn).account
             SignedInConfirmationDialog(
-                onDismissOrTimeout = onSignedInConfirmationDialogDismissOrTimeout,
+                onDismissOrTimeout = { onSignedInConfirmationDialogDismissOrTimeout(account) },
                 modifier = modifier,
                 name = account.name,
                 email = account.email


### PR DESCRIPTION
#### WHAT

Improve `StreamlineSignInDefaultScreen`'s `onSignedInConfirmationDialogDismissOrTimeout` callback to receive an `AccountUiModel`.

#### WHY

So callers can receive the account picked by the user.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
