### PR TITLE
Fix talkback highlight for song title.

### DIFF
--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/components/animated/MarqueeTextMediaDisplay.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/components/animated/MarqueeTextMediaDisplay.kt
@@ -21,6 +21,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.wear.compose.material.MaterialTheme
@@ -41,7 +43,9 @@ public fun MarqueeTextMediaDisplay(
     Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
         MarqueeText(
             text = title.orEmpty(),
-            modifier = Modifier.fillMaxWidth(0.7f),
+            modifier = Modifier.fillMaxWidth(0.7f).clearAndSetSemantics {
+                contentDescription = title.orEmpty()
+            },
             color = MaterialTheme.colors.onBackground,
             style = MaterialTheme.typography.button,
             textAlign = TextAlign.Center


### PR DESCRIPTION
#### WHAT
If the title of the song is long enough that it cannot fit in the screen, then only partial title is shown and then the title scrolls. Talkback highlight also scrolls along with title and finally disappears once end of the title is reached.

#### WHY
clearAndSetSemantics will remove the already set properties of how the talkback highlights and will highlight the text space allocated to the title. This highlight will not scroll along with the title.