### PR TITLE
Remove unused dependency from datalayer

### DIFF
--- a/datalayer/build.gradle.kts
+++ b/datalayer/build.gradle.kts
@@ -29,7 +29,7 @@ android {
     compileSdkPreview = "UpsideDownCake"
 
     defaultConfig {
-        minSdk = 25
+        minSdk = 23
         //noinspection ExpiredTargetSdkVersion
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -109,7 +109,6 @@ dependencies {
     api(libs.protobuf.kotlin.lite)
     implementation(libs.androidx.lifecycle.runtime)
     implementation(libs.androidx.wear.remote.interactions)
-    implementation(libs.androidx.wear.phone.interactions)
 
     testImplementation(libs.junit)
     testImplementation(libs.truth)


### PR DESCRIPTION
#### WHAT

1) Remove `wear-phone-interactions` dependency from `datalayer` module.

2) Decrease minSdk to 23 

#### WHY

1) Doesn't seem to be in use.

2) It is the minSdk of `androidx.wear:wear-remote-interactions:1.0.0`.

Partially addresses https://github.com/google/horologist/pull/1032#discussion_r1115715339


#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
