### PR TITLE
Improve EntityScreenState and PlaylistDownloadScreenState

### DIFF
--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
@@ -101,7 +101,7 @@ fun UampEntityScreen(
     )
 
     // b/243381431 - it should stop listening to uiState emissions while dialog is presented
-    if (uiState is PlaylistDownloadScreenState.Failed) {
+    if (uiState == PlaylistDownloadScreenState.Failed) {
         Dialog(
             showDialog = true,
             onDismissRequest = onErrorDialogCancelClick,

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreenViewModel.kt
@@ -63,14 +63,14 @@ class UampEntityScreenViewModel @Inject constructor(
                     downloadMediaList = playlistDownload.mediaList.map(DownloadMediaUiModelMapper::map)
                 )
             } else {
-                PlaylistDownloadScreenState.Failed()
+                PlaylistDownloadScreenState.Failed
             }
         }.catch {
-            emit(PlaylistDownloadScreenState.Failed())
+            emit(PlaylistDownloadScreenState.Failed)
         }.stateIn(
             viewModelScope,
             SharingStarted.WhileSubscribed(5000),
-            PlaylistDownloadScreenState.Loading()
+            PlaylistDownloadScreenState.Loading
         )
 
     fun play(mediaId: String? = null) {

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampStreamingPlaylistScreenViewModel.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampStreamingPlaylistScreenViewModel.kt
@@ -61,14 +61,14 @@ class UampStreamingPlaylistScreenViewModel @Inject constructor(
                     downloadMediaList = playlistDownload.mediaList.map(DownloadMediaUiModelMapper::map)
                 )
             } else {
-                PlaylistDownloadScreenState.Failed()
+                PlaylistDownloadScreenState.Failed
             }
         }.catch {
-            emit(PlaylistDownloadScreenState.Failed())
+            emit(PlaylistDownloadScreenState.Failed)
         }.stateIn(
             viewModelScope,
             SharingStarted.WhileSubscribed(5000),
-            PlaylistDownloadScreenState.Loading()
+            PlaylistDownloadScreenState.Loading
         )
 
     fun play(mediaId: String? = null) {

--- a/media-sample/src/test/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreenViewModelTest.kt
+++ b/media-sample/src/test/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreenViewModelTest.kt
@@ -109,7 +109,7 @@ class UampEntityScreenViewModelTest {
         )
 
         sut2.uiState.test {
-            assertThat(awaitItem()).isInstanceOf(PlaylistDownloadScreenState.Failed::class.java)
+            assertThat(awaitItem()).isEqualTo(PlaylistDownloadScreenState.Failed)
         }
     }
 

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -377,14 +377,14 @@ package com.google.android.horologist.media.ui.screens.entity {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void DefaultEntityScreenHeader(String title, optional androidx.compose.ui.Modifier modifier);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void EntityScreen(com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, kotlin.jvm.functions.Function0<kotlin.Unit> headerContent, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit>? buttonsContent, optional kotlin.jvm.functions.Function1<? super androidx.wear.compose.foundation.lazy.ScalingLazyListScope,kotlin.Unit>? content);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static <Media> void EntityScreen(com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, kotlin.jvm.functions.Function0<kotlin.Unit> headerContent, java.util.List<? extends Media> mediaList, kotlin.jvm.functions.Function1<? super Media,kotlin.Unit> mediaContent, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit>? buttonsContent);
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static <Media> void EntityScreen(com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, com.google.android.horologist.media.ui.screens.entity.EntityScreenState<Media> entityScreenState, kotlin.jvm.functions.Function0<kotlin.Unit> headerContent, kotlin.jvm.functions.Function1<? super androidx.wear.compose.foundation.lazy.ScalingLazyListScope,kotlin.Unit> loadingContent, kotlin.jvm.functions.Function1<? super Media,kotlin.Unit> mediaContent, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit>? buttonsContent, optional kotlin.jvm.functions.Function0<kotlin.Unit>? failedContent);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static <Media> void EntityScreen(com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, com.google.android.horologist.media.ui.screens.entity.EntityScreenState<? extends Media> entityScreenState, kotlin.jvm.functions.Function0<kotlin.Unit> headerContent, kotlin.jvm.functions.Function1<? super androidx.wear.compose.foundation.lazy.ScalingLazyListScope,kotlin.Unit> loadingContent, kotlin.jvm.functions.Function1<? super Media,kotlin.Unit> mediaContent, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit>? buttonsContent, optional kotlin.jvm.functions.Function0<kotlin.Unit>? failedContent);
   }
 
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public abstract sealed class EntityScreenState<Media> {
   }
 
-  public static final class EntityScreenState.Failed<Media> extends com.google.android.horologist.media.ui.screens.entity.EntityScreenState<Media> {
-    ctor public EntityScreenState.Failed();
+  public static final class EntityScreenState.Failed extends com.google.android.horologist.media.ui.screens.entity.EntityScreenState {
+    field public static final com.google.android.horologist.media.ui.screens.entity.EntityScreenState.Failed INSTANCE;
   }
 
   public static final class EntityScreenState.Loaded<Media> extends com.google.android.horologist.media.ui.screens.entity.EntityScreenState<Media> {
@@ -395,20 +395,20 @@ package com.google.android.horologist.media.ui.screens.entity {
     property public final java.util.List<Media> mediaList;
   }
 
-  public static final class EntityScreenState.Loading<Media> extends com.google.android.horologist.media.ui.screens.entity.EntityScreenState<Media> {
-    ctor public EntityScreenState.Loading();
+  public static final class EntityScreenState.Loading extends com.google.android.horologist.media.ui.screens.entity.EntityScreenState {
+    field public static final com.google.android.horologist.media.ui.screens.entity.EntityScreenState.Loading INSTANCE;
   }
 
   public final class PlaylistDownloadScreenKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PlaylistDownloadScreen(com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, String playlistName, com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState<com.google.android.horologist.media.ui.state.model.PlaylistUiModel,com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel> playlistDownloadScreenState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onDownloadButtonClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onCancelDownloadButtonClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel,kotlin.Unit> onDownloadItemClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel,kotlin.Unit> onDownloadItemInProgressClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onShuffleButtonClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onPlayButtonClick, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit>? onDownloadCompletedButtonClick, optional String defaultMediaTitle, optional androidx.compose.ui.graphics.painter.Painter? downloadItemArtworkPlaceholder, optional String? onDownloadItemInProgressClickActionLabel);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PlaylistDownloadScreen(com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, String playlistName, com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState<com.google.android.horologist.media.ui.state.model.PlaylistUiModel,? extends com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel> playlistDownloadScreenState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onDownloadButtonClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onCancelDownloadButtonClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel,kotlin.Unit> onDownloadItemClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel,kotlin.Unit> onDownloadItemInProgressClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onShuffleButtonClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit> onPlayButtonClick, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.PlaylistUiModel,kotlin.Unit>? onDownloadCompletedButtonClick, optional String defaultMediaTitle, optional androidx.compose.ui.graphics.painter.Painter? downloadItemArtworkPlaceholder, optional String? onDownloadItemInProgressClickActionLabel);
     method @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded<com.google.android.horologist.media.ui.state.model.PlaylistUiModel,com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel> createPlaylistDownloadScreenStateLoaded(com.google.android.horologist.media.ui.state.model.PlaylistUiModel playlistModel, java.util.List<? extends com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel> downloadMediaList);
   }
 
   @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public abstract sealed class PlaylistDownloadScreenState<Collection, Media> {
   }
 
-  public static final class PlaylistDownloadScreenState.Failed<Collection, Media> extends com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState<Collection,Media> {
-    ctor public PlaylistDownloadScreenState.Failed();
+  public static final class PlaylistDownloadScreenState.Failed extends com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState {
+    field public static final com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Failed INSTANCE;
   }
 
   public static final class PlaylistDownloadScreenState.Loaded<Collection, Media> extends com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState<Collection,Media> {
@@ -451,12 +451,12 @@ package com.google.android.horologist.media.ui.screens.entity {
     property public final float progress;
   }
 
-  public static final class PlaylistDownloadScreenState.Loading<Collection, Media> extends com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState<Collection,Media> {
-    ctor public PlaylistDownloadScreenState.Loading();
+  public static final class PlaylistDownloadScreenState.Loading extends com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState {
+    field public static final com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loading INSTANCE;
   }
 
   public final class PlaylistStreamingScreenKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PlaylistStreamingScreen(com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, String playlistName, com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState<com.google.android.horologist.media.ui.state.model.PlaylistUiModel,com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel> playlistDownloadScreenState, kotlin.jvm.functions.Function0<kotlin.Unit> onShuffleButtonClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPlayButtonClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel,kotlin.Unit> onPlayItemClick, optional androidx.compose.ui.Modifier modifier, optional String defaultMediaTitle);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void PlaylistStreamingScreen(com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, String playlistName, com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState<com.google.android.horologist.media.ui.state.model.PlaylistUiModel,? extends com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel> playlistDownloadScreenState, kotlin.jvm.functions.Function0<kotlin.Unit> onShuffleButtonClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPlayButtonClick, kotlin.jvm.functions.Function1<? super com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel,kotlin.Unit> onPlayItemClick, optional androidx.compose.ui.Modifier modifier, optional String defaultMediaTitle);
   }
 
 }

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/EntityScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/EntityScreenPreview.kt
@@ -126,7 +126,7 @@ fun EntityScreenPreviewLoadedState() {
 fun EntityScreenPreviewLoadingState() {
     EntityScreen(
         columnState = belowTimeTextPreview(),
-        entityScreenState = EntityScreenState.Loading<String>(),
+        entityScreenState = EntityScreenState.Loading,
         headerContent = { DefaultEntityScreenHeader(title = "Playlist name") },
         loadingContent = { items(count = 2) { PlaceholderChip(colors = ChipDefaults.secondaryChipColors()) } },
         mediaContent = { },
@@ -139,7 +139,7 @@ fun EntityScreenPreviewLoadingState() {
 fun EntityScreenPreviewFailedState() {
     EntityScreen(
         columnState = belowTimeTextPreview(),
-        entityScreenState = EntityScreenState.Failed<String>(),
+        entityScreenState = EntityScreenState.Failed,
         headerContent = { DefaultEntityScreenHeader(title = "Playlist name") },
         loadingContent = { },
         mediaContent = { },

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenPreview.kt
@@ -35,7 +35,7 @@ fun PlaylistDownloadScreenPreviewLoading() {
     PlaylistDownloadScreen(
         columnState = belowTimeTextPreview(),
         playlistName = "Playlist name",
-        playlistDownloadScreenState = PlaylistDownloadScreenState.Loading(),
+        playlistDownloadScreenState = PlaylistDownloadScreenState.Loading,
         onDownloadButtonClick = { },
         onCancelDownloadButtonClick = { },
         onDownloadItemClick = { },
@@ -189,7 +189,7 @@ fun PlaylistDownloadScreenPreviewFailed() {
     PlaylistDownloadScreen(
         columnState = belowTimeTextPreview(),
         playlistName = "Playlist name",
-        playlistDownloadScreenState = PlaylistDownloadScreenState.Failed(),
+        playlistDownloadScreenState = PlaylistDownloadScreenState.Failed,
         onDownloadButtonClick = { },
         onCancelDownloadButtonClick = { },
         onDownloadItemClick = { },

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/EntityScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/EntityScreen.kt
@@ -103,7 +103,7 @@ public fun <Media> EntityScreen(
     failedContent: (@Composable () -> Unit)? = null
 ) {
     when (entityScreenState) {
-        is EntityScreenState.Loading -> {
+        EntityScreenState.Loading -> {
             EntityScreen(
                 headerContent = headerContent,
                 columnState = columnState,
@@ -124,7 +124,7 @@ public fun <Media> EntityScreen(
             )
         }
 
-        is EntityScreenState.Failed -> {
+        EntityScreenState.Failed -> {
             EntityScreen(
                 columnState = columnState,
                 headerContent = headerContent,
@@ -142,14 +142,14 @@ public fun <Media> EntityScreen(
  * Represents the state of [EntityScreen].
  */
 @ExperimentalHorologistMediaUiApi
-public sealed class EntityScreenState<Media> {
-    public class Loading<Media> : EntityScreenState<Media>()
+public sealed class EntityScreenState<out Media> {
+    public object Loading : EntityScreenState<Nothing>()
 
     public data class Loaded<Media>(
         val mediaList: List<Media>
     ) : EntityScreenState<Media>()
 
-    public class Failed<Media> : EntityScreenState<Media>()
+    public object Failed : EntityScreenState<Nothing>()
 }
 
 /**

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
@@ -96,12 +96,12 @@ public fun PlaylistDownloadScreen(
 ) {
     val entityScreenState: EntityScreenState<DownloadMediaUiModel> =
         when (playlistDownloadScreenState) {
-            is PlaylistDownloadScreenState.Loading -> EntityScreenState.Loading()
+            PlaylistDownloadScreenState.Loading -> EntityScreenState.Loading
             is PlaylistDownloadScreenState.Loaded -> EntityScreenState.Loaded(
                 playlistDownloadScreenState.mediaList
             )
 
-            is PlaylistDownloadScreenState.Failed -> EntityScreenState.Failed()
+            PlaylistDownloadScreenState.Failed -> EntityScreenState.Failed
         }
 
     EntityScreen(
@@ -263,8 +263,8 @@ private fun ButtonsContent(
     onPlayButtonClick: (PlaylistUiModel) -> Unit
 ) {
     when (state) {
-        is PlaylistDownloadScreenState.Failed,
-        is PlaylistDownloadScreenState.Loading -> {
+        PlaylistDownloadScreenState.Failed,
+        PlaylistDownloadScreenState.Loading -> {
             StandardChip(
                 label = stringResource(id = R.string.horologist_playlist_download_button_download),
                 onClick = { /* do nothing */ },
@@ -412,9 +412,9 @@ private fun <Collection> FirstButton(
  * Represents the state of [PlaylistDownloadScreen].
  */
 @ExperimentalHorologistMediaUiApi
-public sealed class PlaylistDownloadScreenState<Collection, Media> {
+public sealed class PlaylistDownloadScreenState<out Collection, out Media> {
 
-    public class Loading<Collection, Media> : PlaylistDownloadScreenState<Collection, Media>()
+    public object Loading : PlaylistDownloadScreenState<Nothing, Nothing>()
 
     public data class Loaded<Collection, Media>(
         val collectionModel: Collection,
@@ -444,7 +444,7 @@ public sealed class PlaylistDownloadScreenState<Collection, Media> {
         }
     }
 
-    public class Failed<Collection, Media> : PlaylistDownloadScreenState<Collection, Media>()
+    public object Failed : PlaylistDownloadScreenState<Nothing, Nothing>()
 }
 
 /**

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistStreamingScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistStreamingScreen.kt
@@ -59,12 +59,12 @@ public fun PlaylistStreamingScreen(
 ) {
     val entityScreenState: EntityScreenState<DownloadMediaUiModel> =
         when (playlistDownloadScreenState) {
-            is PlaylistDownloadScreenState.Loading -> EntityScreenState.Loading()
+            PlaylistDownloadScreenState.Loading -> EntityScreenState.Loading
             is PlaylistDownloadScreenState.Loaded -> EntityScreenState.Loaded(
                 playlistDownloadScreenState.mediaList
             )
 
-            is PlaylistDownloadScreenState.Failed -> EntityScreenState.Failed()
+            PlaylistDownloadScreenState.Failed -> EntityScreenState.Failed
         }
 
     EntityScreen(

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenA11yScreenshotTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenA11yScreenshotTest.kt
@@ -70,7 +70,7 @@ class PlaylistDownloadScreenA11yScreenshotTest {
             PlayerLibraryPreview(state = columnState.state) {
                 PlaylistDownloadScreen(
                     playlistName = "Playlist name",
-                    playlistDownloadScreenState = PlaylistDownloadScreenState.Loading(),
+                    playlistDownloadScreenState = PlaylistDownloadScreenState.Loading,
                     onDownloadButtonClick = { },
                     onCancelDownloadButtonClick = { },
                     onDownloadItemClick = { },
@@ -266,7 +266,7 @@ class PlaylistDownloadScreenA11yScreenshotTest {
             PlayerLibraryPreview(state = columnState.state) {
                 PlaylistDownloadScreen(
                     playlistName = "Playlist name",
-                    playlistDownloadScreenState = PlaylistDownloadScreenState.Failed(),
+                    playlistDownloadScreenState = PlaylistDownloadScreenState.Failed,
                     onDownloadButtonClick = { },
                     onCancelDownloadButtonClick = { },
                     onDownloadItemClick = { },


### PR DESCRIPTION
#### WHAT

Improve `EntityScreenState` and `PlaylistDownloadScreenState`.

#### WHY

In order to have some of states declared as object, avoiding unnecessary creation of instances.

#### HOW

Change type parameter to covariant and change states to extend `EntityScreenState<Nothing>` and `PlaylistDownloadScreenState<Nothing>`.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
