### PR TITLE
Remove androidTest from PR builds

### DIFF
--- a/.github/workflows/android_test.yml
+++ b/.github/workflows/android_test.yml
@@ -1,0 +1,69 @@
+name: Android Test
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: macos-latest
+    timeout-minutes: 50
+
+    strategy:
+      # Allow tests to continue on other devices if they fail on one device.
+      fail-fast: false
+      matrix:
+        api-level: [ 30 ]
+
+    env:
+      TERM: dumb
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          lfs: 'true'
+
+      - name: Install pulseaudio
+        run: brew install pulseaudio
+
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
+      - name: set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Run tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: android-wear
+          profile: wear_round_454
+          emulator-options: -no-window -no-snapshot
+          script: ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=Microbenchmark -x media-benchmark:connectedDebugAndroidTest
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs-${{ matrix.api-level }}-${{ matrix.shard }}
+          path: logcat.txt
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results-${{ matrix.api-level }}-${{ matrix.shard }}
+          path: |
+            **/build/reports/*
+            **/build/outputs/*/connected/*
+            **/out/failures/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
             **/build/test-results/*
             **/build/reports/*
 
-  test:
+  compiletests:
     runs-on: macos-latest
     timeout-minutes: 50
 
@@ -64,9 +64,6 @@ jobs:
         with:
           lfs: 'true'
 
-      - name: Install pulseaudio
-        run: brew install pulseaudio
-
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
@@ -76,34 +73,10 @@ jobs:
           distribution: 'zulu'
           java-version: 11
 
-      - name: Setup Gradle
+      - name: Compile tests
         uses: gradle/gradle-build-action@v2
-
-      - name: Run tests
-        uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: ${{ matrix.api-level }}
-          target: android-wear
-          profile: wear_round_454
-          emulator-options: -no-window -no-snapshot
-          script: ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=Microbenchmark -x media-benchmark:connectedDebugAndroidTest
-
-      - name: Upload logs
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: logs-${{ matrix.api-level }}-${{ matrix.shard }}
-          path: logcat.txt
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: test-results-${{ matrix.api-level }}-${{ matrix.shard }}
-          path: |
-            **/build/reports/*
-            **/build/outputs/*/connected/*
-            **/out/failures/
+          arguments: compileDebugAndroidTestSources
 
   verify:
     # Skip build if head commit contains 'skip ci'


### PR DESCRIPTION
#### WHAT

Remove androidTest from PR builds

#### WHY

Too much noise on github builds.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
