### PR TITLE
Improve auth docs

### DIFF
--- a/auth-composables/src/main/java/com/google/android/horologist/auth/composables/chips/GuestModeChip.kt
+++ b/auth-composables/src/main/java/com/google/android/horologist/auth/composables/chips/GuestModeChip.kt
@@ -29,6 +29,8 @@ import com.google.android.horologist.base.ui.components.StandardChipType
 
 /**
  * An opinionated [Chip] to represent the "Guest mode" action.
+ *
+ * @sample com.google.android.horologist.auth.sample.screens.googlesignin.prompt.GoogleSignInPromptSampleScreen
  */
 @ExperimentalHorologistAuthComposablesApi
 @Composable

--- a/auth-composables/src/main/java/com/google/android/horologist/auth/composables/chips/SignInChip.kt
+++ b/auth-composables/src/main/java/com/google/android/horologist/auth/composables/chips/SignInChip.kt
@@ -29,6 +29,8 @@ import com.google.android.horologist.base.ui.components.StandardChipType
 
 /**
  * An opinionated [Chip] to represent the "Sign in" action.
+ *
+ * @sample com.google.android.horologist.auth.sample.screens.googlesignin.prompt.GoogleSignInPromptSampleScreen
  */
 @ExperimentalHorologistAuthComposablesApi
 @Composable

--- a/auth-data-phone/src/main/java/com/google/android/horologist/auth/data/phone/tokenshare/TokenBundleRepository.kt
+++ b/auth-data-phone/src/main/java/com/google/android/horologist/auth/data/phone/tokenshare/TokenBundleRepository.kt
@@ -20,6 +20,8 @@ import com.google.android.horologist.auth.data.phone.ExperimentalHorologistAuthD
 
 /**
  * Repository of a bundle of information, related to auth tokens.
+ *
+ * @sample com.google.android.horologist.auth.sample.MainActivity
  */
 @ExperimentalHorologistAuthDataPhoneApi
 public interface TokenBundleRepository<T> {

--- a/auth-data-phone/src/main/java/com/google/android/horologist/auth/data/phone/tokenshare/impl/TokenBundleRepositoryImpl.kt
+++ b/auth-data-phone/src/main/java/com/google/android/horologist/auth/data/phone/tokenshare/impl/TokenBundleRepositoryImpl.kt
@@ -25,6 +25,8 @@ import kotlinx.coroutines.CoroutineScope
 
 /**
  * Default implementation for [TokenBundleRepository].
+ *
+ * @sample com.google.android.horologist.auth.sample.MainActivity
  */
 @ExperimentalHorologistAuthDataPhoneApi
 public class TokenBundleRepositoryImpl<T>(

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/common/repository/AuthUserRepository.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/common/repository/AuthUserRepository.kt
@@ -21,6 +21,10 @@ import com.google.android.horologist.auth.data.common.model.AuthUser
 
 /**
  * A repository of [AuthUser].
+ *
+ * @sample com.google.android.horologist.auth.sample.screens.oauth.devicegrant.data.DeviceGrantAuthUserRepositorySample
+ * @sample com.google.android.horologist.auth.sample.screens.oauth.pkce.data.PKCEAuthUserRepositorySample
+ * @sample com.google.android.horologist.auth.sample.screens.common.streamline.AuthUserRepositoryStreamlineImpl
  */
 @ExperimentalHorologistAuthDataApi
 public interface AuthUserRepository {

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/googlesignin/GoogleSignInEventListener.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/googlesignin/GoogleSignInEventListener.kt
@@ -21,6 +21,8 @@ import com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi
 
 /**
  * A listener of events of the Google Sign-In authentication method.
+ *
+ * @sample com.google.android.horologist.auth.sample.screens.googlesignin.signin.GoogleSignInEventListenerSample
  */
 @ExperimentalHorologistAuthDataApi
 public interface GoogleSignInEventListener {

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/tokenshare/TokenBundleRepository.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/tokenshare/TokenBundleRepository.kt
@@ -21,6 +21,9 @@ import kotlinx.coroutines.flow.Flow
 
 /**
  * Repository of a bundle of information, related to auth tokens.
+ *
+ * @sample com.google.android.horologist.auth.sample.screens.tokenshare.customkey.TokenShareCustomKeyViewModel
+ * @sample com.google.android.horologist.auth.sample.screens.tokenshare.defaultkey.TokenShareDefaultKeyViewModel
  */
 @ExperimentalHorologistAuthDataApi
 public interface TokenBundleRepository<T> {

--- a/auth-data/src/main/java/com/google/android/horologist/auth/data/tokenshare/impl/TokenBundleRepositoryImpl.kt
+++ b/auth-data/src/main/java/com/google/android/horologist/auth/data/tokenshare/impl/TokenBundleRepositoryImpl.kt
@@ -25,6 +25,9 @@ import kotlinx.coroutines.flow.Flow
 
 /**
  * Default implementation of [TokenBundleRepository].
+ *
+ * @sample com.google.android.horologist.auth.sample.screens.tokenshare.customkey.TokenShareCustomKeyViewModel
+ * @sample com.google.android.horologist.auth.sample.screens.tokenshare.defaultkey.TokenShareDefaultKeyViewModel
  */
 @ExperimentalHorologistAuthDataApi
 public class TokenBundleRepositoryImpl<T>(

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptScreen.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptScreen.kt
@@ -52,6 +52,9 @@ import com.google.android.horologist.compose.layout.ScalingLazyColumnState
  * The [content] should provide
  * [sign-in alternatives](https://developer.android.com/training/wearables/design/sign-in#alternatives).
  *
+ * @sample com.google.android.horologist.auth.sample.screens.googlesignin.prompt.GoogleSignInPromptSampleScreen
+ * @sample com.google.android.horologist.auth.sample.screens.oauth.devicegrant.prompt.DeviceGrantSignInPromptScreen
+ * @sample com.google.android.horologist.auth.sample.screens.oauth.pkce.prompt.PKCESignInPromptScreen
  */
 @ExperimentalHorologistAuthUiApi
 @Composable

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptViewModel.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptViewModel.kt
@@ -32,6 +32,10 @@ import kotlinx.coroutines.launch
  *
  * It checks if there is a user already signed in, and emits the appropriate
  * [states][SignInPromptScreenState] through the [uiState] property.
+ *
+ * @sample com.google.android.horologist.auth.sample.screens.googlesignin.prompt.GoogleSignInPromptSampleScreen
+ * @sample com.google.android.horologist.auth.sample.screens.oauth.devicegrant.prompt.DeviceGrantSignInPromptScreen
+ * @sample com.google.android.horologist.auth.sample.screens.oauth.pkce.prompt.PKCESignInPromptScreen
  */
 @ExperimentalHorologistAuthUiApi
 public open class SignInPromptViewModel(

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInDefaultScreen.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInDefaultScreen.kt
@@ -36,6 +36,8 @@ import com.google.android.horologist.compose.layout.ScalingLazyColumnState
  * The [content] of this composable would be displayed when the screen is in "loading" state. This
  * is an optional param, in case of no other layout is expected to be displayed while this screen is
  * loading, e.g. in the scenario where the app is already displaying the splash screen.
+ *
+ * @sample com.google.android.horologist.auth.sample.screens.common.streamline.StreamlineSignInSampleScreen
  */
 @ExperimentalHorologistAuthUiApi
 @Composable

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInDefaultViewModel.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInDefaultViewModel.kt
@@ -32,6 +32,8 @@ import kotlinx.coroutines.launch
  *
  * It checks if there is a user already signed in, and emits the appropriate
  * [states][StreamlineSignInDefaultScreenState] through the [uiState] property.
+ *
+ * @sample com.google.android.horologist.auth.sample.screens.common.streamline.StreamlineSignInSampleScreen
  */
 @ExperimentalHorologistAuthUiApi
 public class StreamlineSignInDefaultViewModel(

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/prompt/GoogleSignInPromptViewModelFactory.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/prompt/GoogleSignInPromptViewModelFactory.kt
@@ -27,6 +27,8 @@ import com.google.android.horologist.auth.ui.common.screens.prompt.SignInPromptV
 /**
  * A [factory][ViewModelProvider.Factory] to create a [SignInPromptViewModel] with dependencies with
  * implementation for the Google Sign-In authentication method.
+ *
+ * @sample com.google.android.horologist.auth.sample.screens.googlesignin.prompt.GoogleSignInPromptSampleScreen
  */
 @ExperimentalHorologistAuthUiApi
 public val GoogleSignInPromptViewModelFactory: ViewModelProvider.Factory = viewModelFactory {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -202,7 +202,12 @@ subprojects {
                 noAndroidSdkLink.set(false)
 
                 // Add samples from :sample module
-                samples.from(rootProject.file("sample/src/main/java/"))
+                samples.from(
+                    rootProject.file("auth-sample-phone/src/main/java/"),
+                    rootProject.file("auth-sample-wear/src/main/java/"),
+                    rootProject.file("media-sample/src/main/java/"),
+                    rootProject.file("sample/src/main/java/"),
+                )
 
                 // AndroidX + Compose docs
                 externalDocumentationLink {
@@ -221,6 +226,15 @@ subprojects {
                     // Suffix which is used to append the line number to the URL. Use #L for GitHub
                     remoteLineSuffix.set("#L")
                 }
+
+                perPackageOption {
+                    matchingRegex.set("com.google.android.horologist.auth.sample.shared.*")
+
+                    suppress.set(true)
+                }
+
+                // Remove composable previews from docs
+                suppressedFiles.from(file("src/debug/java"))
             }
         }
         if (plugins.hasPlugin("com.android.library")) {

--- a/docs/auth-overview.md
+++ b/docs/auth-overview.md
@@ -23,7 +23,8 @@ The following libraries are provided:
 - [auth-data-phone](auth-data-phone.md): implementation for Mobile apps for some of the
   authentication methods provided by the `auth-data` library.
 
-- The following sample apps are also provided:
+The following sample apps are also provided:
+
 - [auth-sample-wear](auth-sample-apps.md#wear-sample): sample wear app to authenticate using
   different methods.
 - [auth-sample-phone](auth-sample-apps.md#phone-sample): sample mobile app to authenticate using

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ repo_url: 'https://github.com/google/horologist'
 # Navigation
 nav:
   - 'Overview': index.md
+  - 'API': api/
   - 'Auth':
       - 'Overview': auth-overview.md
       - 'Sample apps': auth-sample-apps.md


### PR DESCRIPTION
#### WHAT

Improve auth docs.

#### HOW

- Include link to [API](https://google.github.io/horologist/api/) to [docs](https://google.github.io/horologist/);
- Change dokka configuration to ignore `debug` folders to avoid documenting composable previews;
- Change dokka configuration to add path to other samples;
- Improve kdocs to add references to sample usages of the classes;


#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
