### PR TITLE
Persist seek button order in RTL layouts

### DIFF
--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/ControlButtonLayout.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/ControlButtonLayout.kt
@@ -23,8 +23,11 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -34,23 +37,25 @@ public fun ControlButtonLayout(
     rightButton: @Composable () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Row(
-        modifier = modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.Center
-    ) {
-        Box(modifier = Modifier.padding(start = 17.dp)) {
-            leftButton()
-        }
+    CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+        Row(
+            modifier = modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Box(modifier = Modifier.padding(start = 17.dp)) {
+                leftButton()
+            }
 
-        Spacer(modifier = Modifier.weight(1f))
+            Spacer(modifier = Modifier.weight(1f))
 
-        middleButton()
+            middleButton()
 
-        Spacer(modifier = Modifier.weight(1f))
+            Spacer(modifier = Modifier.weight(1f))
 
-        Box(modifier = Modifier.padding(end = 17.dp)) {
-            rightButton()
+            Box(modifier = Modifier.padding(end = 17.dp)) {
+                rightButton()
+            }
         }
     }
 }


### PR DESCRIPTION
Per [Bidirectionality - Mirroring elements](https://m2.material.io/design/usability/bidirectionality.html#mirroring-elements):

> Do not mirror media playback buttons and the media progress indicator as they refer to the direction of tape being played, not the direction of time.

This PR forces the `Row` in `ControlButtonLayout` to always treat elements as if the layout is LTR. In effect, this means "start" and "end" always map to "left" and "right" and the first element inside is always the leftmost one, matching the parameter names.