### PR TITLE
Improve docs for auth token sharing

### DIFF
--- a/docs/auth-tokenshare-guide.md
+++ b/docs/auth-tokenshare-guide.md
@@ -37,7 +37,20 @@ your phone and watch apps must:
    }
    ```
 
-2. Create a `WearDataLayerRegistry`
+2. Add capability to phone app project
+
+   On the phone app project, add a `wear.xml` file in the `res/values` folder with the following
+   content:
+
+   ```xml
+   <resources>
+       <string-array name="android_wear_capabilities">
+           <item>horologist_phone</item>
+       </string-array>
+   </resources>
+   ```
+
+3. Create a `WearDataLayerRegistry`
 
    In both projects, create an instance
    of [WearDataLayerRegistry](https://google.github.io/horologist/api/datalayer/com.google.android.horologist.data/-wear-data-layer-registry/index.html)
@@ -52,13 +65,13 @@ your phone and watch apps must:
 
    This class should be created as a singleton in your app.
 
-3. Define the data to be transferred
+4. Define the data to be transferred
 
    Define which authentication data that should be transferred from the phone to the watch. It can
    be a data class with many properties, it can also be a [protocol buffer](https://protobuf.dev/).
    For this guide, we will pass a simple `String` instance.
 
-4. Create a `Serializer` for the data
+5. Create a `Serializer` for the data
 
    Create
    a [DataStore](https://developer.android.com/topic/libraries/architecture/datastore) `Serializer`
@@ -86,7 +99,7 @@ your phone and watch apps must:
    More information about this serialization
    in [this blog post](https://medium.com/androiddevelopers/datastore-and-kotlin-serialization-8b25bf0be66c).
 
-5. Create a `TokenBundleRepository` on the phone project
+6. Create a `TokenBundleRepository` on the phone project
 
    Create an instance
    of [TokenBundleRepository](https://google.github.io/horologist/api/auth-data-phone/com.google.android.horologist.auth.data.phone.tokenshare/-token-bundle-repository/index.html)
@@ -100,7 +113,21 @@ your phone and watch apps must:
    )   
    ```
 
-6. Send authentication data from the phone
+7. Check if the repository is available (optional)
+
+   Before using the repository, you can check if it is available to be used on the current device
+   with:
+
+   ```kotlin
+   tokenBundleRepositoryDefaultKey.isAvailable()
+   ```
+
+   If the repository is not available on the device, all the calls to it will fail silently.
+
+   See the requirements
+   of [Wearable Data Layer API](https://developer.android.com/training/wearables/data/data-layer#send-and-sync-with-API).
+
+8. Send authentication data from the phone
 
    The authentication data can be sent from the phone calling `update`:
 
@@ -108,7 +135,7 @@ your phone and watch apps must:
    tokenBundleRepositoryDefaultKey.update("token")
    ```
 
-7. Create a `TokenBundleRepository` on the watch project
+9. Create a `TokenBundleRepository` on the watch project
 
    Create an instance
    of [TokenBundleRepository](https://google.github.io/horologist/api/auth-data/com.google.android.horologist.auth.data.tokenshare/-token-bundle-repository/index.html)
@@ -121,9 +148,9 @@ your phone and watch apps must:
    )
    ```
 
-8. Receive authentication data on the watch
+10. Receive authentication data on the watch
 
-   The authentication data can be listened from the watch via the `flow` property:
-   ```kotlin
-   tokenBundleRepository.flow
-   ```   
+    The authentication data can be listened from the watch via the `flow` property:
+    ```kotlin
+    tokenBundleRepository.flow
+    ```   


### PR DESCRIPTION
#### WHAT

Improve docs for auth token sharing.

#### WHY

API was improved in https://github.com/google/horologist/pull/1089 to expose a function to check availability of the repository.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [N/A] Run tests
- [N/A] Update metalava's signature text files
