### PR TITLE
Datalayer complications

### DIFF
--- a/datalayer-watch/api/current.api
+++ b/datalayer-watch/api/current.api
@@ -4,6 +4,8 @@ package com.google.android.horologist.datalayer.watch {
   @com.google.android.horologist.data.ExperimentalHorologistDataLayerApi public final class WearDataLayerAppHelper extends com.google.android.horologist.data.DataLayerAppHelper {
     ctor public WearDataLayerAppHelper(android.content.Context context, optional String? appStoreUri);
     method public suspend Object? installOnNode(String node, kotlin.coroutines.Continuation<? super kotlin.Unit>);
+    method public suspend Object? markComplicationAsInstalled(String complicationName, kotlin.coroutines.Continuation<? super kotlin.Unit>);
+    method public suspend Object? markComplicationAsRemoved(String complicationName, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? markTileAsInstalled(String tileName, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? markTileAsRemoved(String tileName, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? startCompanion(String node, kotlin.coroutines.Continuation<? super com.google.android.horologist.data.AppHelperResultCode>);

--- a/datalayer-watch/api/current.api
+++ b/datalayer-watch/api/current.api
@@ -4,8 +4,8 @@ package com.google.android.horologist.datalayer.watch {
   @com.google.android.horologist.data.ExperimentalHorologistDataLayerApi public final class WearDataLayerAppHelper extends com.google.android.horologist.data.DataLayerAppHelper {
     ctor public WearDataLayerAppHelper(android.content.Context context, optional String? appStoreUri);
     method public suspend Object? installOnNode(String node, kotlin.coroutines.Continuation<? super kotlin.Unit>);
-    method public suspend Object? markComplicationAsInstalled(String complicationName, kotlin.coroutines.Continuation<? super kotlin.Unit>);
-    method public suspend Object? markComplicationAsRemoved(String complicationName, kotlin.coroutines.Continuation<? super kotlin.Unit>);
+    method public suspend Object? markComplicationAsActivated(String complicationName, kotlin.coroutines.Continuation<? super kotlin.Unit>);
+    method public suspend Object? markComplicationAsDeactivated(String complicationName, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? markTileAsInstalled(String tileName, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? markTileAsRemoved(String tileName, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? startCompanion(String node, kotlin.coroutines.Continuation<? super com.google.android.horologist.data.AppHelperResultCode>);

--- a/datalayer-watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
+++ b/datalayer-watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
@@ -83,22 +83,22 @@ public class WearDataLayerAppHelper(context: Context, private val appStoreUri: S
     public suspend fun markTileAsRemoved(tileName: String): Unit = markSurfaceAsRemoved(tilePrefix, tileName)
 
     /**
-     * Marks a complication as installed. Call this in
+     * Marks a complication as active on the current watch face. Call this in
      * [ComplicationDataSourceService#onComplicationActivated]. Supplying a name is mandatory to
      * disambiguate from the installation or removal of other complications your app may have.
      *
      * @param complicationName The name of the complication.
      */
-    public suspend fun markComplicationAsInstalled(complicationName: String): Unit = markSurfaceAsInstalled(complicationPrefix, complicationName)
+    public suspend fun markComplicationAsActivated(complicationName: String): Unit = markSurfaceAsInstalled(complicationPrefix, complicationName)
 
     /**
-     * Marks a complication as removed. Call this in
+     * Marks a complication as deactivated. Call this in
      * [ComplicationDataSourceService#onComplicationDeactivated]. Supplying a name is mandatory to
      * disambiguate from the installation or removal of other complications your app may have.
      *
      * @param complicationName The name of the complication.
      */
-    public suspend fun markComplicationAsRemoved(complicationName: String): Unit = markSurfaceAsRemoved(complicationPrefix, complicationName)
+    public suspend fun markComplicationAsDeactivated(complicationName: String): Unit = markSurfaceAsRemoved(complicationPrefix, complicationName)
 
     private suspend fun markSurfaceAsInstalled(surfacePrefix: String, name: String) {
         require(name.isNotEmpty())

--- a/datalayer-watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
+++ b/datalayer-watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
@@ -72,16 +72,7 @@ public class WearDataLayerAppHelper(context: Context, private val appStoreUri: S
      *
      * @param tileName The name of the tile.
      */
-    public suspend fun markTileAsInstalled(tileName: String) {
-        require(tileName.isNotEmpty())
-        try {
-            capabilityClient.addLocalCapability("$tilePrefix$tileName").await()
-        } catch (e: ApiException) {
-            if (e.statusCode != WearableStatusCodes.DUPLICATE_CAPABILITY) {
-                throw e
-            }
-        }
-    }
+    public suspend fun markTileAsInstalled(tileName: String): Unit = markSurfaceAsInstalled(tilePrefix, tileName)
 
     /**
      * Marks a tile as removed. Call this in [TileService#onTileRemoveEvent]. Supplying a name is
@@ -89,8 +80,39 @@ public class WearDataLayerAppHelper(context: Context, private val appStoreUri: S
      *
      * @param tileName The name of the tile.
      */
-    public suspend fun markTileAsRemoved(tileName: String) {
-        require(tileName.isNotEmpty())
-        capabilityClient.removeLocalCapability("$tilePrefix$tileName").await()
+    public suspend fun markTileAsRemoved(tileName: String): Unit = markSurfaceAsRemoved(tilePrefix, tileName)
+
+    /**
+     * Marks a complication as installed. Call this in
+     * [ComplicationDataSourceService#onComplicationActivated]. Supplying a name is mandatory to
+     * disambiguate from the installation or removal of other complications your app may have.
+     *
+     * @param complicationName The name of the complication.
+     */
+    public suspend fun markComplicationAsInstalled(complicationName: String): Unit = markSurfaceAsInstalled(complicationPrefix, complicationName)
+
+    /**
+     * Marks a complication as removed. Call this in
+     * [ComplicationDataSourceService#onComplicationDeactivated]. Supplying a name is mandatory to
+     * disambiguate from the installation or removal of other complications your app may have.
+     *
+     * @param complicationName The name of the complication.
+     */
+    public suspend fun markComplicationAsRemoved(complicationName: String): Unit = markSurfaceAsRemoved(complicationPrefix, complicationName)
+
+    private suspend fun markSurfaceAsInstalled(surfacePrefix: String, name: String) {
+        require(name.isNotEmpty())
+        try {
+            capabilityClient.addLocalCapability("$surfacePrefix$name").await()
+        } catch (e: ApiException) {
+            if (e.statusCode != WearableStatusCodes.DUPLICATE_CAPABILITY) {
+                throw e
+            }
+        }
+    }
+
+    private suspend fun markSurfaceAsRemoved(surfacePrefix: String, name: String) {
+        require(name.isNotEmpty())
+        capabilityClient.removeLocalCapability("$surfacePrefix$name").await()
     }
 }

--- a/datalayer-watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
+++ b/datalayer-watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
@@ -19,6 +19,7 @@ package com.google.android.horologist.datalayer.watch
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.util.Log
 import androidx.wear.phone.interactions.PhoneTypeHelper
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.wearable.WearableStatusCodes
@@ -26,6 +27,7 @@ import com.google.android.horologist.data.AppHelperResult
 import com.google.android.horologist.data.AppHelperResultCode
 import com.google.android.horologist.data.DataLayerAppHelper
 import com.google.android.horologist.data.ExperimentalHorologistDataLayerApi
+import com.google.android.horologist.data.TAG
 import com.google.android.horologist.data.companionConfig
 import com.google.android.horologist.data.launchRequest
 import kotlinx.coroutines.guava.await
@@ -113,6 +115,13 @@ public class WearDataLayerAppHelper(context: Context, private val appStoreUri: S
 
     private suspend fun markSurfaceAsRemoved(surfacePrefix: String, name: String) {
         require(name.isNotEmpty())
-        capabilityClient.removeLocalCapability("$surfacePrefix$name").await()
+        try {
+            capabilityClient.removeLocalCapability("$surfacePrefix$name").await()
+        } catch (e: ApiException) {
+            if (e.statusCode != WearableStatusCodes.UNKNOWN_CAPABILITY) {
+                throw e
+            }
+            Log.w(TAG, "Unknown capability: $surfacePrefix$name")
+        }
     }
 }

--- a/datalayer/src/main/java/com/google/android/horologist/data/AppHelperNodeStatus.kt
+++ b/datalayer/src/main/java/com/google/android/horologist/data/AppHelperNodeStatus.kt
@@ -25,7 +25,8 @@ public data class AppHelperNodeStatus(
     val displayName: String,
     val isAppInstalled: Boolean,
     val nodeType: AppHelperNodeType,
-    val installedTiles: Set<String> = setOf()
+    val installedTiles: Set<String> = setOf(),
+    val installedComplications: Set<String> = setOf()
 )
 
 public enum class AppHelperNodeType {

--- a/docs/datalayer-helpers-guide.md
+++ b/docs/datalayer-helpers-guide.md
@@ -130,16 +130,16 @@ phone.
 
 1.  **Tracking Complication installation** (Wear-only)
 
-    To determine whether your Complication(s) are installed, add the following to your `ComplicationDataSourceService`:
+    To determine whether your Complication(s) are in-use, add the following to your `ComplicationDataSourceService`:
 
     In `onComplicationActivated`:
 
     ```kotlin
-    wearAppHelper.markComplicationAsInstalled("GoalsComplication")
+    wearAppHelper.markComplicationAsActivated("GoalsComplication")
     ```
 
     In `onComplicationDeactivated`:
 
     ```kotlin
-    wearAppHelper.markComplicationAsRemoved("GoalsComplication")
+    wearAppHelper.markComplicationAsDeactivated("GoalsComplication")
     ```

--- a/docs/datalayer-helpers-guide.md
+++ b/docs/datalayer-helpers-guide.md
@@ -51,6 +51,7 @@ phone.
         id=1e56d2,
         displayName=Pixel Watch,
         isAppInstalled=true,
+        installedComplications=[GoalsComplication],
         installedTiles=[SummaryTile]
     )
     ```
@@ -125,4 +126,20 @@ phone.
 
     ```kotlin
     wearAppHelper.markTileAsRemoved("SummaryTile")
+    ```
+
+1.  **Tracking Complication installation** (Wear-only)
+
+    To determine whether your Complication(s) are installed, add the following to your `ComplicationDataSourceService`:
+
+    In `onComplicationActivated`:
+
+    ```kotlin
+    wearAppHelper.markComplicationAsInstalled("GoalsComplication")
+    ```
+
+    In `onComplicationDeactivated`:
+
+    ```kotlin
+    wearAppHelper.markComplicationAsRemoved("GoalsComplication")
     ```


### PR DESCRIPTION
#### WHAT

Adds Complication activation/deactivation status to the App Helper

#### WHY

Aids apps in determining whether their Wear app has one of its Complications added to the current watch face.

#### HOW

Provides a set of `installedComplications` in `AppHelperNodeStatus` and guidance on adding necessary hooks to `ComplicationDataSourceService`.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
