### PR TITLE
Volume fix to rememberstate for onvalue change

### DIFF
--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/AccumulatedRotaryInputModifier.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/AccumulatedRotaryInputModifier.kt
@@ -17,7 +17,9 @@
 package com.google.android.horologist.compose.rotaryinput
 
 import androidx.compose.foundation.focusable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.focus.FocusRequester
@@ -61,12 +63,13 @@ public fun Modifier.onRotaryInputAccumulated(
     rateLimitCoolDownMs: Long = RotaryInputConfigDefaults.DEFAULT_RATE_LIMIT_COOL_DOWN_MS,
     onValueChange: (change: Float) -> Unit
 ): Modifier = composed {
+    val updatedOnValueChange by rememberUpdatedState(onValueChange)
     val rotaryInputAccumulator = remember {
         RotaryInputAccumulator(
             eventAccumulationThresholdMs = eventAccumulationThresholdMs,
             minValueChangeDistancePx = minValueChangeDistancePx,
             rateLimitCoolDownMs = rateLimitCoolDownMs,
-            onValueChange = onValueChange
+            onValueChange = { updatedOnValueChange(it) }
         )
     }
     return@composed onRotaryScrollEvent(rotaryInputAccumulator::onRotaryScrollEvent)


### PR DESCRIPTION
#### WHAT
Volume fix to rememberUpdatedState for value change

#### WHY
To make sure rotary modifier recomposes when the onValueChange lambda changes and also make sure the recomposition only happens when lambda changes, not at every value change.

#### HOW
Following [suggestion](https://github.com/google/horologist/pull/1150/files/e7b56c64f5cce3b6a9c1b4919a992ee55208a9c1#r1153467411) 

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [X] Run spotless check
- [X] Run tests
- [X] Update metalava's signature text files
