### PR TITLE
Add a saveSnapshot API method for overriding

### DIFF
--- a/roboscreenshots/api/current.api
+++ b/roboscreenshots/api/current.api
@@ -25,6 +25,7 @@ package com.google.android.horologist.screenshots {
     method public final String? getTestLabel();
     method @org.junit.Rule public final org.junit.rules.TestName getTestName();
     method public final float getTolerance();
+    method public suspend Object? saveSnapshot(com.quickbird.snapshot.FileSnapshotting<androidx.compose.ui.test.SemanticsNodeInteraction,android.graphics.Bitmap> snapshotting, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public final void setFakeImageLoader(com.google.android.horologist.compose.tools.coil.FakeImageLoader);
     method public final void setRecord(boolean);
     method public final void setScreenTimeText(kotlin.jvm.functions.Function0<kotlin.Unit>);

--- a/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/ScreenshotTest.kt
+++ b/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/ScreenshotTest.kt
@@ -231,7 +231,7 @@ public abstract class ScreenshotTest {
         }
     }
 
-    open suspend fun saveSnapshot(snapshotting: FileSnapshotting<SemanticsNodeInteraction, Bitmap>) {
+    public open suspend fun saveSnapshot(snapshotting: FileSnapshotting<SemanticsNodeInteraction, Bitmap>) {
         snapshotting.snapshot(
             rule.onRoot(),
             testName = testName.methodName + (if (testLabel != null) "_$testLabel" else ""),

--- a/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/ScreenshotTest.kt
+++ b/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/ScreenshotTest.kt
@@ -60,6 +60,7 @@ import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.screenshots.a11y.A11ySnapshotTransformer
 import com.quickbird.snapshot.Diffing
+import com.quickbird.snapshot.FileSnapshotting
 import com.quickbird.snapshot.Snapshotting
 import com.quickbird.snapshot.fileSnapshotting
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -158,12 +159,7 @@ public abstract class ScreenshotTest {
                 }
             ).fileSnapshotting
 
-            snapshotting.snapshot(
-                rule.onRoot(),
-                testName = testName.methodName + (if (testLabel != null) "_$testLabel" else ""),
-                record = record,
-                testClass = this@ScreenshotTest.javaClass
-            )
+            saveSnapshot(snapshotting)
         }
     }
 
@@ -231,13 +227,17 @@ public abstract class ScreenshotTest {
                 }
             ).fileSnapshotting
 
-            snapshotting.snapshot(
-                rule.onRoot(),
-                record = record,
-                testName = testName.methodName + (if (testLabel != null) "_$testLabel" else ""),
-                testClass = this@ScreenshotTest.javaClass
-            )
+            saveSnapshot(snapshotting)
         }
+    }
+
+    open suspend fun saveSnapshot(snapshotting: FileSnapshotting<SemanticsNodeInteraction, Bitmap>) {
+        snapshotting.snapshot(
+            rule.onRoot(),
+            testName = testName.methodName + (if (testLabel != null) "_$testLabel" else ""),
+            record = record,
+            testClass = this@ScreenshotTest.javaClass
+        )
     }
 
     @Composable


### PR DESCRIPTION
#### WHAT

Add a saveSnapshot API method for overriding

#### WHY

ScreenshotTest is opinionated and default to Paparazzi naming, but allow this to be overridden. 

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
