### PR TITLE
Improve Section.State

### DIFF
--- a/composables/api/current.api
+++ b/composables/api/current.api
@@ -35,7 +35,7 @@ package com.google.android.horologist.composables {
   }
 
   @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public final class Section<T> {
-    ctor public Section(com.google.android.horologist.composables.Section.State<T> state, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? headerContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? loadingContent, optional int loadingContentCount, kotlin.jvm.functions.Function2<? super com.google.android.horologist.composables.SectionContentScope,? super T,kotlin.Unit> loadedContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? failedContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? emptyContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? footerContent, optional boolean displayFooterOnlyOnLoadedState);
+    ctor public Section(com.google.android.horologist.composables.Section.State<? extends T> state, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? headerContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? loadingContent, optional int loadingContentCount, kotlin.jvm.functions.Function2<? super com.google.android.horologist.composables.SectionContentScope,? super T,kotlin.Unit> loadedContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? failedContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? emptyContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? footerContent, optional boolean displayFooterOnlyOnLoadedState);
     method public com.google.android.horologist.composables.Section.State<T> component1();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? component2();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? component3();
@@ -45,7 +45,7 @@ package com.google.android.horologist.composables {
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? component7();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? component8();
     method public boolean component9();
-    method public com.google.android.horologist.composables.Section<T> copy(com.google.android.horologist.composables.Section.State<T> state, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? headerContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? loadingContent, int loadingContentCount, kotlin.jvm.functions.Function2<? super com.google.android.horologist.composables.SectionContentScope,? super T,kotlin.Unit> loadedContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? failedContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? emptyContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? footerContent, boolean displayFooterOnlyOnLoadedState);
+    method public com.google.android.horologist.composables.Section<T> copy(com.google.android.horologist.composables.Section.State<? extends T> state, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? headerContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? loadingContent, int loadingContentCount, kotlin.jvm.functions.Function2<? super com.google.android.horologist.composables.SectionContentScope,? super T,kotlin.Unit> loadedContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? failedContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? emptyContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? footerContent, boolean displayFooterOnlyOnLoadedState);
     method public boolean getDisplayFooterOnlyOnLoadedState();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? getEmptyContent();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? getFailedContent();
@@ -70,12 +70,12 @@ package com.google.android.horologist.composables {
   public abstract static sealed class Section.State<T> {
   }
 
-  public static final class Section.State.Empty<T> extends com.google.android.horologist.composables.Section.State<T> {
-    ctor public Section.State.Empty();
+  public static final class Section.State.Empty extends com.google.android.horologist.composables.Section.State {
+    field public static final com.google.android.horologist.composables.Section.State.Empty INSTANCE;
   }
 
-  public static final class Section.State.Failed<T> extends com.google.android.horologist.composables.Section.State<T> {
-    ctor public Section.State.Failed();
+  public static final class Section.State.Failed extends com.google.android.horologist.composables.Section.State {
+    field public static final com.google.android.horologist.composables.Section.State.Failed INSTANCE;
   }
 
   public static final class Section.State.Loaded<T> extends com.google.android.horologist.composables.Section.State<T> {
@@ -86,8 +86,8 @@ package com.google.android.horologist.composables {
     property public final java.util.List<T> list;
   }
 
-  public static final class Section.State.Loading<T> extends com.google.android.horologist.composables.Section.State<T> {
-    ctor public Section.State.Loading();
+  public static final class Section.State.Loading extends com.google.android.horologist.composables.Section.State {
+    field public static final com.google.android.horologist.composables.Section.State.Loading INSTANCE;
   }
 
   @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public final class SectionContentScope {
@@ -111,7 +111,7 @@ package com.google.android.horologist.composables {
 
   @com.google.android.horologist.composables.ExperimentalHorologistComposablesApi public final class SectionedListScope {
     ctor public SectionedListScope();
-    method public <T> void section(com.google.android.horologist.composables.Section.State<T> state, optional boolean displayFooterOnlyOnLoadedState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionScope<T>,kotlin.Unit> content);
+    method public <T> void section(com.google.android.horologist.composables.Section.State<? extends T> state, optional boolean displayFooterOnlyOnLoadedState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionScope<T>,kotlin.Unit> content);
     method public <T> void section(java.util.List<? extends T> list, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionScope<T>,kotlin.Unit> content);
     method public void section(kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionScope<kotlin.Unit>,kotlin.Unit> content);
   }

--- a/composables/src/debug/java/com/google/android/horologist/composables/SectionedListPreview.kt
+++ b/composables/src/debug/java/com/google/android/horologist/composables/SectionedListPreview.kt
@@ -44,9 +44,9 @@ import com.google.android.horologist.compose.tools.WearPreviewDevices
 @Composable
 fun SectionedListPreviewLoadingSection() {
     SectionedList {
-        downloadsSection(state = Section.State.Loading())
+        downloadsSection(state = Section.State.Loading)
 
-        favouritesSection(state = Section.State.Empty())
+        favouritesSection(state = Section.State.Empty)
     }
 }
 
@@ -56,7 +56,7 @@ fun SectionedListPreviewLoadedSection() {
     SectionedList {
         downloadsSection(state = Section.State.Loaded(downloads))
 
-        favouritesSection(state = Section.State.Failed())
+        favouritesSection(state = Section.State.Failed)
     }
 }
 
@@ -64,7 +64,7 @@ fun SectionedListPreviewLoadedSection() {
 @Composable
 fun SectionedListPreviewFailedSection() {
     SectionedList {
-        downloadsSection(state = Section.State.Failed())
+        downloadsSection(state = Section.State.Failed)
 
         favouritesSection(state = Section.State.Loaded(favourites))
     }
@@ -74,9 +74,9 @@ fun SectionedListPreviewFailedSection() {
 @Composable
 fun SectionedListPreviewEmptySection() {
     SectionedList {
-        downloadsSection(state = Section.State.Empty())
+        downloadsSection(state = Section.State.Empty)
 
-        favouritesSection(state = Section.State.Loading())
+        favouritesSection(state = Section.State.Loading)
     }
 }
 

--- a/composables/src/main/java/com/google/android/horologist/composables/SectionedList.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/SectionedList.kt
@@ -76,7 +76,7 @@ internal fun <T> Section<T>.display(scope: ScalingLazyListScope) {
     }
 
     when (section.state) {
-        is Section.State.Loading -> {
+        Section.State.Loading -> {
             section.loadingContent?.let { content ->
                 scope.items(section.loadingContentCount) { SectionContentScope.content() }
             }
@@ -89,13 +89,13 @@ internal fun <T> Section<T>.display(scope: ScalingLazyListScope) {
             }
         }
 
-        is Section.State.Failed -> {
+        Section.State.Failed -> {
             section.failedContent?.let { content ->
                 scope.item { SectionContentScope.content() }
             }
         }
 
-        is Section.State.Empty -> {
+        Section.State.Empty -> {
             section.emptyContent?.let { content ->
                 scope.item { SectionContentScope.content() }
             }
@@ -127,16 +127,16 @@ public data class Section<T> constructor(
     /**
      * A state of a [Section].
      */
-    public sealed class State<T> {
-        public class Loading<T> : State<T>()
+    public sealed class State<out T> {
+        public object Loading : State<Nothing>()
 
         public data class Loaded<T>(
             val list: List<T>
         ) : State<T>()
 
-        public class Failed<T> : State<T>()
+        public object Failed : State<Nothing>()
 
-        public class Empty<T> : State<T>()
+        public object Empty : State<Nothing>()
     }
 
     internal companion object {

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/SectionedListTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/SectionedListTest.kt
@@ -66,9 +66,9 @@ class SectionedListTest {
 
             SectionedListPreview(columnState.state) {
                 SectionedList(columnState = columnState) {
-                    downloadsSection(state = Section.State.Loading())
+                    downloadsSection(state = Section.State.Loading)
 
-                    favouritesSection(state = Section.State.Empty())
+                    favouritesSection(state = Section.State.Empty)
                 }
             }
         }
@@ -83,7 +83,7 @@ class SectionedListTest {
                 SectionedList(columnState = columnState) {
                     downloadsSection(state = Section.State.Loaded(downloads))
 
-                    favouritesSection(state = Section.State.Failed())
+                    favouritesSection(state = Section.State.Failed)
                 }
             }
         }
@@ -98,7 +98,7 @@ class SectionedListTest {
                 SectionedList(columnState = columnState) {
                     downloadsSection(state = Section.State.Loaded(downloads))
 
-                    favouritesSection(state = Section.State.Failed())
+                    favouritesSection(state = Section.State.Failed)
                 }
             }
         }
@@ -111,7 +111,7 @@ class SectionedListTest {
 
             SectionedListPreview(columnState.state) {
                 SectionedList(columnState = columnState) {
-                    downloadsSection(state = Section.State.Failed())
+                    downloadsSection(state = Section.State.Failed)
 
                     favouritesSection(state = Section.State.Loaded(favourites))
                 }
@@ -126,7 +126,7 @@ class SectionedListTest {
 
             SectionedListPreview(columnState.state) {
                 SectionedList(columnState = columnState) {
-                    downloadsSection(state = Section.State.Failed())
+                    downloadsSection(state = Section.State.Failed)
 
                     favouritesSection(state = Section.State.Loaded(favourites))
                 }
@@ -141,9 +141,9 @@ class SectionedListTest {
 
             SectionedListPreview(columnState.state) {
                 SectionedList(columnState = columnState) {
-                    downloadsSection(state = Section.State.Empty())
+                    downloadsSection(state = Section.State.Empty)
 
-                    favouritesSection(state = Section.State.Loading())
+                    favouritesSection(state = Section.State.Loading)
                 }
             }
         }

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -334,9 +334,9 @@ package com.google.android.horologist.media.ui.screens.browse {
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public final class BrowseScreenScope {
     ctor public BrowseScreenScope();
     method public void button(com.google.android.horologist.media.ui.screens.browse.BrowseScreenPlaylistsSectionButton button);
-    method public <T> void downloadsSection(com.google.android.horologist.composables.Section.State<T> state, optional boolean displayFooterOnlyOnLoadedState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.screens.browse.BrowseScreenSectionScope<T>,kotlin.Unit> content);
+    method public <T> void downloadsSection(com.google.android.horologist.composables.Section.State<? extends T> state, optional boolean displayFooterOnlyOnLoadedState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.screens.browse.BrowseScreenSectionScope<T>,kotlin.Unit> content);
     method public void playlistsSection(java.util.List<com.google.android.horologist.media.ui.screens.browse.BrowseScreenPlaylistsSectionButton> buttons);
-    method public <T> void section(com.google.android.horologist.composables.Section.State<T> state, @StringRes int titleId, @StringRes int emptyMessageId, optional @StringRes Integer? failedMessageId, optional boolean displayFooterOnlyOnLoadedState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.screens.browse.BrowseScreenSectionScope<T>,kotlin.Unit> content);
+    method public <T> void section(com.google.android.horologist.composables.Section.State<? extends T> state, @StringRes int titleId, @StringRes int emptyMessageId, optional @StringRes Integer? failedMessageId, optional boolean displayFooterOnlyOnLoadedState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.screens.browse.BrowseScreenSectionScope<T>,kotlin.Unit> content);
   }
 
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public final class BrowseScreenSectionScope<T> {

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreenPreview.kt
@@ -56,8 +56,8 @@ fun BrowseScreenPreview() {
 @Composable
 fun BrowseScreenPreviewLoading() {
     BrowseScreenPreviewSample(
-        trendingSectionState = Section.State.Loading(),
-        downloadsSectionState = Section.State.Loading()
+        trendingSectionState = Section.State.Loading,
+        downloadsSectionState = Section.State.Loading
     )
 }
 
@@ -65,8 +65,8 @@ fun BrowseScreenPreviewLoading() {
 @Composable
 fun BrowseScreenPreviewFailed() {
     BrowseScreenPreviewSample(
-        trendingSectionState = Section.State.Failed(),
-        downloadsSectionState = Section.State.Failed()
+        trendingSectionState = Section.State.Failed,
+        downloadsSectionState = Section.State.Failed
     )
 }
 

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/browse/PlaylistDownloadBrowseScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/browse/PlaylistDownloadBrowseScreen.kt
@@ -57,18 +57,18 @@ public fun PlaylistDownloadBrowseScreen(
         modifier = modifier
     ) {
         val downloadsSectionState = when (browseScreenState) {
-            is BrowseScreenState.Loading -> Section.State.Loading()
+            BrowseScreenState.Loading -> Section.State.Loading
             is BrowseScreenState.Loaded -> {
                 if (browseScreenState.downloadList.isEmpty()) {
-                    Section.State.Empty()
+                    Section.State.Empty
                 } else {
                     Section.State.Loaded(browseScreenState.downloadList)
                 }
             }
 
-            is BrowseScreenState.Failed ->
+            BrowseScreenState.Failed ->
                 // display empty state
-                Section.State.Empty()
+                Section.State.Empty
         }
 
         downloadsSection(state = downloadsSectionState) {

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreen.kt
@@ -70,8 +70,8 @@ public fun <T> PlaylistsScreen(
                 Section.State.Loaded(playlistsScreenState.playlistList)
             }
 
-            is PlaylistsScreenState.Failed -> Section.State.Failed()
-            is PlaylistsScreenState.Loading -> Section.State.Loading()
+            is PlaylistsScreenState.Failed -> Section.State.Failed
+            is PlaylistsScreenState.Loading -> Section.State.Loading
         }
 
         section(state = sectionState) {

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/stateful/SectionedListStatefulScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/stateful/SectionedListStatefulScreen.kt
@@ -107,12 +107,12 @@ private fun SectionedListScope.recommendationsSection(
 ) {
     val recommendationsState: Section.State<Recommendation> =
         when (val recommendationSectionState = state.recommendationSectionState) {
-            RecommendationSectionState.Loading -> Section.State.Loading()
+            RecommendationSectionState.Loading -> Section.State.Loading
             is RecommendationSectionState.Loaded -> Section.State.Loaded(
                 recommendationSectionState.list
             )
 
-            RecommendationSectionState.Failed -> Section.State.Failed()
+            RecommendationSectionState.Failed -> Section.State.Failed
         }
 
     section(recommendationsState) {
@@ -158,12 +158,12 @@ private fun SectionedListScope.trendingSection(
 ) {
     val trendingState: Section.State<Trending> =
         when (val recommendationSectionState = state.trendingSectionState) {
-            TrendingSectionState.Loading -> Section.State.Loading()
+            TrendingSectionState.Loading -> Section.State.Loading
             is TrendingSectionState.Loaded -> Section.State.Loaded(
                 recommendationSectionState.list
             )
 
-            TrendingSectionState.Failed -> Section.State.Failed()
+            TrendingSectionState.Failed -> Section.State.Failed
         }
 
     section(trendingState) {


### PR DESCRIPTION
#### WHAT

Improve `Section.State`.

#### WHY

In order to have some of states declared as object, avoiding unnecessary creation of instances.

#### HOW

Change type parameter to covariant and change states to extend `Section.State<Nothing>`.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
