### PR TITLE
Fix naming of version files

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -265,8 +265,11 @@ subprojects {
             if (isLibrary) {
                 val library = extensions.getByType(LibraryExtension::class)
 
-                val resources = library.sourceSets.findByName("main")?.resources
-                resources?.srcDir(outputDirectory)
+                val resources = library.sourceSets.findByName("main")?.resources!!
+                resources.srcDir(outputDirectory)
+                if (resources.includes.isNotEmpty()) {
+                    resources.include("META-INF/*.version")
+                }
 
                 library.libraryVariants.all {
                     processJavaResourcesProvider.get().dependsOn(generateVersionFile)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -243,7 +243,7 @@ subprojects {
                 manifestDir.mkdirs()
                 File(
                     manifestDir,
-                    "${project.group}_${project.name}.version"
+                    "com.google.android.horologist_${project.name}.version"
                 ).writeText("${versionName}\n")
             }
         }

--- a/datalayer/src/androidTest/java/com/google/android/horologist/data/VersionFileTest.kt
+++ b/datalayer/src/androidTest/java/com/google/android/horologist/data/VersionFileTest.kt
@@ -27,7 +27,7 @@ import java.io.InputStreamReader
 class VersionFileTest {
     @Test
     fun testVersionFileIsPresent() = runTest {
-        val resource = TargetNodeId::class.java.getResource("/META-INF/horologist_datalayer.version")
+        val resource = TargetNodeId::class.java.getResource("/META-INF/com.google.android.horologist_datalayer.version")
         assertThat(resource).isNotNull()
 
         val version = resource.openStream().use {

--- a/datalayer/src/androidTest/java/com/google/android/horologist/data/VersionFileTest.kt
+++ b/datalayer/src/androidTest/java/com/google/android/horologist/data/VersionFileTest.kt
@@ -26,11 +26,11 @@ import java.io.InputStreamReader
 
 class VersionFileTest {
     @Test
-    fun testVersionFileIsPresent() = runTest {
+    fun testVersionFileIsPresent() {
         val resource = TargetNodeId::class.java.getResource("/META-INF/com.google.android.horologist_datalayer.version")
         assertThat(resource).isNotNull()
 
-        val version = resource.openStream().use {
+        val version = resource!!.openStream().use {
             InputStreamReader(it).readText().trim()
         }
 

--- a/datalayer/src/androidTest/java/com/google/android/horologist/data/VersionFileTest.kt
+++ b/datalayer/src/androidTest/java/com/google/android/horologist/data/VersionFileTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalCoroutinesApi::class, ExperimentalCoroutinesApi::class)
+
+package com.google.android.horologist.data
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.io.InputStreamReader
+
+class VersionFileTest {
+    @Test
+    fun testVersionFileIsPresent() = runTest {
+        val resource = TargetNodeId::class.java.getResource("/META-INF/horologist_datalayer.version")
+        assertThat(resource).isNotNull()
+
+        val version = resource.openStream().use {
+            InputStreamReader(it).readText().trim()
+        }
+
+        assertThat(version).matches("0\\.[3-9]\\.\\d+.*".toPattern())
+    }
+}

--- a/datalayer/src/androidTest/java/com/google/android/horologist/data/VersionFileTest.kt
+++ b/datalayer/src/androidTest/java/com/google/android/horologist/data/VersionFileTest.kt
@@ -20,7 +20,6 @@ package com.google.android.horologist.data
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import java.io.InputStreamReader
 


### PR DESCRIPTION
#### WHAT

Test for version files.

Files are in

horologist-media-0.3.2.jar:META-INF/horologist_media.version
horologist-audio-ui-0.3.2.aar:classes.jar:META-INF/horologist_audio-ui.version

#### WHY

Things can break on AGP upgrade, so confirm files are in place.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
