### PR TITLE
default without volumeuistate

### DIFF
--- a/audio-ui/api/current.api
+++ b/audio-ui/api/current.api
@@ -111,8 +111,7 @@ package com.google.android.horologist.audio.ui.components.actions {
   }
 
   public final class SetVolumeButtonKt {
-    method @androidx.compose.runtime.Composable public static void SetVolumeButton(kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, optional androidx.compose.ui.Modifier modifier, optional boolean enabled);
-    method @androidx.compose.runtime.Composable public static void SetVolumeButton(kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, com.google.android.horologist.audio.ui.VolumeUiState volumeUiState, optional androidx.compose.ui.Modifier modifier, optional boolean enabled);
+    method @androidx.compose.runtime.Composable public static void SetVolumeButton(kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, optional com.google.android.horologist.audio.ui.VolumeUiState? volumeUiState, optional androidx.compose.ui.Modifier modifier, optional boolean enabled);
   }
 
   public final class SettingsButtonKt {

--- a/audio-ui/api/current.api
+++ b/audio-ui/api/current.api
@@ -111,6 +111,7 @@ package com.google.android.horologist.audio.ui.components.actions {
   }
 
   public final class SetVolumeButtonKt {
+    method @androidx.compose.runtime.Composable public static void SetVolumeButton(kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, optional androidx.compose.ui.Modifier modifier, optional boolean enabled);
     method @androidx.compose.runtime.Composable public static void SetVolumeButton(kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, com.google.android.horologist.audio.ui.VolumeUiState volumeUiState, optional androidx.compose.ui.Modifier modifier, optional boolean enabled);
   }
 

--- a/audio-ui/api/current.api
+++ b/audio-ui/api/current.api
@@ -111,7 +111,7 @@ package com.google.android.horologist.audio.ui.components.actions {
   }
 
   public final class SetVolumeButtonKt {
-    method @androidx.compose.runtime.Composable public static void SetVolumeButton(kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, optional com.google.android.horologist.audio.ui.VolumeUiState? volumeUiState, optional androidx.compose.ui.Modifier modifier, optional boolean enabled);
+    method @androidx.compose.runtime.Composable public static void SetVolumeButton(kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.audio.ui.VolumeUiState? volumeUiState, optional boolean enabled);
   }
 
   public final class SettingsButtonKt {

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
@@ -28,6 +28,24 @@ import com.google.android.horologist.audio.ui.VolumeUiState
 import com.google.android.horologist.base.ui.components.IconRtlMode
 
 /**
+ * Button to launch a screen to control the system volume, using volume up image vector is icon as
+ * default.
+ */
+@Composable
+public fun SetVolumeButton(
+    onVolumeClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true
+) {
+    SetVolumeButton(
+        onVolumeClick = onVolumeClick,
+        volumeUiState = VolumeUiState(isMax = true),
+        modifier = modifier,
+        enabled = enabled
+    )
+}
+
+/**
  * Button to launch a screen to control the system volume.
  *
  * See [VolumeUiState]

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
@@ -44,15 +44,12 @@ public fun SetVolumeButton(
         modifier = modifier,
         onClick = onVolumeClick,
         enabled = enabled,
-        imageVector = if (volumeUiState == null) {
-            Icons.Default.VolumeUp
-        } else {
+        imageVector =
             when {
-                volumeUiState.isMin -> Icons.Default.VolumeMute
-                volumeUiState.isMax -> Icons.Default.VolumeUp
+                volumeUiState?.isMin == true -> Icons.Default.VolumeMute
+                volumeUiState?.isMax == true -> Icons.Default.VolumeUp
                 else -> Icons.Default.VolumeDown
-            }
-        },
+            },
         iconRtlMode = IconRtlMode.Mirrored,
         contentDescription = stringResource(R.string.horologist_set_volume_content_description)
     )

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
@@ -36,8 +36,8 @@ import com.google.android.horologist.base.ui.components.IconRtlMode
 @Composable
 public fun SetVolumeButton(
     onVolumeClick: () -> Unit,
-    volumeUiState: VolumeUiState? = null,
     modifier: Modifier = Modifier,
+    volumeUiState: VolumeUiState? = null,
     enabled: Boolean = true
 ) {
     SettingsButton(
@@ -45,11 +45,11 @@ public fun SetVolumeButton(
         onClick = onVolumeClick,
         enabled = enabled,
         imageVector =
-            when {
-                volumeUiState?.isMin == true -> Icons.Default.VolumeMute
-                volumeUiState?.isMax == true -> Icons.Default.VolumeUp
-                else -> Icons.Default.VolumeDown
-            },
+        when {
+            volumeUiState?.isMin == true -> Icons.Default.VolumeMute
+            volumeUiState?.isMax == true -> Icons.Default.VolumeUp
+            else -> Icons.Default.VolumeDown
+        },
         iconRtlMode = IconRtlMode.Mirrored,
         contentDescription = stringResource(R.string.horologist_set_volume_content_description)
     )

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
@@ -28,32 +28,15 @@ import com.google.android.horologist.audio.ui.VolumeUiState
 import com.google.android.horologist.base.ui.components.IconRtlMode
 
 /**
- * Button to launch a screen to control the system volume, using volume up image vector is icon as
- * default.
- */
-@Composable
-public fun SetVolumeButton(
-    onVolumeClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    enabled: Boolean = true
-) {
-    SetVolumeButton(
-        onVolumeClick = onVolumeClick,
-        volumeUiState = VolumeUiState(current = 1, max = 1),
-        modifier = modifier,
-        enabled = enabled
-    )
-}
-
-/**
- * Button to launch a screen to control the system volume.
+ * Button to launch a screen to control the system volume, using volume up icon as
+ * default if no [volumeUiState] is passed in.
  *
  * See [VolumeUiState]
  */
 @Composable
 public fun SetVolumeButton(
     onVolumeClick: () -> Unit,
-    volumeUiState: VolumeUiState,
+    volumeUiState: VolumeUiState? = null,
     modifier: Modifier = Modifier,
     enabled: Boolean = true
 ) {
@@ -61,10 +44,14 @@ public fun SetVolumeButton(
         modifier = modifier,
         onClick = onVolumeClick,
         enabled = enabled,
-        imageVector = when {
-            volumeUiState.isMin -> Icons.Default.VolumeMute
-            volumeUiState.isMax -> Icons.Default.VolumeUp
-            else -> Icons.Default.VolumeDown
+        imageVector = if (volumeUiState == null) {
+            Icons.Default.VolumeUp
+        } else {
+            when {
+                volumeUiState.isMin -> Icons.Default.VolumeMute
+                volumeUiState.isMax -> Icons.Default.VolumeUp
+                else -> Icons.Default.VolumeDown
+            }
         },
         iconRtlMode = IconRtlMode.Mirrored,
         contentDescription = stringResource(R.string.horologist_set_volume_content_description)

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
@@ -39,7 +39,7 @@ public fun SetVolumeButton(
 ) {
     SetVolumeButton(
         onVolumeClick = onVolumeClick,
-        volumeUiState = VolumeUiState(isMax = true),
+        volumeUiState = VolumeUiState(current = 1, max = 1),
         modifier = modifier,
         enabled = enabled
     )

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
@@ -44,8 +44,7 @@ public fun SetVolumeButton(
         modifier = modifier,
         onClick = onVolumeClick,
         enabled = enabled,
-        imageVector =
-        when {
+        imageVector = when {
             volumeUiState?.isMin == true -> Icons.Default.VolumeMute
             volumeUiState?.isMax == true -> Icons.Default.VolumeUp
             else -> Icons.Default.VolumeDown


### PR DESCRIPTION
#### WHAT
Make `SetVolumeButton` `VolumeUiState` optional and default to null so it can use volume up icon as default without a `VolumeUiState`

#### WHY
So people do not have to create a VolumeUiState just to use the button with max icon.

#### HOW


#### Checklist :clipboard:
- [X] Add explicit visibility modifier and explicit return types for public declarations
- [X] Run spotless check
- [X] Run tests
- [X] Update metalava's signature text files
