### PR TITLE
Remove opt-ins for ExperimentalHorologistApi

### DIFF
--- a/composables/src/test/kotlin/com/google/android/horologist/composables/DatePickerA11yTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/DatePickerA11yTest.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.composables
 
 import androidx.compose.ui.semantics.SemanticsProperties
@@ -23,7 +21,6 @@ import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.screenshots.ScreenshotTest
 import org.junit.Test
 import java.time.LocalDate

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/TimePicker12hA11yTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/TimePicker12hA11yTest.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.composables
 
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.onNodeWithContentDescription
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.screenshots.ScreenshotTest
 import org.junit.Test
 import java.time.LocalTime

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/TimePickerA11yTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/TimePickerA11yTest.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package com.google.android.horologist.composables
 
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.onNodeWithContentDescription
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.screenshots.ScreenshotTest
 import org.junit.Test
 import java.time.LocalTime

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
@@ -96,7 +96,6 @@ public interface RotaryHapticHandler {
  * @param hapticsChannel Channel to which haptic events will be sent
  * @param hapticsThreshold A scroll threshold after which haptic is produced.
  */
-@OptIn(ExperimentalHorologistApi::class)
 public class DefaultRotaryHapticHandler(
     private val scrollableState: ScrollableState,
     private val hapticsChannel: Channel<RotaryHapticsType>,


### PR DESCRIPTION
#### WHAT

Remove opt-ins for `ExperimentalHorologistApi`.

#### WHY

Modules are opting in in their build.gradle files - https://github.com/google/horologist/pull/1125

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
