### PR TITLE
Add loading state to TrackPositionUiModel for the progress ring to animate

### DIFF
--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -864,9 +864,7 @@ package com.google.android.horologist.media.ui.state.model {
   }
 
   public static final class TrackPositionUiModel.Actual.Companion {
-    method public com.google.android.horologist.media.ui.state.model.TrackPositionUiModel.Actual getLOADING();
     method public com.google.android.horologist.media.ui.state.model.TrackPositionUiModel.Actual getZERO();
-    property public final com.google.android.horologist.media.ui.state.model.TrackPositionUiModel.Actual LOADING;
     property public final com.google.android.horologist.media.ui.state.model.TrackPositionUiModel.Actual ZERO;
   }
 
@@ -878,6 +876,16 @@ package com.google.android.horologist.media.ui.state.model {
     property public boolean shouldAnimate;
     property public boolean showProgress;
     field public static final com.google.android.horologist.media.ui.state.model.TrackPositionUiModel.Hidden INSTANCE;
+  }
+
+  public static final class TrackPositionUiModel.Loading extends com.google.android.horologist.media.ui.state.model.TrackPositionUiModel {
+    method public boolean getShouldAnimate();
+    method public boolean getShowProgress();
+    method public boolean isLoading();
+    property public boolean isLoading;
+    property public boolean shouldAnimate;
+    property public boolean showProgress;
+    field public static final com.google.android.horologist.media.ui.state.model.TrackPositionUiModel.Loading INSTANCE;
   }
 
   public static final class TrackPositionUiModel.Predictive extends com.google.android.horologist.media.ui.state.model.TrackPositionUiModel {

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -879,13 +879,16 @@ package com.google.android.horologist.media.ui.state.model {
   }
 
   public static final class TrackPositionUiModel.Loading extends com.google.android.horologist.media.ui.state.model.TrackPositionUiModel {
+    ctor public TrackPositionUiModel.Loading(optional boolean shouldAnimate, optional boolean showProgress);
+    method public boolean component1();
+    method public boolean component2();
+    method public com.google.android.horologist.media.ui.state.model.TrackPositionUiModel.Loading copy(boolean shouldAnimate, boolean showProgress);
     method public boolean getShouldAnimate();
     method public boolean getShowProgress();
     method public boolean isLoading();
     property public boolean isLoading;
     property public boolean shouldAnimate;
     property public boolean showProgress;
-    field public static final com.google.android.horologist.media.ui.state.model.TrackPositionUiModel.Loading INSTANCE;
   }
 
   public static final class TrackPositionUiModel.Predictive extends com.google.android.horologist.media.ui.state.model.TrackPositionUiModel {

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -76,7 +76,7 @@ package com.google.android.horologist.media.ui.components {
 
   public final class PlayPauseButtonKt {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PlayPauseButton(kotlin.jvm.functions.Function0<kotlin.Unit> onPlayClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPauseClick, boolean playing, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional androidx.wear.compose.material.ButtonColors colors, optional float iconSize, optional long tapTargetSize, optional long backgroundColor, optional kotlin.jvm.functions.Function0<kotlin.Unit> progress);
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PlayPauseProgressButton(kotlin.jvm.functions.Function0<kotlin.Unit> onPlayClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPauseClick, boolean playing, com.google.android.horologist.media.ui.state.model.TrackPositionUiModel trackPositionUiModel, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional androidx.wear.compose.material.ButtonColors colors, optional float iconSize, optional long tapTargetSize, optional long progressColour, optional long trackColor, optional long backgroundColor);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PlayPauseProgressButton(kotlin.jvm.functions.Function0<kotlin.Unit> onPlayClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPauseClick, boolean playing, com.google.android.horologist.media.ui.state.model.TrackPositionUiModel trackPositionUiModel, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional androidx.wear.compose.material.ButtonColors colors, optional float iconSize, optional long tapTargetSize, optional float progressStrokeWidth, optional long progressColour, optional long trackColor, optional long backgroundColor);
   }
 
   public final class PodcastControlButtonsKt {
@@ -834,23 +834,28 @@ package com.google.android.horologist.media.ui.state.model {
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public abstract sealed class TrackPositionUiModel {
     method public abstract boolean getShouldAnimate();
     method public abstract boolean getShowProgress();
+    method public abstract boolean isLoading();
+    property public abstract boolean isLoading;
     property public abstract boolean shouldAnimate;
     property public abstract boolean showProgress;
   }
 
   public static final class TrackPositionUiModel.Actual extends com.google.android.horologist.media.ui.state.model.TrackPositionUiModel {
-    ctor public TrackPositionUiModel.Actual(float percent, long duration, long position, optional boolean shouldAnimate);
+    ctor public TrackPositionUiModel.Actual(float percent, long duration, long position, optional boolean shouldAnimate, optional boolean isLoading);
     method public float component1();
     method public long component2-UwyO8pc();
     method public long component3-UwyO8pc();
     method public boolean component4();
-    method public com.google.android.horologist.media.ui.state.model.TrackPositionUiModel.Actual copy-vLdBGDU(float percent, long duration, long position, boolean shouldAnimate);
+    method public boolean component5();
+    method public com.google.android.horologist.media.ui.state.model.TrackPositionUiModel.Actual copy-jKevqZI(float percent, long duration, long position, boolean shouldAnimate, boolean isLoading);
     method public long getDuration();
     method public float getPercent();
     method public long getPosition();
     method public boolean getShouldAnimate();
     method public boolean getShowProgress();
+    method public boolean isLoading();
     property public final long duration;
+    property public boolean isLoading;
     property public final float percent;
     property public final long position;
     property public boolean shouldAnimate;
@@ -859,26 +864,33 @@ package com.google.android.horologist.media.ui.state.model {
   }
 
   public static final class TrackPositionUiModel.Actual.Companion {
+    method public com.google.android.horologist.media.ui.state.model.TrackPositionUiModel.Actual getLOADING();
     method public com.google.android.horologist.media.ui.state.model.TrackPositionUiModel.Actual getZERO();
+    property public final com.google.android.horologist.media.ui.state.model.TrackPositionUiModel.Actual LOADING;
     property public final com.google.android.horologist.media.ui.state.model.TrackPositionUiModel.Actual ZERO;
   }
 
   public static final class TrackPositionUiModel.Hidden extends com.google.android.horologist.media.ui.state.model.TrackPositionUiModel {
     method public boolean getShouldAnimate();
     method public boolean getShowProgress();
+    method public boolean isLoading();
+    property public boolean isLoading;
     property public boolean shouldAnimate;
     property public boolean showProgress;
     field public static final com.google.android.horologist.media.ui.state.model.TrackPositionUiModel.Hidden INSTANCE;
   }
 
   public static final class TrackPositionUiModel.Predictive extends com.google.android.horologist.media.ui.state.model.TrackPositionUiModel {
-    ctor public TrackPositionUiModel.Predictive(com.google.android.horologist.media.model.PositionPredictor predictor, optional boolean shouldAnimate);
+    ctor public TrackPositionUiModel.Predictive(com.google.android.horologist.media.model.PositionPredictor predictor, optional boolean shouldAnimate, optional boolean isLoading);
     method public com.google.android.horologist.media.model.PositionPredictor component1();
     method public boolean component2();
-    method public com.google.android.horologist.media.ui.state.model.TrackPositionUiModel.Predictive copy(com.google.android.horologist.media.model.PositionPredictor predictor, boolean shouldAnimate);
+    method public boolean component3();
+    method public com.google.android.horologist.media.ui.state.model.TrackPositionUiModel.Predictive copy(com.google.android.horologist.media.model.PositionPredictor predictor, boolean shouldAnimate, boolean isLoading);
     method public com.google.android.horologist.media.model.PositionPredictor getPredictor();
     method public boolean getShouldAnimate();
     method public boolean getShowProgress();
+    method public boolean isLoading();
+    property public boolean isLoading;
     property public final com.google.android.horologist.media.model.PositionPredictor predictor;
     property public boolean shouldAnimate;
     property public boolean showProgress;

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/PlayPauseProgressButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/PlayPauseProgressButtonPreview.kt
@@ -93,6 +93,22 @@ fun PlayPauseProgressButtonPreview100() {
 }
 
 @Preview(
+    "Loading",
+    backgroundColor = 0xff000000,
+    showBackground = true
+)
+@Composable
+fun PlayPauseProgressButtonLoadingPreview() {
+    PlayPauseProgressButton(
+        onPlayClick = {},
+        onPauseClick = {},
+        enabled = true,
+        playing = false,
+        trackPositionUiModel = TrackPositionUiModel.Actual(0.5f, 50.seconds, 100.seconds, shouldAnimate = true, isLoading = true)
+    )
+}
+
+@Preview(
     "On Background - Progress 50%",
     backgroundColor = 0xff000000,
     showBackground = true

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/PlayPauseProgressButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/PlayPauseProgressButtonPreview.kt
@@ -104,7 +104,7 @@ fun PlayPauseProgressButtonLoadingPreview() {
         onPauseClick = {},
         enabled = true,
         playing = true,
-        trackPositionUiModel = TrackPositionUiModel.Loading
+        trackPositionUiModel = TrackPositionUiModel.Loading(showProgress = true)
     )
 }
 

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/PlayPauseProgressButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/PlayPauseProgressButtonPreview.kt
@@ -103,8 +103,8 @@ fun PlayPauseProgressButtonLoadingPreview() {
         onPlayClick = {},
         onPauseClick = {},
         enabled = true,
-        playing = false,
-        trackPositionUiModel = TrackPositionUiModel.Actual(0.5f, 50.seconds, 100.seconds, shouldAnimate = true, isLoading = true)
+        playing = true,
+        trackPositionUiModel = TrackPositionUiModel.Loading
     )
 }
 

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/PlayPauseButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/PlayPauseButton.kt
@@ -107,32 +107,29 @@ public fun PlayPauseProgressButton(
         onPlayClick = onPlayClick,
         onPauseClick = onPauseClick,
         enabled = enabled,
-        playing = if (trackPositionUiModel.isLoading) true else playing,
+        playing = playing,
         modifier = modifier,
         colors = colors,
         iconSize = iconSize,
         tapTargetSize = tapTargetSize,
         backgroundColor = backgroundColor
     ) {
-        if (trackPositionUiModel.showProgress) {
-            if (trackPositionUiModel.isLoading) {
-                CircularProgressIndicator(
-                    modifier = Modifier.fillMaxSize(),
-                    indicatorColor = progressColour,
-                    trackColor = trackColor,
-                    strokeWidth = progressStrokeWidth
-                )
-            } else {
-                val progress by ProgressStateHolder.fromTrackPositionUiModel(trackPositionUiModel)
-
-                CircularProgressIndicator(
-                    modifier = Modifier.fillMaxSize(),
-                    progress = progress,
-                    indicatorColor = progressColour,
-                    trackColor = trackColor,
-                    strokeWidth = progressStrokeWidth
-                )
-            }
+        val progress by ProgressStateHolder.fromTrackPositionUiModel(trackPositionUiModel)
+        if (trackPositionUiModel.showProgress && trackPositionUiModel.isLoading) {
+            CircularProgressIndicator(
+                modifier = Modifier.fillMaxSize(),
+                indicatorColor = progressColour,
+                trackColor = trackColor,
+                strokeWidth = progressStrokeWidth
+            )
+        } else if (trackPositionUiModel.showProgress) {
+            CircularProgressIndicator(
+                modifier = Modifier.fillMaxSize(),
+                progress = progress,
+                indicatorColor = progressColour,
+                trackColor = trackColor,
+                strokeWidth = progressStrokeWidth
+            )
         }
     }
 }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/PlayPauseButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/PlayPauseButton.kt
@@ -115,7 +115,7 @@ public fun PlayPauseProgressButton(
         backgroundColor = backgroundColor
     ) {
         val progress by ProgressStateHolder.fromTrackPositionUiModel(trackPositionUiModel)
-        if (trackPositionUiModel.showProgress && trackPositionUiModel.isLoading) {
+        if (trackPositionUiModel.isLoading) {
             CircularProgressIndicator(
                 modifier = Modifier.fillMaxSize(),
                 indicatorColor = progressColour,

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/PlayPauseButton.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/PlayPauseButton.kt
@@ -98,6 +98,7 @@ public fun PlayPauseProgressButton(
     colors: ButtonColors = ButtonDefaults.iconButtonColors(),
     iconSize: Dp = 30.dp,
     tapTargetSize: DpSize = DpSize(60.dp, 60.dp),
+    progressStrokeWidth: Dp = 4.dp,
     progressColour: Color = MaterialTheme.colors.primary,
     trackColor: Color = MaterialTheme.colors.onSurface.copy(alpha = 0.10f),
     backgroundColor: Color = MaterialTheme.colors.onBackground.copy(alpha = 0.10f)
@@ -106,21 +107,32 @@ public fun PlayPauseProgressButton(
         onPlayClick = onPlayClick,
         onPauseClick = onPauseClick,
         enabled = enabled,
-        playing = playing,
+        playing = if (trackPositionUiModel.isLoading) true else playing,
         modifier = modifier,
         colors = colors,
         iconSize = iconSize,
         tapTargetSize = tapTargetSize,
         backgroundColor = backgroundColor
     ) {
-        val progress by ProgressStateHolder.fromTrackPositionUiModel(trackPositionUiModel)
         if (trackPositionUiModel.showProgress) {
-            CircularProgressIndicator(
-                modifier = Modifier.fillMaxSize(),
-                progress = progress,
-                indicatorColor = progressColour,
-                trackColor = trackColor
-            )
+            if (trackPositionUiModel.isLoading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.fillMaxSize(),
+                    indicatorColor = progressColour,
+                    trackColor = trackColor,
+                    strokeWidth = progressStrokeWidth
+                )
+            } else {
+                val progress by ProgressStateHolder.fromTrackPositionUiModel(trackPositionUiModel)
+
+                CircularProgressIndicator(
+                    modifier = Modifier.fillMaxSize(),
+                    progress = progress,
+                    indicatorColor = progressColour,
+                    trackColor = trackColor,
+                    strokeWidth = progressStrokeWidth
+                )
+            }
         }
     }
 }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/PlayerUiStateMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/PlayerUiStateMapper.kt
@@ -45,6 +45,7 @@ public object PlayerUiStateMapper {
         seekForwardIncrement: Duration?
     ): PlayerUiState {
         val playPauseCommandAvailable = availableCommands.contains(Command.PlayPause) && currentState != PlayerState.Idle
+        val trackPositionUiModel = TrackPositionUiModelMapper.map(playbackStateEvent)
 
         return PlayerUiState(
             playEnabled = playPauseCommandAvailable,
@@ -56,9 +57,9 @@ public object PlayerUiStateMapper {
             shuffleEnabled = availableCommands.contains(Command.SetShuffle),
             shuffleOn = shuffleModeEnabled,
             playPauseEnabled = playPauseCommandAvailable,
-            playing = currentState == PlayerState.Playing || currentState == PlayerState.Loading,
+            playing = trackPositionUiModel.isLoading || currentState == PlayerState.Playing || currentState == PlayerState.Loading,
             media = media?.let(MediaUiModelMapper::map),
-            trackPositionUiModel = TrackPositionUiModelMapper.map(playbackStateEvent),
+            trackPositionUiModel = trackPositionUiModel,
             connected = connected,
             seekBackButtonIncrement = seekBackIncrement?.let { SeekButtonIncrement.ofDuration(it) } ?: SeekButtonIncrement.Unknown,
             seekForwardButtonIncrement = seekForwardIncrement?.let { SeekButtonIncrement.ofDuration(it) } ?: SeekButtonIncrement.Unknown

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/PlayerUiStateMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/PlayerUiStateMapper.kt
@@ -45,7 +45,6 @@ public object PlayerUiStateMapper {
         seekForwardIncrement: Duration?
     ): PlayerUiState {
         val playPauseCommandAvailable = availableCommands.contains(Command.PlayPause) && currentState != PlayerState.Idle
-        val trackPositionUiModel = TrackPositionUiModelMapper.map(playbackStateEvent)
 
         return PlayerUiState(
             playEnabled = playPauseCommandAvailable,
@@ -57,9 +56,9 @@ public object PlayerUiStateMapper {
             shuffleEnabled = availableCommands.contains(Command.SetShuffle),
             shuffleOn = shuffleModeEnabled,
             playPauseEnabled = playPauseCommandAvailable,
-            playing = trackPositionUiModel.isLoading || currentState == PlayerState.Playing || currentState == PlayerState.Loading,
+            playing = currentState == PlayerState.Playing || currentState == PlayerState.Loading,
             media = media?.let(MediaUiModelMapper::map),
-            trackPositionUiModel = trackPositionUiModel,
+            trackPositionUiModel = TrackPositionUiModelMapper.map(playbackStateEvent),
             connected = connected,
             seekBackButtonIncrement = seekBackIncrement?.let { SeekButtonIncrement.ofDuration(it) } ?: SeekButtonIncrement.Unknown,
             seekForwardButtonIncrement = seekForwardIncrement?.let { SeekButtonIncrement.ofDuration(it) } ?: SeekButtonIncrement.Unknown

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
@@ -35,7 +35,7 @@ public object TrackPositionUiModelMapper {
         val durationMs = duration?.inWholeMilliseconds
         val currentPositionMs = currentPosition?.inWholeMilliseconds
         if (event.playbackState.playerState == PlayerState.Loading) {
-            return TrackPositionUiModel.Loading
+            return TrackPositionUiModel.Loading(showProgress = true)
         }
         if (currentPositionMs == null || durationMs == null || durationMs <= 0) {
             return TrackPositionUiModel.Hidden

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
@@ -35,7 +35,7 @@ public object TrackPositionUiModelMapper {
         val durationMs = duration?.inWholeMilliseconds
         val currentPositionMs = currentPosition?.inWholeMilliseconds
         if (event.playbackState.playerState == PlayerState.Loading) {
-            return TrackPositionUiModel.Actual.LOADING
+            return TrackPositionUiModel.Loading
         }
         if (currentPositionMs == null || durationMs == null || durationMs <= 0) {
             return TrackPositionUiModel.Hidden

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
@@ -35,7 +35,7 @@ public object TrackPositionUiModelMapper {
         val durationMs = duration?.inWholeMilliseconds
         val currentPositionMs = currentPosition?.inWholeMilliseconds
         if (event.playbackState.playerState == PlayerState.Loading) {
-            return TrackPositionUiModel.Actual.ZERO
+            return TrackPositionUiModel.Actual.LOADING
         }
         if (currentPositionMs == null || durationMs == null || durationMs <= 0) {
             return TrackPositionUiModel.Hidden

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
@@ -48,13 +48,11 @@ public sealed class TrackPositionUiModel {
         }
     }
 
-    public object Loading : TrackPositionUiModel() {
-        override val showProgress: Boolean
-            get() = true
-        override val shouldAnimate: Boolean
-            get() = true
-        override val isLoading: Boolean
-            get() = true
+    public data class Loading (
+        public override val shouldAnimate: Boolean = false,
+        public override val showProgress: Boolean = false
+    ) : TrackPositionUiModel() {
+        override val isLoading: Boolean get() = true
     }
 
     public object Hidden : TrackPositionUiModel() {

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
@@ -44,7 +44,7 @@ public sealed class TrackPositionUiModel {
         override val showProgress: Boolean get() = true
 
         public companion object {
-            public val ZERO: Actual = Actual(0f, Duration.ZERO, Duration.ZERO)
+            public val ZRO: Actual = Actual(0f, Duration.ZERO, Duration.ZERO)
             public val LOADING: Actual =
                 Actual(0f, Duration.ZERO, Duration.ZERO, shouldAnimate = true, isLoading = true)
         }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
@@ -44,7 +44,7 @@ public sealed class TrackPositionUiModel {
         override val showProgress: Boolean get() = true
 
         public companion object {
-            public val ZRO: Actual = Actual(0f, Duration.ZERO, Duration.ZERO)
+            public val ZERO: Actual = Actual(0f, Duration.ZERO, Duration.ZERO)
             public val LOADING: Actual =
                 Actual(0f, Duration.ZERO, Duration.ZERO, shouldAnimate = true, isLoading = true)
         }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
@@ -48,7 +48,7 @@ public sealed class TrackPositionUiModel {
         }
     }
 
-    public data class Loading (
+    public data class Loading(
         public override val shouldAnimate: Boolean = false,
         public override val showProgress: Boolean = false
     ) : TrackPositionUiModel() {

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
@@ -24,10 +24,12 @@ import kotlin.time.Duration
 public sealed class TrackPositionUiModel {
     public abstract val showProgress: Boolean
     public abstract val shouldAnimate: Boolean
+    public abstract val isLoading: Boolean
 
     public data class Predictive(
         public val predictor: PositionPredictor,
-        public override val shouldAnimate: Boolean = false
+        public override val shouldAnimate: Boolean = false,
+        public override val isLoading: Boolean = false
     ) : TrackPositionUiModel() {
         override val showProgress: Boolean get() = true
     }
@@ -36,17 +38,21 @@ public sealed class TrackPositionUiModel {
         public val percent: Float,
         public val duration: Duration,
         public val position: Duration,
-        public override val shouldAnimate: Boolean = false
+        public override val shouldAnimate: Boolean = false,
+        public override val isLoading: Boolean = false
     ) : TrackPositionUiModel() {
         override val showProgress: Boolean get() = true
 
         public companion object {
             public val ZERO: Actual = Actual(0f, Duration.ZERO, Duration.ZERO)
+            public val LOADING: Actual =
+                Actual(0f, Duration.ZERO, Duration.ZERO, shouldAnimate = true, isLoading = true)
         }
     }
 
     public object Hidden : TrackPositionUiModel() {
         override val showProgress: Boolean get() = false
         override val shouldAnimate: Boolean get() = false
+        override val isLoading: Boolean get() = false
     }
 }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
@@ -45,9 +45,16 @@ public sealed class TrackPositionUiModel {
 
         public companion object {
             public val ZERO: Actual = Actual(0f, Duration.ZERO, Duration.ZERO)
-            public val LOADING: Actual =
-                Actual(0f, Duration.ZERO, Duration.ZERO, shouldAnimate = true, isLoading = true)
         }
+    }
+
+    public object Loading : TrackPositionUiModel() {
+        override val showProgress: Boolean
+            get() = true
+        override val shouldAnimate: Boolean
+            get() = true
+        override val isLoading: Boolean
+            get() = true
     }
 
     public object Hidden : TrackPositionUiModel() {

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapperTest.kt
@@ -104,8 +104,8 @@ class TrackPositionUiModelMapperTest {
         val result = TrackPositionUiModelMapper.map(playbackStateEvent)
 
         // then
-        assertThat(result).isInstanceOf(TrackPositionUiModel.Actual::class.java)
-        result as TrackPositionUiModel.Actual
+        assertThat(result).isInstanceOf(TrackPositionUiModel.Loading::class.java)
+        result as TrackPositionUiModel.Loading
         assertThat(result.isLoading).isTrue()
     }
 

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapperTest.kt
@@ -85,6 +85,31 @@ class TrackPositionUiModelMapperTest {
     }
 
     @Test
+    fun givenLoadingPlayerState_thenMapsCorrectly() {
+        // given
+        val current = 1.seconds
+        val duration = 2.seconds
+        val playbackStateEvent = PlaybackStateEvent(
+            PlaybackState(
+                playerState = PlayerState.Loading,
+                isLive = false,
+                currentPosition = current,
+                duration = duration,
+                playbackSpeed = 1f
+            ),
+            cause = PlaybackStateEvent.Cause.PositionDiscontinuity
+        )
+
+        // when
+        val result = TrackPositionUiModelMapper.map(playbackStateEvent)
+
+        // then
+        assertThat(result).isInstanceOf(TrackPositionUiModel.Actual::class.java)
+        result as TrackPositionUiModel.Actual
+        assertThat(result.isLoading).isTrue()
+    }
+
+    @Test
     fun givenUnknownMediaPosition_thenMapsCorrectly() {
         // given
         val playbackState = PlaybackState.IDLE


### PR DESCRIPTION
#### WHAT
Add loading animation to progress ring

#### WHY
Instead of only show Play / Pause, we should show when the PlayerState is loading.

#### HOW
- Add a loading state to TrackPositionUiModel and let the Mapper map to it when PlayerState is Loading. In PlayPauseButton, does not assign "progress" to the CircularProgressIndicator to allow it animate loading state.
- Add Preview for the animated loading state
- Add test for mapper

#### Checklist :clipboard:
- [X] Add explicit visibility modifier and explicit return types for public declarations
- [X] Run spotless check
- [X] Run tests
- [X] Update metalava's signature text files
