### PR TITLE
Move opt-ins for experimental annotation to build.gradle file

### DIFF
--- a/audio-ui/build.gradle.kts
+++ b/audio-ui/build.gradle.kts
@@ -44,6 +44,7 @@ android {
 
     kotlinOptions {
         jvmTarget = "11"
+        freeCompilerArgs = freeCompilerArgs + "-opt-in=com.google.android.horologist.annotations.ExperimentalHorologistApi"
     }
 
     composeOptions {

--- a/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/VolumeScreenTest.kt
+++ b/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/VolumeScreenTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class, ExperimentalCoroutinesApi::class)
+@file:OptIn(ExperimentalCoroutinesApi::class)
 
 package com.google.android.horologist.audio.ui
 
@@ -29,7 +29,6 @@ import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performRotaryScrollInput
 import androidx.test.filters.MediumTest
 import androidx.test.platform.app.InstrumentationRegistry
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.audio.VolumeState
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SettingsButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SettingsButton.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Button
 import androidx.wear.compose.material.ButtonDefaults.buttonColors
 import androidx.wear.compose.material.MaterialTheme
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.audio.VolumeState
 import com.google.android.horologist.base.ui.components.IconRtlMode
 import com.google.android.horologist.base.ui.components.StandardIcon
@@ -37,7 +36,6 @@ import com.google.android.horologist.base.ui.components.StandardIcon
  *
  * See [VolumeState]
  */
-@OptIn(ExperimentalHorologistApi::class)
 @Composable
 public fun SettingsButton(
     onClick: () -> Unit,

--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenA11yScreenshotTest.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenA11yScreenshotTest.kt
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.audio.ui
 
 import androidx.wear.compose.material.MaterialTheme
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.audio.AudioOutput
 import com.google.android.horologist.audio.VolumeState
 import com.google.android.horologist.screenshots.ScreenshotTest

--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenIndividualTest.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenIndividualTest.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.audio.ui
 
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Scaffold
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.audio.AudioOutput
 import com.google.android.horologist.audio.VolumeState
 import com.google.android.horologist.audio.ui.mapper.VolumeUiStateMapper

--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenThemeTest.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenThemeTest.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.audio.ui
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.audio.AudioOutput
 import com.google.android.horologist.audio.VolumeState
 import com.google.android.horologist.compose.tools.ThemeValues

--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonTest.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonTest.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.audio.ui.components.actions
 
 import androidx.compose.foundation.background
@@ -27,7 +25,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.audio.ui.VolumeUiState
 import com.google.android.horologist.screenshots.ScreenshotTest
 import org.junit.Test

--- a/audio/src/androidTest/java/com/google/android/horologist/audio/SystemAudioRepositoryTest.kt
+++ b/audio/src/androidTest/java/com/google/android/horologist/audio/SystemAudioRepositoryTest.kt
@@ -19,7 +19,6 @@ package com.google.android.horologist.audio
 import androidx.test.annotation.UiThreadTest
 import androidx.test.filters.MediumTest
 import androidx.test.platform.app.InstrumentationRegistry
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -30,7 +29,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import org.junit.Test
 
-@OptIn(ExperimentalCoroutinesApi::class, ExperimentalHorologistApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 @MediumTest
 class SystemAudioRepositoryTest {
     @Test

--- a/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/chips/CreateAccountChipPreview.kt
+++ b/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/chips/CreateAccountChipPreview.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.auth.composables.chips
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 @Preview(
     backgroundColor = 0xff000000,

--- a/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/chips/GuestModeChipPreview.kt
+++ b/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/chips/GuestModeChipPreview.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.auth.composables.chips
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 @Preview(
     backgroundColor = 0xff000000,

--- a/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/chips/OtherOptionsChipPreview.kt
+++ b/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/chips/OtherOptionsChipPreview.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.auth.composables.chips
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 @Preview(
     backgroundColor = 0xff000000,

--- a/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/chips/SignInChipPreview.kt
+++ b/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/chips/SignInChipPreview.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.auth.composables.chips
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 @Preview(
     backgroundColor = 0xff000000,

--- a/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogPreview.kt
+++ b/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogPreview.kt
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.auth.composables.dialogs
 
 import androidx.compose.runtime.Composable
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 
 @WearPreviewDevices

--- a/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/screens/AuthErrorScreenPreview.kt
+++ b/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/screens/AuthErrorScreenPreview.kt
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.auth.composables.screens
 
 import androidx.compose.runtime.Composable
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 
 @WearPreviewDevices

--- a/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/screens/CheckYourPhoneScreenPreview.kt
+++ b/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/screens/CheckYourPhoneScreenPreview.kt
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.auth.composables.screens
 
 import androidx.compose.runtime.Composable
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 
 @WearPreviewDevices

--- a/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/screens/SelectAccountScreenPreview.kt
+++ b/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/screens/SelectAccountScreenPreview.kt
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.auth.composables.screens
 
 import androidx.compose.runtime.Composable
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.auth.composables.model.AccountUiModel
 import com.google.android.horologist.compose.layout.belowTimeTextPreview
 import com.google.android.horologist.compose.tools.WearPreviewDevices

--- a/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/screens/SignInPlaceholderScreenPreview.kt
+++ b/auth-composables/src/debug/java/com/google/android/horologist/auth/composables/screens/SignInPlaceholderScreenPreview.kt
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.auth.composables.screens
 
 import androidx.compose.runtime.Composable
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 
 @WearPreviewDevices

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/CreateAccountChipTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/CreateAccountChipTest.kt
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.auth.composables.chips
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.base.ui.components.StandardChipType
 import com.google.android.horologist.screenshots.ScreenshotTest
 import org.junit.Test

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/GuestModeChipTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/GuestModeChipTest.kt
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.auth.composables.chips
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.base.ui.components.StandardChipType
 import com.google.android.horologist.screenshots.ScreenshotTest
 import org.junit.Test

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/OtherOptionsChipTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/OtherOptionsChipTest.kt
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.auth.composables.chips
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.base.ui.components.StandardChipType
 import com.google.android.horologist.screenshots.ScreenshotTest
 import org.junit.Test

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/SignInChipTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/chips/SignInChipTest.kt
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.auth.composables.chips
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.base.ui.components.StandardChipType
 import com.google.android.horologist.screenshots.ScreenshotTest
 import org.junit.Test

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogTest.kt
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.auth.composables.dialogs
 
 import androidx.compose.foundation.background
@@ -25,7 +21,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.screenshots.ScreenshotTest
 import org.junit.Test

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/screens/AuthErrorScreenTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/screens/AuthErrorScreenTest.kt
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.auth.composables.screens
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.screenshots.ScreenshotTest
 import org.junit.Test
 

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/screens/CheckYourPhoneScreenTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/screens/CheckYourPhoneScreenTest.kt
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.auth.composables.screens
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.screenshots.ScreenshotTest
 import org.junit.Test
 

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/screens/SelectAccountScreenTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/screens/SelectAccountScreenTest.kt
@@ -14,15 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.auth.composables.screens
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Face
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.auth.composables.model.AccountUiModel
 import com.google.android.horologist.screenshots.ScreenshotTest
 import com.google.android.horologist.test.toolbox.positionedState

--- a/auth-composables/src/test/java/com/google/android/horologist/auth/composables/screens/SignInPlaceholderScreenTest.kt
+++ b/auth-composables/src/test/java/com/google/android/horologist/auth/composables/screens/SignInPlaceholderScreenTest.kt
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.auth.composables.screens
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.screenshots.ScreenshotTest
 import org.junit.Test
 

--- a/auth-ui/build.gradle.kts
+++ b/auth-ui/build.gradle.kts
@@ -44,7 +44,7 @@ android {
 
     kotlinOptions {
         jvmTarget = "11"
-        freeCompilerArgs = listOf(
+        freeCompilerArgs = freeCompilerArgs + listOf(
             "-opt-in=com.google.android.horologist.annotations.ExperimentalHorologistApi",
             "-opt-in=kotlin.RequiresOptIn"
         )

--- a/auth-ui/src/debug/java/com/google/android/horologist/auth/composables/screens/SignInPromptScreenPreview.kt
+++ b/auth-ui/src/debug/java/com/google/android/horologist/auth/composables/screens/SignInPromptScreenPreview.kt
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.auth.composables.screens
 
 import androidx.compose.runtime.Composable
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.auth.composables.chips.GuestModeChip
 import com.google.android.horologist.auth.composables.chips.SignInChip
 import com.google.android.horologist.auth.ui.common.screens.prompt.SignInPromptScreen

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptScreen.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptScreen.kt
@@ -81,7 +81,6 @@ public fun SignInPromptScreen(
     )
 }
 
-@OptIn(ExperimentalHorologistApi::class)
 @Composable
 internal fun SignInPromptScreen(
     state: SignInPromptScreenState,

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInScreen.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInScreen.kt
@@ -71,7 +71,6 @@ public fun StreamlineSignInScreen(
     )
 }
 
-@OptIn(ExperimentalHorologistApi::class)
 @Composable
 internal fun StreamlineSignInScreen(
     state: StreamlineSignInScreenState,

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/mapper/AccountUiModelMapper.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/mapper/AccountUiModelMapper.kt
@@ -29,7 +29,6 @@ public object AccountUiModelMapper {
     /**
      * Maps from a [GoogleSignInAccount].
      */
-    @OptIn(ExperimentalHorologistApi::class)
     public fun map(
         account: GoogleSignInAccount,
         defaultEmail: String = ""

--- a/auth-ui/src/main/java/com/google/android/horologist/auth/ui/mapper/AccountUiModelMapper.kt
+++ b/auth-ui/src/main/java/com/google/android/horologist/auth/ui/mapper/AccountUiModelMapper.kt
@@ -29,7 +29,6 @@ public object AccountUiModelMapper {
     /**
      * Maps from a [AuthUser].
      */
-    @OptIn(ExperimentalHorologistApi::class)
     public fun map(authUser: AuthUser, defaultEmail: String = ""): AccountUiModel = AccountUiModel(
         email = authUser.email ?: defaultEmail,
         name = authUser.displayName,

--- a/auth-ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptScreenTest.kt
+++ b/auth-ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptScreenTest.kt
@@ -14,14 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.auth.ui.common.screens.prompt
 
 import androidx.wear.compose.foundation.lazy.ScalingLazyListScope
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.auth.composables.chips.GuestModeChip
 import com.google.android.horologist.auth.composables.chips.SignInChip
 import com.google.android.horologist.auth.composables.model.AccountUiModel

--- a/auth-ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptViewModelTest.kt
+++ b/auth-ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptViewModelTest.kt
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class,
-    ExperimentalCoroutinesApi::class
-)
+@file:OptIn(ExperimentalCoroutinesApi::class)
 
 package com.google.android.horologist.auth.ui.common.screens.prompt
 
 import app.cash.turbine.test
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.auth.composables.model.AccountUiModel
 import com.google.android.horologist.auth.data.common.model.AuthUser
 import com.google.android.horologist.test.toolbox.rules.MainDispatcherRule

--- a/auth-ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInDefaultViewModelTest.kt
+++ b/auth-ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInDefaultViewModelTest.kt
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class, ExperimentalCoroutinesApi::class)
+@file:OptIn(ExperimentalCoroutinesApi::class)
 
 package com.google.android.horologist.auth.ui.common.screens.streamline
 
 import app.cash.turbine.test
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.auth.composables.model.AccountUiModel
 import com.google.android.horologist.auth.data.common.model.AuthUser
 import com.google.android.horologist.test.toolbox.rules.MainDispatcherRule

--- a/auth-ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInViewModelTest.kt
+++ b/auth-ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInViewModelTest.kt
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class, ExperimentalCoroutinesApi::class)
+@file:OptIn(ExperimentalCoroutinesApi::class)
 
 package com.google.android.horologist.auth.ui.common.screens.streamline
 
 import app.cash.turbine.test
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.auth.composables.model.AccountUiModel
 import com.google.android.horologist.auth.data.common.model.AuthUser
 import com.google.android.horologist.test.toolbox.rules.MainDispatcherRule

--- a/auth-ui/src/test/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInViewModelTest.kt
+++ b/auth-ui/src/test/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInViewModelTest.kt
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class,
-    ExperimentalCoroutinesApi::class
-)
+@file:OptIn(ExperimentalCoroutinesApi::class)
 
 package com.google.android.horologist.auth.ui.googlesignin.signin
 
@@ -26,7 +23,6 @@ import app.cash.turbine.test
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.auth.data.googlesignin.GoogleSignInEventListener
 import com.google.android.horologist.test.toolbox.rules.MainDispatcherRule
 import com.google.common.truth.Truth.assertThat

--- a/base-ui/build.gradle.kts
+++ b/base-ui/build.gradle.kts
@@ -44,6 +44,7 @@ android {
 
     kotlinOptions {
         jvmTarget = "11"
+        freeCompilerArgs = freeCompilerArgs + "-opt-in=com.google.android.horologist.annotations.ExperimentalHorologistApi"
     }
 
     composeOptions {

--- a/base-ui/src/androidTest/java/com/google/android/horologist/base/ui/components/TitleTest.kt
+++ b/base-ui/src/androidTest/java/com/google/android/horologist/base/ui/components/TitleTest.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.base.ui.components
 
 import androidx.compose.ui.Modifier
@@ -23,7 +21,6 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.junit4.createComposeRule
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import org.junit.Rule
 import org.junit.Test
 

--- a/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/AlertDialogAlertPreview.kt
+++ b/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/AlertDialogAlertPreview.kt
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.base.ui.components
 
 import androidx.compose.runtime.Composable
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 
 @WearPreviewDevices

--- a/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/IconOnlyButtonPreview.kt
+++ b/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/IconOnlyButtonPreview.kt
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.base.ui.components
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.WearPreview
 
 @WearPreview

--- a/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/PrimaryButtonPreview.kt
+++ b/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/PrimaryButtonPreview.kt
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.base.ui.components
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.WearPreview
 
 @WearPreview

--- a/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/PrimaryChipPreview.kt
+++ b/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/PrimaryChipPreview.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.base.ui.components
 
 import androidx.compose.material.icons.Icons
@@ -26,7 +24,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.base.ui.util.rememberVectorPainter
 
 @Preview(

--- a/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/SecondaryButtonPreview.kt
+++ b/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/SecondaryButtonPreview.kt
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.base.ui.components
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.WearPreview
 
 @WearPreview

--- a/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/SecondaryChipPreview.kt
+++ b/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/SecondaryChipPreview.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.base.ui.components
 
 import androidx.compose.material.icons.Icons
@@ -26,7 +24,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.base.ui.util.rememberVectorPainter
 
 @Preview(

--- a/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/StandardChipIconWithProgressPreview.kt
+++ b/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/StandardChipIconWithProgressPreview.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.base.ui.components
 
 import androidx.compose.material.icons.materialPath
@@ -23,7 +21,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 @Preview(
     name = "Standard",

--- a/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/TitlePreview.kt
+++ b/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/TitlePreview.kt
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.base.ui.components
 
 import androidx.compose.runtime.Composable
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.WearPreview
 
 @WearPreview

--- a/base-ui/src/main/java/com/google/android/horologist/base/ui/components/StandardIcon.kt
+++ b/base-ui/src/main/java/com/google/android/horologist/base/ui/components/StandardIcon.kt
@@ -24,10 +24,8 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.wear.compose.material.Icon
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.base.ui.semantics.CustomSemanticsProperties.iconImageVector
 
-@OptIn(ExperimentalHorologistApi::class)
 @Composable
 public fun StandardIcon(
     imageVector: ImageVector,
@@ -35,7 +33,8 @@ public fun StandardIcon(
     modifier: Modifier = Modifier,
     rtlMode: IconRtlMode = IconRtlMode.Default
 ) {
-    val shouldMirror = rtlMode == IconRtlMode.Mirrored && LocalLayoutDirection.current == LayoutDirection.Rtl
+    val shouldMirror =
+        rtlMode == IconRtlMode.Mirrored && LocalLayoutDirection.current == LayoutDirection.Rtl
     Icon(
         modifier = modifier
             .semantics { iconImageVector = imageVector }

--- a/base-ui/src/test/java/com/google/android/horologist/base/ui/components/PrimaryChipTest.kt
+++ b/base-ui/src/test/java/com/google/android/horologist/base/ui/components/PrimaryChipTest.kt
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.base.ui.components
 
 import androidx.compose.material.icons.Icons
@@ -28,7 +24,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.dp
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.base.ui.util.rememberVectorPainter
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.screenshots.ScreenshotTest

--- a/base-ui/src/test/java/com/google/android/horologist/base/ui/components/SecondaryChipTest.kt
+++ b/base-ui/src/test/java/com/google/android/horologist/base/ui/components/SecondaryChipTest.kt
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.base.ui.components
 
 import androidx.compose.foundation.background
@@ -32,7 +28,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.dp
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.base.ui.util.rememberVectorPainter
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.screenshots.ScreenshotTest

--- a/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardButtonTest.kt
+++ b/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardButtonTest.kt
@@ -14,15 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.base.ui.components
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.screenshots.ScreenshotTest
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardChipIconWithProgressTest.kt
+++ b/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardChipIconWithProgressTest.kt
@@ -14,16 +14,11 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.base.ui.components
 
 import androidx.compose.material.icons.materialPath
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.screenshots.ScreenshotTest
 import org.junit.Test

--- a/base-ui/src/test/java/com/google/android/horologist/base/ui/components/TitleTest.kt
+++ b/base-ui/src/test/java/com/google/android/horologist/base/ui/components/TitleTest.kt
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.base.ui.components
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.screenshots.ScreenshotTest
 import org.junit.Test
 

--- a/composables/src/androidTest/java/com/google/android/horologist/DatePickerTest.kt
+++ b/composables/src/androidTest/java/com/google/android/horologist/DatePickerTest.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist
 
 import androidx.compose.runtime.getValue
@@ -29,7 +27,6 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.wear.compose.material.Text
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.composables.DatePicker
 import com.google.android.horologist.composables.DatePickerState
 import com.google.common.truth.Truth.assertThat

--- a/composables/src/androidTest/java/com/google/android/horologist/TimePickerTest.kt
+++ b/composables/src/androidTest/java/com/google/android/horologist/TimePickerTest.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist
 
 import androidx.compose.runtime.getValue
@@ -29,7 +27,6 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.wear.compose.material.Text
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.composables.TimePicker
 import com.google.android.horologist.composables.TimePickerWith12HourClock
 import org.junit.Ignore

--- a/composables/src/debug/java/com/google/android/horologist/composables/DatePickerPreview.kt
+++ b/composables/src/debug/java/com/google/android/horologist/composables/DatePickerPreview.kt
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.composables
 
 import androidx.compose.runtime.Composable
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 import com.google.android.horologist.compose.tools.WearPreviewFontSizes
 import java.time.LocalDate
@@ -27,7 +24,6 @@ import java.time.LocalDate
 @WearPreviewDevices
 @WearPreviewFontSizes
 @Composable
-@OptIn(ExperimentalHorologistApi::class)
 fun DatePickerPreview() {
     // Due to a limitation with ScalingLazyColumn,
     // previews only work in interactive mode.

--- a/composables/src/debug/java/com/google/android/horologist/composables/MarqueeTextPreview.kt
+++ b/composables/src/debug/java/com/google/android/horologist/composables/MarqueeTextPreview.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.composables
 
 import androidx.compose.foundation.layout.width
@@ -23,7 +21,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.WearPreview
 import kotlin.time.Duration.Companion.seconds
 

--- a/composables/src/debug/java/com/google/android/horologist/composables/PlaceholderChipPreview.kt
+++ b/composables/src/debug/java/com/google/android/horologist/composables/PlaceholderChipPreview.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.composables
 
 import androidx.compose.runtime.Composable
 import androidx.wear.compose.material.ChipDefaults
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.WearPreview
 
 @WearPreview

--- a/composables/src/debug/java/com/google/android/horologist/composables/SectionedListPreview.kt
+++ b/composables/src/debug/java/com/google/android/horologist/composables/SectionedListPreview.kt
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.composables
 
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -38,7 +34,6 @@ import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 
 @WearPreviewDevices

--- a/composables/src/debug/java/com/google/android/horologist/composables/SegmentedProgressIndicatorPreview.kt
+++ b/composables/src/debug/java/com/google/android/horologist/composables/SegmentedProgressIndicatorPreview.kt
@@ -24,10 +24,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.WearSmallRoundDevicePreview
 
-@OptIn(ExperimentalHorologistApi::class)
 @Preview(device = Devices.WEAR_OS_LARGE_ROUND, showSystemUi = true)
 @Composable
 private fun SegmentedProgressIndicatorRoundPreview() {
@@ -49,7 +47,6 @@ private fun SegmentedProgressIndicatorRoundPreview() {
     )
 }
 
-@OptIn(ExperimentalHorologistApi::class)
 @Preview(device = Devices.WEAR_OS_SQUARE, showSystemUi = true)
 @Composable
 private fun SegmentedProgressIndicatorSquarePreview() {
@@ -69,7 +66,6 @@ private fun SegmentedProgressIndicatorSquarePreview() {
     )
 }
 
-@OptIn(ExperimentalHorologistApi::class)
 @WearSmallRoundDevicePreview
 @Composable
 private fun SegmentedProgressIndicatorBrushPreview() {
@@ -102,7 +98,6 @@ private fun SegmentedProgressIndicatorBrushPreview() {
     )
 }
 
-@OptIn(ExperimentalHorologistApi::class)
 @WearSmallRoundDevicePreview
 @Composable
 private fun SegmentedProgressIndicatorBrushColorCombinedPreview() {

--- a/composables/src/debug/java/com/google/android/horologist/composables/SquareSegmentedProgressIndicatorPreview.kt
+++ b/composables/src/debug/java/com/google/android/horologist/composables/SquareSegmentedProgressIndicatorPreview.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.composables
 
 import androidx.compose.animation.core.LinearEasing
@@ -44,7 +42,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Text
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.WearSquareDevicePreview
 import kotlinx.coroutines.delay
 
@@ -52,7 +49,6 @@ enum class PreviewAnimationState(val target: Float) {
     Start(0f), End(1f)
 }
 
-@OptIn(ExperimentalHorologistApi::class)
 @WearSquareDevicePreview
 @Composable
 fun PreviewProgressAnimation() {
@@ -147,7 +143,6 @@ fun PreviewProgressAnimation() {
     }
 }
 
-@OptIn(ExperimentalHorologistApi::class)
 @WearSquareDevicePreview
 @Composable
 fun PreviewHighCornerRadius() {
@@ -167,7 +162,6 @@ fun PreviewHighCornerRadius() {
     }
 }
 
-@OptIn(ExperimentalHorologistApi::class)
 @WearSquareDevicePreview
 @Composable
 fun PreviewSquare() {
@@ -182,7 +176,6 @@ fun PreviewSquare() {
     )
 }
 
-@OptIn(ExperimentalHorologistApi::class)
 @WearSquareDevicePreview
 @Composable
 fun PreviewSquareWithBrushColors() {
@@ -197,7 +190,6 @@ fun PreviewSquareWithBrushColors() {
     )
 }
 
-@OptIn(ExperimentalHorologistApi::class)
 @WearSquareDevicePreview
 @Composable
 fun PreviewSquareWithBrushAndColorsCombined() {

--- a/composables/src/debug/java/com/google/android/horologist/composables/TimePicker12hPreview.kt
+++ b/composables/src/debug/java/com/google/android/horologist/composables/TimePicker12hPreview.kt
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.composables
 
 import androidx.compose.runtime.Composable
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 import com.google.android.horologist.compose.tools.WearPreviewFontSizes
 import java.time.LocalTime
@@ -27,7 +24,6 @@ import java.time.LocalTime
 @WearPreviewDevices
 @WearPreviewFontSizes
 @Composable
-@OptIn(ExperimentalHorologistApi::class)
 fun TimePicker12hPreview() {
     // Due to a limitation with ScalingLazyColumn,
     // previews only work in interactive mode.

--- a/composables/src/debug/java/com/google/android/horologist/composables/TimePickerPreview.kt
+++ b/composables/src/debug/java/com/google/android/horologist/composables/TimePickerPreview.kt
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.composables
 
 import androidx.compose.runtime.Composable
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 import com.google.android.horologist.compose.tools.WearPreviewFontSizes
 import java.time.LocalTime
@@ -27,7 +24,6 @@ import java.time.LocalTime
 @WearPreviewDevices
 @WearPreviewFontSizes
 @Composable
-@OptIn(ExperimentalHorologistApi::class)
 fun TimePickerPreview() {
     // Due to a limitation with ScalingLazyColumn,
     // previews only work in interactive mode.

--- a/composables/src/main/java/com/google/android/horologist/composables/SectionedList.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/SectionedList.kt
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.composables
 
 import androidx.compose.foundation.layout.fillMaxSize

--- a/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.composables
 
 import android.content.Context
@@ -74,7 +72,6 @@ import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.TouchExplorationStateProvider
 import androidx.wear.compose.material.rememberPickerGroupState
 import androidx.wear.compose.material.rememberPickerState
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.rotaryinput.onRotaryInputAccumulated
 import kotlinx.coroutines.launch
 import java.time.LocalTime

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/DatePickerTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/DatePickerTest.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.composables
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.screenshots.ScreenshotTest
 import org.junit.Test
 import java.time.LocalDate

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/PlaceholderChipTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/PlaceholderChipTest.kt
@@ -14,14 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.composables
 
 import androidx.wear.compose.material.ChipDefaults
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.screenshots.ScreenshotTest
 import org.junit.Test
 

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/SectionedListTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/SectionedListTest.kt
@@ -15,9 +15,6 @@
  */
 
 @file:Suppress("TestFunctionName" /* incorrectly flagging composable functions */)
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
 
 package com.google.android.horologist.composables
 
@@ -45,7 +42,6 @@ import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.PositionIndicator
 import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.Text
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.tools.RoundPreview

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/SegmentedProgressIndicatorTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/SegmentedProgressIndicatorTest.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.composables
 
 import androidx.compose.foundation.layout.fillMaxSize
@@ -24,7 +22,6 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.unit.dp
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.screenshots.ScreenshotTest
 import org.junit.Test
 
@@ -33,7 +30,6 @@ class SegmentedProgressIndicatorTest : ScreenshotTest() {
         screenTimeText = {}
     }
 
-    @OptIn(ExperimentalHorologistApi::class)
     @Test
     fun segmentedPicker() {
         takeScreenshot {
@@ -61,7 +57,6 @@ class SegmentedProgressIndicatorTest : ScreenshotTest() {
         }
     }
 
-    @OptIn(ExperimentalHorologistApi::class)
     @Test
     fun segmentedPickerWithBrushColors() {
         takeScreenshot {
@@ -95,7 +90,6 @@ class SegmentedProgressIndicatorTest : ScreenshotTest() {
         }
     }
 
-    @OptIn(ExperimentalHorologistApi::class)
     @Test
     fun segmentedPickerWithBrushColorsAndColorsCombined() {
         takeScreenshot {

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/SquareSegmentedProgressIndicatorTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/SquareSegmentedProgressIndicatorTest.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.screenshots.ScreenshotTest
 import org.junit.Test
 import org.robolectric.annotation.Config
@@ -39,7 +38,6 @@ class SquareSegmentedProgressIndicatorTest : ScreenshotTest() {
         screenTimeText = {}
     }
 
-    @OptIn(ExperimentalHorologistApi::class)
     @Test
     fun squareSegmentedIndicatorLowCornerRadius() {
         takeScreenshot {
@@ -75,7 +73,6 @@ class SquareSegmentedProgressIndicatorTest : ScreenshotTest() {
         }
     }
 
-    @OptIn(ExperimentalHorologistApi::class)
     @Test
     fun squareSegmentedIndicatorHighCornerRadius() {
         takeScreenshot {
@@ -111,7 +108,6 @@ class SquareSegmentedProgressIndicatorTest : ScreenshotTest() {
         }
     }
 
-    @OptIn(ExperimentalHorologistApi::class)
     @Test
     fun squareSegmentedIndicatorManySegments() {
         takeScreenshot {
@@ -155,7 +151,6 @@ class SquareSegmentedProgressIndicatorTest : ScreenshotTest() {
         }
     }
 
-    @OptIn(ExperimentalHorologistApi::class)
     @Test
     fun squareSegmentedIndicatorFewSegments() {
         takeScreenshot {
@@ -187,7 +182,6 @@ class SquareSegmentedProgressIndicatorTest : ScreenshotTest() {
         }
     }
 
-    @OptIn(ExperimentalHorologistApi::class)
     @Test
     fun squareSegmentedIndicatorFewSegmentsAndBrushColor() {
         takeScreenshot {
@@ -227,7 +221,6 @@ class SquareSegmentedProgressIndicatorTest : ScreenshotTest() {
         }
     }
 
-    @OptIn(ExperimentalHorologistApi::class)
     @Test
     fun squareSegmentedIndicatorFewSegmentsAndBrushColorAndColorsCombined() {
         takeScreenshot {

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/TimePicker12hTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/TimePicker12hTest.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.composables
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.screenshots.ScreenshotTest
 import org.junit.Test
 import java.time.LocalTime

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/TimePickerTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/TimePickerTest.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.composables
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.screenshots.ScreenshotTest
 import org.junit.Test
 import java.time.LocalTime

--- a/compose-layout/build.gradle.kts
+++ b/compose-layout/build.gradle.kts
@@ -47,6 +47,7 @@ android {
         // Allow for widescale experimental APIs in Alpha libraries we build upon
         freeCompilerArgs = freeCompilerArgs + """
             kotlin.RequiresOptIn
+            com.google.android.horologist.annotations.ExperimentalHorologistApi
             """.trim().split("\\s+".toRegex()).map { "-opt-in=$it" }
     }
 

--- a/compose-layout/src/androidTest/java/com/google/android/horologist/compose/navscaffold/NavScaffoldTest.kt
+++ b/compose-layout/src/androidTest/java/com/google/android/horologist/compose/navscaffold/NavScaffoldTest.kt
@@ -16,7 +16,6 @@
 
 @file:OptIn(
     ExperimentalCoroutinesApi::class,
-    ExperimentalHorologistApi::class,
     ExperimentalWearFoundationApi::class
 )
 
@@ -54,7 +53,6 @@ import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.TimeText
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.rotaryinput.rotaryWithFling
 import com.google.common.truth.Truth.assertThat

--- a/compose-layout/src/androidTest/java/com/google/android/horologist/compose/pager/PagerScreenTest.kt
+++ b/compose-layout/src/androidTest/java/com/google/android/horologist/compose/pager/PagerScreenTest.kt
@@ -16,7 +16,6 @@
 
 @file:OptIn(
     ExperimentalCoroutinesApi::class,
-    ExperimentalHorologistApi::class,
     ExperimentalFoundationApi::class,
     ExperimentalWearFoundationApi::class
 )
@@ -44,7 +43,6 @@ import androidx.test.filters.MediumTest
 import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
 import androidx.wear.compose.foundation.RequestFocusWhenActive
 import androidx.wear.compose.material.Text
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.rotaryinput.rotaryWithFling
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.Dispatchers

--- a/compose-layout/src/androidTest/java/com/google/android/horologist/compose/snackbar/SnackbarHostTest.kt
+++ b/compose-layout/src/androidTest/java/com/google/android/horologist/compose/snackbar/SnackbarHostTest.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.compose.snackbar
 
 import androidx.compose.runtime.LaunchedEffect
@@ -34,7 +32,6 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performSemanticsAction
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.MediumTest
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.common.truth.Truth
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/layout/BelowTimeTextPreview.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/layout/BelowTimeTextPreview.kt
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.compose.layout
 
 import androidx.compose.runtime.Composable
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 @Composable
 public fun belowTimeTextPreview(): ScalingLazyColumnState {

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/layout/ScrollAway.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/layout/ScrollAway.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.foundation.lazy.ScalingLazyListState
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import androidx.wear.compose.material.scrollAway as scrollAwayCompose
 
 /**
@@ -103,7 +102,6 @@ public fun Modifier.scrollAway(
  *
  * @param scalingLazyColumnState The list config.
  */
-@OptIn(ExperimentalHorologistApi::class)
 public fun Modifier.scrollAway(
     scalingLazyColumnState: ScalingLazyColumnState
 ): Modifier = composed {

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/NavScaffoldViewModel.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/NavScaffoldViewModel.kt
@@ -37,7 +37,6 @@ import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.TimeText
 import androidx.wear.compose.material.Vignette
 import androidx.wear.compose.material.VignettePosition
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel.PositionIndicatorMode
 import com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel.TimeTextMode
@@ -131,7 +130,6 @@ public open class NavScaffoldViewModel(
         return _scrollableState as ScalingLazyListState
     }
 
-    @OptIn(ExperimentalHorologistApi::class)
     internal fun initializeScalingLazyListState(
         columnState: ScalingLazyColumnState
     ) {
@@ -239,7 +237,6 @@ public data class NonScrollableScaffoldContext(
  *
  * The [viewModel] can be used to customise the scaffold behaviour.
  */
-@OptIn(ExperimentalHorologistApi::class)
 public data class ScrollableScaffoldContext(
     val backStackEntry: NavBackStackEntry,
     val columnState: ScalingLazyColumnState,

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/WearNavScaffold.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/WearNavScaffold.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class, ExperimentalWearFoundationApi::class)
+@file:OptIn(ExperimentalWearFoundationApi::class)
 
 package com.google.android.horologist.compose.navscaffold
 

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
@@ -233,7 +233,6 @@ public fun rememberRotaryHapticHandler(
     }
 }
 
-@OptIn(ExperimentalHorologistApi::class)
 @Composable
 private fun rememberHapticChannel() =
     remember {

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Rotary.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Rotary.kt
@@ -813,7 +813,6 @@ public fun Flow<TimestampedDelta>.batchRequestsWithinTimeframe(timeframe: Long):
  *
  * This scroll handler supports fling. It can be set with [RotaryFlingBehavior].
  */
-@OptIn(ExperimentalHorologistApi::class)
 internal class HighResRotaryScrollHandler(
     private val rotaryFlingBehaviorFactory: () -> RotaryFlingBehavior?,
     private val scrollBehaviorFactory: () -> RotaryScrollBehavior,
@@ -900,7 +899,6 @@ internal class HighResRotaryScrollHandler(
  * A scroll handler for Bezel(low-res) without snapping.
  * This scroll handler supports fling. It can be set with RotaryFlingBehavior.
  */
-@OptIn(ExperimentalHorologistApi::class)
 internal class LowResRotaryScrollHandler(
     private val rotaryFlingBehaviorFactory: () -> RotaryFlingBehavior?,
     private val scrollBehaviorFactory: () -> RotaryScrollBehavior
@@ -972,7 +970,6 @@ internal class LowResRotaryScrollHandler(
  *
  * This scroll handler doesn't support fling.
  */
-@OptIn(ExperimentalHorologistApi::class)
 internal class RotaryScrollSnapHandler(
     val snapBehaviourFactory: () -> RotarySnapBehavior,
     val scrollBehaviourFactory: () -> RotaryScrollBehavior
@@ -1074,7 +1071,6 @@ internal class RotaryScrollSnapHandler(
     }
 }
 
-@OptIn(ExperimentalHorologistApi::class)
 @Composable
 private fun rememberTimestampChannel() =
     remember {

--- a/compose-tools/build.gradle.kts
+++ b/compose-tools/build.gradle.kts
@@ -44,6 +44,7 @@ android {
 
     kotlinOptions {
         jvmTarget = "11"
+        freeCompilerArgs = freeCompilerArgs + "-opt-in=com.google.android.horologist.annotations.ExperimentalHorologistApi"
     }
 
     composeOptions {

--- a/compose-tools/src/main/java/com/google/android/horologist/compose/tools/TilePreview.kt
+++ b/compose-tools/src/main/java/com/google/android/horologist/compose/tools/TilePreview.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.compose.tools
 
 import android.content.res.Resources

--- a/datalayer/src/main/java/com/google/android/horologist/data/ProtoDataStoreHelper.kt
+++ b/datalayer/src/main/java/com/google/android/horologist/data/ProtoDataStoreHelper.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.data
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.data.store.ProtoDataListener
 import kotlinx.coroutines.CoroutineScope
 

--- a/datalayer/src/main/java/com/google/android/horologist/data/TargetNodeId.kt
+++ b/datalayer/src/main/java/com/google/android/horologist/data/TargetNodeId.kt
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.data
 
 import com.google.android.gms.wearable.CapabilityClient
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import kotlinx.coroutines.tasks.await
 
 /**

--- a/datalayer/src/main/java/com/google/android/horologist/data/WearDataService.kt
+++ b/datalayer/src/main/java/com/google/android/horologist/data/WearDataService.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.data
 
 import com.google.android.gms.wearable.DataEventBuffer
 import com.google.android.gms.wearable.WearableListenerService
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 /**
  * Base service class for applications wishing to be woken up to receive data layer events.

--- a/datalayer/src/main/java/com/google/android/horologist/data/apphelper/DataLayerAppHelper.kt
+++ b/datalayer/src/main/java/com/google/android/horologist/data/apphelper/DataLayerAppHelper.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.data.apphelper
 
 import android.content.Context
@@ -23,7 +21,6 @@ import android.net.Uri
 import androidx.wear.remote.interactions.RemoteActivityHelper
 import com.google.android.gms.wearable.CapabilityClient
 import com.google.android.gms.wearable.Node
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.data.ActivityConfig
 import com.google.android.horologist.data.AppHelperResult
 import com.google.android.horologist.data.AppHelperResultCode

--- a/health-composables/src/main/java/com/google/android/horologist/health/composables/ActiveDurationText.kt
+++ b/health-composables/src/main/java/com/google/android/horologist/health/composables/ActiveDurationText.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.health.composables
 
 import androidx.compose.foundation.clickable

--- a/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaMapper.kt
+++ b/media-data/src/main/java/com/google/android/horologist/media/data/mapper/MediaMapper.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.data.mapper
 
 import androidx.media3.common.MediaItem

--- a/media-data/src/test/java/com/google/android/horologist/media/data/database/mapper/MediaDownloadEntityStatusMapperTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/database/mapper/MediaDownloadEntityStatusMapperTest.kt
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.data.database.mapper
 
 import androidx.media3.exoplayer.offline.Download
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.data.database.model.MediaDownloadEntityStatus
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test

--- a/media-data/src/test/java/com/google/android/horologist/media/data/database/mapper/MediaEntityMapperTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/database/mapper/MediaEntityMapperTest.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.data.database.mapper
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.data.database.model.MediaEntity
 import com.google.android.horologist.media.model.Media
 import com.google.common.truth.Truth.assertThat

--- a/media-data/src/test/java/com/google/android/horologist/media/data/database/mapper/PlaylistEntityMapperTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/database/mapper/PlaylistEntityMapperTest.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.data.database.mapper
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.data.database.model.PlaylistEntity
 import com.google.android.horologist.media.model.Playlist
 import com.google.common.truth.Truth.assertThat

--- a/media-data/src/test/java/com/google/android/horologist/media/data/database/mapper/PlaylistMediaEntityMapperTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/database/mapper/PlaylistMediaEntityMapperTest.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.data.database.mapper
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.data.database.model.PlaylistMediaEntity
 import com.google.android.horologist.media.model.Media
 import com.google.android.horologist.media.model.Playlist

--- a/media-data/src/test/java/com/google/android/horologist/media/data/mapper/CommandMapperTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/mapper/CommandMapperTest.kt
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.data.mapper
 
 import androidx.media3.common.Player
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.Command
 import com.google.common.truth.Truth.assertThat
 import org.junit.Assert

--- a/media-data/src/test/java/com/google/android/horologist/media/data/mapper/MediaDownloadMapperTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/mapper/MediaDownloadMapperTest.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.data.mapper
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.data.database.model.MediaDownloadEntity
 import com.google.android.horologist.media.data.database.model.MediaDownloadEntityStatus
 import com.google.android.horologist.media.model.Media

--- a/media-data/src/test/java/com/google/android/horologist/media/data/mapper/MediaDownloadStatusMapperTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/mapper/MediaDownloadStatusMapperTest.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.data.mapper
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.data.database.model.MediaDownloadEntity
 import com.google.android.horologist.media.data.database.model.MediaDownloadEntityStatus
 import com.google.android.horologist.media.model.MediaDownload

--- a/media-data/src/test/java/com/google/android/horologist/media/data/mapper/MediaItemMapperTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/mapper/MediaItemMapperTest.kt
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.data.mapper
 
 import android.net.Uri
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaItem.RequestMetadata
 import androidx.media3.common.MediaMetadata
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.Media
 import com.google.common.truth.Truth.assertThat
 import org.junit.Before

--- a/media-data/src/test/java/com/google/android/horologist/media/data/mapper/MediaMapperTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/mapper/MediaMapperTest.kt
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.data.mapper
 
 import android.net.Uri
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.data.database.model.MediaEntity
 import com.google.common.truth.Truth.assertThat
 import org.junit.Before

--- a/media-data/src/test/java/com/google/android/horologist/media/data/mapper/PlaybackStateMapperTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/mapper/PlaybackStateMapperTest.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.data.mapper
 
 import androidx.media3.common.C
 import androidx.media3.common.Player
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.PlaybackState
 import com.google.android.horologist.media.model.PlaybackStateEvent
 import com.google.android.horologist.test.toolbox.testdoubles.FakeStatePlayer

--- a/media-data/src/test/java/com/google/android/horologist/media/data/mapper/PlayerStateMapperTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/mapper/PlayerStateMapperTest.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.data.mapper
 
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.PlayerState
 import com.google.android.horologist.test.toolbox.testdoubles.FakeStatePlayer
 import com.google.common.truth.Truth.assertThat

--- a/media-data/src/test/java/com/google/android/horologist/media/data/mapper/PlaylistDownloadMapperTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/mapper/PlaylistDownloadMapperTest.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.data.mapper
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.data.database.model.MediaDownloadEntity
 import com.google.android.horologist.media.data.database.model.MediaEntity
 import com.google.android.horologist.media.data.database.model.PlaylistEntity

--- a/media-data/src/test/java/com/google/android/horologist/media/data/mapper/PlaylistMapperTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/mapper/PlaylistMapperTest.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.data.mapper
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.data.database.model.MediaEntity
 import com.google.android.horologist.media.data.database.model.PlaylistEntity
 import com.google.android.horologist.media.data.database.model.PopulatedPlaylist

--- a/media-data/src/test/java/com/google/android/horologist/media/data/mapper/SetCommandMapperTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/mapper/SetCommandMapperTest.kt
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.data.mapper
 
 import androidx.media3.common.Player
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.Command
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test

--- a/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplCloseTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplCloseTest.kt
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.data.repository
 
 import android.content.Context
 import android.os.Looper.getMainLooper
 import androidx.media3.test.utils.TestExoPlayerBuilder
 import androidx.test.core.app.ApplicationProvider
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.Media
 import org.junit.Assert.assertThrows
 import org.junit.Before

--- a/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplNotConnectedTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplNotConnectedTest.kt
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.data.repository
 
 import android.content.Context
 import android.os.Looper.getMainLooper
 import androidx.test.core.app.ApplicationProvider
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.Media
 import com.google.android.horologist.media.model.PlaybackStateEvent
 import com.google.common.truth.Truth.assertThat

--- a/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplTest.kt
+++ b/media-data/src/test/java/com/google/android/horologist/media/data/repository/PlayerRepositoryImplTest.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.data.repository
 
 import android.content.Context
@@ -26,7 +24,6 @@ import androidx.media3.test.utils.robolectric.TestPlayerRunHelper.playUntilPosit
 import androidx.media3.test.utils.robolectric.TestPlayerRunHelper.runUntilPendingCommandsAreFullyHandled
 import androidx.media3.test.utils.robolectric.TestPlayerRunHelper.runUntilPlaybackState
 import androidx.test.core.app.ApplicationProvider
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.data.mapper.MediaItemExtrasMapperNoopImpl
 import com.google.android.horologist.media.data.mapper.MediaItemMapper
 import com.google.android.horologist.media.model.Command
@@ -57,7 +54,6 @@ class PlayerRepositoryImplTest {
 
     private lateinit var mediaItemMapper: MediaItemMapper
 
-    @OptIn(ExperimentalHorologistApi::class)
     @Before
     fun setUp() {
         // execute all tasks posted to main looper

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/auth/prompt/GoogleSignInPromptScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/auth/prompt/GoogleSignInPromptScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.navigation.NavHostController
 import androidx.wear.compose.material.Text
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.auth.composables.chips.GuestModeChip
 import com.google.android.horologist.auth.composables.chips.SignInChip
 import com.google.android.horologist.auth.ui.common.screens.prompt.SignInPromptScreen
@@ -37,7 +36,6 @@ import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.mediasample.R
 import com.google.android.horologist.mediasample.ui.navigation.navigateToGoogleSignIn
 
-@OptIn(ExperimentalHorologistApi::class)
 @Composable
 fun GoogleSignInPromptScreen(
     navController: NavHostController,

--- a/media-sample/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/FakeMediaDownloadRepository.kt
+++ b/media-sample/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/FakeMediaDownloadRepository.kt
@@ -16,10 +16,8 @@
 
 package com.google.android.horologist.test.toolbox.testdoubles
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.repository.MediaDownloadRepository
 
-@OptIn(ExperimentalHorologistApi::class)
 class FakeMediaDownloadRepository(
     private val fakePlaylistDownloadDataSource: FakePlaylistDownloadDataSource
 ) : MediaDownloadRepository {

--- a/media-sample/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/FakePlaylistDownloadRepository.kt
+++ b/media-sample/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/FakePlaylistDownloadRepository.kt
@@ -16,13 +16,11 @@
 
 package com.google.android.horologist.test.toolbox.testdoubles
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.Playlist
 import com.google.android.horologist.media.model.PlaylistDownload
 import com.google.android.horologist.media.repository.PlaylistDownloadRepository
 import kotlinx.coroutines.flow.Flow
 
-@OptIn(ExperimentalHorologistApi::class)
 class FakePlaylistDownloadRepository(
     private val fakePlaylistDownloadDataSource: FakePlaylistDownloadDataSource
 ) : PlaylistDownloadRepository {

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/ProgressStateHolderTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/ProgressStateHolderTest.kt
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.junit4.createComposeRule
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.MediaPositionPredictor
 import com.google.android.horologist.media.model.TimestampProvider
 import com.google.android.horologist.media.ui.state.LocalTimestampProvider

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/MediaControlButtonsTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/MediaControlButtonsTest.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components
 
 import androidx.compose.ui.test.assertIsDisplayed
@@ -24,7 +22,6 @@ import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.test.toolbox.matchers.hasProgressBar
 import org.junit.Rule
 import org.junit.Test

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/MediaControlButtonsWithProgressTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/MediaControlButtonsWithProgressTest.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components
 
 import androidx.compose.ui.test.assertIsDisplayed
@@ -24,7 +22,6 @@ import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
 import com.google.android.horologist.test.toolbox.matchers.hasProgressBar
 import org.junit.Rule

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/PlayPauseButtonTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/PlayPauseButtonTest.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components
 
 import androidx.compose.ui.test.assertIsDisplayed
@@ -23,7 +21,6 @@ import androidx.compose.ui.test.hasAnyChild
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.performClick
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.test.toolbox.matchers.hasProgressBar
 import org.junit.Rule
 import org.junit.Test

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/PlayPauseProgressButtonTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/PlayPauseProgressButtonTest.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components
 
 import android.os.SystemClock
@@ -27,7 +25,6 @@ import androidx.compose.ui.test.hasProgressBarRangeInfo
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.performClick
 import androidx.test.filters.FlakyTest
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.MediaPositionPredictor
 import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
 import com.google.android.horologist.test.toolbox.matchers.hasProgressBar

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/PodcastControlButtonsTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/PodcastControlButtonsTest.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components
 
 import androidx.compose.ui.test.assertIsDisplayed
@@ -25,7 +23,6 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
 import androidx.test.filters.FlakyTest
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement
 import com.google.android.horologist.test.toolbox.matchers.hasProgressBar
 import org.junit.Rule

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/PodcastControlButtonsWithProgressTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/components/PodcastControlButtonsWithProgressTest.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components
 
 import androidx.compose.ui.semantics.ProgressBarRangeInfo
@@ -27,7 +25,6 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
 import androidx.test.filters.FlakyTest
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement
 import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
 import org.junit.Rule

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenTest.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenTest.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.screens.player
 
 import android.os.Vibrator
@@ -32,7 +30,6 @@ import androidx.test.filters.FlakyTest
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.wear.compose.material.Text
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.audio.VolumeState
 import com.google.android.horologist.audio.ui.VolumeViewModel
 import com.google.android.horologist.media.model.Command

--- a/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/test/FakeAudioOutputRepository.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/media/ui/test/FakeAudioOutputRepository.kt
@@ -16,11 +16,10 @@
 
 package com.google.android.horologist.media.ui.test
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.audio.AudioOutput
 import com.google.android.horologist.audio.AudioOutputRepository
 import kotlinx.coroutines.flow.MutableStateFlow
-@OptIn(ExperimentalHorologistApi::class)
+
 class FakeAudioOutputRepository : AudioOutputRepository {
     override val audioOutput: MutableStateFlow<AudioOutput> = MutableStateFlow(AudioOutput.None)
     override val available: MutableStateFlow<List<AudioOutput>> = MutableStateFlow(listOf())

--- a/media-ui/src/androidTest/java/com/google/android/horologist/test/toolbox/testdoubles/FakePlayerRepository.kt
+++ b/media-ui/src/androidTest/java/com/google/android/horologist/test/toolbox/testdoubles/FakePlayerRepository.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.test.toolbox.testdoubles
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.Command
 import com.google.android.horologist.media.model.Media
 import com.google.android.horologist.media.model.PlaybackStateEvent

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/EntityButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/EntityButtonPreview.kt
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 @Preview(
     name = "Enabled",

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/MediaArtworkPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/MediaArtworkPreview.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components
 
 import androidx.compose.material.icons.Icons
@@ -23,7 +21,6 @@ import androidx.compose.material.icons.filled.Album
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.ui.state.model.MediaUiModel
 
 @Preview(

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/MediaChipPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/MediaChipPreview.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components
 
 import androidx.compose.material.icons.Icons
@@ -23,7 +21,6 @@ import androidx.compose.material.icons.filled.Album
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.base.ui.util.rememberVectorPainter
 import com.google.android.horologist.compose.tools.WearPreview
 import com.google.android.horologist.media.ui.state.model.MediaUiModel

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/MediaControlButtonsPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/MediaControlButtonsPreview.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
 import kotlin.time.Duration.Companion.minutes
 

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/PlayPauseButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/PlayPauseButtonPreview.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 @Preview(
     "Enabled - Playing",

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/PlayPauseProgressButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/PlayPauseProgressButtonPreview.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components
 
 import androidx.compose.foundation.background
@@ -24,7 +22,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
 import kotlin.time.Duration.Companion.seconds
 

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/PodcastControlButtonsPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/PodcastControlButtonsPreview.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement
 import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
 import kotlin.time.Duration.Companion.seconds

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChipPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChipPreview.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components.actions
 
 import androidx.compose.material.icons.Icons
@@ -23,7 +21,6 @@ import androidx.compose.material.icons.filled.FeaturedPlayList
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.base.ui.util.rememberVectorPainter
 import com.google.android.horologist.compose.tools.WearPreview
 

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/animated/AnimatedSeekToNextButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/animated/AnimatedSeekToNextButtonPreview.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components.animated
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.audio.ui.components.animated.InteractivePreviewAware
 
 @Preview(

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/controls/MediaButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/controls/MediaButtonPreview.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components.controls
 
 import androidx.compose.material.icons.Icons
@@ -23,7 +21,6 @@ import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 @Preview(
     name = "Play - Enabled",

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/controls/PauseButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/controls/PauseButtonPreview.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components.controls
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 @Preview(
     name = "Enabled",

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/controls/PlayButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/controls/PlayButtonPreview.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components.controls
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 @Preview(
     name = "Enabled",

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/controls/SeekBackButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/controls/SeekBackButtonPreview.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components.controls
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 @Preview(
     name = "5 seconds increment - Enabled",

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/controls/SeekForwardButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/controls/SeekForwardButtonPreview.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components.controls
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 @Preview(
     name = "5 seconds increment - Enabled",

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/controls/SeekToNextButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/controls/SeekToNextButtonPreview.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components.controls
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 @Preview(
     name = "Enabled",

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/controls/SeekToPreviousButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/controls/SeekToPreviousButtonPreview.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components.controls
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 @Preview(
     name = "Enabled",

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/controls/ShuffleToggleButtonPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/controls/ShuffleToggleButtonPreview.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components.controls
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 @Preview(
     "Disabled - Off",

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/display/TextMediaDisplayPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/display/TextMediaDisplayPreview.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components.display
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.WearPreview
 
 @WearPreview

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/display/TrackMediaDisplayPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/components/display/TrackMediaDisplayPreview.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.components.display
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.WearPreview
 import com.google.android.horologist.media.ui.state.model.MediaUiModel
 

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreenPreview.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.screens.browse
 
 import androidx.compose.material.icons.Icons
@@ -27,7 +25,6 @@ import androidx.compose.material.icons.filled.Podcasts
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import androidx.wear.compose.material.ChipDefaults
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.base.ui.components.StandardChip
 import com.google.android.horologist.base.ui.components.StandardChipType
 import com.google.android.horologist.composables.PlaceholderChip

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/browse/PlaylistDownloadBrowseScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/browse/PlaylistDownloadBrowseScreenPreview.kt
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.screens.browse
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FeaturedPlayList
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.base.ui.util.rememberVectorPainter
 import com.google.android.horologist.compose.layout.belowTimeTextPreview
 import com.google.android.horologist.compose.tools.WearPreviewDevices

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/EntityScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/EntityScreenPreview.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.screens.entity
 
 import androidx.compose.foundation.background
@@ -45,7 +43,6 @@ import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.Text
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.base.ui.components.StandardButton
 import com.google.android.horologist.base.ui.components.StandardChip
 import com.google.android.horologist.composables.PlaceholderChip

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenPreview.kt
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.screens.entity
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.base.ui.util.rememberVectorPainter
 import com.google.android.horologist.compose.layout.belowTimeTextPreview
 import com.google.android.horologist.compose.tools.WearPreviewDevices

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenPreview.kt
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class,
-    ExperimentalFoundationApi::class
-)
+@file:OptIn(ExperimentalFoundationApi::class)
 
 package com.google.android.horologist.media.ui.screens.player
 
@@ -39,7 +36,6 @@ import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.TimeText
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.audio.ui.VolumeUiState
 import com.google.android.horologist.audio.ui.components.SettingsButtons
 import com.google.android.horologist.audio.ui.components.SettingsButtonsDefaults

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreenPreview.kt
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.screens.playlists
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FeaturedPlayList
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.base.ui.components.StandardChip
 import com.google.android.horologist.base.ui.components.StandardChipType
 import com.google.android.horologist.base.ui.util.rememberVectorPainter

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/navigation/MediaPlayerScaffold.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/navigation/MediaPlayerScaffold.kt
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class,
-    ExperimentalFoundationApi::class
-)
+@file:OptIn(ExperimentalFoundationApi::class)
 
 package com.google.android.horologist.media.ui.navigation
 
@@ -34,7 +31,6 @@ import androidx.navigation.NavHostController
 import androidx.wear.compose.material.TimeText
 import androidx.wear.compose.navigation.SwipeDismissableNavHostState
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavHostState
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.audio.ui.VolumeScreen
 import com.google.android.horologist.audio.ui.VolumeViewModel
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreen.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.screens.browse
 
 import androidx.annotation.StringRes

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.screens.entity
 
 import android.text.format.Formatter

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistStreamingScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistStreamingScreen.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.screens.entity
 
 import androidx.compose.foundation.layout.Row

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/player/PlayerScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/player/PlayerScreen.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class, ExperimentalWearFoundationApi::class)
+@file:OptIn(ExperimentalWearFoundationApi::class)
 
 package com.google.android.horologist.media.ui.screens.player
 

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/playerlibrarypager/PlayerLibraryPagerScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/playerlibrarypager/PlayerLibraryPagerScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavBackStackEntry
 import androidx.wear.compose.material.PositionIndicator
 import androidx.wear.compose.material.Scaffold
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.audio.ui.VolumePositionIndicator
 import com.google.android.horologist.audio.ui.VolumeUiState
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
@@ -41,7 +40,6 @@ import java.util.concurrent.CancellationException
  * A HorizontalPager with a player screen, using volume control on the left,
  * and library screen with column scrolling on the right.
  */
-@OptIn(ExperimentalHorologistApi::class)
 @Composable
 public fun PlayerLibraryPagerScreen(
     pagerState: PagerState,

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreen.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.screens.playlists
 
 import androidx.compose.foundation.layout.Column

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/PlayerUiStateProducer.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/PlayerUiStateProducer.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.state
 
 import com.google.android.horologist.annotations.ExperimentalHorologistApi

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/PlayerViewModel.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/PlayerViewModel.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.state
 
 import androidx.lifecycle.ViewModel

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/DownloadMediaUiModelMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/DownloadMediaUiModelMapper.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.state.mapper
 
 import com.google.android.horologist.annotations.ExperimentalHorologistApi

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/MediaUiModelMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/MediaUiModelMapper.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.state.mapper
 
 import androidx.compose.ui.graphics.Color

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/PlaylistDownloadUiModelMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/PlaylistDownloadUiModelMapper.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.state.mapper
 
 import com.google.android.horologist.annotations.ExperimentalHorologistApi

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/PlaylistUiModelMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/PlaylistUiModelMapper.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.state.mapper
 
 import com.google.android.horologist.annotations.ExperimentalHorologistApi

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.state.mapper
 
 import com.google.android.horologist.annotations.ExperimentalHorologistApi

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/tiles/MediaCollectionsTileRenderer.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/tiles/MediaCollectionsTileRenderer.kt
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
 @file:Suppress("DEPRECATION")
 
 package com.google.android.horologist.media.ui.tiles

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerA11yScreenshotTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerA11yScreenshotTest.kt
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.media.ui
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.ui.state.PlayerUiState
 import com.google.android.horologist.media.ui.state.model.MediaUiModel
 import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerDeviceScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerDeviceScreenTest.kt
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.media.ui
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.ui.state.PlayerUiState
 import com.google.android.horologist.media.ui.state.model.MediaUiModel
 import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerScreenTest.kt
@@ -14,17 +14,12 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.media.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.ThemeValues
 import com.google.android.horologist.compose.tools.themeValues
 import com.google.android.horologist.media.ui.state.PlayerUiState

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerStatesScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerStatesScreenTest.kt
@@ -14,17 +14,12 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.media.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.ui.state.PlayerUiState
 import com.google.android.horologist.media.ui.state.model.MediaUiModel
 import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerTestCase.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerTestCase.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class, ExperimentalFoundationApi::class)
+@file:OptIn(ExperimentalFoundationApi::class)
 
 package com.google.android.horologist.media.ui
 
@@ -30,7 +30,6 @@ import androidx.compose.ui.Modifier
 import androidx.wear.compose.material.Colors
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Scaffold
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.audio.VolumeState
 import com.google.android.horologist.audio.ui.VolumePositionIndicator
 import com.google.android.horologist.audio.ui.VolumeUiState

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/PodcastPlayerScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/PodcastPlayerScreenTest.kt
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.ui.components.PodcastControlButtons
 import com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement
 import com.google.android.horologist.media.ui.state.PlayerUiState

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/MediaArtworkA11yTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/MediaArtworkA11yTest.kt
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.media.ui.components
 
 import androidx.compose.foundation.layout.Box
@@ -27,7 +23,6 @@ import androidx.compose.material.icons.filled.Album
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.media.ui.state.model.MediaUiModel
 import com.google.android.horologist.screenshots.ScreenshotTest

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/MediaChipA11yTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/MediaChipA11yTest.kt
@@ -14,17 +14,12 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.media.ui.components
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.media.ui.state.model.MediaUiModel
 import com.google.android.horologist.screenshots.ScreenshotTest

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/MediaChipTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/MediaChipTest.kt
@@ -14,16 +14,11 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.media.ui.components
 
 import androidx.compose.foundation.layout.height
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.media.ui.R
 import com.google.android.horologist.media.ui.state.model.MediaUiModel

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChipA11yTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChipA11yTest.kt
@@ -14,17 +14,12 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.media.ui.components.actions
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.media.ui.R
 import com.google.android.horologist.screenshots.ScreenshotTest

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChipTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChipTest.kt
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.media.ui.components.actions
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.media.ui.R
 import com.google.android.horologist.screenshots.ScreenshotTest

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/SeekBackButtonA11yTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/SeekBackButtonA11yTest.kt
@@ -14,17 +14,12 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.media.ui.controls
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.ui.components.controls.SeekBackButton
 import com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement
 import com.google.android.horologist.screenshots.ScreenshotTest

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/SeekBackButtonTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/SeekBackButtonTest.kt
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.media.ui.controls
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.ui.components.controls.SeekBackButton
 import com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement
 import com.google.android.horologist.screenshots.ScreenshotTest

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/SeekForwardButtonA11yTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/SeekForwardButtonA11yTest.kt
@@ -14,17 +14,12 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.media.ui.controls
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement
 import com.google.android.horologist.media.ui.components.controls.SeekForwardButton
 import com.google.android.horologist.screenshots.ScreenshotTest

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/SeekForwardButtonTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/SeekForwardButtonTest.kt
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.media.ui.controls
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.ui.components.controls.SeekButtonIncrement
 import com.google.android.horologist.media.ui.components.controls.SeekForwardButton
 import com.google.android.horologist.screenshots.ScreenshotTest

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/ShuffleToggleButtonTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/controls/ShuffleToggleButtonTest.kt
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.media.ui.controls
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.ui.components.controls.ShuffleToggleButton
 import com.google.android.horologist.screenshots.ScreenshotTest
 import org.junit.Test
@@ -37,7 +32,6 @@ class ShuffleToggleButtonTest : ScreenshotTest() {
         }
     }
 
-    @OptIn(ExperimentalHorologistApi::class)
     @Test
     fun givenShuffleIsOff_thenIconIsShuffle() {
         takeComponentScreenshot {

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/screens/browse/PlaylistDownloadBrowseScreenA11yScreenshotTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/screens/browse/PlaylistDownloadBrowseScreenA11yScreenshotTest.kt
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.media.ui.screens.browse
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.media.ui.PlayerLibraryPreview
 import com.google.android.horologist.media.ui.components.positionedState

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/screens/browse/PlaylistDownloadBrowseScreenA11yTallScreenshotTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/screens/browse/PlaylistDownloadBrowseScreenA11yTallScreenshotTest.kt
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
 @file:Suppress("ObjectLiteralToLambda")
 
 package com.google.android.horologist.media.ui.screens.browse
 
 import androidx.wear.compose.foundation.lazy.ScalingParams
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.tools.a11y.forceState

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/screens/entity/CreatePlaylistDownloadScreenStateLoadedTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/screens/entity/CreatePlaylistDownloadScreenStateLoadedTest.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.screens.entity
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
 import com.google.common.truth.Truth.assertThat

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenA11yScreenshotTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenA11yScreenshotTest.kt
@@ -14,16 +14,11 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.media.ui.screens.entity
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.ui.graphics.Color
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.base.ui.util.rememberVectorPainter
 import com.google.android.horologist.media.ui.PlayerLibraryPreview
 import com.google.android.horologist.media.ui.components.positionedState

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/PlayerUiStateProducerTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/PlayerUiStateProducerTest.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.state
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.Command
 import com.google.android.horologist.media.model.Media
 import com.google.android.horologist.media.model.MediaPositionPredictor

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/PlayerViewModelTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/PlayerViewModelTest.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.state
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
 import com.google.android.horologist.test.toolbox.testdoubles.MockPlayerRepository
 import com.google.common.truth.Truth.assertThat

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/DownloadMediaUiModelMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/DownloadMediaUiModelMapperTest.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.state.mapper
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.Media
 import com.google.android.horologist.media.model.MediaDownload
 import com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/MediaUiModelMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/MediaUiModelMapperTest.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.state.mapper
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.Media
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/PlayerUiStateMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/PlayerUiStateMapperTest.kt
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.state.mapper
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.Command
 import com.google.android.horologist.media.model.Media
 import com.google.android.horologist.media.model.PlaybackState

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/PlaylistDownloadUiModelMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/PlaylistDownloadUiModelMapperTest.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.state.mapper
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.Playlist
 import com.google.android.horologist.media.ui.state.model.PlaylistDownloadUiModel
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/PlaylistUiModelMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/PlaylistUiModelMapperTest.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.state.mapper
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.Playlist
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
 import com.google.common.truth.Truth.assertThat

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapperTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapperTest.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.ui.state.mapper
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.PlaybackState
 import com.google.android.horologist.media.model.PlaybackStateEvent
 import com.google.android.horologist.media.model.PlayerState

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/tiles/MediaCollectionsTileTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/tiles/MediaCollectionsTileTest.kt
@@ -14,17 +14,12 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.media.ui.tiles
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.wear.tiles.ActionBuilders
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.TileLayoutPreview
 import com.google.android.horologist.media.ui.R
 import com.google.android.horologist.media.ui.uamp.UampColors

--- a/media-ui/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/MockPlayerRepository.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/test/toolbox/testdoubles/MockPlayerRepository.kt
@@ -16,7 +16,6 @@
 
 package com.google.android.horologist.test.toolbox.testdoubles
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.Command
 import com.google.android.horologist.media.model.Media
 import com.google.android.horologist.media.model.PlaybackStateEvent
@@ -25,7 +24,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlin.time.Duration
 
-@OptIn(ExperimentalHorologistApi::class)
 class MockPlayerRepository(
     private val connectedValue: Boolean = false,
     private val availableCommandsValue: Set<Command> = emptySet(),

--- a/media/build.gradle.kts
+++ b/media/build.gradle.kts
@@ -43,4 +43,10 @@ dependencies {
     testImplementation(libs.truth)
 }
 
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    compilerOptions {
+        freeCompilerArgs.add("-opt-in=com.google.android.horologist.annotations.ExperimentalHorologistApi")
+    }
+}
+
 apply(plugin = "com.vanniktech.maven.publish")

--- a/media/src/test/java/com/google/android/horologist/media/model/PlaybackStateTest.kt
+++ b/media/src/test/java/com/google/android/horologist/media/model/PlaybackStateTest.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media.model
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import kotlin.time.Duration

--- a/media3-backend/src/main/java/com/google/android/horologist/media3/flows/WaitForPlaying.kt
+++ b/media3-backend/src/main/java/com/google/android/horologist/media3/flows/WaitForPlaying.kt
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media3.flows
 
 import androidx.media3.common.Player
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 

--- a/media3-backend/src/main/java/com/google/android/horologist/media3/logging/ErrorReporter.kt
+++ b/media3-backend/src/main/java/com/google/android/horologist/media3/logging/ErrorReporter.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media3.logging
 
 import androidx.annotation.StringRes

--- a/media3-backend/src/main/java/com/google/android/horologist/media3/logging/TransferListener.kt
+++ b/media3-backend/src/main/java/com/google/android/horologist/media3/logging/TransferListener.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.media3.logging
 
 import android.annotation.SuppressLint

--- a/media3-backend/src/test/java/com/google/android/horologist/media3/FakeAudioOutputRepository.kt
+++ b/media3-backend/src/test/java/com/google/android/horologist/media3/FakeAudioOutputRepository.kt
@@ -16,11 +16,10 @@
 
 package com.google.android.horologist.media3
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.audio.AudioOutput
 import com.google.android.horologist.audio.AudioOutputRepository
 import kotlinx.coroutines.flow.MutableStateFlow
-@OptIn(ExperimentalHorologistApi::class)
+
 open class FakeAudioOutputRepository : AudioOutputRepository {
     override val audioOutput: MutableStateFlow<AudioOutput> = MutableStateFlow(AudioOutput.None)
     override val available: MutableStateFlow<List<AudioOutput>> = MutableStateFlow(listOf())

--- a/media3-backend/src/test/java/com/google/android/horologist/media3/FakeAudioOutputSelector.kt
+++ b/media3-backend/src/test/java/com/google/android/horologist/media3/FakeAudioOutputSelector.kt
@@ -16,11 +16,9 @@
 
 package com.google.android.horologist.media3
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.audio.AudioOutput
 import com.google.android.horologist.media3.audio.AudioOutputSelector
 
-@OptIn(ExperimentalHorologistApi::class)
 open class FakeAudioOutputSelector(
     private val newOutput: AudioOutput?,
     private val audioOutputRepository: FakeAudioOutputRepository

--- a/media3-backend/src/test/java/com/google/android/horologist/media3/FakeErrorReporter.kt
+++ b/media3-backend/src/test/java/com/google/android/horologist/media3/FakeErrorReporter.kt
@@ -16,10 +16,8 @@
 
 package com.google.android.horologist.media3
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media3.logging.ErrorReporter
 
-@OptIn(ExperimentalHorologistApi::class)
 open class FakeErrorReporter : ErrorReporter {
     val messages = mutableListOf<Int>()
     val logs = mutableListOf<String>()

--- a/media3-backend/src/test/java/com/google/android/horologist/media3/WearConfiguredPlayerTest.kt
+++ b/media3-backend/src/test/java/com/google/android/horologist/media3/WearConfiguredPlayerTest.kt
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalHorologistApi::class
-)
-
 package com.google.android.horologist.media3
 
 import android.content.Context
@@ -26,7 +22,6 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.test.utils.TestExoPlayerBuilder
 import androidx.test.core.app.ApplicationProvider
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.audio.AudioOutput
 import com.google.android.horologist.media3.rules.PlaybackRules
 import com.google.common.truth.Truth.assertThat

--- a/network-awareness/build.gradle.kts
+++ b/network-awareness/build.gradle.kts
@@ -47,6 +47,7 @@ android {
     kotlinOptions {
         jvmTarget = "11"
         freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn"
+        freeCompilerArgs = freeCompilerArgs + "-opt-in=com.google.android.horologist.annotations.ExperimentalHorologistApi"
     }
 
     composeOptions {

--- a/network-awareness/src/androidTest/java/com/google/android/horologist/networks/NetworkRepositoryTest.kt
+++ b/network-awareness/src/androidTest/java/com/google/android/horologist/networks/NetworkRepositoryTest.kt
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-@file:OptIn(
-    ExperimentalCoroutinesApi::class,
-    ExperimentalHorologistApi::class
-)
+@file:OptIn(ExperimentalCoroutinesApi::class)
 
 package com.google.android.horologist.networks
 
@@ -26,7 +23,6 @@ import android.net.ConnectivityManager
 import androidx.activity.ComponentActivity
 import androidx.test.filters.MediumTest
 import androidx.test.platform.app.InstrumentationRegistry
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.networks.data.id
 import com.google.android.horologist.networks.status.NetworkRepositoryImpl
 import com.google.common.truth.Truth

--- a/network-awareness/src/main/java/com/google/android/horologist/networks/okhttp/RequestType.kt
+++ b/network-awareness/src/main/java/com/google/android/horologist/networks/okhttp/RequestType.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.networks.okhttp
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.networks.data.NetworkInfo
 import com.google.android.horologist.networks.data.RequestType
 import com.google.android.horologist.networks.highbandwidth.HighBandwidthConnectionLease

--- a/network-awareness/src/test/java/com/google/android/horologist/networks/rules/ConservativeTest.kt
+++ b/network-awareness/src/test/java/com/google/android/horologist/networks/rules/ConservativeTest.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.networks.rules
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.networks.data.RequestType.ImageRequest
 import com.google.android.horologist.networks.data.RequestType.MediaRequest
 import com.google.android.horologist.networks.data.RequestType.MediaRequest.MediaRequestType.Download

--- a/network-awareness/src/test/java/com/google/android/horologist/networks/rules/LenientTest.kt
+++ b/network-awareness/src/test/java/com/google/android/horologist/networks/rules/LenientTest.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.networks.rules
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.networks.data.RequestType.ImageRequest
 import com.google.android.horologist.networks.rules.NetworkingRules.Lenient
 import com.google.android.horologist.networks.rules.helpers.Fixtures

--- a/network-awareness/src/test/java/com/google/android/horologist/networks/rules/NetworkSelectingCallFactoryTest.kt
+++ b/network-awareness/src/test/java/com/google/android/horologist/networks/rules/NetworkSelectingCallFactoryTest.kt
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class, ExperimentalCoroutinesApi::class)
+@file:OptIn(ExperimentalCoroutinesApi::class)
 
 package com.google.android.horologist.networks.rules
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.networks.data.InMemoryDataRequestRepository
 import com.google.android.horologist.networks.data.NetworkType
 import com.google.android.horologist.networks.data.NetworkType.BT

--- a/network-awareness/src/test/java/com/google/android/horologist/networks/rules/StandardHighBandwidthNetworkMediatorTest.kt
+++ b/network-awareness/src/test/java/com/google/android/horologist/networks/rules/StandardHighBandwidthNetworkMediatorTest.kt
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class, ExperimentalCoroutinesApi::class)
+@file:OptIn(ExperimentalCoroutinesApi::class)
 
 package com.google.android.horologist.networks.rules
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.networks.data.NetworkType
 import com.google.android.horologist.networks.data.NetworkType.Wifi
 import com.google.android.horologist.networks.highbandwidth.StandardHighBandwidthNetworkMediator

--- a/network-awareness/src/test/java/com/google/android/horologist/networks/rules/helpers/ConfigurableNetworkingRules.kt
+++ b/network-awareness/src/test/java/com/google/android/horologist/networks/rules/helpers/ConfigurableNetworkingRules.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.networks.rules.helpers
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.networks.data.NetworkInfo
 import com.google.android.horologist.networks.data.NetworkStatus
 import com.google.android.horologist.networks.data.NetworkType

--- a/network-awareness/src/test/java/com/google/android/horologist/networks/rules/helpers/FakeNetworkRepository.kt
+++ b/network-awareness/src/test/java/com/google/android/horologist/networks/rules/helpers/FakeNetworkRepository.kt
@@ -17,7 +17,6 @@
 package com.google.android.horologist.networks.rules.helpers
 
 import android.net.Network
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.networks.data.NetworkInfo
 import com.google.android.horologist.networks.data.NetworkStatus
 import com.google.android.horologist.networks.data.NetworkType
@@ -27,7 +26,6 @@ import com.google.android.horologist.networks.status.NetworkRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import java.net.InetAddress
 
-@OptIn(ExperimentalHorologistApi::class)
 class FakeNetworkRepository : NetworkRepository {
     private var defaultNetworks = listOf(BtNetwork)
     private var pinned: NetworkType? = null

--- a/network-awareness/src/test/java/com/google/android/horologist/networks/rules/helpers/FakeNetworkRequester.kt
+++ b/network-awareness/src/test/java/com/google/android/horologist/networks/rules/helpers/FakeNetworkRequester.kt
@@ -16,7 +16,6 @@
 
 package com.google.android.horologist.networks.rules.helpers
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.networks.data.NetworkType.Cell
 import com.google.android.horologist.networks.data.NetworkType.Wifi
 import com.google.android.horologist.networks.request.HighBandwidthRequest
@@ -26,7 +25,6 @@ import com.google.android.horologist.networks.request.NetworkRequester
 import kotlinx.coroutines.flow.MutableStateFlow
 import java.time.Instant
 
-@OptIn(ExperimentalHorologistApi::class)
 class FakeNetworkRequester(
     private val networkRepository: FakeNetworkRepository
 ) : NetworkRequester {

--- a/network-awareness/src/test/java/com/google/android/horologist/networks/rules/helpers/Fixtures.kt
+++ b/network-awareness/src/test/java/com/google/android/horologist/networks/rules/helpers/Fixtures.kt
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.networks.rules.helpers
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.networks.data.NetworkInfo
 import com.google.android.horologist.networks.data.NetworkStatus
 import com.google.android.horologist.networks.data.Networks

--- a/network-awareness/src/test/java/com/google/android/horologist/networks/rules/helpers/TestLogger.kt
+++ b/network-awareness/src/test/java/com/google/android/horologist/networks/rules/helpers/TestLogger.kt
@@ -16,12 +16,10 @@
 
 package com.google.android.horologist.networks.rules.helpers
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.networks.data.NetworkInfo
 import com.google.android.horologist.networks.data.RequestType
 import com.google.android.horologist.networks.logging.NetworkStatusLogger
 
-@OptIn(ExperimentalHorologistApi::class)
 public class TestLogger : NetworkStatusLogger {
     public val events: MutableList<String> = mutableListOf()
 

--- a/roboscreenshots/build.gradle.kts
+++ b/roboscreenshots/build.gradle.kts
@@ -43,6 +43,7 @@ android {
 
     kotlinOptions {
         jvmTarget = "11"
+        freeCompilerArgs = freeCompilerArgs + "-opt-in=com.google.android.horologist.annotations.ExperimentalHorologistApi"
     }
 
     composeOptions {

--- a/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/ScreenshotTest.kt
+++ b/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/ScreenshotTest.kt
@@ -16,7 +16,6 @@
 
 @file:OptIn(
     ExperimentalCoroutinesApi::class,
-    ExperimentalHorologistApi::class,
     ExperimentalTestApi::class
 )
 @file:Suppress("UnstableApiUsage")

--- a/sample/src/main/java/com/google/android/horologist/datalayer/SampleDataService.kt
+++ b/sample/src/main/java/com/google/android/horologist/datalayer/SampleDataService.kt
@@ -16,12 +16,10 @@
 
 package com.google.android.horologist.datalayer
 
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.components.SampleApplication
 import com.google.android.horologist.data.WearDataLayerRegistry
 import com.google.android.horologist.data.WearDataService
 
-@OptIn(ExperimentalHorologistApi::class)
 class SampleDataService : WearDataService() {
     override lateinit var registry: WearDataLayerRegistry
 

--- a/sample/src/main/java/com/google/android/horologist/sample/FillMaxRectangleScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/FillMaxRectangleScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.layout.fillMaxRectangle
 import com.google.android.horologist.compose.tools.WearPreviewDevices
 
@@ -34,7 +33,6 @@ fun FillMaxRectangleScreen() {
     )
 }
 
-@OptIn(ExperimentalHorologistApi::class)
 @WearPreviewDevices
 @Composable
 fun FillMaxRectanglePreview() {

--- a/sample/src/main/java/com/google/android/horologist/tile/SampleTheme.kt
+++ b/sample/src/main/java/com/google/android/horologist/tile/SampleTheme.kt
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
 @file:Suppress("DEPRECATION")
 
 package com.google.android.horologist.tile
@@ -23,7 +22,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.wear.tiles.material.Colors
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.TileLayoutPreview
 import com.google.android.horologist.compose.tools.WearLargeRoundDevicePreview
 import com.google.android.horologist.tiles.preview.ThemePreviewTileRenderer

--- a/sample/src/main/java/com/google/android/horologist/tile/SampleTileRenderer.kt
+++ b/sample/src/main/java/com/google/android/horologist/tile/SampleTileRenderer.kt
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
 @file:Suppress("DEPRECATION")
 
 package com.google.android.horologist.tile
@@ -39,7 +38,6 @@ import androidx.wear.tiles.material.Text
 import androidx.wear.tiles.material.Typography
 import androidx.wear.tiles.material.layouts.MultiButtonLayout
 import androidx.wear.tiles.material.layouts.PrimaryLayout
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.LayoutElementPreview
 import com.google.android.horologist.compose.tools.TileLayoutPreview
 import com.google.android.horologist.compose.tools.WearPreviewDevices
@@ -122,7 +120,6 @@ class SampleTileRenderer(context: Context) :
     }
 }
 
-@OptIn(ExperimentalHorologistApi::class)
 @WearPreviewDevices
 @WearPreviewFontSizes
 @Composable

--- a/tiles/build.gradle.kts
+++ b/tiles/build.gradle.kts
@@ -46,6 +46,7 @@ android {
 
     kotlinOptions {
         jvmTarget = "11"
+        freeCompilerArgs = freeCompilerArgs + "-opt-in=com.google.android.horologist.annotations.ExperimentalHorologistApi"
     }
 
     composeOptions {

--- a/tiles/src/main/java/com/google/android/horologist/tiles/preview/ThemePreviewTileRenderer.kt
+++ b/tiles/src/main/java/com/google/android/horologist/tiles/preview/ThemePreviewTileRenderer.kt
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
 @file:Suppress("DEPRECATION")
 
 package com.google.android.horologist.tiles.preview
@@ -37,7 +36,6 @@ import androidx.wear.tiles.material.Colors
 import androidx.wear.tiles.material.CompactChip
 import androidx.wear.tiles.material.Text
 import androidx.wear.tiles.material.Typography
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.tiles.R
 import com.google.android.horologist.tiles.components.NoOpClickable
 import com.google.android.horologist.tiles.images.drawableResToImageResource

--- a/tiles/src/main/java/com/google/android/horologist/tiles/render/RendererPreviewTileService.kt
+++ b/tiles/src/main/java/com/google/android/horologist/tiles/render/RendererPreviewTileService.kt
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.tiles.render
 
 import androidx.wear.tiles.RequestBuilders.ResourcesRequest
 import androidx.wear.tiles.RequestBuilders.TileRequest
 import androidx.wear.tiles.ResourceBuilders.Resources
 import androidx.wear.tiles.TileBuilders.Tile
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.tiles.SuspendingTileService
 
 /**

--- a/tiles/src/test/java/com/google/android/horologist/tiles/TestTileService.kt
+++ b/tiles/src/test/java/com/google/android/horologist/tiles/TestTileService.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.tiles
 
 import androidx.wear.tiles.LayoutElementBuilders.Column
@@ -28,7 +26,6 @@ import androidx.wear.tiles.ResourceBuilders
 import androidx.wear.tiles.TileBuilders.Tile
 import androidx.wear.tiles.TimelineBuilders.Timeline
 import androidx.wear.tiles.TimelineBuilders.TimelineEntry
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.seconds
 


### PR DESCRIPTION
#### WHAT

Move opt-ins for experimental annotation to build.gradle file

#### WHY

https://github.com/google/horologist/pull/1123#discussion_r1143312738

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
