### PR TITLE
Ignore WearDataLayerRegistryTest because it's flaky

### DIFF
--- a/datalayer/src/androidTest/java/com/google/android/horologist/data/WearDataLayerRegistryTest.kt
+++ b/datalayer/src/androidTest/java/com/google/android/horologist/data/WearDataLayerRegistryTest.kt
@@ -32,8 +32,10 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
+import org.junit.Ignore
 import org.junit.Test
 
+@Ignore("flaky, tracked in https://github.com/google/horologist/issues/1191")
 class WearDataLayerRegistryTest {
 
     @Test


### PR DESCRIPTION
#### WHAT
Ignore flaking test

#### WHY


#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
