### PR TITLE
Fix auth samples

### DIFF
--- a/auth-sample-phone/build.gradle.kts
+++ b/auth-sample-phone/build.gradle.kts
@@ -97,7 +97,6 @@ dependencies {
     implementation(projects.authDataPhone)
     implementation(projects.authSampleShared)
     implementation(projects.datalayer)
-    implementation(projects.datalayerPhone)
 
     implementation(libs.androidx.corektx)
     implementation(libs.androidx.lifecycle.runtime)

--- a/auth-sample-phone/src/main/res/values/wear.xml
+++ b/auth-sample-phone/src/main/res/values/wear.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2023 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string-array
+        name="android_wear_capabilities"
+        translatable="false"
+        tools:ignore="UnusedResources">
+        <!-- declaring the provided capabilities -->
+        <item>horologist_phone</item>
+    </string-array>
+</resources>

--- a/auth-sample-wear/build.gradle.kts
+++ b/auth-sample-wear/build.gradle.kts
@@ -96,7 +96,6 @@ dependencies {
     implementation(projects.composables)
     implementation(projects.composeLayout)
     implementation(projects.datalayer)
-    implementation(projects.datalayerWatch)
 
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)


### PR DESCRIPTION
#### WHAT

Fix auth samples.

#### WHY

They are broken since https://github.com/google/horologist/pull/1067

#### HOW

- Add `wear.xml` file with `horologist_phone` capability to `auth-sample-phone`.
- Remove dependencies that were supposed to bring the `wear.xml` contents but don't seem to be;

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
