### PR TITLE
TimePicker double tap on minute column fix

### DIFF
--- a/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
@@ -242,7 +242,10 @@ public fun TimePicker(
                         focusRequester = focusRequesterMinutes,
                         modifier = Modifier.size(40.dp, 100.dp),
                         onSelected = {
-                            doubleTapToNext(FocusableElement.MINUTES, FocusableElement.SECONDS)
+                            doubleTapToNext(
+                                FocusableElement.MINUTES,
+                                if (showSeconds) FocusableElement.SECONDS else FocusableElement.CONFIRM_BUTTON
+                            )
                         },
                         contentDescription = minuteContentDescription,
                         userScrollEnabled = !talkbackEnabled ||
@@ -251,7 +254,10 @@ public fun TimePicker(
                         TimePiece(
                             selected = focusedElement == FocusableElement.MINUTES,
                             onSelected = {
-                                doubleTapToNext(FocusableElement.MINUTES, FocusableElement.SECONDS)
+                                doubleTapToNext(
+                                    FocusableElement.MINUTES,
+                                    if (showSeconds) FocusableElement.SECONDS else FocusableElement.CONFIRM_BUTTON
+                                )
                             },
                             text = "%02d".format(minute),
                             style = textStyle,


### PR DESCRIPTION
#### WHAT
Double tap on minute column of TimePicker lep to app crash when Talkback is On.

#### WHY
When seconds column is missing, after double tapping on the minutes' column, focus was still requested on seconds' column.

#### HOW
Added condition in double tap when showSeconds is false.
