### PR TITLE
Updates docs menu

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
       - 'Guide': compose-layout.md
   - 'Data Layer':
       - 'Guide': datalayer.md
+      - 'App Helpers': datalayer-helpers-guide.md
   - 'Media':
       - 'Overview': media-toolkit.md
       - 'Simple app guide': simple-media-app-guide.md


### PR DESCRIPTION
#### WHAT

DataLayer app helpers was missing from the docs menu. Added it.

#### WHY

To make documentation discoverable

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
