### PR TITLE
Volume button

### DIFF
--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
@@ -17,7 +17,6 @@
 package com.google.android.horologist.audio.ui.components.actions
 
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.VolumeDown
 import androidx.compose.material.icons.filled.VolumeMute
 import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.runtime.Composable

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
@@ -47,7 +47,7 @@ public fun SetVolumeButton(
         imageVector = when {
             volumeUiState?.isMin == true -> Icons.Default.VolumeMute
             volumeUiState?.isMax == true -> Icons.Default.VolumeUp
-            else -> Icons.Default.VolumeDown
+            else -> Icons.Default.VolumeUp
         },
         iconRtlMode = IconRtlMode.Mirrored,
         contentDescription = stringResource(R.string.horologist_set_volume_content_description)


### PR DESCRIPTION
#### WHAT
Default volume button to volume up icon instead of volume down when no volume ui state is passed in.

#### WHY


#### HOW


#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [X] Run spotless check
- [X] Run tests
- [X] Update metalava's signature text files
