### PR TITLE
Unused

### DIFF
--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
@@ -112,7 +112,7 @@ public class DefaultRotaryHapticHandler(
             (scrollDelta < 0 && !scrollableState.canScrollBackward)
         ) {
             if (!overscrollHapticTriggered) {
-                val unused = hapticsChannel.trySend(RotaryHapticsType.ScrollLimit)
+                hapticsChannel.trySend(RotaryHapticsType.ScrollLimit)
                 overscrollHapticTriggered = true
             }
         } else {
@@ -121,7 +121,7 @@ public class DefaultRotaryHapticHandler(
             val diff = abs(currScrollPosition - prevHapticsPosition)
 
             if (diff >= hapticsThreshold) {
-                val unused = hapticsChannel.trySend(RotaryHapticsType.ScrollTick)
+                hapticsChannel.trySend(RotaryHapticsType.ScrollTick)
                 prevHapticsPosition = currScrollPosition
             }
         }
@@ -132,12 +132,12 @@ public class DefaultRotaryHapticHandler(
             (scrollDelta < 0 && !scrollableState.canScrollBackward)
         ) {
             if (!overscrollHapticTriggered) {
-                val unused = hapticsChannel.trySend(RotaryHapticsType.ScrollLimit)
+                hapticsChannel.trySend(RotaryHapticsType.ScrollLimit)
                 overscrollHapticTriggered = true
             }
         } else {
             overscrollHapticTriggered = false
-            val unused = hapticsChannel.trySend(RotaryHapticsType.ScrollItemFocus)
+            hapticsChannel.trySend(RotaryHapticsType.ScrollItemFocus)
         }
     }
 }

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
@@ -112,7 +112,7 @@ public class DefaultRotaryHapticHandler(
             (scrollDelta < 0 && !scrollableState.canScrollBackward)
         ) {
             if (!overscrollHapticTriggered) {
-                hapticsChannel.trySend(RotaryHapticsType.ScrollLimit)
+                val unused = hapticsChannel.trySend(RotaryHapticsType.ScrollLimit)
                 overscrollHapticTriggered = true
             }
         } else {
@@ -121,7 +121,7 @@ public class DefaultRotaryHapticHandler(
             val diff = abs(currScrollPosition - prevHapticsPosition)
 
             if (diff >= hapticsThreshold) {
-                hapticsChannel.trySend(RotaryHapticsType.ScrollTick)
+                val unused = hapticsChannel.trySend(RotaryHapticsType.ScrollTick)
                 prevHapticsPosition = currScrollPosition
             }
         }
@@ -132,12 +132,12 @@ public class DefaultRotaryHapticHandler(
             (scrollDelta < 0 && !scrollableState.canScrollBackward)
         ) {
             if (!overscrollHapticTriggered) {
-                hapticsChannel.trySend(RotaryHapticsType.ScrollLimit)
+                val unused = hapticsChannel.trySend(RotaryHapticsType.ScrollLimit)
                 overscrollHapticTriggered = true
             }
         } else {
             overscrollHapticTriggered = false
-            hapticsChannel.trySend(RotaryHapticsType.ScrollItemFocus)
+            val unused = hapticsChannel.trySend(RotaryHapticsType.ScrollItemFocus)
         }
     }
 }

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Rotary.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Rotary.kt
@@ -761,7 +761,7 @@ public fun Modifier.rotaryHandler(
         }
         this
             .onRotaryScrollEvent {
-                channel.trySend(
+                val unused = channel.trySend(
                     TimestampedDelta(
                         it.uptimeMillis,
                         it.verticalScrollPixels * if (reverseDirection) -1f else 1f

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Rotary.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Rotary.kt
@@ -761,7 +761,7 @@ public fun Modifier.rotaryHandler(
         }
         this
             .onRotaryScrollEvent {
-                val unused = channel.trySend(
+                channel.trySend(
                     TimestampedDelta(
                         it.uptimeMillis,
                         it.verticalScrollPixels * if (reverseDirection) -1f else 1f


### PR DESCRIPTION
#### WHAT
Add `val unused` to trySend

#### WHY
Fix errorprone CheckReturnValue warnings, and [trySend](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-send-channel/try-send.html) has a return value that is currently unused.

#### HOW

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [X] Run spotless check
- [X] Run tests
- [N/A] Update metalava's signature text files
