### PR TITLE
Revert SystemOutputSwitcherDialogController.showDialog 

### DIFF
--- a/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/FakeAudioOutputRepository.kt
+++ b/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/FakeAudioOutputRepository.kt
@@ -18,18 +18,12 @@ package com.google.android.horologist.audio.ui
 
 import com.google.android.horologist.audio.AudioOutput
 import com.google.android.horologist.audio.AudioOutputRepository
-import com.google.android.horologist.audio.ExperimentalHorologistAudioApi
 import kotlinx.coroutines.flow.MutableStateFlow
-@OptIn(ExperimentalHorologistAudioApi::class)
 class FakeAudioOutputRepository : AudioOutputRepository {
     override val audioOutput: MutableStateFlow<AudioOutput> = MutableStateFlow(AudioOutput.None)
     override val available: MutableStateFlow<List<AudioOutput>> = MutableStateFlow(listOf())
 
-    @Suppress("OVERRIDE_DEPRECATION")
     override fun launchOutputSelection(closeOnConnect: Boolean) {
-    }
-
-    override fun launchOutputSelection() {
     }
 
     override fun close() {

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeViewModel.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeViewModel.kt
@@ -73,7 +73,7 @@ public open class VolumeViewModel(
     }
 
     public fun launchOutputSelection() {
-        audioOutputRepository.launchOutputSelection()
+        audioOutputRepository.launchOutputSelection(closeOnConnect = false)
     }
 
     override fun onCleared() {

--- a/audio/api/current.api
+++ b/audio/api/current.api
@@ -80,15 +80,14 @@ package com.google.android.horologist.audio {
   public interface AudioOutputRepository extends java.lang.AutoCloseable {
     method public kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.AudioOutput> getAudioOutput();
     method public kotlinx.coroutines.flow.StateFlow<java.util.List<com.google.android.horologist.audio.AudioOutput>> getAvailable();
-    method @Deprecated public void launchOutputSelection(boolean closeOnConnect);
-    method public void launchOutputSelection();
+    method public void launchOutputSelection(boolean closeOnConnect);
     property public abstract kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.AudioOutput> audioOutput;
     property public abstract kotlinx.coroutines.flow.StateFlow<java.util.List<com.google.android.horologist.audio.AudioOutput>> available;
   }
 
-  @Deprecated public final class BluetoothSettings {
-    method @Deprecated public void launchBluetoothSettings(android.content.Context, optional boolean closeOnConnect);
-    field @Deprecated public static final com.google.android.horologist.audio.BluetoothSettings INSTANCE;
+  public final class BluetoothSettings {
+    method public void launchBluetoothSettings(android.content.Context, optional boolean closeOnConnect);
+    field public static final com.google.android.horologist.audio.BluetoothSettings INSTANCE;
   }
 
   @kotlin.RequiresOptIn(message="Horologist Audio is experimental. The API may be changed in the future.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.BINARY) public @interface ExperimentalHorologistAudioApi {
@@ -103,7 +102,6 @@ package com.google.android.horologist.audio {
     method public kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.VolumeState> getVolumeState();
     method public void increaseVolume();
     method public void launchOutputSelection(boolean closeOnConnect);
-    method public void launchOutputSelection();
     property public kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.AudioOutput> audioOutput;
     property public kotlinx.coroutines.flow.StateFlow<java.util.List<com.google.android.horologist.audio.AudioOutput>> available;
     property public kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.VolumeState> volumeState;

--- a/audio/src/main/java/com/google/android/horologist/audio/AudioOutputRepository.kt
+++ b/audio/src/main/java/com/google/android/horologist/audio/AudioOutputRepository.kt
@@ -35,14 +35,5 @@ public interface AudioOutputRepository : AutoCloseable {
     /**
      * Action to launch output selection by the user.
      */
-    @Deprecated(
-        "closeOnConnect is always true, use #launchOutputSelection() instead",
-        ReplaceWith("launchOutputSelection()")
-    )
     public fun launchOutputSelection(closeOnConnect: Boolean)
-
-    /**
-     * Action to launch output selection by the user.
-     */
-    public fun launchOutputSelection()
 }

--- a/audio/src/main/java/com/google/android/horologist/audio/BluetoothSettings.kt
+++ b/audio/src/main/java/com/google/android/horologist/audio/BluetoothSettings.kt
@@ -17,7 +17,8 @@
 package com.google.android.horologist.audio
 
 import android.content.Context
-import androidx.mediarouter.app.SystemOutputSwitcherDialogController
+import android.content.Intent
+import android.provider.Settings
 
 /**
  * Support for launching the user directly into the bluetooth settings page in order to connect
@@ -25,13 +26,21 @@ import androidx.mediarouter.app.SystemOutputSwitcherDialogController
  *
  * https://developer.android.com/training/wearables/overlays/audio?hl=ca
  */
-@Deprecated(message = "Use https://developer.android.com/reference/androidx/mediarouter/app/SystemOutputSwitcherDialogController instead")
 public object BluetoothSettings {
     /**
      * Open the bluetooth settings activity and optionally close after connection established.
      */
-    @Suppress("UNUSED_PARAMETER")
     public fun Context.launchBluetoothSettings(closeOnConnect: Boolean = true) {
-        SystemOutputSwitcherDialogController.showDialog(this)
+        val intent = with(Intent(Settings.ACTION_BLUETOOTH_SETTINGS)) {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            putExtra("EXTRA_CONNECTION_ONLY", true)
+            if (closeOnConnect) {
+                putExtra("EXTRA_CLOSE_ON_CONNECT", true)
+            }
+            putExtra("android.bluetooth.devicepicker.extra.FILTER_TYPE", FILTER_TYPE_AUDIO)
+        }
+        startActivity(intent)
     }
+
+    internal const val FILTER_TYPE_AUDIO = 1
 }

--- a/audio/src/main/java/com/google/android/horologist/audio/SystemAudioRepository.kt
+++ b/audio/src/main/java/com/google/android/horologist/audio/SystemAudioRepository.kt
@@ -17,11 +17,11 @@
 package com.google.android.horologist.audio
 
 import android.content.Context
-import androidx.mediarouter.app.SystemOutputSwitcherDialogController
 import androidx.mediarouter.media.MediaControlIntent
 import androidx.mediarouter.media.MediaRouteSelector
 import androidx.mediarouter.media.MediaRouter
 import androidx.mediarouter.media.MediaRouter.RouteInfo
+import com.google.android.horologist.audio.BluetoothSettings.launchBluetoothSettings
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -96,13 +96,8 @@ public class SystemAudioRepository(
         _available.value = listOf()
     }
 
-    @Suppress("OVERRIDE_DEPRECATION")
     override fun launchOutputSelection(closeOnConnect: Boolean) {
-        launchOutputSelection()
-    }
-
-    override fun launchOutputSelection() {
-        SystemOutputSwitcherDialogController.showDialog(application)
+        application.launchBluetoothSettings(closeOnConnect)
     }
 
     public companion object {

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/test/FakeAudioOutputRepository.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/test/FakeAudioOutputRepository.kt
@@ -25,11 +25,7 @@ class FakeAudioOutputRepository : AudioOutputRepository {
     override val audioOutput: MutableStateFlow<AudioOutput> = MutableStateFlow(AudioOutput.None)
     override val available: MutableStateFlow<List<AudioOutput>> = MutableStateFlow(listOf())
 
-    @Suppress("OVERRIDE_DEPRECATION")
     override fun launchOutputSelection(closeOnConnect: Boolean) {
-    }
-
-    override fun launchOutputSelection() {
     }
 
     override fun close() {

--- a/media3-backend/src/main/java/com/google/android/horologist/media3/audio/BluetoothSettingsOutputSelector.kt
+++ b/media3-backend/src/main/java/com/google/android/horologist/media3/audio/BluetoothSettingsOutputSelector.kt
@@ -32,7 +32,7 @@ public class BluetoothSettingsOutputSelector(
     private val audioOutputRepository: AudioOutputRepository
 ) : AudioOutputSelector {
     override suspend fun selectNewOutput(currentAudioOutput: AudioOutput): AudioOutput? {
-        audioOutputRepository.launchOutputSelection()
+        audioOutputRepository.launchOutputSelection(true)
 
         val newAudioOutput = withTimeoutOrNull(15000) {
             audioOutputRepository.audioOutput.filter {
@@ -44,6 +44,6 @@ public class BluetoothSettingsOutputSelector(
     }
 
     override fun launchSelector() {
-        audioOutputRepository.launchOutputSelection()
+        audioOutputRepository.launchOutputSelection(false)
     }
 }

--- a/media3-backend/src/test/java/com/google/android/horologist/media3/FakeAudioOutputRepository.kt
+++ b/media3-backend/src/test/java/com/google/android/horologist/media3/FakeAudioOutputRepository.kt
@@ -25,11 +25,7 @@ open class FakeAudioOutputRepository : AudioOutputRepository {
     override val audioOutput: MutableStateFlow<AudioOutput> = MutableStateFlow(AudioOutput.None)
     override val available: MutableStateFlow<List<AudioOutput>> = MutableStateFlow(listOf())
 
-    @Suppress("OVERRIDE_DEPRECATION")
     override fun launchOutputSelection(closeOnConnect: Boolean) {
-    }
-
-    override fun launchOutputSelection() {
     }
 
     override fun close() {


### PR DESCRIPTION
#### WHAT
This reverts calling SystemOutputSwitcherDialogController.showDialog to open the bt settings fragment.

#### WHY
The API does not autoclose after selection.

#### HOW
Revert the commit and use the old invocation of OutputSwitcher

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
