### PR TITLE
Attempt to fix markdown

### DIFF
--- a/docs/auth-googlesignin-guide.md
+++ b/docs/auth-googlesignin-guide.md
@@ -1,5 +1,8 @@
 # Google Sign-In guide
 
+This guide will walk you through on how to display a screen on your watch app so that users can
+select their Google account to sign-in to your app.
+
 ## Requirements
 
 Follow the setup instructions for integrating Google Sign-in into an Android app
@@ -7,7 +10,7 @@ from [this link](https://developers.google.com/identity/sign-in/android/start-in
 
 ## Getting started
 
-1. Add dependencies
+1.  Add dependencies
 
    Add the following dependencies to your project’s build.gradle:
 
@@ -19,7 +22,7 @@ from [this link](https://developers.google.com/identity/sign-in/android/start-in
    }
    ```
 
-2. Create an instance of `GoogleSignInClient`
+2.  Create an instance of `GoogleSignInClient`
 
    Create an instance
    of [GoogleSignInClient](https://developers.google.com/android/reference/com/google/android/gms/auth/api/signin/GoogleSignInClient),
@@ -36,7 +39,7 @@ from [this link](https://developers.google.com/identity/sign-in/android/start-in
 
 ## Display the screen
 
-1. Create a ViewModel
+1.  Create a ViewModel
 
    Create your implementation of `GoogleSignInViewModel`, passing the `GoogleSignInClient` created:
    ```kotlin
@@ -45,7 +48,7 @@ from [this link](https://developers.google.com/identity/sign-in/android/start-in
    ) : GoogleSignInViewModel(googleSignInClient)
    ```   
 
-2. Display the screen
+2.  Display the screen
 
    Display the `GoogleSignInScreen` passing an instance of the `GoogleSignInViewModel` created:
 
@@ -64,11 +67,11 @@ from [this link](https://developers.google.com/identity/sign-in/android/start-in
 
 ## Retrieve the signed in account
 
-In order to have access to an instance of
+In order to have access an instance of
 the [GoogleSignInAccount](https://developers.google.com/android/reference/com/google/android/gms/auth/api/signin/GoogleSignInAccount)
 selected by the user, follow the steps:
 
-1. Implement `GoogleSignInEventListener`
+1.  Implement `GoogleSignInEventListener`
 
    ```kotlin
    class GoogleSignInEventListenerImpl : GoogleSignInEventListener {
@@ -78,7 +81,7 @@ selected by the user, follow the steps:
    }
    ```
 
-2. Pass the listener to the ViewModel
+2.  Pass the listener to the ViewModel
 
    Pass an instance of `GoogleSignInEventListener` to `GoogleSignInViewModel`:
 

--- a/docs/auth-tokenshare-guide.md
+++ b/docs/auth-tokenshare-guide.md
@@ -15,7 +15,7 @@ your phone and watch apps must:
 
 ## Getting started
 
-1. Add dependencies
+1.  Add dependencies
 
    Add the following dependencies to your project’s build.gradle.
 
@@ -37,7 +37,7 @@ your phone and watch apps must:
    }
    ```
 
-2. Add capability to phone app project
+2.  Add capability to phone app project
 
    On the phone app project, add a `wear.xml` file in the `res/values` folder with the following
    content:
@@ -50,7 +50,7 @@ your phone and watch apps must:
    </resources>
    ```
 
-3. Create a `WearDataLayerRegistry`
+3.  Create a `WearDataLayerRegistry`
 
    In both projects, create an instance
    of [WearDataLayerRegistry](https://google.github.io/horologist/api/datalayer/com.google.android.horologist.data/-wear-data-layer-registry/index.html)
@@ -65,13 +65,13 @@ your phone and watch apps must:
 
    This class should be created as a singleton in your app.
 
-4. Define the data to be transferred
+4.  Define the data to be transferred
 
    Define which authentication data that should be transferred from the phone to the watch. It can
    be a data class with many properties, it can also be a [protocol buffer](https://protobuf.dev/).
    For this guide, we will pass a simple `String` instance.
 
-5. Create a `Serializer` for the data
+5.  Create a `Serializer` for the data
 
    Create
    a [DataStore](https://developer.android.com/topic/libraries/architecture/datastore) `Serializer`
@@ -101,21 +101,21 @@ your phone and watch apps must:
 
 ## Send authentication data from the phone
 
-1. Create a `TokenBundleRepository` on the phone project
+1.  Create a `TokenBundleRepository` on the phone project
 
    Create an instance
    of [TokenBundleRepository](https://google.github.io/horologist/api/auth-data-phone/com.google.android.horologist.auth.data.phone.tokenshare/-token-bundle-repository/index.html)
    on the phone app project:
 
    ```kotlin
-   val tokenBundleRepository = TokenBundleRepositoryImpl.create(
+   val tokenBundleRepository = TokenBundleRepositoryImpl(
        registry = registry,
        coroutineScope = // a coroutine scope,
        serializer = TokenSerializer
    )   
    ```
 
-2. Check if the repository is available (optional)
+2.  Check if the repository is available (optional)
 
    Before using the repository, you can check if it is available to be used on the current device
    with:
@@ -129,7 +129,7 @@ your phone and watch apps must:
    See the requirements
    of [Wearable Data Layer API](https://developer.android.com/training/wearables/data/data-layer#send-and-sync-with-API).
 
-3. Send authentication data
+3.  Send authentication data
 
    The authentication data can be sent from the phone calling `update`:
 
@@ -139,7 +139,7 @@ your phone and watch apps must:
 
 ## Receive authentication data on the watch
 
-1. Create a `TokenBundleRepository` on the watch project
+1.  Create a `TokenBundleRepository` on the watch project
 
    Create an instance
    of [TokenBundleRepository](https://google.github.io/horologist/api/auth-data/com.google.android.horologist.auth.data.tokenshare/-token-bundle-repository/index.html)
@@ -152,7 +152,7 @@ your phone and watch apps must:
    )
    ```
 
-2. Receive authentication data
+2.  Receive authentication data
 
    The authentication data can be listened from the watch via the `flow` property:
    ```kotlin


### PR DESCRIPTION
#### WHAT

Attempt to fix markdown for lists.

#### WHY

Docs are repeating showing digit 1 for all items of numbered lists.

#### HOW

Add an extra space after the dot, in an attempt to markdown not pick it up as a list and just display the text.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [N/A] Run tests
- [N/A] Update metalava's signature text files
