### PR TITLE
Enable  to take in progressColour

### DIFF
--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -102,7 +102,7 @@ package com.google.android.horologist.media.ui.components.animated {
   }
 
   public final class AnimatedMediaControlButtonsKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void AnimatedMediaControlButtons(kotlin.jvm.functions.Function0<kotlin.Unit> onPlayButtonClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPauseButtonClick, boolean playPauseButtonEnabled, boolean playing, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekToPreviousButtonClick, boolean seekToPreviousButtonEnabled, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekToNextButtonClick, boolean seekToNextButtonEnabled, optional androidx.compose.ui.Modifier modifier, com.google.android.horologist.media.ui.state.model.TrackPositionUiModel trackPositionUiModel, optional androidx.wear.compose.material.ButtonColors colors);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi public static void AnimatedMediaControlButtons(kotlin.jvm.functions.Function0<kotlin.Unit> onPlayButtonClick, kotlin.jvm.functions.Function0<kotlin.Unit> onPauseButtonClick, boolean playPauseButtonEnabled, boolean playing, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekToPreviousButtonClick, boolean seekToPreviousButtonEnabled, kotlin.jvm.functions.Function0<kotlin.Unit> onSeekToNextButtonClick, boolean seekToNextButtonEnabled, optional androidx.compose.ui.Modifier modifier, com.google.android.horologist.media.ui.state.model.TrackPositionUiModel trackPositionUiModel, optional long progressColour, optional androidx.wear.compose.material.ButtonColors colors);
   }
 
   public final class AnimatedMediaInfoDisplayKt {

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/animated/AnimatedMediaControlButtons.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/animated/AnimatedMediaControlButtons.kt
@@ -19,8 +19,10 @@ package com.google.android.horologist.media.ui.components.animated
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.wear.compose.material.ButtonColors
 import androidx.wear.compose.material.ButtonDefaults
+import androidx.wear.compose.material.MaterialTheme
 import com.google.android.horologist.media.ui.ExperimentalHorologistMediaUiApi
 import com.google.android.horologist.media.ui.components.ControlButtonLayout
 import com.google.android.horologist.media.ui.components.PlayPauseProgressButton
@@ -46,6 +48,7 @@ public fun AnimatedMediaControlButtons(
     seekToNextButtonEnabled: Boolean,
     modifier: Modifier = Modifier,
     trackPositionUiModel: TrackPositionUiModel,
+    progressColour: Color = MaterialTheme.colors.primary,
     colors: ButtonColors = MediaButtonDefaults.mediaButtonDefaultColors
 ) {
     ControlButtonLayout(
@@ -66,7 +69,8 @@ public fun AnimatedMediaControlButtons(
                     playing = playing,
                     trackPositionUiModel = trackPositionUiModel,
                     modifier = Modifier.size(ButtonDefaults.LargeButtonSize),
-                    colors = colors
+                    colors = colors,
+                    progressColour = progressColour
                 )
             } else {
                 AnimatedPlayPauseButton(


### PR DESCRIPTION
#### WHAT
Enable `AnimatedMediaControlButtons` to take in progressColour and default it to the `MaterialTheme.colors.primary` to be consistent with the original behaviour. 

#### WHY
This allows whoever calls to create `AnimatedMediaControlButtons` to be able to set the progress colour as they need.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
