### PR TITLE
Remove unnecessary dependency from datalayer-phone module

### DIFF
--- a/auth-data-phone/build.gradle.kts
+++ b/auth-data-phone/build.gradle.kts
@@ -27,7 +27,7 @@ android {
     compileSdkPreview = "UpsideDownCake"
 
     defaultConfig {
-        minSdk = 26
+        minSdk = 23
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/auth-sample-phone/build.gradle.kts
+++ b/auth-sample-phone/build.gradle.kts
@@ -27,7 +27,7 @@ android {
     defaultConfig {
         applicationId = "com.google.android.horologist.auth.sample"
 
-        minSdk = 30
+        minSdk = 23
         targetSdk = 33
 
         versionCode = 1

--- a/auth-sample-shared/build.gradle.kts
+++ b/auth-sample-shared/build.gradle.kts
@@ -29,7 +29,7 @@ android {
     compileSdkPreview = "UpsideDownCake"
 
     defaultConfig {
-        minSdk = 26
+        minSdk = 21
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/datalayer-phone/build.gradle.kts
+++ b/datalayer-phone/build.gradle.kts
@@ -27,7 +27,7 @@ android {
     compileSdkPreview = "UpsideDownCake"
 
     defaultConfig {
-        minSdk = 26
+        minSdk = 23
     }
 
     compileOptions {
@@ -94,7 +94,6 @@ dependencies {
     implementation(libs.kotlinx.coroutines.playservices)
     implementation(libs.androidx.lifecycle.runtime)
     implementation(libs.androidx.wear.remote.interactions)
-    implementation(libs.androidx.wear.phone.interactions)
 }
 
 apply(plugin = "com.vanniktech.maven.publish")


### PR DESCRIPTION
#### WHAT

1) Remove `wear-phone-interactions` dependency from `datalayer-phone` module.

2) Decrease minSdk to 23.

#### WHY

1) Doesn't seem to be in use.

2) It is the minSdk of `androidx.wear:wear-remote-interactions:1.0.0`.


#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
