### PR TITLE
Fix Volume Position Indicator

### DIFF
--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumePositionIndicator.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumePositionIndicator.kt
@@ -42,7 +42,7 @@ public fun VolumePositionIndicator(
     modifier: Modifier = Modifier,
     displayIndicatorEvents: Flow<Unit>? = null
 ) {
-    val visible by produceState(false) {
+    val visible by produceState(displayIndicatorEvents == null, displayIndicatorEvents) {
         displayIndicatorEvents?.collectLatest {
             value = true
             delay(2000)
@@ -52,7 +52,7 @@ public fun VolumePositionIndicator(
     val uiState = volumeUiState()
 
     AnimatedVisibility(
-        visible = visible.takeIf { displayIndicatorEvents != null } ?: true,
+        visible = visible,
         enter = fadeIn(),
         exit = fadeOut()
     ) {

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumePositionIndicator.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumePositionIndicator.kt
@@ -42,7 +42,7 @@ public fun VolumePositionIndicator(
     modifier: Modifier = Modifier,
     displayIndicatorEvents: Flow<Unit>? = null
 ) {
-    val visible by produceState(displayIndicatorEvents == null, displayIndicatorEvents) {
+    val visible by produceState(false) {
         displayIndicatorEvents?.collectLatest {
             value = true
             delay(2000)
@@ -52,7 +52,7 @@ public fun VolumePositionIndicator(
     val uiState = volumeUiState()
 
     AnimatedVisibility(
-        visible = visible,
+        visible = visible.takeIf { displayIndicatorEvents != null } ?: true,
         enter = fadeIn(),
         exit = fadeOut()
     ) {

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
@@ -17,7 +17,6 @@
 package com.google.android.horologist.audio.ui.components.actions
 
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.VolumeDown
 import androidx.compose.material.icons.filled.VolumeMute
 import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.runtime.Composable

--- a/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
+++ b/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
@@ -17,6 +17,7 @@
 package com.google.android.horologist.audio.ui.components.actions
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.VolumeDown
 import androidx.compose.material.icons.filled.VolumeMute
 import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.runtime.Composable


### PR DESCRIPTION
#### WHAT
Fix VolumePositionIndicator

#### WHY
So compose knows to swap out the `displayIndicatorEvents` for a different session.

#### HOW
Make `visible` in `VolumePositionIndicator` observe with key `displayIndicatorEvents` in `produceState`

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [X] Run spotless check
- [X] Run tests
- [X] Update metalava's signature text files


