### PR TITLE
Typo in docs breaks formatting

### DIFF
--- a/docs/datalayer-helpers-guide.md
+++ b/docs/datalayer-helpers-guide.md
@@ -62,9 +62,8 @@ phone.
     on the phone when the watch is connected.
 
     ```kotlin
-    val nodes by appHelper.connectedAndInstalledNodes
-        .collectAsStateWithLifecycle()
-    ````
+    val nodes by appHelper.connectedAndInstalledNodes.collectAsStateWithLifecycle()
+    ```
 
 1.  **Installing the app on the other device**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
       - 'Guide': compose-layout.md
   - 'Data Layer':
       - 'Guide': datalayer.md
+      - 'App Helpers': datalayer-helpers-guide.md
   - 'Media':
       - 'Overview': media-toolkit.md
       - 'Simple app guide': simple-media-app-guide.md


### PR DESCRIPTION
#### WHAT

Typo breaks formatting

#### WHY


#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
