### PR TITLE
fix ismax ismin

### DIFF
--- a/audio-ui/api/current.api
+++ b/audio-ui/api/current.api
@@ -29,12 +29,10 @@ package com.google.android.horologist.audio.ui {
   }
 
   public final class VolumeUiState {
-    ctor public VolumeUiState(optional int current, optional int max, optional boolean isMax, optional boolean isMin);
+    ctor public VolumeUiState(optional int current, optional int max);
     method public int component1();
     method public int component2();
-    method public boolean component3();
-    method public boolean component4();
-    method public com.google.android.horologist.audio.ui.VolumeUiState copy(int current, int max, boolean isMax, boolean isMin);
+    method public com.google.android.horologist.audio.ui.VolumeUiState copy(int current, int max);
     method public int getCurrent();
     method public int getMax();
     method public boolean isMax();

--- a/audio-ui/api/current.api
+++ b/audio-ui/api/current.api
@@ -29,20 +29,21 @@ package com.google.android.horologist.audio.ui {
   }
 
   public final class VolumeUiState {
-    ctor public VolumeUiState(optional int current, optional int max, optional boolean isMax, optional boolean isMin);
+    ctor public VolumeUiState(optional int current, optional int max, optional int min);
     method public int component1();
     method public int component2();
-    method public boolean component3();
-    method public boolean component4();
-    method public com.google.android.horologist.audio.ui.VolumeUiState copy(int current, int max, boolean isMax, boolean isMin);
+    method public int component3();
+    method public com.google.android.horologist.audio.ui.VolumeUiState copy(int current, int max, int min);
     method public int getCurrent();
     method public int getMax();
+    method public int getMin();
     method public boolean isMax();
     method public boolean isMin();
     property public final int current;
     property public final boolean isMax;
     property public final boolean isMin;
     property public final int max;
+    property public final int min;
   }
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public class VolumeViewModel extends androidx.lifecycle.ViewModel {

--- a/audio-ui/api/current.api
+++ b/audio-ui/api/current.api
@@ -29,10 +29,12 @@ package com.google.android.horologist.audio.ui {
   }
 
   public final class VolumeUiState {
-    ctor public VolumeUiState(optional int current, optional int max);
+    ctor public VolumeUiState(optional int current, optional int max, optional boolean isMax, optional boolean isMin);
     method public int component1();
     method public int component2();
-    method public com.google.android.horologist.audio.ui.VolumeUiState copy(int current, int max);
+    method public boolean component3();
+    method public boolean component4();
+    method public com.google.android.horologist.audio.ui.VolumeUiState copy(int current, int max, boolean isMax, boolean isMin);
     method public int getCurrent();
     method public int getMax();
     method public boolean isMax();

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumePositionIndicator.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumePositionIndicator.kt
@@ -63,7 +63,7 @@ public fun VolumePositionIndicator(
             value = {
                 uiState.current.toFloat()
             },
-            range = 0F.rangeTo(
+            range = uiState.min.toFloat().rangeTo(
                 uiState.max.toFloat()
             )
         )

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeUiState.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeUiState.kt
@@ -17,13 +17,14 @@
 package com.google.android.horologist.audio.ui
 
 /*
-* A UI state for volume which contains the volume ui state info including a timestamp. The
-* timestamp is used for compose to know that a trigger has happened so @compose
-* VolumePositionIndicator can pick up the change to make itself visible even at min or max volume.
+* A UI state for volume.
 */
 public data class VolumeUiState(
     val current: Int = 0,
-    val max: Int = 1,
-    val isMax: Boolean = false,
-    val isMin: Boolean = false
-)
+    val max: Int = 1
+) {
+    val isMax: Boolean
+        get() = current >= max
+    val isMin: Boolean
+        get() = current == 0
+}

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeUiState.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeUiState.kt
@@ -21,10 +21,7 @@ package com.google.android.horologist.audio.ui
 */
 public data class VolumeUiState(
     val current: Int = 0,
-    val max: Int = 1
-) {
-    val isMax: Boolean
-        get() = current >= max
-    val isMin: Boolean
-        get() = current == 0
-}
+    val max: Int = 1,
+    val isMax: Boolean = current >= max,
+    val isMin: Boolean = current == 0
+)

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeUiState.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeUiState.kt
@@ -16,12 +16,18 @@
 
 package com.google.android.horologist.audio.ui
 
-/*
-* A UI state for volume.
-*/
+/**
+ * A UI state for volume.
+ */
 public data class VolumeUiState(
     val current: Int = 0,
     val max: Int = 1,
-    val isMax: Boolean = current >= max,
-    val isMin: Boolean = current == 0
-)
+    val min: Int = 0
+) {
+
+    public val isMax: Boolean
+        get() = current >= max
+
+    public val isMin: Boolean
+        get() = current == min
+}

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/mapper/VolumeUiStateMapper.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/mapper/VolumeUiStateMapper.kt
@@ -25,8 +25,6 @@ import com.google.android.horologist.audio.ui.VolumeUiState
 public object VolumeUiStateMapper {
     public fun map(volumeState: VolumeState): VolumeUiState = VolumeUiState(
         current = volumeState.current,
-        max = volumeState.max,
-        isMax = volumeState.isMax,
-        isMin = volumeState.isMin
+        max = volumeState.max
     )
 }

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/mapper/VolumeUiStateMapper.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/mapper/VolumeUiStateMapper.kt
@@ -25,6 +25,7 @@ import com.google.android.horologist.audio.ui.VolumeUiState
 public object VolumeUiStateMapper {
     public fun map(volumeState: VolumeState): VolumeUiState = VolumeUiState(
         current = volumeState.current,
-        max = volumeState.max
+        max = volumeState.max,
+        min = volumeState.min
     )
 }

--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonTest.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonTest.kt
@@ -46,20 +46,24 @@ class SetVolumeButtonTest {
 
     @Test
     fun givenCurrentVolumeIsMinimum_thenIconIsVolumeMute() {
+        val currentVolume = 0
+
         paparazzi.snapshotInABox {
             SetVolumeButton(
                 onVolumeClick = {},
-                volumeUiState = VolumeUiState(isMin = true)
+                volumeUiState = VolumeUiState(current = currentVolume)
             )
         }
     }
 
     @Test
     fun givenCurrentVolumeIsMaximum_thenIconIsVolumeUp() {
+        val currentVolume = 1
+
         paparazzi.snapshotInABox {
             SetVolumeButton(
                 onVolumeClick = {},
-                volumeUiState = VolumeUiState(isMax = true)
+                volumeUiState = VolumeUiState(current = currentVolume)
             )
         }
     }

--- a/audio/api/current.api
+++ b/audio/api/current.api
@@ -123,18 +123,21 @@ package com.google.android.horologist.audio {
   }
 
   public final class VolumeState {
-    ctor public VolumeState(int current, int max);
+    ctor public VolumeState(int current, int max, optional int min);
     method public int component1();
     method public int component2();
-    method public com.google.android.horologist.audio.VolumeState copy(int current, int max);
+    method public int component3();
+    method public com.google.android.horologist.audio.VolumeState copy(int current, int max, int min);
     method public int getCurrent();
     method public int getMax();
+    method public int getMin();
     method public boolean isMax();
     method public boolean isMin();
     property public final int current;
     property public final boolean isMax;
     property public final boolean isMin;
     property public final int max;
+    property public final int min;
   }
 
 }

--- a/audio/api/current.api
+++ b/audio/api/current.api
@@ -131,11 +131,7 @@ package com.google.android.horologist.audio {
     method public int getCurrent();
     method public int getMax();
     method public int getMin();
-    method public boolean isMax();
-    method public boolean isMin();
     property public final int current;
-    property public final boolean isMax;
-    property public final boolean isMin;
     property public final int max;
     property public final int min;
   }

--- a/audio/src/androidTest/java/com/google/android/horologist/audio/SystemAudioRepositoryTest.kt
+++ b/audio/src/androidTest/java/com/google/android/horologist/audio/SystemAudioRepositoryTest.kt
@@ -54,7 +54,7 @@ class SystemAudioRepositoryTest {
         withContext(Dispatchers.Main) {
             val context = InstrumentationRegistry.getInstrumentation().targetContext
             SystemAudioRepository.fromContext(context).use { repository ->
-                if (repository.volumeState.value.isMax) {
+                if (repository.volumeState.value.current == repository.volumeState.value.max) {
                     repository.decreaseVolume()
                 }
 

--- a/audio/src/androidTest/java/com/google/android/horologist/audio/SystemAudioRepositoryTest.kt
+++ b/audio/src/androidTest/java/com/google/android/horologist/audio/SystemAudioRepositoryTest.kt
@@ -54,7 +54,7 @@ class SystemAudioRepositoryTest {
         withContext(Dispatchers.Main) {
             val context = InstrumentationRegistry.getInstrumentation().targetContext
             SystemAudioRepository.fromContext(context).use { repository ->
-                if (repository.volumeState.value.current == repository.volumeState.value.max) {
+                if (repository.volumeState.value.current >= repository.volumeState.value.max) {
                     repository.decreaseVolume()
                 }
 

--- a/audio/src/main/java/com/google/android/horologist/audio/VolumeState.kt
+++ b/audio/src/main/java/com/google/android/horologist/audio/VolumeState.kt
@@ -23,11 +23,4 @@ public data class VolumeState(
     val current: Int,
     val max: Int,
     val min: Int = 0
-) {
-
-    public val isMax: Boolean
-        get() = current >= max
-
-    public val isMin: Boolean
-        get() = current == min
-}
+)

--- a/audio/src/main/java/com/google/android/horologist/audio/VolumeState.kt
+++ b/audio/src/main/java/com/google/android/horologist/audio/VolumeState.kt
@@ -20,12 +20,14 @@ package com.google.android.horologist.audio
  * Data class holding the current state of the volume system.
  */
 public data class VolumeState(
-    public val current: Int,
-    public val max: Int
+    val current: Int,
+    val max: Int,
+    val min: Int = 0
 ) {
+
     public val isMax: Boolean
         get() = current >= max
 
     public val isMin: Boolean
-        get() = current == 0
+        get() = current == min
 }


### PR DESCRIPTION
#### WHAT
- Make `isMax` and `isMin` derived in `VolumeUiState`
- Remove these helper methods from the `VolumeState`

#### WHY
- The `isMin` and `isMax` are states that should be derived from current/min/max and should not be settable by callers
- The helper methods were mostly used by UI, domain model data class does not need to have them.
- Add min to both `VolumeState` and `VolumeUiState` and default to 0 but can still be set by caller if needed.

#### HOW

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
