### PR TITLE
Improve TokenBundleRepositoryImpl to check if API is available

### DIFF
--- a/auth-data-phone/api/current.api
+++ b/auth-data-phone/api/current.api
@@ -16,6 +16,7 @@ package com.google.android.horologist.auth.data.phone.common {
 package com.google.android.horologist.auth.data.phone.tokenshare {
 
   @com.google.android.horologist.auth.data.phone.ExperimentalHorologistAuthDataPhoneApi public interface TokenBundleRepository<T> {
+    method public suspend Object? isAvailable(kotlin.coroutines.Continuation<? super java.lang.Boolean>);
     method public suspend Object? update(T? tokenBundle, kotlin.coroutines.Continuation<? super kotlin.Unit>);
   }
 
@@ -24,13 +25,13 @@ package com.google.android.horologist.auth.data.phone.tokenshare {
 package com.google.android.horologist.auth.data.phone.tokenshare.impl {
 
   @com.google.android.horologist.auth.data.phone.ExperimentalHorologistAuthDataPhoneApi public final class TokenBundleRepositoryImpl<T> implements com.google.android.horologist.auth.data.phone.tokenshare.TokenBundleRepository<T> {
-    ctor public TokenBundleRepositoryImpl(androidx.datastore.core.DataStore<T> dataStore);
+    ctor public TokenBundleRepositoryImpl(com.google.android.horologist.data.WearDataLayerRegistry registry, optional String key, kotlinx.coroutines.CoroutineScope coroutineScope, androidx.datastore.core.Serializer<T> serializer);
+    method public suspend Object? isAvailable(kotlin.coroutines.Continuation<? super java.lang.Boolean>);
     method public suspend Object? update(T? tokenBundle, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     field public static final com.google.android.horologist.auth.data.phone.tokenshare.impl.TokenBundleRepositoryImpl.Companion Companion;
   }
 
   public static final class TokenBundleRepositoryImpl.Companion {
-    method public <T> com.google.android.horologist.auth.data.phone.tokenshare.impl.TokenBundleRepositoryImpl<T> create(com.google.android.horologist.data.WearDataLayerRegistry registry, optional String key, kotlinx.coroutines.CoroutineScope coroutineScope, androidx.datastore.core.Serializer<T> serializer);
   }
 
 }

--- a/auth-data-phone/src/main/java/com/google/android/horologist/auth/data/phone/tokenshare/TokenBundleRepository.kt
+++ b/auth-data-phone/src/main/java/com/google/android/horologist/auth/data/phone/tokenshare/TokenBundleRepository.kt
@@ -27,4 +27,9 @@ import com.google.android.horologist.auth.data.phone.ExperimentalHorologistAuthD
 public interface TokenBundleRepository<T> {
 
     public suspend fun update(tokenBundle: T)
+
+    /**
+     * Check if this repository is available to be used on this device.
+     */
+    public suspend fun isAvailable(): Boolean
 }

--- a/auth-sample-phone/src/main/res/values/strings.xml
+++ b/auth-sample-phone/src/main/res/values/strings.xml
@@ -18,4 +18,5 @@
     <string name="app_name">Horologist Auth Sample</string>
     <string name="token_share_button_update_token_default">Update token - default key</string>
     <string name="token_share_button_update_token_custom">Update token - custom key</string>
+    <string name="token_share_message_api_unavailable">This device does not have capability to communicate to Wearable Data Layer API</string>
 </resources>


### PR DESCRIPTION
#### WHAT

Improve `TokenBundleRepositoryImpl` to check if DataClient API is available.

#### WHY

In order to handle the following exception when device doesn't have the API available:
```
com.google.android.gms.common.api.ApiException: 17: API: Wearable.API is not available on this device.
```

#### HOW

- Delay creation of `DataStore` in `TokenBundleRepositoryImpl` until `update` function is called;
- Change `update` to check for api availability and fail silently when not available;
- Add `isAvailable` function to `TokenBundleRepository` so developers can check if the repository can be used on the device running;
- Improve sample app to show usage of new function;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
