### PR TITLE
Fixes App Helper protos to undo breaking changes in compatibility

### DIFF
--- a/datalayer/src/main/proto/app_helper_pb.proto
+++ b/datalayer/src/main/proto/app_helper_pb.proto
@@ -39,10 +39,10 @@ message ActivityConfig {
 }
 
 message ComplicationInfo {
-  int64 timestamp = 1;
-  string name = 2;
-  int32 instanceId = 3;
-  string type = 4;
+  string name = 1;
+  int32 instanceId = 2;
+  string type = 3;
+  int64 timestamp = 4;
 }
 
 message TileInfo {
@@ -51,6 +51,7 @@ message TileInfo {
 }
 
 message SurfacesInfo {
-  repeated TileInfo tiles = 1;
+  reserved 1;
   repeated ComplicationInfo complications = 2;
+  repeated TileInfo tiles = 3;
 }


### PR DESCRIPTION
#### WHAT

Fixes App Helper protos to undo breaking changes in compatibility

#### WHY

#1118 added greated flexibility and future proofing to the representation of installed surfaces (Tiles, Complications), but in doing so broke compatibility with previous proto definitions.

This PR fixes that issue.

#### HOW

Moves new fields to simply being added to the existing definition, instead of renumbering the definition.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
