### PR TITLE
Increase size of metaspace

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ android.useAndroidX=true
 android.disableAutomaticComponentCreation=true
 
 # Increase memory
-org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=2596m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=3072m -XX:+HeapDumpOnOutOfMemoryError
 
 # Required to publish to Nexus (see https://github.com/gradle/gradle/issues/11308)
 systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
#### WHAT

Increase size of metaspace

#### WHY

https://github.com/google/horologist/issues/984#issuecomment-1450079838

Publish docs action keeps failing with:

```
> Task :tiles:dokkaHtmlPartial FAILED

> Task :network-awareness:dokkaHtmlPartial FAILED

347 actionable tasks: 80 executed, 267 from cache
Could not stop ProjectScopeServices.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.
java.lang.OutOfMemoryError: Metaspace

FAILURE: Build failed with an exception.

* What went wrong:
Metaspace

* Exception is:
java.lang.OutOfMemoryError: Metaspace
```

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [N/A] Run tests
- [N/A] Update metalava's signature text files
