### PR TITLE
Update actions/setup-python

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -38,7 +38,7 @@ jobs:
           key: gradle-${{ hashFiles('checksum.txt') }}
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 


### PR DESCRIPTION
#### WHAT

Update version of `actions/setup-python`.

#### WHY

Address warnings:

```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/setup-python@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [N/A] Run tests
- [N/A] Update metalava's signature text files
