### PR TITLE
Add overloaded SignedInConfirmationDialog 

### DIFF
--- a/auth-composables/api/current.api
+++ b/auth-composables/api/current.api
@@ -30,6 +30,7 @@ package com.google.android.horologist.auth.composables.dialogs {
 
   public final class SignedInConfirmationDialogKt {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi public static void SignedInConfirmationDialog(kotlin.jvm.functions.Function0<kotlin.Unit> onDismissOrTimeout, optional androidx.compose.ui.Modifier modifier, optional String? name, optional String? email, optional Object? avatar, optional java.time.Duration duration);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi public static void SignedInConfirmationDialog(kotlin.jvm.functions.Function0<kotlin.Unit> onDismissOrTimeout, optional androidx.compose.ui.Modifier modifier, com.google.android.horologist.auth.composables.model.AccountUiModel accountUiModel, optional java.time.Duration duration);
   }
 
 }

--- a/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogPreview.kt
+++ b/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogPreview.kt
@@ -26,7 +26,7 @@ import com.google.android.horologist.compose.tools.WearPreviewDevices
 @Composable
 fun SignedInConfirmationDialogPreview() {
     SignedInConfirmationDialogContent(
-        displayName = "Maggie",
+        name = "Maggie",
         email = "maggie@example.com"
     )
 }
@@ -43,7 +43,7 @@ fun SignedInConfirmationDialogPreviewNoName() {
 @Composable
 fun SignedInConfirmationDialogPreviewNoEmail() {
     SignedInConfirmationDialogContent(
-        displayName = "Maggie"
+        name = "Maggie"
     )
 }
 
@@ -57,7 +57,7 @@ fun SignedInConfirmationDialogPreviewNoInformation() {
 @Composable
 fun SignedInConfirmationDialogPreviewTruncation() {
     SignedInConfirmationDialogContent(
-        displayName = "Wolfeschlegelsteinhausenbergerdorff",
+        name = "Wolfeschlegelsteinhausenbergerdorff",
         email = "wolfeschlegelsteinhausenbergerdorff@example.com"
     )
 }

--- a/auth-composables/src/main/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialog.kt
+++ b/auth-composables/src/main/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialog.kt
@@ -44,6 +44,7 @@ import androidx.wear.compose.material.dialog.DialogDefaults
 import coil.compose.rememberAsyncImagePainter
 import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
 import com.google.android.horologist.auth.composables.R
+import com.google.android.horologist.auth.composables.model.AccountUiModel
 import com.google.android.horologist.base.ui.components.ConfirmationDialog
 import com.google.android.horologist.base.ui.util.DECORATIVE_ELEMENT_CONTENT_DESCRIPTION
 import java.time.Duration
@@ -73,18 +74,40 @@ public fun SignedInConfirmationDialog(
     ) {
         SignedInConfirmationDialogContent(
             modifier = modifier,
-            displayName = name,
+            name = name,
             email = email,
             avatar = avatar
         )
     }
 }
 
+/**
+ * A [SignedInConfirmationDialog] that can display the name, email and avatar image of an
+ * [AccountUiModel].
+ */
+@ExperimentalHorologistAuthComposablesApi
+@Composable
+public fun SignedInConfirmationDialog(
+    onDismissOrTimeout: () -> Unit,
+    modifier: Modifier = Modifier,
+    accountUiModel: AccountUiModel,
+    duration: Duration = Duration.ofMillis(DialogDefaults.ShortDurationMillis)
+) {
+    SignedInConfirmationDialog(
+        onDismissOrTimeout = onDismissOrTimeout,
+        modifier = modifier,
+        name = accountUiModel.name,
+        email = accountUiModel.email,
+        avatar = accountUiModel.avatar,
+        duration = duration
+    )
+}
+
 @ExperimentalHorologistAuthComposablesApi
 @Composable
 internal fun SignedInConfirmationDialogContent(
     modifier: Modifier = Modifier,
-    displayName: String? = null,
+    name: String? = null,
     email: String? = null,
     avatar: Any? = null
 ) {
@@ -100,7 +123,7 @@ internal fun SignedInConfirmationDialogContent(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        val hasName = displayName != null
+        val hasName = name != null
         val hasAvatar = avatar != null
 
         Box(
@@ -118,7 +141,7 @@ internal fun SignedInConfirmationDialogContent(
                 )
             } else if (hasName) {
                 Text(
-                    text = displayName!!.first().uppercase(),
+                    text = name!!.first().uppercase(),
                     modifier = Modifier
                         .align(Alignment.Center)
                         .fillMaxWidth(),
@@ -133,7 +156,7 @@ internal fun SignedInConfirmationDialogContent(
             text = if (hasName) {
                 stringResource(
                     id = R.string.horologist_signedin_confirmation_greeting,
-                    displayName!!
+                    name!!
                 )
             } else {
                 stringResource(id = R.string.horologist_signedin_confirmation_greeting_no_name)

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogTest.kt
@@ -50,7 +50,7 @@ class SignedInConfirmationDialogTest {
                     contentAlignment = Alignment.Center
                 ) {
                     SignedInConfirmationDialogContent(
-                        displayName = "Maggie",
+                        name = "Maggie",
                         email = "maggie@example.com",
                         avatar = android.R.drawable.sym_def_app_icon
                     )
@@ -85,7 +85,7 @@ class SignedInConfirmationDialogTest {
         paparazzi.snapshotInABox {
             FakeImageLoader.Resources.override {
                 SignedInConfirmationDialogContent(
-                    displayName = "Maggie",
+                    name = "Maggie",
                     avatar = android.R.drawable.sym_def_app_icon
                 )
             }
@@ -104,7 +104,7 @@ class SignedInConfirmationDialogTest {
         paparazzi.snapshotInABox {
             FakeImageLoader.Resources.override {
                 SignedInConfirmationDialogContent(
-                    displayName = "Wolfeschlegelsteinhausenbergerdorff",
+                    name = "Wolfeschlegelsteinhausenbergerdorff",
                     email = "wolfeschlegelsteinhausenbergerdorff@example.com",
                     avatar = android.R.drawable.sym_def_app_icon
                 )

--- a/auth-ui/api/current.api
+++ b/auth-ui/api/current.api
@@ -147,6 +147,15 @@ package com.google.android.horologist.auth.ui.ext {
 
 }
 
+package com.google.android.horologist.auth.ui.googlesignin.mapper {
+
+  @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public final class AccountUiModelMapper {
+    method public com.google.android.horologist.auth.composables.model.AccountUiModel map(com.google.android.gms.auth.api.signin.GoogleSignInAccount account, optional String defaultEmail);
+    field public static final com.google.android.horologist.auth.ui.googlesignin.mapper.AccountUiModelMapper INSTANCE;
+  }
+
+}
+
 package com.google.android.horologist.auth.ui.googlesignin.prompt {
 
   public final class GoogleSignInPromptViewModelFactoryKt {
@@ -183,17 +192,11 @@ package com.google.android.horologist.auth.ui.googlesignin.signin {
   }
 
   public static final class GoogleSignInScreenState.Success extends com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreenState {
-    ctor public GoogleSignInScreenState.Success(String? displayName, String? email, android.net.Uri? photoUrl);
-    method public String? component1();
-    method public String? component2();
-    method public android.net.Uri? component3();
-    method public com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreenState.Success copy(String? displayName, String? email, android.net.Uri? photoUrl);
-    method public String? getDisplayName();
-    method public String? getEmail();
-    method public android.net.Uri? getPhotoUrl();
-    property public final String? displayName;
-    property public final String? email;
-    property public final android.net.Uri? photoUrl;
+    ctor public GoogleSignInScreenState.Success(com.google.android.horologist.auth.composables.model.AccountUiModel accountUiModel);
+    method public com.google.android.horologist.auth.composables.model.AccountUiModel component1();
+    method public com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreenState.Success copy(com.google.android.horologist.auth.composables.model.AccountUiModel accountUiModel);
+    method public com.google.android.horologist.auth.composables.model.AccountUiModel getAccountUiModel();
+    property public final com.google.android.horologist.auth.composables.model.AccountUiModel accountUiModel;
   }
 
   @com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi public class GoogleSignInViewModel extends androidx.lifecycle.ViewModel {

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInDefaultScreen.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInDefaultScreen.kt
@@ -65,8 +65,7 @@ public fun StreamlineSignInDefaultScreen(
             SignedInConfirmationDialog(
                 onDismissOrTimeout = { onSignedInConfirmationDialogDismissOrTimeout(account) },
                 modifier = modifier,
-                name = account.name,
-                email = account.email
+                accountUiModel = account
             )
         }
 

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/mapper/AccountUiModelMapper.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/mapper/AccountUiModelMapper.kt
@@ -17,6 +17,7 @@
 package com.google.android.horologist.auth.ui.googlesignin.mapper
 
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import com.google.android.horologist.auth.composables.ExperimentalHorologistAuthComposablesApi
 import com.google.android.horologist.auth.composables.model.AccountUiModel
 import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
 
@@ -29,6 +30,7 @@ public object AccountUiModelMapper {
     /**
      * Maps from a [GoogleSignInAccount].
      */
+    @OptIn(ExperimentalHorologistAuthComposablesApi::class)
     public fun map(
         account: GoogleSignInAccount,
         defaultEmail: String = ""

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/mapper/AccountUiModelMapper.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/mapper/AccountUiModelMapper.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.ui.googlesignin.mapper
+
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import com.google.android.horologist.auth.composables.model.AccountUiModel
+import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
+
+/**
+ * Functions to map models from Google Sign In into a [AccountUiModel].
+ */
+@ExperimentalHorologistAuthUiApi
+public object AccountUiModelMapper {
+
+    /**
+     * Maps from a [GoogleSignInAccount].
+     */
+    public fun map(
+        account: GoogleSignInAccount,
+        defaultEmail: String = ""
+    ): AccountUiModel = AccountUiModel(
+        email = account.email ?: defaultEmail,
+        name = account.displayName,
+        avatar = account.photoUrl
+    )
+}

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInScreen.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInScreen.kt
@@ -155,9 +155,7 @@ public fun GoogleSignInScreen(
         SignedInConfirmationDialog(
             onDismissOrTimeout = { onAuthSucceed() },
             modifier = modifier,
-            name = successState.displayName,
-            email = successState.email,
-            avatar = successState.photoUrl
+            accountUiModel = successState.accountUiModel
         )
     }
 }

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInViewModel.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInViewModel.kt
@@ -16,14 +16,15 @@
 
 package com.google.android.horologist.auth.ui.googlesignin.signin
 
-import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
+import com.google.android.horologist.auth.composables.model.AccountUiModel
 import com.google.android.horologist.auth.data.googlesignin.GoogleSignInEventListener
 import com.google.android.horologist.auth.data.googlesignin.GoogleSignInEventListenerNoOpImpl
 import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
+import com.google.android.horologist.auth.ui.googlesignin.mapper.AccountUiModelMapper
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -60,9 +61,7 @@ public open class GoogleSignInViewModel(
         }
 
         _uiState.value = GoogleSignInScreenState.Success(
-            displayName = account.displayName,
-            email = account.email,
-            photoUrl = account.photoUrl
+            AccountUiModelMapper.map(account)
         )
     }
 
@@ -93,11 +92,7 @@ public sealed class GoogleSignInScreenState {
 
     public object SelectAccount : GoogleSignInScreenState()
 
-    public data class Success(
-        val displayName: String?,
-        val email: String?,
-        val photoUrl: Uri?
-    ) : GoogleSignInScreenState()
+    public data class Success(val accountUiModel: AccountUiModel) : GoogleSignInScreenState()
 
     public object Failed : GoogleSignInScreenState()
 

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/mapper/AccountUiModelMapper.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/mapper/AccountUiModelMapper.kt
@@ -30,7 +30,7 @@ public object AccountUiModelMapper {
     /**
      * Maps from a [AuthUser].
      */
-    @OptIn(ExperimentalHorologistAuthComposablesApi::class) // lint is complaining
+    @OptIn(ExperimentalHorologistAuthComposablesApi::class)
     public fun map(authUser: AuthUser, defaultEmail: String = ""): AccountUiModel = AccountUiModel(
         email = authUser.email ?: defaultEmail,
         name = authUser.displayName,


### PR DESCRIPTION
#### WHAT

Add overloaded `SignedInConfirmationDialog` with `AccountUiModel` as parameter.

#### WHY

For convenience.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
