### PR TITLE
Refactor rememberActiveFocusRequester

### DIFF
--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeScreen.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeScreen.kt
@@ -28,13 +28,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.wear.compose.foundation.rememberActiveFocusRequester
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.InlineSlider
 import androidx.wear.compose.material.MaterialTheme
@@ -72,11 +69,9 @@ public fun VolumeScreen(
 ) {
     val volumeState by volumeViewModel.volumeState.collectAsState()
     val audioOutput by volumeViewModel.audioOutput.collectAsState()
-    val focusRequester: FocusRequester = rememberActiveFocusRequester()
 
     VolumeScreen(
         modifier = modifier.onRotaryInputAccumulatedWithFocus(
-            focusRequester = focusRequester,
             onValueChange = volumeViewModel::onVolumeChangeByScroll
         ),
         volume = { volumeState },

--- a/compose-layout/api/current.api
+++ b/compose-layout/api/current.api
@@ -280,7 +280,7 @@ package com.google.android.horologist.compose.rotaryinput {
 
   public final class AccumulatedRotaryInputModifierKt {
     method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public static androidx.compose.ui.Modifier onRotaryInputAccumulated(androidx.compose.ui.Modifier, optional long eventAccumulationThresholdMs, optional float minValueChangeDistancePx, optional long rateLimitCoolDownMs, kotlin.jvm.functions.Function1<? super java.lang.Float,kotlin.Unit> onValueChange);
-    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public static androidx.compose.ui.Modifier onRotaryInputAccumulatedWithFocus(androidx.compose.ui.Modifier, androidx.compose.ui.focus.FocusRequester focusRequester, kotlin.jvm.functions.Function1<? super java.lang.Float,kotlin.Unit> onValueChange);
+    method @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public static androidx.compose.ui.Modifier onRotaryInputAccumulatedWithFocus(androidx.compose.ui.Modifier, optional androidx.compose.ui.focus.FocusRequester? focusRequester, kotlin.jvm.functions.Function1<? super java.lang.Float,kotlin.Unit> onValueChange);
   }
 
   @com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi public final class AnimationScrollBehavior implements com.google.android.horologist.compose.rotaryinput.RotaryScrollBehavior {

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/AccumulatedRotaryInputModifier.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/AccumulatedRotaryInputModifier.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.rotary.RotaryScrollEvent
 import androidx.compose.ui.input.rotary.onRotaryScrollEvent
-import androidx.wear.compose.foundation.RequestFocusWhenActive
+import androidx.wear.compose.foundation.rememberActiveFocusRequester
 import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 
 /**
@@ -36,12 +36,12 @@ import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistC
  */
 @ExperimentalHorologistComposeLayoutApi
 public fun Modifier.onRotaryInputAccumulatedWithFocus(
-    focusRequester: FocusRequester,
+    focusRequester: FocusRequester? = null,
     onValueChange: (Float) -> Unit
 ): Modifier = composed {
-    RequestFocusWhenActive(focusRequester)
+    val localFocusRequester = focusRequester ?: rememberActiveFocusRequester()
     onRotaryInputAccumulated(onValueChange = onValueChange)
-        .focusRequester(focusRequester)
+        .focusRequester(localFocusRequester)
         .focusable()
 }
 

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/RotaryInputAccumulator.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/RotaryInputAccumulator.kt
@@ -16,7 +16,6 @@
 
 package com.google.android.horologist.compose.rotaryinput
 
-import android.util.Log
 import kotlin.math.abs
 
 /** Accumulator to trigger callbacks based on rotary input event. */
@@ -48,7 +47,6 @@ internal class RotaryInputAccumulator(
     }
 
     private fun onEventAccumulated(eventTimeMs: Long) {
-        Log.d("Volume_Test", "lastUpdateTimeMs=$lastUpdateTimeMs")
         if (abs(accumulatedDistance) < minValueChangeDistancePx ||
             eventTimeMs - lastUpdateTimeMs < rateLimitCoolDownMs
         ) {

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/RotaryInputAccumulator.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/RotaryInputAccumulator.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.horologist.compose.rotaryinput
 
+import android.util.Log
 import kotlin.math.abs
 
 /** Accumulator to trigger callbacks based on rotary input event. */
@@ -47,6 +48,7 @@ internal class RotaryInputAccumulator(
     }
 
     private fun onEventAccumulated(eventTimeMs: Long) {
+        Log.d("Volume_Test", "lastUpdateTimeMs=$lastUpdateTimeMs")
         if (abs(accumulatedDistance) < minValueChangeDistancePx ||
             eventTimeMs - lastUpdateTimeMs < rateLimitCoolDownMs
         ) {


### PR DESCRIPTION
#### WHAT
Set mark focusRequester not required and set it to rememberActiveFocusRequester if not set

#### WHY


#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
