### PR TITLE
Addresses issues in App Helper from #1085

### DIFF
--- a/datalayer-phone/src/main/AndroidManifest.xml
+++ b/datalayer-phone/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
                 <action android:name="com.google.android.gms.wearable.REQUEST_RECEIVED" />
                 <data
                     android:host="*"
-                    android:path="/launch_app"
+                    android:path="/data_layer_app_helper/launch_app"
                     android:scheme="wear" />
             </intent-filter>
         </service>

--- a/datalayer-phone/src/main/java/com/google/android/horologist/datalayer/phone/PhoneDataLayerListenerService.kt
+++ b/datalayer-phone/src/main/java/com/google/android/horologist/datalayer/phone/PhoneDataLayerListenerService.kt
@@ -22,6 +22,7 @@ import com.google.android.horologist.data.apphelper.DataLayerAppHelperService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 
 public class PhoneDataLayerListenerService : DataLayerAppHelperService() {
     private val serviceScope = CoroutineScope(Dispatchers.IO + Job())
@@ -29,5 +30,10 @@ public class PhoneDataLayerListenerService : DataLayerAppHelperService() {
     public override val appHelper: DataLayerAppHelper by lazy {
         val registry = WearDataLayerRegistry.fromContext(this, serviceScope)
         PhoneDataLayerAppHelper(this, registry)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        serviceScope.cancel()
     }
 }

--- a/datalayer-watch/src/main/AndroidManifest.xml
+++ b/datalayer-watch/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
                 <action android:name="com.google.android.gms.wearable.REQUEST_RECEIVED" />
                 <data
                     android:host="*"
-                    android:path="/launch_app"
+                    android:path="/data_layer_app_helper/launch_app"
                     android:scheme="wear" />
             </intent-filter>
         </service>

--- a/datalayer-watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerListenerService.kt
+++ b/datalayer-watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerListenerService.kt
@@ -22,6 +22,7 @@ import com.google.android.horologist.data.apphelper.DataLayerAppHelperService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 
 public class WearDataLayerListenerService : DataLayerAppHelperService() {
     private val serviceScope = CoroutineScope(Dispatchers.IO + Job())
@@ -29,5 +30,10 @@ public class WearDataLayerListenerService : DataLayerAppHelperService() {
     public override val appHelper: DataLayerAppHelper by lazy {
         val registry = WearDataLayerRegistry.fromContext(this, serviceScope)
         WearDataLayerAppHelper(this, registry, serviceScope)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        serviceScope.cancel()
     }
 }

--- a/datalayer/api/current.api
+++ b/datalayer/api/current.api
@@ -133,10 +133,10 @@ package com.google.android.horologist.data.apphelper {
     property protected final androidx.wear.remote.interactions.RemoteActivityHelper remoteActivityHelper;
     field public static final String CAPABILITY_DEVICE_PREFIX = "data_layer_app_helper_device";
     field public static final com.google.android.horologist.data.apphelper.DataLayerAppHelper.Companion Companion;
-    field public static final String DATA_LAYER_APP_HELPER_CAPABILITY = "data_layer_app_helper";
-    field public static final String LAUNCH_APP = "/launch_app";
+    field public static final String DATA_LAYER_APP_HELPER = "data_layer_app_helper";
+    field public static final String LAUNCH_APP = "/data_layer_app_helper/launch_app";
     field public static final String PHONE_CAPABILITY = "data_layer_app_helper_device_phone";
-    field public static final String SURFACE_INFO_PATH = "/surface_info";
+    field public static final String SURFACE_INFO_PATH = "/data_layer_app_helper/surface_info";
     field public static final String WATCH_CAPABILITY = "data_layer_app_helper_device_watch";
   }
 

--- a/datalayer/src/main/java/com/google/android/horologist/data/apphelper/DataLayerAppHelper.kt
+++ b/datalayer/src/main/java/com/google/android/horologist/data/apphelper/DataLayerAppHelper.kt
@@ -158,12 +158,12 @@ abstract class DataLayerAppHelper(
     }
 
     public companion object {
-        public const val DATA_LAYER_APP_HELPER_CAPABILITY: String = "data_layer_app_helper"
-        public const val CAPABILITY_DEVICE_PREFIX = "${DATA_LAYER_APP_HELPER_CAPABILITY}_device"
+        public const val DATA_LAYER_APP_HELPER: String = "data_layer_app_helper"
+        public const val CAPABILITY_DEVICE_PREFIX = "${DATA_LAYER_APP_HELPER}_device"
         public const val PHONE_CAPABILITY = "${CAPABILITY_DEVICE_PREFIX}_phone"
         public const val WATCH_CAPABILITY = "${CAPABILITY_DEVICE_PREFIX}_watch"
-        public const val LAUNCH_APP: String = "/launch_app"
-        public const val SURFACE_INFO_PATH: String = "/surface_info"
+        public const val LAUNCH_APP: String = "/$DATA_LAYER_APP_HELPER/launch_app"
+        public const val SURFACE_INFO_PATH: String = "/$DATA_LAYER_APP_HELPER/surface_info"
     }
 }
 


### PR DESCRIPTION
#### WHAT

Addresses issues in #1085 

#### WHY

Improve App Helper library

#### HOW

1. Ensure that the coroutine scope is cancelled in the listener service ([link](https://github.com/google/horologist/pull/1085#discussion_r1132423782))
2. Have better naming for the paths used with `messageClient` to avoid clashes ([link](https://github.com/google/horologist/pull/1085#discussion_r1132426768))

#### Checklist :clipboard:
- [ x] Add explicit visibility modifier and explicit return types for public declarations
- [ x] Run spotless check
- [ x] Run tests
- [ x] Update metalava's signature text files
