### PR TITLE
Switch to 0.4.x branch and compose 1.5 alphas

### DIFF
--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_PrimaryChipTest_disabled.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_PrimaryChipTest_disabled.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b5ad37e6585f1e22bc59131afd5ad0da732ada43f321a3e72a561d7c6408b38c
-size 9891
+oid sha256:3eda943e164d213f514c73ce667c8f956f17b9581369860e6201aa34d87265cc
+size 11124

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_PrimaryChipTest_disabledWithIconPlaceholder.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_PrimaryChipTest_disabledWithIconPlaceholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f9a5c89cd064c695718f3092dd6ba73628af84a4de05daa430ba828614e217da
-size 9687
+oid sha256:3eda943e164d213f514c73ce667c8f956f17b9581369860e6201aa34d87265cc
+size 11124

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,8 +38,6 @@ buildscript {
 
         classpath(libs.affectedmoduledetector)
 
-        classpath(libs.paparazziPlugin)
-
         classpath(libs.dagger.hiltandroidplugin)
 
         classpath(libs.googleSecretsGradlePlugin)

--- a/compose-layout/src/androidTest/java/com/google/android/horologist/compose/navscaffold/NavScaffoldTest.kt
+++ b/compose-layout/src/androidTest/java/com/google/android/horologist/compose/navscaffold/NavScaffoldTest.kt
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalCoroutinesApi::class, ExperimentalHorologistApi::class)
+@file:OptIn(
+    ExperimentalCoroutinesApi::class,
+    ExperimentalHorologistApi::class,
+    ExperimentalWearFoundationApi::class
+)
 
 package com.google.android.horologist.compose.navscaffold
 
@@ -41,6 +45,7 @@ import androidx.lifecycle.get
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.test.filters.MediumTest
+import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
 import androidx.wear.compose.foundation.RequestFocusWhenActive
 import androidx.wear.compose.foundation.curvedComposable
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn

--- a/compose-layout/src/androidTest/java/com/google/android/horologist/compose/pager/PagerScreenTest.kt
+++ b/compose-layout/src/androidTest/java/com/google/android/horologist/compose/pager/PagerScreenTest.kt
@@ -17,7 +17,8 @@
 @file:OptIn(
     ExperimentalCoroutinesApi::class,
     ExperimentalHorologistApi::class,
-    ExperimentalFoundationApi::class
+    ExperimentalFoundationApi::class,
+    ExperimentalWearFoundationApi::class
 )
 
 package com.google.android.horologist.compose.pager
@@ -40,6 +41,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onParent
 import androidx.test.filters.MediumTest
+import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
 import androidx.wear.compose.foundation.RequestFocusWhenActive
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.annotations.ExperimentalHorologistApi

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/focus/FocusNode.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/focus/FocusNode.kt
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalWearFoundationApi::class)
+
 package com.google.android.horologist.compose.focus
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.focus.FocusRequester
+import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
 import androidx.wear.compose.foundation.HierarchicalFocusCoordinator
 import kotlinx.coroutines.CoroutineScope
 

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/layout/ScalingLazyColumnState.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/layout/ScalingLazyColumnState.kt
@@ -15,6 +15,7 @@
  */
 
 @file:Suppress("ObjectLiteralToLambda")
+@file:OptIn(ExperimentalWearFoundationApi::class)
 
 package com.google.android.horologist.compose.layout
 
@@ -26,6 +27,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
 import androidx.wear.compose.foundation.lazy.AutoCenteringParams
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.ScalingLazyListAnchorType

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/WearNavScaffold.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/WearNavScaffold.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
+@file:OptIn(ExperimentalHorologistApi::class, ExperimentalWearFoundationApi::class)
 
 package com.google.android.horologist.compose.navscaffold
 
@@ -41,6 +41,7 @@ import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavDeepLink
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
+import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
 import androidx.wear.compose.foundation.HierarchicalFocusCoordinator
 import androidx.wear.compose.foundation.lazy.ScalingLazyListState
 import androidx.wear.compose.material.PositionIndicator

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/pager/PagerScreen.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/pager/PagerScreen.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalFoundationApi::class)
+@file:OptIn(ExperimentalFoundationApi::class, ExperimentalWearFoundationApi::class)
 
 package com.google.android.horologist.compose.pager
 
@@ -40,6 +40,7 @@ import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
 import androidx.wear.compose.foundation.HierarchicalFocusCoordinator
 import androidx.wear.compose.material.HorizontalPageIndicator
 import androidx.wear.compose.material.PageIndicatorState

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/AccumulatedRotaryInputModifier.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/AccumulatedRotaryInputModifier.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalWearFoundationApi::class)
+
 package com.google.android.horologist.compose.rotaryinput
 
 import androidx.compose.foundation.focusable
@@ -26,6 +28,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.rotary.RotaryScrollEvent
 import androidx.compose.ui.input.rotary.onRotaryScrollEvent
+import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
 import androidx.wear.compose.foundation.rememberActiveFocusRequester
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ systemProp.org.gradle.internal.http.socketTimeout=120000
 
 GROUP=com.google.android.horologist
 # !! No longer need to update this manually when using a Compose SNAPSHOT
-VERSION_NAME=0.3.10
+VERSION_NAME=0.4.0
 
 POM_DESCRIPTION=Utilities for Wear OS
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,18 +11,16 @@ androidx-media3 = "1.0.0"
 androidx-wear-watchface = "1.2.0-alpha07"
 androidxActivity = "1.7.0"
 androidxCore = "1.9.0"
-androidxFragment = "1.5.6"
 androidxLifecycle = "2.6.1"
-androidxNavigation = "2.6.0-alpha06"
+androidxNavigation = "2.6.0-alpha08"
 androidxPhoneInteractions = "1.1.0-alpha03"
 androidxRemoteInteractions = "1.0.0"
 androidxStartup = "1.1.1"
 androidxTracing = "1.2.0-beta02"
 androidxWear = "1.3.0-alpha04"
 androidxWork = "2.8.1"
-androidxtiles = "1.1.0"
+androidxtiles = "1.2.0-alpha02"
 annotation = "1.0.1"
-app-cash-paparazzi = "1.2.0"
 app-cash-turbine = "0.12.3"
 benManes = "0.46.0"
 com-squareup-okhttp3 = "4.10.0"
@@ -72,7 +70,6 @@ androidx-concurrent-future-ktx = { module = "androidx.concurrent:concurrent-futu
 androidx-corektx = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
 androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "androidx-datastore" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidx-datastore" }
-androidx-fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "androidxFragment" }
 androidx-health-services = { module = "androidx.health:health-services-client", version.ref = "androidx-health-services" }
 androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidxLifecycle" }
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
@@ -156,7 +153,6 @@ moshi-adapters = { module = "com.squareup.moshi:moshi-adapters", version.ref = "
 moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
 moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
-paparazziPlugin = { module = "app.cash.paparazzi:paparazzi-gradle-plugin", version.ref = "app-cash-paparazzi" }
 playservices-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "playServicesAuth" }
 playservices-wearable = "com.google.android.gms:play-services-wearable:18.0.0"
 protobuf-kotlin-lite = { module = "com.google.protobuf:protobuf-kotlin-lite", version.ref = "protobuf" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 affectedmoduledetector = "0.2.1"
 androidx-benchmark = "1.2.0-alpha12"
-androidx-complications-data = "1.1.1"
+androidx-complications-data = "1.2.0-alpha07"
 androidx-compose-material = "1.4.0"
 androidx-concurrent = "1.1.0"
 androidx-datastore = "1.0.0"
@@ -13,21 +13,21 @@ androidxActivity = "1.7.0"
 androidxCore = "1.9.0"
 androidxFragment = "1.5.6"
 androidxLifecycle = "2.6.1"
-androidxNavigation = "2.5.3"
+androidxNavigation = "2.6.0-alpha06"
 androidxPhoneInteractions = "1.1.0-alpha03"
 androidxRemoteInteractions = "1.0.0"
 androidxStartup = "1.1.1"
-androidxTracing = "1.1.0"
+androidxTracing = "1.2.0-beta02"
 androidxWear = "1.3.0-alpha04"
 androidxWork = "2.8.1"
 androidxtiles = "1.1.0"
 annotation = "1.0.1"
 app-cash-paparazzi = "1.2.0"
-app-cash-turbine = "0.12.1"
+app-cash-turbine = "0.12.3"
 benManes = "0.46.0"
 com-squareup-okhttp3 = "4.10.0"
 com-squareup-retrofit2 = "2.9.0"
-compose = "1.4.0"
+compose = "1.5.0-alpha01"
 compose-compiler = "1.4.3"
 composesnapshot = "-"
 dokka = "1.8.10"
@@ -45,7 +45,7 @@ metalava = "0.3.3"
 moshi = "1.14.0"
 okio = "3.3.0"
 playServicesAuth = "20.4.1"
-protobuf = "3.21.12"
+protobuf = "3.22.2"
 room = "2.5.1"
 runtimeTracing = "1.0.0-alpha03"
 snapshot-android = "v1.0.2"
@@ -54,7 +54,7 @@ tracingPerfetto = "1.0"
 tracingPerfettoBinary = "1.0"
 truth = "1.1.3"
 versionCatalogUpdate = "0.8.0"
-wearcompose = "1.2.0-alpha05"
+wearcompose = "1.2.0-alpha07"
 
 [libraries]
 affectedmoduledetector = { module = "com.dropbox.affectedmoduledetector:affectedmoduledetector", version.ref = "affectedmoduledetector" }
@@ -156,7 +156,6 @@ moshi-adapters = { module = "com.squareup.moshi:moshi-adapters", version.ref = "
 moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
 moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
-paparazzi = { module = "app.cash.paparazzi:paparazzi", version.ref = "app-cash-paparazzi" }
 paparazziPlugin = { module = "app.cash.paparazzi:paparazzi-gradle-plugin", version.ref = "app-cash-paparazzi" }
 playservices-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "playServicesAuth" }
 playservices-wearable = "com.google.android.gms:play-services-wearable:18.0.0"
@@ -168,7 +167,6 @@ room-common = { module = "androidx.room:room-common", version.ref = "room" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
 snapshot-android = { module = "com.github.QuickBirdEng.kotlin-snapshot-testing:snapshot-android", version.ref = "snapshot-android" }
-snapshot-jvm = { module = "com.github.QuickBirdEng.kotlin-snapshot-testing:snapshot-jvm", version.ref = "snapshot-android" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "app-cash-turbine" }
 wearcompose-foundation = { module = "androidx.wear.compose:compose-foundation", version.ref = "wearcompose" }

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/player/PlayerScreen.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/screens/player/PlayerScreen.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
+@file:OptIn(ExperimentalHorologistApi::class, ExperimentalWearFoundationApi::class)
 
 package com.google.android.horologist.media.ui.screens.player
 
@@ -39,6 +39,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
 import androidx.wear.compose.foundation.rememberActiveFocusRequester
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.audio.ui.VolumeViewModel

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/tiles/MediaCollectionsTileRenderer.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/tiles/MediaCollectionsTileRenderer.kt
@@ -15,6 +15,7 @@
  */
 
 @file:OptIn(ExperimentalHorologistApi::class)
+@file:Suppress("DEPRECATION")
 
 package com.google.android.horologist.media.ui.tiles
 

--- a/media-ui/src/main/java/com/google/android/horologist/media/ui/tiles/ToTileColors.kt
+++ b/media-ui/src/main/java/com/google/android/horologist/media/ui/tiles/ToTileColors.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.google.android.horologist.media.ui.tiles
 
 import androidx.compose.ui.graphics.toArgb

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -152,7 +152,6 @@ dependencies {
     implementation(libs.wearcompose.navigation)
 
     implementation(libs.androidx.corektx)
-    implementation(libs.androidx.fragment)
     implementation(libs.androidx.lifecycle.runtime)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.activity.compose)

--- a/sample/src/main/java/com/google/android/horologist/navsample/FillerScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/navsample/FillerScreen.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalWearFoundationApi::class)
+
 package com.google.android.horologist.navsample
 
 import androidx.compose.foundation.ScrollState
@@ -27,6 +29,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.ScalingLazyListState
 import androidx.wear.compose.foundation.rememberActiveFocusRequester

--- a/sample/src/main/java/com/google/android/horologist/navsample/NavMenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/navsample/NavMenuScreen.kt
@@ -14,12 +14,15 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalWearFoundationApi::class)
+
 package com.google.android.horologist.navsample
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
 import androidx.wear.compose.foundation.lazy.AutoCenteringParams
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.ScalingLazyListState

--- a/sample/src/main/java/com/google/android/horologist/rotary/RotaryScrollMenuList.kt
+++ b/sample/src/main/java/com/google/android/horologist/rotary/RotaryScrollMenuList.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalWearFoundationApi::class)
+
 package com.google.android.horologist.rotary
 
 import androidx.compose.foundation.background
@@ -43,6 +45,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumnDefaults.scalingParams
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumnDefaults.snapFlingBehavior

--- a/sample/src/main/java/com/google/android/horologist/sample/ScrollAwayScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/ScrollAwayScreen.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalWearFoundationApi::class)
+
 package com.google.android.horologist.sample
 
 import androidx.compose.foundation.ScrollState
@@ -31,6 +33,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
 import androidx.wear.compose.foundation.rememberActiveFocusRequester
 import androidx.wear.compose.material.Card
 import androidx.wear.compose.material.MaterialTheme

--- a/sample/src/main/java/com/google/android/horologist/tile/SampleTheme.kt
+++ b/sample/src/main/java/com/google/android/horologist/tile/SampleTheme.kt
@@ -15,6 +15,7 @@
  */
 
 @file:OptIn(ExperimentalHorologistApi::class)
+@file:Suppress("DEPRECATION")
 
 package com.google.android.horologist.tile
 

--- a/sample/src/main/java/com/google/android/horologist/tile/SampleTileRenderer.kt
+++ b/sample/src/main/java/com/google/android/horologist/tile/SampleTileRenderer.kt
@@ -15,6 +15,7 @@
  */
 
 @file:OptIn(ExperimentalHorologistApi::class)
+@file:Suppress("DEPRECATION")
 
 package com.google.android.horologist.tile
 

--- a/tiles/src/main/AndroidManifest.xml
+++ b/tiles/src/main/AndroidManifest.xml
@@ -24,5 +24,15 @@
     on older devices (25).  We also don't want this to bleed into other modules via
     compose-tools which is used just for testing.
      -->
-    <uses-sdk android:minSdkVersion="25" tools:ignore="GradleOverrides" tools:overrideLibrary="androidx.wear.tiles.material, androidx.wear.tiles.renderer, androidx.wear.tiles.testing, androidx.wear.watchface.style, androidx.wear.watchface.complications.datasource.ktx, androidx.wear.protolayout.expression, androidx.wear.protolayout.expression.pipeline" />
+    <uses-sdk
+        android:minSdkVersion="25"
+        tools:ignore="GradleOverrides"
+        tools:overrideLibrary="androidx.wear.tiles.material,
+            androidx.wear.tiles.renderer,
+            androidx.wear.tiles.testing,
+            androidx.wear.watchface.style,
+            androidx.wear.watchface.complications.datasource.ktx,
+            androidx.wear.protolayout.expression,
+            androidx.wear.protolayout.expression.pipeline,
+            androidx.wear.protolayout.renderer" />
 </manifest>

--- a/tiles/src/main/java/com/google/android/horologist/tiles/preview/ThemePreviewTileRenderer.kt
+++ b/tiles/src/main/java/com/google/android/horologist/tiles/preview/ThemePreviewTileRenderer.kt
@@ -15,6 +15,7 @@
  */
 
 @file:OptIn(ExperimentalHorologistApi::class)
+@file:Suppress("DEPRECATION")
 
 package com.google.android.horologist.tiles.preview
 

--- a/tiles/src/main/java/com/google/android/horologist/tiles/render/SingleTileLayoutRenderer.kt
+++ b/tiles/src/main/java/com/google/android/horologist/tiles/render/SingleTileLayoutRenderer.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.google.android.horologist.tiles.render
 
 import android.content.Context


### PR DESCRIPTION
#### WHAT

Switch to 0.4.x branch and compose 1.5 alphas

#### WHY

Wear Compose 1.2-alpha07, moved from Compose 1.4.  So follow on a new release branch 0.4.x

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
