### PR TITLE
Change datalayer-watch to minSdk 26

### DIFF
--- a/datalayer-watch/src/main/AndroidManifest.xml
+++ b/datalayer-watch/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
     package="com.google.android.horologist.datalayer.watch">
 
     <uses-sdk
-        android:minSdkVersion="30"
+        android:minSdkVersion="26"
         tools:ignore="GradleOverrides" />
 
     <application>


### PR DESCRIPTION
#### WHAT

Change datalayer-watch to minSdk 26

#### WHY

match the gradle config.

https://github.com/google/horologist/blob/main/datalayer-watch/build.gradle.kts#LL30C18-L30C20

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
