### PR TITLE
Removes timestamp from volume state

### DIFF
--- a/audio-ui/api/current.api
+++ b/audio-ui/api/current.api
@@ -5,7 +5,7 @@ package com.google.android.horologist.audio.ui {
   }
 
   public final class VolumePositionIndicatorKt {
-    method @androidx.compose.runtime.Composable public static void VolumePositionIndicator(kotlin.jvm.functions.Function0<com.google.android.horologist.audio.ui.VolumeUiState> volumeUiState, optional androidx.compose.ui.Modifier modifier, optional boolean autoHide);
+    method @androidx.compose.runtime.Composable public static void VolumePositionIndicator(kotlin.jvm.functions.Function0<com.google.android.horologist.audio.ui.VolumeUiState> volumeUiState, optional androidx.compose.ui.Modifier modifier, optional kotlinx.coroutines.flow.Flow<kotlin.Unit>? displayIndicatorEvents);
   }
 
   public final class VolumeScreenDefaults {
@@ -16,8 +16,8 @@ package com.google.android.horologist.audio.ui {
 
   public final class VolumeScreenKt {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void VolumeScreen(optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.audio.ui.VolumeViewModel volumeViewModel, optional boolean showVolumeIndicator, optional kotlin.jvm.functions.Function0<kotlin.Unit> increaseIcon, optional kotlin.jvm.functions.Function0<kotlin.Unit> decreaseIcon);
-    method @androidx.compose.runtime.Composable public static void VolumeScreen(kotlin.jvm.functions.Function0<com.google.android.horologist.audio.VolumeState> volume, com.google.android.horologist.audio.ui.components.AudioOutputUi audioOutputUi, kotlin.jvm.functions.Function0<kotlin.Unit> increaseVolume, kotlin.jvm.functions.Function0<kotlin.Unit> decreaseVolume, kotlin.jvm.functions.Function0<kotlin.Unit> onAudioOutputClick, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit> increaseIcon, optional kotlin.jvm.functions.Function0<kotlin.Unit> decreaseIcon, optional boolean showVolumeIndicator);
-    method @androidx.compose.runtime.Composable public static void VolumeWithLabelScreen(kotlin.jvm.functions.Function0<com.google.android.horologist.audio.VolumeState> volume, kotlin.jvm.functions.Function0<kotlin.Unit> increaseVolume, kotlin.jvm.functions.Function0<kotlin.Unit> decreaseVolume, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit> increaseIcon, optional kotlin.jvm.functions.Function0<kotlin.Unit> decreaseIcon, optional boolean showVolumeIndicator);
+    method @androidx.compose.runtime.Composable public static void VolumeScreen(kotlin.jvm.functions.Function0<com.google.android.horologist.audio.ui.VolumeUiState> volume, com.google.android.horologist.audio.ui.components.AudioOutputUi audioOutputUi, kotlin.jvm.functions.Function0<kotlin.Unit> increaseVolume, kotlin.jvm.functions.Function0<kotlin.Unit> decreaseVolume, kotlin.jvm.functions.Function0<kotlin.Unit> onAudioOutputClick, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit> increaseIcon, optional kotlin.jvm.functions.Function0<kotlin.Unit> decreaseIcon, optional boolean showVolumeIndicator);
+    method @androidx.compose.runtime.Composable public static void VolumeWithLabelScreen(kotlin.jvm.functions.Function0<com.google.android.horologist.audio.ui.VolumeUiState> volume, kotlin.jvm.functions.Function0<kotlin.Unit> increaseVolume, kotlin.jvm.functions.Function0<kotlin.Unit> decreaseVolume, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit> increaseIcon, optional kotlin.jvm.functions.Function0<kotlin.Unit> decreaseIcon, optional boolean showVolumeIndicator);
   }
 
   @Deprecated public final class VolumeScrollableState implements androidx.compose.foundation.gestures.ScrollableState {
@@ -29,24 +29,20 @@ package com.google.android.horologist.audio.ui {
   }
 
   public final class VolumeUiState {
-    ctor public VolumeUiState(optional long timestamp, optional int current, optional int max, optional boolean isMax, optional boolean isMin);
-    method public long component1();
+    ctor public VolumeUiState(optional int current, optional int max, optional boolean isMax, optional boolean isMin);
+    method public int component1();
     method public int component2();
-    method public int component3();
+    method public boolean component3();
     method public boolean component4();
-    method public boolean component5();
-    method public com.google.android.horologist.audio.ui.VolumeUiState copy(long timestamp, int current, int max, boolean isMax, boolean isMin);
+    method public com.google.android.horologist.audio.ui.VolumeUiState copy(int current, int max, boolean isMax, boolean isMin);
     method public int getCurrent();
     method public int getMax();
-    method public long getTimestamp();
     method public boolean isMax();
     method public boolean isMin();
-    method public void setTimestamp(long);
     property public final int current;
     property public final boolean isMax;
     property public final boolean isMin;
     property public final int max;
-    property public final long timestamp;
   }
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public class VolumeViewModel extends androidx.lifecycle.ViewModel {
@@ -54,14 +50,14 @@ package com.google.android.horologist.audio.ui {
     method public final void decreaseVolume();
     method public final void decreaseVolumeWithHaptics();
     method public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.AudioOutput> getAudioOutput();
-    method public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.VolumeState> getVolumeState();
+    method public final kotlinx.coroutines.flow.Flow<kotlin.Unit> getDisplayIndicatorEvents();
     method public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.ui.VolumeUiState> getVolumeUiState();
     method public final void increaseVolume();
     method public final void increaseVolumeWithHaptics();
     method public final void launchOutputSelection();
     method public final void onVolumeChangeByScroll(float pixels);
     property public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.AudioOutput> audioOutput;
-    property public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.VolumeState> volumeState;
+    property public final kotlinx.coroutines.flow.Flow<kotlin.Unit> displayIndicatorEvents;
     property public final kotlinx.coroutines.flow.StateFlow<com.google.android.horologist.audio.ui.VolumeUiState> volumeUiState;
     field public static final com.google.android.horologist.audio.ui.VolumeViewModel.Companion Companion;
   }
@@ -103,7 +99,7 @@ package com.google.android.horologist.audio.ui.components {
   }
 
   public final class SettingsButtonsKt {
-    method @androidx.compose.runtime.Composable public static void SettingsButtons(com.google.android.horologist.audio.VolumeState volumeState, kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, kotlin.jvm.functions.Function0<kotlin.Unit> onOutputClick, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit> brandIcon, optional boolean enabled);
+    method @androidx.compose.runtime.Composable public static void SettingsButtons(com.google.android.horologist.audio.ui.VolumeUiState volumeUiState, kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, kotlin.jvm.functions.Function0<kotlin.Unit> onOutputClick, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit> brandIcon, optional boolean enabled);
   }
 
 }
@@ -115,7 +111,7 @@ package com.google.android.horologist.audio.ui.components.actions {
   }
 
   public final class SetVolumeButtonKt {
-    method @androidx.compose.runtime.Composable public static void SetVolumeButton(kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, com.google.android.horologist.audio.VolumeState volumeState, optional androidx.compose.ui.Modifier modifier, optional boolean enabled);
+    method @androidx.compose.runtime.Composable public static void SetVolumeButton(kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, com.google.android.horologist.audio.ui.VolumeUiState volumeUiState, optional androidx.compose.ui.Modifier modifier, optional boolean enabled);
   }
 
   public final class SettingsButtonKt {
@@ -127,7 +123,7 @@ package com.google.android.horologist.audio.ui.components.actions {
 package com.google.android.horologist.audio.ui.components.animated {
 
   public final class AnimatedSetVolumeButtonKt {
-    method @androidx.compose.runtime.Composable public static void AnimatedSetVolumeButton(kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, com.google.android.horologist.audio.VolumeState volumeState, optional androidx.compose.ui.Modifier modifier);
+    method @androidx.compose.runtime.Composable public static void AnimatedSetVolumeButton(kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, com.google.android.horologist.audio.ui.VolumeUiState volumeUiState, optional androidx.compose.ui.Modifier modifier);
   }
 
   public final class InteractivePreviewAwareKt {
@@ -143,7 +139,7 @@ package com.google.android.horologist.audio.ui.components.animated {
 package com.google.android.horologist.audio.ui.mapper {
 
   public final class VolumeUiStateMapper {
-    method public com.google.android.horologist.audio.ui.VolumeUiState map(optional long timestamp, com.google.android.horologist.audio.VolumeState volumeState);
+    method public com.google.android.horologist.audio.ui.VolumeUiState map(com.google.android.horologist.audio.VolumeState volumeState);
     field public static final com.google.android.horologist.audio.ui.mapper.VolumeUiStateMapper INSTANCE;
   }
 

--- a/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/VolumePositionIndicatorTest.kt
+++ b/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/VolumePositionIndicatorTest.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.test.printToLog
 import androidx.test.filters.MediumTest
 import com.google.android.horologist.audio.VolumeState
 import com.google.android.horologist.audio.ui.mapper.VolumeUiStateMapper
+import kotlinx.coroutines.flow.flowOf
 import org.junit.Rule
 import org.junit.Test
 
@@ -51,8 +52,7 @@ class VolumePositionIndicatorTest {
         composeTestRule.setContent {
             VolumePositionIndicator(
                 modifier = Modifier.testTag(TEST_TAG),
-                volumeUiState = { VolumeUiStateMapper.map(volumeState = volumeState) },
-                autoHide = false
+                volumeUiState = { VolumeUiStateMapper.map(volumeState = volumeState) }
             )
         }
 
@@ -67,7 +67,7 @@ class VolumePositionIndicatorTest {
             VolumePositionIndicator(
                 modifier = Modifier.testTag(TEST_TAG),
                 volumeUiState = { VolumeUiStateMapper.map(volumeState = volumeState) },
-                autoHide = true
+                displayIndicatorEvents = flowOf(Unit)
             )
         }
 

--- a/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/VolumeScreenTestCase.kt
+++ b/audio-ui/src/androidTest/java/com/google/android/horologist/audio/ui/VolumeScreenTestCase.kt
@@ -28,16 +28,16 @@ fun VolumeScreenTestCase(
     volumeState: VolumeState,
     audioOutput: AudioOutput.BluetoothHeadset
 ) {
+    val volumeUiState = VolumeUiStateMapper.map(volumeState = volumeState)
     Scaffold(
         positionIndicator = {
             VolumePositionIndicator(
-                volumeUiState = { VolumeUiStateMapper.map(volumeState = volumeState) },
-                autoHide = false
+                volumeUiState = { volumeUiState }
             )
         }
     ) {
         VolumeScreen(
-            volume = { volumeState },
+            volume = { volumeUiState },
             audioOutputUi = audioOutput.toAudioOutputUi(),
             increaseVolume = { },
             decreaseVolume = { },

--- a/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/VolumeScreenLocalePreview.kt
+++ b/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/VolumeScreenLocalePreview.kt
@@ -34,13 +34,12 @@ fun VolumeScreenLocalePreview() {
     Scaffold(
         positionIndicator = {
             VolumePositionIndicator(
-                volumeUiState = { volumeUiState },
-                autoHide = false
+                volumeUiState = { volumeUiState }
             )
         }
     ) {
         VolumeScreen(
-            volume = { volume },
+            volume = { volumeUiState },
             audioOutputUi = AudioOutput.WatchSpeaker(
                 id = "1",
                 name = LocalConfiguration.current.locales.get(0).displayName

--- a/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/VolumeScreenPreview.kt
+++ b/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/VolumeScreenPreview.kt
@@ -45,13 +45,12 @@ fun VolumeScreenGuideWithLongText() {
         Scaffold(
             positionIndicator = {
                 VolumePositionIndicator(
-                    volumeUiState = { volumeUiState },
-                    autoHide = false
+                    volumeUiState = { volumeUiState }
                 )
             }
         ) {
             VolumeScreen(
-                volume = { volume },
+                volume = { volumeUiState },
                 audioOutputUi = AudioOutput.BluetoothHeadset(id = "1", name = "Galaxy Watch 4")
                     .toAudioOutputUi(),
                 increaseVolume = { },
@@ -74,13 +73,12 @@ fun VolumeScreenPreview(
     Scaffold(
         positionIndicator = {
             VolumePositionIndicator(
-                volumeUiState = { volumeUiState },
-                autoHide = false
+                volumeUiState = { volumeUiState }
             )
         }
     ) {
         VolumeScreen(
-            volume = { volume },
+            volume = { volumeUiState },
             audioOutputUi = audioOutput.toAudioOutputUi(),
             increaseVolume = { },
             decreaseVolume = { },
@@ -102,13 +100,12 @@ fun VolumeScreenTheme(
             Scaffold(
                 positionIndicator = {
                     VolumePositionIndicator(
-                        volumeUiState = { volumeUiState },
-                        autoHide = false
+                        volumeUiState = { volumeUiState }
                     )
                 }
             ) {
                 VolumeScreen(
-                    volume = { volume },
+                    volume = { volumeUiState },
                     audioOutputUi = AudioOutput.BluetoothHeadset(id = "1", name = "PixelBuds")
                         .toAudioOutputUi(),
                     increaseVolume = { },
@@ -131,13 +128,12 @@ fun VolumeScreenWithLabel() {
         Scaffold(
             positionIndicator = {
                 VolumePositionIndicator(
-                    volumeUiState = { volumeUiState },
-                    autoHide = false
+                    volumeUiState = { volumeUiState }
                 )
             }
         ) {
             VolumeWithLabelScreen(
-                volume = { volume },
+                volume = { volumeUiState },
                 increaseVolume = { },
                 decreaseVolume = { }
             )

--- a/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonPreview.kt
+++ b/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonPreview.kt
@@ -18,7 +18,7 @@ package com.google.android.horologist.audio.ui.components.actions
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.audio.VolumeState
+import com.google.android.horologist.audio.ui.VolumeUiState
 
 @Preview(
     name = "Other volume",
@@ -29,7 +29,7 @@ import com.google.android.horologist.audio.VolumeState
 fun SetVolumeButtonPreview() {
     SetVolumeButton(
         onVolumeClick = {},
-        volumeState = VolumeState(current = 4, max = 10)
+        volumeUiState = VolumeUiState(current = 4, max = 10)
     )
 }
 
@@ -42,7 +42,7 @@ fun SetVolumeButtonPreview() {
 fun SetVolumeButtonPreviewMinVolume() {
     SetVolumeButton(
         onVolumeClick = {},
-        volumeState = VolumeState(current = 0, max = 10)
+        volumeUiState = VolumeUiState(current = 0, max = 10)
     )
 }
 
@@ -55,6 +55,6 @@ fun SetVolumeButtonPreviewMinVolume() {
 fun SetVolumeButtonPreviewMaxVolume() {
     SetVolumeButton(
         onVolumeClick = {},
-        volumeState = VolumeState(current = 10, max = 10)
+        volumeUiState = VolumeUiState(current = 10, max = 10)
     )
 }

--- a/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/actions/SettingsButtonsPreview.kt
+++ b/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/actions/SettingsButtonsPreview.kt
@@ -17,8 +17,8 @@
 package com.google.android.horologist.audio.ui.components.actions
 
 import androidx.compose.runtime.Composable
-import com.google.android.horologist.audio.VolumeState
 import com.google.android.horologist.audio.ui.R
+import com.google.android.horologist.audio.ui.VolumeUiState
 import com.google.android.horologist.audio.ui.components.SettingsButtons
 import com.google.android.horologist.audio.ui.components.SettingsButtonsDefaults.BrandIcon
 import com.google.android.horologist.compose.tools.WearPreview
@@ -27,7 +27,7 @@ import com.google.android.horologist.compose.tools.WearPreview
 @Composable
 fun SettingsButtonsPreview() {
     SettingsButtons(
-        volumeState = VolumeState(4, 10),
+        volumeUiState = VolumeUiState(4, 10),
         onVolumeClick = {},
         onOutputClick = {}
     )
@@ -37,7 +37,7 @@ fun SettingsButtonsPreview() {
 @Composable
 fun SettingsButtonsWithBrandIconPreview() {
     SettingsButtons(
-        volumeState = VolumeState(5, 10),
+        volumeUiState = VolumeUiState(5, 10),
         onVolumeClick = {},
         onOutputClick = {},
         brandIcon = {
@@ -50,7 +50,7 @@ fun SettingsButtonsWithBrandIconPreview() {
 @Composable
 fun SettingsButtonsDisabledPreview() {
     SettingsButtons(
-        volumeState = VolumeState(5, 10),
+        volumeUiState = VolumeUiState(5, 10),
         onVolumeClick = {},
         onOutputClick = {},
         enabled = false,

--- a/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/animated/AnimatedSetVolumeButtonPreview.kt
+++ b/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/animated/AnimatedSetVolumeButtonPreview.kt
@@ -22,22 +22,22 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.wear.compose.material.Stepper
-import com.google.android.horologist.audio.VolumeState
 import com.google.android.horologist.audio.ui.VolumeScreenDefaults.DecreaseIcon
 import com.google.android.horologist.audio.ui.VolumeScreenDefaults.IncreaseIcon
+import com.google.android.horologist.audio.ui.VolumeUiState
 import com.google.android.horologist.compose.tools.WearSmallRoundDevicePreview
 
 @WearSmallRoundDevicePreview
 @Composable
 fun AnimatedSetVolumeButtonPreview() {
-    var volumeState by remember { mutableStateOf(VolumeState(3, 5)) }
+    var volumeUiState by remember { mutableStateOf(VolumeUiState(3, 5)) }
 
     InteractivePreviewAware {
         Stepper(
-            value = volumeState.current.toFloat(),
-            onValueChange = { volumeState = volumeState.copy(current = it.toInt()) },
-            steps = volumeState.max - 1,
-            valueRange = (0f..volumeState.max.toFloat()),
+            value = volumeUiState.current.toFloat(),
+            onValueChange = { volumeUiState = volumeUiState.copy(current = it.toInt()) },
+            steps = volumeUiState.max - 1,
+            valueRange = (0f..volumeUiState.max.toFloat()),
             increaseIcon = {
                 IncreaseIcon()
             },
@@ -45,7 +45,7 @@ fun AnimatedSetVolumeButtonPreview() {
                 DecreaseIcon()
             }
         ) {
-            AnimatedSetVolumeButton(onVolumeClick = { }, volumeState = volumeState)
+            AnimatedSetVolumeButton(onVolumeClick = { }, volumeUiState = volumeUiState)
         }
     }
 }

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeScreen.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeScreen.kt
@@ -39,11 +39,9 @@ import androidx.wear.compose.material.Stepper
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.audio.AudioOutput
-import com.google.android.horologist.audio.VolumeState
 import com.google.android.horologist.audio.ui.components.AudioOutputUi
 import com.google.android.horologist.audio.ui.components.DeviceChip
 import com.google.android.horologist.audio.ui.components.toAudioOutputUi
-import com.google.android.horologist.audio.ui.mapper.VolumeUiStateMapper
 import com.google.android.horologist.compose.rotaryinput.onRotaryInputAccumulatedWithFocus
 
 /**
@@ -67,14 +65,14 @@ public fun VolumeScreen(
     increaseIcon: @Composable () -> Unit = { VolumeScreenDefaults.IncreaseIcon() },
     decreaseIcon: @Composable () -> Unit = { VolumeScreenDefaults.DecreaseIcon() }
 ) {
-    val volumeState by volumeViewModel.volumeState.collectAsState()
+    val volumeUiState by volumeViewModel.volumeUiState.collectAsState()
     val audioOutput by volumeViewModel.audioOutput.collectAsState()
 
     VolumeScreen(
         modifier = modifier.onRotaryInputAccumulatedWithFocus(
             onValueChange = volumeViewModel::onVolumeChangeByScroll
         ),
-        volume = { volumeState },
+        volume = { volumeUiState },
         audioOutputUi = audioOutput.toAudioOutputUi(),
         increaseVolume = { volumeViewModel.increaseVolume() },
         decreaseVolume = { volumeViewModel.decreaseVolume() },
@@ -90,7 +88,7 @@ public fun VolumeScreen(
  */
 @Composable
 public fun VolumeScreen(
-    volume: () -> VolumeState,
+    volume: () -> VolumeUiState,
     audioOutputUi: AudioOutputUi,
     increaseVolume: () -> Unit,
     decreaseVolume: () -> Unit,
@@ -132,7 +130,7 @@ public fun VolumeScreen(
  */
 @Composable
 public fun VolumeWithLabelScreen(
-    volume: () -> VolumeState,
+    volume: () -> VolumeUiState,
     increaseVolume: () -> Unit,
     decreaseVolume: () -> Unit,
     modifier: Modifier = Modifier,
@@ -161,7 +159,7 @@ public fun VolumeWithLabelScreen(
 
 @Composable
 internal fun VolumeScreen(
-    volume: () -> VolumeState,
+    volume: () -> VolumeUiState,
     contentSlot: @Composable () -> Unit,
     increaseVolume: () -> Unit,
     decreaseVolume: () -> Unit,
@@ -188,8 +186,7 @@ internal fun VolumeScreen(
     }
     if (showVolumeIndicator) {
         VolumePositionIndicator(
-            volumeUiState = { VolumeUiStateMapper.map(volumeState = volumeState) },
-            autoHide = false
+            volumeUiState = { volume() }
         )
     }
 }
@@ -217,9 +214,9 @@ public object VolumeScreenDefaults {
 }
 
 @Composable
-private fun volumeDescription(volumeState: VolumeState, isAudioOutputConnected: Boolean): String {
+private fun volumeDescription(volumeUiState: VolumeUiState, isAudioOutputConnected: Boolean): String {
     return if (isAudioOutputConnected) {
-        stringResource(id = R.string.horologist_volume_screen_connected_state, volumeState.current)
+        stringResource(id = R.string.horologist_volume_screen_connected_state, volumeUiState.current)
     } else {
         stringResource(id = R.string.horologist_volume_screen_not_connected_state)
     }

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeUiState.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeUiState.kt
@@ -22,9 +22,8 @@ package com.google.android.horologist.audio.ui
 * VolumePositionIndicator can pick up the change to make itself visible even at min or max volume.
 * */
 public data class VolumeUiState(
-    var timestamp: Long = System.currentTimeMillis(),
     val current: Int = 0,
-    val max: Int = 0,
+    val max: Int = 1,
     val isMax: Boolean = false,
     val isMin: Boolean = false
 )

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/SettingsButtons.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/SettingsButtons.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import com.google.android.horologist.audio.VolumeState
+import com.google.android.horologist.audio.ui.VolumeUiState
 import com.google.android.horologist.audio.ui.components.actions.AudioOutputButton
 import com.google.android.horologist.audio.ui.components.actions.SetVolumeButton
 
@@ -38,7 +38,7 @@ import com.google.android.horologist.audio.ui.components.actions.SetVolumeButton
  */
 @Composable
 public fun SettingsButtons(
-    volumeState: VolumeState,
+    volumeUiState: VolumeUiState,
     onVolumeClick: () -> Unit,
     onOutputClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -51,7 +51,7 @@ public fun SettingsButtons(
     ) {
         SetVolumeButton(
             onVolumeClick = onVolumeClick,
-            volumeState = volumeState,
+            volumeUiState = volumeUiState,
             enabled = enabled
         )
         brandIcon()

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.google.android.horologist.audio.VolumeState
 import com.google.android.horologist.audio.ui.R
+import com.google.android.horologist.audio.ui.VolumeUiState
 
 /**
  * Button to launch a screen to control the system volume.
@@ -34,7 +35,7 @@ import com.google.android.horologist.audio.ui.R
 @Composable
 public fun SetVolumeButton(
     onVolumeClick: () -> Unit,
-    volumeState: VolumeState,
+    volumeUiState: VolumeUiState,
     modifier: Modifier = Modifier,
     enabled: Boolean = true
 ) {
@@ -43,8 +44,8 @@ public fun SetVolumeButton(
         onClick = onVolumeClick,
         enabled = enabled,
         imageVector = when {
-            volumeState.isMin -> Icons.Default.VolumeMute
-            volumeState.isMax -> Icons.Default.VolumeUp
+            volumeUiState.isMin -> Icons.Default.VolumeMute
+            volumeUiState.isMax -> Icons.Default.VolumeUp
             else -> Icons.Default.VolumeDown
         },
         contentDescription = stringResource(R.string.horologist_set_volume_content_description)

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/animated/AnimatedSetVolumeButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/animated/AnimatedSetVolumeButton.kt
@@ -32,6 +32,7 @@ import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.rememberLottieAnimatable
 import com.airbnb.lottie.compose.rememberLottieComposition
 import com.google.android.horologist.audio.VolumeState
+import com.google.android.horologist.audio.ui.VolumeUiState
 import com.google.android.horologist.audio.ui.components.actions.SetVolumeButton
 
 /**
@@ -42,13 +43,13 @@ import com.google.android.horologist.audio.ui.components.actions.SetVolumeButton
 @Composable
 public fun AnimatedSetVolumeButton(
     onVolumeClick: () -> Unit,
-    volumeState: VolumeState,
+    volumeUiState: VolumeUiState,
     modifier: Modifier = Modifier
 ) {
     if (LocalStaticPreview.current) {
         SetVolumeButton(
             onVolumeClick = onVolumeClick,
-            volumeState = volumeState,
+            volumeUiState = volumeUiState,
             modifier = modifier
         )
     } else {
@@ -60,12 +61,12 @@ public fun AnimatedSetVolumeButton(
         )
         val lottieAnimatable = rememberLottieAnimatable()
 
-        var lastVolume by remember { mutableStateOf(volumeState.current) }
+        var lastVolume by remember { mutableStateOf(volumeUiState.current) }
 
-        LaunchedEffect(volumeState) {
+        LaunchedEffect(volumeUiState) {
             val lastVolumeBefore = lastVolume
-            lastVolume = volumeState.current
-            if (volumeState.current > lastVolumeBefore) {
+            lastVolume = volumeUiState.current
+            if (volumeUiState.current > lastVolumeBefore) {
                 lottieAnimatable.animate(
                     iterations = 1,
                     composition = volumeUp

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/mapper/VolumeUiStateMapper.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/mapper/VolumeUiStateMapper.kt
@@ -23,12 +23,7 @@ import com.google.android.horologist.audio.ui.VolumeUiState
  * Functions to map a [VolumeUiState] from a [VolumeState].
  */
 public object VolumeUiStateMapper {
-    public fun map(
-        timestamp: Long = System.currentTimeMillis(),
-        volumeState: VolumeState
-    ): VolumeUiState = VolumeUiState(
-
-        timestamp = timestamp,
+    public fun map(volumeState: VolumeState): VolumeUiState = VolumeUiState(
         current = volumeState.current,
         max = volumeState.max,
         isMax = volumeState.isMax,

--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenIndividualTest.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenIndividualTest.kt
@@ -126,18 +126,18 @@ class VolumeScreenIndividualTest {
             current = 50,
             max = 100
         )
+        val volumeUiState = VolumeUiStateMapper.map(volumeState = volumeState)
 
         paparazzi.snapshot {
             Scaffold(
                 positionIndicator = {
                     VolumePositionIndicator(
-                        volumeUiState = { VolumeUiStateMapper.map(volumeState = volumeState) },
-                        autoHide = false
+                        volumeUiState = { volumeUiState }
                     )
                 }
             ) {
                 VolumeWithLabelScreen(
-                    volume = { volumeState },
+                    volume = { volumeUiState },
                     increaseVolume = { },
                     decreaseVolume = { },
                     showVolumeIndicator = false

--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenTestCase.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenTestCase.kt
@@ -32,18 +32,18 @@ fun VolumeScreenTestCase(
     volumeState: VolumeState,
     audioOutput: AudioOutput
 ) {
+    val volumeUiState = VolumeUiStateMapper.map(volumeState = volumeState)
     RoundPreview {
         MaterialTheme(colors = colors) {
             Scaffold(
                 positionIndicator = {
                     VolumePositionIndicator(
-                        volumeUiState = { VolumeUiStateMapper.map(volumeState = volumeState) },
-                        autoHide = false
+                        volumeUiState = { volumeUiState }
                     )
                 }
             ) {
                 VolumeScreen(
-                    volume = { volumeState },
+                    volume = { volumeUiState },
                     audioOutputUi = audioOutput.toAudioOutputUi(),
                     increaseVolume = { },
                     decreaseVolume = { },

--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonTest.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonTest.kt
@@ -21,7 +21,7 @@
 package com.google.android.horologist.audio.ui.components.actions
 
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.audio.VolumeState
+import com.google.android.horologist.audio.ui.VolumeUiState
 import com.google.android.horologist.compose.tools.snapshotInABox
 import com.google.android.horologist.paparazzi.WearPaparazzi
 import org.junit.Rule
@@ -39,30 +39,27 @@ class SetVolumeButtonTest {
         paparazzi.snapshotInABox {
             SetVolumeButton(
                 onVolumeClick = {},
-                volumeState = VolumeState(current = currentVolume, max = 10)
+                volumeUiState = VolumeUiState(current = currentVolume, max = 10)
             )
         }
     }
 
     @Test
     fun givenCurrentVolumeIsMinimum_thenIconIsVolumeMute() {
-        val currentVolume = 0
-
         paparazzi.snapshotInABox {
             SetVolumeButton(
                 onVolumeClick = {},
-                volumeState = VolumeState(current = currentVolume, max = 10)
+                volumeUiState = VolumeUiState(isMin = true)
             )
         }
     }
 
     @Test
     fun givenCurrentVolumeIsMaximum_thenIconIsVolumeUp() {
-        val currentVolume = 10
         paparazzi.snapshotInABox {
             SetVolumeButton(
                 onVolumeClick = {},
-                volumeState = VolumeState(current = currentVolume, max = currentVolume)
+                volumeUiState = VolumeUiState(isMax = true)
             )
         }
     }

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/player/UampMediaPlayerScreen.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/player/UampMediaPlayerScreen.kt
@@ -42,7 +42,7 @@ fun UampMediaPlayerScreen(
     onVolumeClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val volumeState by volumeViewModel.volumeState.collectAsStateWithLifecycle()
+    val volumeUiState by volumeViewModel.volumeUiState.collectAsStateWithLifecycle()
     val settingsState by mediaPlayerScreenViewModel.settingsState.collectAsStateWithLifecycle()
 
     PlayerScreen(
@@ -62,7 +62,7 @@ fun UampMediaPlayerScreen(
         },
         buttons = {
             UampSettingsButtons(
-                volumeState = volumeState,
+                volumeUiState = volumeUiState,
                 onVolumeClick = onVolumeClick,
                 enabled = it.connected && it.media != null
             )

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/player/UampSettingsButtons.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/player/UampSettingsButtons.kt
@@ -20,7 +20,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.google.android.horologist.audio.VolumeState
+import com.google.android.horologist.audio.ui.VolumeUiState
 import com.google.android.horologist.audio.ui.components.SettingsButtonsDefaults
 import com.google.android.horologist.audio.ui.components.actions.SetVolumeButton
 import com.google.android.horologist.mediasample.R
@@ -31,7 +31,7 @@ import com.google.android.horologist.mediasample.R
  */
 @Composable
 public fun UampSettingsButtons(
-    volumeState: VolumeState,
+    volumeUiState: VolumeUiState,
     onVolumeClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true
@@ -49,7 +49,7 @@ public fun UampSettingsButtons(
 
         SetVolumeButton(
             onVolumeClick = onVolumeClick,
-            volumeState = volumeState
+            volumeUiState = volumeUiState
         )
     }
 }

--- a/media-ui/api/current.api
+++ b/media-ui/api/current.api
@@ -475,7 +475,7 @@ package com.google.android.horologist.media.ui.screens.player {
 package com.google.android.horologist.media.ui.screens.playerlibrarypager {
 
   public final class PlayerLibraryPagerScreenKt {
-    method @androidx.compose.runtime.Composable public static void PlayerLibraryPagerScreen(androidx.compose.foundation.pager.PagerState pagerState, kotlin.jvm.functions.Function0<com.google.android.horologist.audio.ui.VolumeUiState> volumeUiState, kotlin.jvm.functions.Function1<? super androidx.compose.ui.Modifier,kotlin.Unit> timeText, kotlin.jvm.functions.Function0<kotlin.Unit> playerScreen, kotlin.jvm.functions.Function1<? super com.google.android.horologist.compose.layout.ScalingLazyColumnState,kotlin.Unit> libraryScreen, androidx.navigation.NavBackStackEntry backStack, optional androidx.compose.ui.Modifier modifier);
+    method @androidx.compose.runtime.Composable public static void PlayerLibraryPagerScreen(androidx.compose.foundation.pager.PagerState pagerState, kotlin.jvm.functions.Function0<com.google.android.horologist.audio.ui.VolumeUiState> volumeUiState, kotlinx.coroutines.flow.Flow<kotlin.Unit> displayVolumeIndicatorEvents, kotlin.jvm.functions.Function1<? super androidx.compose.ui.Modifier,kotlin.Unit> timeText, kotlin.jvm.functions.Function0<kotlin.Unit> playerScreen, kotlin.jvm.functions.Function1<? super com.google.android.horologist.compose.layout.ScalingLazyColumnState,kotlin.Unit> libraryScreen, androidx.navigation.NavBackStackEntry backStack, optional androidx.compose.ui.Modifier modifier);
   }
 
 }

--- a/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenPreview.kt
+++ b/media-ui/src/debug/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenPreview.kt
@@ -40,7 +40,7 @@ import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.TimeText
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.audio.VolumeState
+import com.google.android.horologist.audio.ui.VolumeUiState
 import com.google.android.horologist.audio.ui.components.SettingsButtons
 import com.google.android.horologist.audio.ui.components.SettingsButtonsDefaults
 import com.google.android.horologist.compose.pager.PagerScreen
@@ -108,7 +108,7 @@ fun PlayerScreenPreview() {
                 },
                 buttons = {
                     SettingsButtons(
-                        volumeState = VolumeState(5, 10),
+                        volumeUiState = VolumeUiState(5, 10),
                         onVolumeClick = { },
                         onOutputClick = { },
                         brandIcon = {
@@ -178,7 +178,7 @@ fun PlayerScreenPreviewCustomMediaDisplay() {
                 },
                 buttons = {
                     SettingsButtons(
-                        volumeState = VolumeState(5, 10),
+                        volumeUiState = VolumeUiState(5, 10),
                         onVolumeClick = { },
                         onOutputClick = { },
                         brandIcon = {
@@ -246,7 +246,7 @@ fun PlayerScreenPreviewCustomBackground() {
                 },
                 buttons = {
                     SettingsButtons(
-                        volumeState = VolumeState(5, 10),
+                        volumeUiState = VolumeUiState(5, 10),
                         onVolumeClick = { },
                         onOutputClick = { },
                         brandIcon = {
@@ -335,7 +335,7 @@ fun DefaultMediaPreview() {
                 },
                 buttons = {
                     SettingsButtons(
-                        volumeState = VolumeState(5, 10),
+                        volumeUiState = VolumeUiState(5, 10),
                         onVolumeClick = { },
                         onOutputClick = { },
                         brandIcon = {
@@ -401,7 +401,7 @@ fun PlayerScreenPreviewNotingPlayingDisplay() {
                 },
                 buttons = {
                     SettingsButtons(
-                        volumeState = VolumeState(5, 10),
+                        volumeUiState = VolumeUiState(5, 10),
                         onVolumeClick = { },
                         onOutputClick = { },
                         brandIcon = {

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/navigation/MediaPlayerScaffold.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/navigation/MediaPlayerScaffold.kt
@@ -114,6 +114,7 @@ public fun MediaPlayerScaffold(
             PlayerLibraryPagerScreen(
                 pagerState = pagerState,
                 volumeUiState = { volumeState },
+                displayVolumeIndicatorEvents = volumeViewModel.displayIndicatorEvents,
                 timeText = timeText,
                 playerScreen = {
                     playerScreen()

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/playerlibrarypager/PlayerLibraryPagerScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/playerlibrarypager/PlayerLibraryPagerScreen.kt
@@ -34,6 +34,7 @@ import com.google.android.horologist.compose.layout.belowTimeTextPreview
 import com.google.android.horologist.compose.layout.scrollAway
 import com.google.android.horologist.compose.pager.PagerScreen
 import com.google.android.horologist.media.ui.navigation.NavigationScreens
+import kotlinx.coroutines.flow.Flow
 import java.util.concurrent.CancellationException
 
 /**
@@ -45,6 +46,7 @@ import java.util.concurrent.CancellationException
 public fun PlayerLibraryPagerScreen(
     pagerState: PagerState,
     volumeUiState: () -> VolumeUiState,
+    displayVolumeIndicatorEvents: Flow<Unit>,
     timeText: @Composable (Modifier) -> Unit,
     playerScreen: @Composable () -> Unit,
     libraryScreen: @Composable (ScalingLazyColumnState) -> Unit,
@@ -77,7 +79,7 @@ public fun PlayerLibraryPagerScreen(
                         timeText(Modifier)
                     },
                     positionIndicator = {
-                        VolumePositionIndicator(volumeUiState = volumeUiState)
+                        VolumePositionIndicator(volumeUiState = volumeUiState, displayIndicatorEvents = displayVolumeIndicatorEvents)
                     }
                 ) {
                     playerScreen()

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/FigmaPlayerScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/FigmaPlayerScreenTest.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import app.cash.paparazzi.DeviceConfig
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.audio.VolumeState
+import com.google.android.horologist.audio.ui.VolumeUiState
 import com.google.android.horologist.audio.ui.components.SettingsButtonsDefaults
 import com.google.android.horologist.audio.ui.components.actions.SetVolumeButton
 import com.google.android.horologist.audio.ui.components.actions.SettingsButton
@@ -90,7 +90,7 @@ class FigmaPlayerScreenTest(
                 round = deviceConfig != DeviceConfig.WEAR_OS_SQUARE,
                 buttons = {
                     UampSettingsButtons(
-                        volumeState = VolumeState(10, 10),
+                        volumeUiState = VolumeUiState(10, 10),
                         onVolumeClick = { }
                     )
                 }
@@ -111,7 +111,7 @@ class FigmaPlayerScreenTest(
 
 @Composable
 public fun UampSettingsButtons(
-    volumeState: VolumeState,
+    volumeUiState: VolumeUiState,
     onVolumeClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true
@@ -133,7 +133,7 @@ public fun UampSettingsButtons(
 
         SetVolumeButton(
             onVolumeClick = onVolumeClick,
-            volumeState = volumeState
+            volumeUiState = volumeUiState
         )
     }
 }

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/FigmaVolumeScreenTest.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/FigmaVolumeScreenTest.kt
@@ -21,8 +21,8 @@ package com.google.android.horologist.media.ui
 import androidx.compose.runtime.Composable
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.audio.AudioOutput
-import com.google.android.horologist.audio.VolumeState
 import com.google.android.horologist.audio.ui.VolumeScreen
+import com.google.android.horologist.audio.ui.VolumeUiState
 import com.google.android.horologist.audio.ui.components.toAudioOutputUi
 import com.google.android.horologist.compose.tools.RoundPreview
 import com.google.android.horologist.media.ui.uamp.UampTheme
@@ -42,7 +42,7 @@ class FigmaVolumeScreenTest {
         paparazzi.snapshot {
             UampRoundPreview {
                 VolumeScreen(
-                    volume = { VolumeState(5, 10) },
+                    volume = { VolumeUiState(5, 10) },
                     audioOutputUi = AudioOutput.BluetoothHeadset("1", "Device").toAudioOutputUi(),
                     increaseVolume = { },
                     decreaseVolume = { },

--- a/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerTestCase.kt
+++ b/media-ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerTestCase.kt
@@ -36,6 +36,7 @@ import androidx.wear.compose.material.TimeText
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.audio.VolumeState
 import com.google.android.horologist.audio.ui.VolumePositionIndicator
+import com.google.android.horologist.audio.ui.VolumeUiState
 import com.google.android.horologist.audio.ui.components.SettingsButtons
 import com.google.android.horologist.audio.ui.components.SettingsButtonsDefaults
 import com.google.android.horologist.audio.ui.mapper.VolumeUiStateMapper
@@ -46,6 +47,7 @@ import com.google.android.horologist.media.ui.components.background.RadialBackgr
 import com.google.android.horologist.media.ui.screens.player.DefaultMediaInfoDisplay
 import com.google.android.horologist.media.ui.screens.player.PlayerScreen
 import com.google.android.horologist.media.ui.state.PlayerUiState
+import kotlinx.coroutines.flow.flowOf
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -69,7 +71,7 @@ fun MediaPlayerTestCase(
     },
     buttons: @Composable RowScope.() -> Unit = {
         SettingsButtons(
-            volumeState = VolumeState(5, 10),
+            volumeUiState = VolumeUiState(5, 10),
             onVolumeClick = { /*TODO*/ },
             onOutputClick = { },
             brandIcon = {
@@ -106,7 +108,8 @@ fun MediaPlayerTestCase(
                         VolumePositionIndicator(
                             volumeUiState = {
                                 VolumeUiStateMapper.map(volumeState = VolumeState(6, 10))
-                            }
+                            },
+                            displayIndicatorEvents = flowOf()
                         )
                     }
                 ) {


### PR DESCRIPTION
#### WHAT
Removes timestamp from `VolumeUiState` and decouples "show volume indicator" from the state.

#### WHY
To not pollute state with events and make it easier to merge #1057.

#### HOW
Adds a private flow `userActionEvents`into `VolumeViewModel` which can be emitted to to force display the indicator. Then merges this flow with `volumeUiState`, giving a unified flow of `displayIndicatorEvents`. `VolumePositionIndicator` listens to this combined flow and show the indicator for two seconds on every emit.

#### Checklist :clipboard:
- [X] Add explicit visibility modifier and explicit return types for public declarations
- [X] Run spotless check
- [X] Run tests
- [X] Update metalava's signature text files
