### PR TITLE
Improve PlaylistsScreenState

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/UampPlaylistsScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/UampPlaylistsScreen.kt
@@ -62,8 +62,8 @@ fun UampPlaylistsScreen(
             PlaylistsScreenState.Loaded(modifiedPlaylistList)
         }
 
-        is PlaylistsScreenState.Failed,
-        is PlaylistsScreenState.Loading -> uiState
+        PlaylistsScreenState.Failed,
+        PlaylistsScreenState.Loading -> uiState
     }
 
     PlaylistsScreen(
@@ -75,7 +75,7 @@ fun UampPlaylistsScreen(
     )
 
     // b/242302037 - it should stop listening to uiState emissions while dialog is presented
-    if (modifiedState is PlaylistsScreenState.Failed) {
+    if (modifiedState == PlaylistsScreenState.Failed) {
         Dialog(
             showDialog = true,
             onDismissRequest = onErrorDialogCancelClick,

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/UampPlaylistsScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/playlists/UampPlaylistsScreenViewModel.kt
@@ -40,13 +40,13 @@ class UampPlaylistsScreenViewModel @Inject constructor(
             if (it.isNotEmpty()) {
                 PlaylistsScreenState.Loaded(it.map(PlaylistUiModelMapper::map))
             } else {
-                PlaylistsScreenState.Failed()
+                PlaylistsScreenState.Failed
             }
         }.catch {
-            emit(PlaylistsScreenState.Failed())
+            emit(PlaylistsScreenState.Failed)
         }.stateIn(
             viewModelScope,
             started = SharingStarted.Eagerly,
-            initialValue = PlaylistsScreenState.Loading()
+            initialValue = PlaylistsScreenState.Loading
         )
 }

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -484,15 +484,15 @@ package com.google.android.horologist.media.ui.screens.playlists {
 
   public final class PlaylistsScreenKt {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static <T> void PlaylistsScreen(com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, java.util.List<? extends T> playlists, kotlin.jvm.functions.Function1<? super T,kotlin.Unit> playlistContent, optional androidx.compose.ui.Modifier modifier);
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static <T> void PlaylistsScreen(com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, com.google.android.horologist.media.ui.screens.playlists.PlaylistsScreenState<T> playlistsScreenState, kotlin.jvm.functions.Function1<? super T,kotlin.Unit> playlistContent, optional androidx.compose.ui.Modifier modifier);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static <T> void PlaylistsScreen(com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, com.google.android.horologist.media.ui.screens.playlists.PlaylistsScreenState<? extends T> playlistsScreenState, kotlin.jvm.functions.Function1<? super T,kotlin.Unit> playlistContent, optional androidx.compose.ui.Modifier modifier);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PlaylistsScreen(com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, com.google.android.horologist.media.ui.screens.playlists.PlaylistsScreenState<com.google.android.horologist.media.ui.state.model.PlaylistUiModel> playlistsScreenState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onPlaylistItemClick, optional androidx.compose.ui.Modifier modifier, optional androidx.compose.ui.graphics.painter.Painter? playlistItemArtworkPlaceholder);
   }
 
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public abstract sealed class PlaylistsScreenState<T> {
   }
 
-  public static final class PlaylistsScreenState.Failed<T> extends com.google.android.horologist.media.ui.screens.playlists.PlaylistsScreenState<T> {
-    ctor public PlaylistsScreenState.Failed();
+  public static final class PlaylistsScreenState.Failed extends com.google.android.horologist.media.ui.screens.playlists.PlaylistsScreenState {
+    field public static final com.google.android.horologist.media.ui.screens.playlists.PlaylistsScreenState.Failed INSTANCE;
   }
 
   public static final class PlaylistsScreenState.Loaded<T> extends com.google.android.horologist.media.ui.screens.playlists.PlaylistsScreenState<T> {
@@ -503,8 +503,8 @@ package com.google.android.horologist.media.ui.screens.playlists {
     property public final java.util.List<T> playlistList;
   }
 
-  public static final class PlaylistsScreenState.Loading<T> extends com.google.android.horologist.media.ui.screens.playlists.PlaylistsScreenState<T> {
-    ctor public PlaylistsScreenState.Loading();
+  public static final class PlaylistsScreenState.Loading extends com.google.android.horologist.media.ui.screens.playlists.PlaylistsScreenState {
+    field public static final com.google.android.horologist.media.ui.screens.playlists.PlaylistsScreenState.Loading INSTANCE;
   }
 
 }

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreenPreview.kt
@@ -66,7 +66,7 @@ fun PlaylistsScreenPreview() {
 fun PlaylistsScreenPreviewLoading() {
     PlaylistsScreen(
         columnState = belowTimeTextPreview(),
-        playlistsScreenState = PlaylistsScreenState.Loading(),
+        playlistsScreenState = PlaylistsScreenState.Loading,
         onPlaylistItemClick = { }
     )
 }
@@ -76,7 +76,7 @@ fun PlaylistsScreenPreviewLoading() {
 fun PlaylistsScreenPreviewFailed() {
     PlaylistsScreen(
         columnState = belowTimeTextPreview(),
-        playlistsScreenState = PlaylistsScreenState.Failed(),
+        playlistsScreenState = PlaylistsScreenState.Failed,
         onPlaylistItemClick = { }
     )
 }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreen.kt
@@ -70,8 +70,8 @@ public fun <T> PlaylistsScreen(
                 Section.State.Loaded(playlistsScreenState.playlistList)
             }
 
-            is PlaylistsScreenState.Failed -> Section.State.Failed
-            is PlaylistsScreenState.Loading -> Section.State.Loading
+            PlaylistsScreenState.Failed -> Section.State.Failed
+            PlaylistsScreenState.Loading -> Section.State.Loading
         }
 
         section(state = sectionState) {
@@ -125,13 +125,13 @@ public fun PlaylistsScreen(
  * Represents the state of [PlaylistsScreen].
  */
 @ExperimentalHorologistMediaUiApi
-public sealed class PlaylistsScreenState<T> {
+public sealed class PlaylistsScreenState<out T> {
 
-    public class Loading<T> : PlaylistsScreenState<T>()
+    public object Loading : PlaylistsScreenState<Nothing>()
 
     public data class Loaded<T>(
         val playlistList: List<T>
     ) : PlaylistsScreenState<T>()
 
-    public class Failed<T> : PlaylistsScreenState<T>()
+    public object Failed : PlaylistsScreenState<Nothing>()
 }


### PR DESCRIPTION
#### WHAT

Improve `PlaylistsScreenState`.

#### WHY

In order to have some of states declared as object, avoiding unnecessary creation of instances.

#### HOW

Change type parameter to covariant and change states to extend `PlaylistsScreenState<Nothing>`.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
