### PR TITLE
Volume indicator fix

### DIFF
--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumePositionIndicator.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumePositionIndicator.kt
@@ -42,7 +42,7 @@ public fun VolumePositionIndicator(
     modifier: Modifier = Modifier,
     displayIndicatorEvents: Flow<Unit>? = null
 ) {
-    val visible by produceState(false) {
+    val visible by produceState(displayIndicatorEvents == null, displayIndicatorEvents) {
         displayIndicatorEvents?.collectLatest {
             value = true
             delay(2000)
@@ -52,7 +52,7 @@ public fun VolumePositionIndicator(
     val uiState = volumeUiState()
 
     AnimatedVisibility(
-        visible = visible.takeIf { displayIndicatorEvents != null } ?: true,
+        visible = visible,
         enter = fadeIn(),
         exit = fadeOut()
     ) {

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumePositionIndicator.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumePositionIndicator.kt
@@ -42,7 +42,7 @@ public fun VolumePositionIndicator(
     modifier: Modifier = Modifier,
     displayIndicatorEvents: Flow<Unit>? = null
 ) {
-    val visible by produceState(displayIndicatorEvents == null, displayIndicatorEvents) {
+    val visible by produceState(false) {
         displayIndicatorEvents?.collectLatest {
             value = true
             delay(2000)
@@ -52,7 +52,7 @@ public fun VolumePositionIndicator(
     val uiState = volumeUiState()
 
     AnimatedVisibility(
-        visible = visible,
+        visible = visible.takeIf { displayIndicatorEvents != null } ?: true,
         enter = fadeIn(),
         exit = fadeOut()
     ) {

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
@@ -17,7 +17,6 @@
 package com.google.android.horologist.audio.ui.components.actions
 
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.VolumeDown
 import androidx.compose.material.icons.filled.VolumeMute
 import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.runtime.Composable

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
@@ -47,7 +47,7 @@ public fun SetVolumeButton(
         imageVector = when {
             volumeUiState?.isMin == true -> Icons.Default.VolumeMute
             volumeUiState?.isMax == true -> Icons.Default.VolumeUp
-            else -> Icons.Default.VolumeDown
+            else -> Icons.Default.VolumeUp
         },
         iconRtlMode = IconRtlMode.Mirrored,
         contentDescription = stringResource(R.string.horologist_set_volume_content_description)

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
@@ -17,6 +17,7 @@
 package com.google.android.horologist.audio.ui.components.actions
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.VolumeDown
 import androidx.compose.material.icons.filled.VolumeMute
 import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.runtime.Composable
@@ -45,8 +46,8 @@ public fun SetVolumeButton(
         enabled = enabled,
         imageVector = when {
             volumeUiState?.isMin == true -> Icons.Default.VolumeMute
-            volumeUiState?.isMax == true -> Icons.Default.VolumeUp
-            else -> Icons.Default.VolumeUp
+            volumeUiState?.isMax == false -> Icons.Default.VolumeDown
+            else -> Icons.Default.VolumeUp // volumeUiState == null || volumeUiState.isMax == true
         },
         iconRtlMode = IconRtlMode.Mirrored,
         contentDescription = stringResource(R.string.horologist_set_volume_content_description)

--- a/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonTest.kt
+++ b/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/components/actions/SetVolumeButtonTest.kt
@@ -76,4 +76,11 @@ class SetVolumeButtonTest : ScreenshotTest() {
             )
         }
     }
+
+    @Test
+    fun givenNoVolumeUiState_thenIconIsVolumeUp() {
+        takeComponentScreenshot {
+            SetVolumeButton(onVolumeClick = {})
+        }
+    }
 }

--- a/audio-ui/src/test/snapshots/images/com.google.android.horologist.audio.ui.components.actions_SetVolumeButtonTest_givenNoVolumeUiState_thenIconIsVolumeUp.png
+++ b/audio-ui/src/test/snapshots/images/com.google.android.horologist.audio.ui.components.actions_SetVolumeButtonTest_givenNoVolumeUiState_thenIconIsVolumeUp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a01408392e35315eed84d9bf5518ead31cc7770a7689e2fd694f4484505a398d
+size 1452


### PR DESCRIPTION
#### WHAT
Fix VolumePositionIndicator

#### WHY
So compose knows to swap out the `displayIndicatorEvents` for a different session.

#### HOW
Make `visible` in `VolumePositionIndicator` observe with key `displayIndicatorEvents` in `produceState`

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [X] Run spotless check
- [X] Run tests
- [X] Update metalava's signature text files
