### PR TITLE
Improve marquee

### DIFF
--- a/composables/src/main/java/com/google/android/horologist/composables/MarqueeText.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/MarqueeText.kt
@@ -148,15 +148,10 @@ internal fun SimpleMarqueeText(
     text: String,
     textAlign: TextAlign,
     color: Color,
-    style: TextStyle
+    style: TextStyle,
+    modifier: Modifier = Modifier,
 ) {
-    Box(modifier = Modifier.drawWithContent {
-        drawContent()
-
-        // Fade out the edges with a gradient
-        drawFadeGradient(leftEdge = true, edgeGradientWidth = edgeGradientWidth)
-        drawFadeGradient(leftEdge = false, edgeGradientWidth = edgeGradientWidth)
-    }) {
+    BoxWithEdgeFade(edgeGradientWidth = edgeGradientWidth, modifier = modifier) {
         StaticMarqueeText(
             modifier = Modifier
                 .basicMarquee(
@@ -178,6 +173,46 @@ internal fun SimpleMarqueeText(
 }
 
 @Composable
+internal fun BoxWithEdgeFade(
+    edgeGradientWidth: Dp,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    fun ContentDrawScope.drawFadeGradient(
+        leftEdge: Boolean,
+        edgeGradientWidth: Dp
+    ) {
+        val width = edgeGradientWidth.toPx()
+        drawRect(
+            size = Size(width, size.height),
+            topLeft = Offset(
+                if (leftEdge) 0f else size.width - width,
+                0f
+            ),
+            brush = Brush.horizontalGradient(
+                listOf(
+                    Color.Transparent,
+                    Color.Black
+                ),
+                startX = if (leftEdge) 0f else size.width,
+                endX = if (leftEdge) width else size.width - width
+            ),
+            blendMode = BlendMode.DstIn
+        )
+    }
+
+    Box(modifier = modifier.drawWithContent {
+        drawContent()
+
+        // Fade out the edges with a gradient
+        drawFadeGradient(leftEdge = true, edgeGradientWidth = edgeGradientWidth)
+        drawFadeGradient(leftEdge = false, edgeGradientWidth = edgeGradientWidth)
+    }) {
+        content()
+    }
+}
+
+@Composable
 internal fun StaticMarqueeText(
     text: String,
     textAlign: TextAlign,
@@ -192,29 +227,6 @@ internal fun StaticMarqueeText(
         color = color,
         style = style,
         maxLines = 1
-    )
-}
-
-private fun ContentDrawScope.drawFadeGradient(
-    leftEdge: Boolean,
-    edgeGradientWidth: Dp
-) {
-    val width = edgeGradientWidth.toPx()
-    drawRect(
-        size = Size(width, size.height),
-        topLeft = Offset(
-            if (leftEdge) 0f else size.width - width,
-            0f
-        ),
-        brush = Brush.horizontalGradient(
-            listOf(
-                Color.Transparent,
-                Color.Black
-            ),
-            startX = if (leftEdge) 0f else size.width,
-            endX = if (leftEdge) width else size.width - width
-        ),
-        blendMode = BlendMode.DstIn
     )
 }
 

--- a/composables/src/main/java/com/google/android/horologist/composables/MarqueeText.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/MarqueeText.kt
@@ -14,20 +14,16 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalFoundationApi::class)
+
 package com.google.android.horologist.composables
 
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.MutableTransitionState
-import androidx.compose.animation.core.animateDp
-import androidx.compose.animation.core.snap
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.core.updateTransition
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.MarqueeSpacing
+import androidx.compose.foundation.basicMarquee
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.drawWithContent
@@ -47,34 +43,8 @@ import androidx.wear.compose.material.LocalContentColor
 import androidx.wear.compose.material.LocalTextStyle
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import kotlinx.coroutines.delay
-import kotlin.math.roundToInt
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
-
-// TODO: Deprecate this MarqueeText and replace with the Compose [Modifier.basicMarquee]. https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/BasicMarquee.kt
-private enum class MarqueeComponents {
-    First,
-    Second,
-}
-
-private enum class AnimationState {
-    // Text will scroll after some delay
-    WaitingToScroll,
-
-    // Text is scrolling
-    Scrolling,
-
-    // Initial state before or assuming it is determined that scrolling is not required
-    NotNeeded,
-}
-
-private data class ElementWidths(
-    val text: Dp,
-    val container: Dp
-) {
-    val isScrollRequired: Boolean = text > container
-}
 
 /**
  * Show a single line Marquee text, with a pause (initial and between cycles) and speed.
@@ -111,10 +81,10 @@ public fun MarqueeText(
     marqueeDpPerSecond: Dp = 64.dp,
     pauseTime: Duration = 4.seconds
 ) {
-    val textFn = @Composable {
+    val textFn: @Composable (Modifier) -> Unit = {
         Text(
             text = text,
-            modifier = modifier,
+            modifier = it,
             textAlign = textAlign,
             color = color,
             style = style,
@@ -122,143 +92,94 @@ public fun MarqueeText(
         )
     }
 
-    var measuredWidths by remember {
-        mutableStateOf(
-            ElementWidths(
-                text = 0.dp,
-                container = 0.dp
-            )
-        )
-    }
-
-    val transitionState = remember { MutableTransitionState(AnimationState.NotNeeded) }
-    val transition = updateTransition(transitionState, label = "Animation State")
-
-    val durationMillis = remember(measuredWidths, marqueeDpPerSecond, followGap) {
-        ((measuredWidths.text + followGap).value / marqueeDpPerSecond.value * 1000).roundToInt()
-    }
-
-    val firstTextStartOffset by transition.animateDp(
-        label = "Marquee Offset",
-        transitionSpec = {
-            if (this.targetState == AnimationState.Scrolling) {
-                tween(durationMillis = durationMillis, easing = LinearEasing)
-            } else {
-                snap()
-            }
-        }
-    ) { state ->
-        if (state == AnimationState.Scrolling) {
-            edgeGradientWidth - (measuredWidths.text + followGap)
-        } else {
-            edgeGradientWidth
-        }
-    }
-
-    // Reset animation to the initial state, before we even know (based on width) if scrolling
-    // is required.  It should also reset the timer, since the launched effect below will cancel
-    // because current state cahnges.
-    LaunchedEffect(text) {
-        transitionState.targetState = AnimationState.NotNeeded
-    }
-
-    // Reset from completed marquee to pause, whenever we reach Marquee state, it's time to
-    // Move back to paused state.
-    LaunchedEffect(transitionState.currentState) {
-        if (transitionState.currentState == AnimationState.Scrolling) {
-            transitionState.targetState = AnimationState.WaitingToScroll
-        }
-    }
-
-    // Run marquee after a delay, this is the main scrolling loop.
-    // While we are in idle / paused state, wait the pause time, then start the animation.
-    LaunchedEffect(transitionState.currentState) {
-        if (transitionState.currentState == AnimationState.WaitingToScroll && transitionState.isIdle) {
-            delay(pauseTime)
-            transitionState.targetState = AnimationState.Scrolling
-        }
-    }
-
-    fun ContentDrawScope.drawFadeGradient(
-        leftEdge: Boolean
-    ) {
-        val width = edgeGradientWidth.toPx()
-        drawRect(
-            size = Size(width, size.height),
-            topLeft = Offset(
-                if (leftEdge) 0f else size.width - width,
-                0f
-            ),
-            brush = Brush.horizontalGradient(
-                listOf(
-                    Color.Transparent,
-                    Color.Black
-                ),
-                startX = if (leftEdge) 0f else size.width,
-                endX = if (leftEdge) width else size.width - width
-            ),
-            blendMode = BlendMode.DstIn
-        )
-    }
-
     SubcomposeLayout(
         modifier = modifier
-            .clipToBounds()
-            .drawWithContent {
-                drawContent()
-
-                if (measuredWidths.isScrollRequired) {
-                    drawFadeGradient(leftEdge = true)
-                    drawFadeGradient(leftEdge = false)
-                }
-            }
     ) { constraints ->
-        val firstTextPlaceable = subcompose(MarqueeComponents.First) {
-            textFn()
+        // Measure without any constraints to get the ideal unconstrained width
+        val textPlaceable = subcompose(MarqueeComponents.First) {
+            textFn(Modifier)
         }.first().measure(Constraints())
 
-        measuredWidths = ElementWidths(
-            text = firstTextPlaceable.width.toDp(),
-            container = constraints.maxWidth.toDp()
-        )
+        val textWidth = textPlaceable.width.toDp()
+        val containerWidth = constraints.maxWidth.toDp()
+        val isScrollRequired = textWidth > containerWidth
 
-        if (transitionState.currentState == AnimationState.NotNeeded && measuredWidths.isScrollRequired) {
-            transitionState.targetState = AnimationState.WaitingToScroll
-        }
-
-        if (measuredWidths.isScrollRequired) {
-            val secondTextPlaceable = subcompose(MarqueeComponents.Second) {
-                textFn()
-            }.first().measure(Constraints())
-
-            val secondTextStartOffset = firstTextStartOffset + measuredWidths.text + followGap
-
-            layout(
-                width = constraints.maxWidth,
-                height = firstTextPlaceable.height
-            ) {
-                firstTextPlaceable.place(firstTextStartOffset.toPx().roundToInt(), 0)
-
-                val secondTextSpace = constraints.maxWidth.toDp() - secondTextStartOffset
-                if (secondTextSpace > 0.dp) {
-                    secondTextPlaceable.place(secondTextStartOffset.toPx().roundToInt(), 0)
-                }
-            }
-        } else {
+        if (isScrollRequired) {
             // Render a fixed position single text since it fits
 
             val x = when (textAlign) {
-                TextAlign.Right -> constraints.maxWidth - firstTextPlaceable.width
-                TextAlign.Center -> (constraints.maxWidth - firstTextPlaceable.width) / 2
+                TextAlign.Right -> constraints.maxWidth - textPlaceable.width
+                TextAlign.Center -> (constraints.maxWidth - textPlaceable.width) / 2
                 else -> 0
             }
 
             layout(
                 width = constraints.maxWidth,
-                height = firstTextPlaceable.height
+                height = textPlaceable.height
             ) {
-                firstTextPlaceable.place(x, 0)
+                textPlaceable.place(x, 0)
+            }
+        } else {
+            // Render a marquee text since it's too wide
+            val marqueeTextPlaceable = subcompose(MarqueeComponents.Second) {
+                val textModifier = Modifier
+                    .basicMarquee(
+                        iterations = Int.MAX_VALUE,
+                        delayMillis = pauseTime.inWholeMilliseconds.toInt(),
+                        initialDelayMillis = pauseTime.inWholeMilliseconds.toInt(),
+                        spacing = MarqueeSpacing(followGap),
+                        velocity = marqueeDpPerSecond
+                    )
+                    // Start unobscured by the edge gradients
+                    // and avoid painting past the gradients
+                    .offset(edgeGradientWidth)
+                    .clipToBounds()
+
+                Box(modifier = Modifier.drawWithContent {
+                    drawContent()
+
+                    // Fade out the edges with a gradient
+                    drawFadeGradient(leftEdge = true, edgeGradientWidth = edgeGradientWidth)
+                    drawFadeGradient(leftEdge = false, edgeGradientWidth = edgeGradientWidth)
+                }) {
+                    textFn(textModifier)
+                }
+            }.first().measure(constraints)
+
+            layout(
+                width = constraints.maxWidth,
+                height = textPlaceable.height
+            ) {
+                marqueeTextPlaceable.place(0, 0)
             }
         }
     }
+}
+
+fun ContentDrawScope.drawFadeGradient(
+    leftEdge: Boolean,
+    edgeGradientWidth: Dp
+) {
+    val width = edgeGradientWidth.toPx()
+    drawRect(
+        size = Size(width, size.height),
+        topLeft = Offset(
+            if (leftEdge) 0f else size.width - width,
+            0f
+        ),
+        brush = Brush.horizontalGradient(
+            listOf(
+                Color.Transparent,
+                Color.Black
+            ),
+            startX = if (leftEdge) 0f else size.width,
+            endX = if (leftEdge) width else size.width - width
+        ),
+        blendMode = BlendMode.DstIn
+    )
+}
+
+private enum class MarqueeComponents {
+    First,
+    Second,
 }

--- a/composables/src/main/java/com/google/android/horologist/composables/MarqueeText.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/MarqueeText.kt
@@ -149,7 +149,7 @@ internal fun SimpleMarqueeText(
     textAlign: TextAlign,
     color: Color,
     style: TextStyle,
-    modifier: Modifier = Modifier,
+    modifier: Modifier = Modifier
 ) {
     BoxWithEdgeFade(edgeGradientWidth = edgeGradientWidth, modifier = modifier) {
         StaticMarqueeText(
@@ -167,7 +167,7 @@ internal fun SimpleMarqueeText(
             text = text,
             textAlign = textAlign,
             color = color,
-            style = style,
+            style = style
         )
     }
 }
@@ -201,13 +201,15 @@ internal fun BoxWithEdgeFade(
         )
     }
 
-    Box(modifier = modifier.drawWithContent {
-        drawContent()
+    Box(
+        modifier = modifier.drawWithContent {
+            drawContent()
 
-        // Fade out the edges with a gradient
-        drawFadeGradient(leftEdge = true, edgeGradientWidth = edgeGradientWidth)
-        drawFadeGradient(leftEdge = false, edgeGradientWidth = edgeGradientWidth)
-    }) {
+            // Fade out the edges with a gradient
+            drawFadeGradient(leftEdge = true, edgeGradientWidth = edgeGradientWidth)
+            drawFadeGradient(leftEdge = false, edgeGradientWidth = edgeGradientWidth)
+        }
+    ) {
         content()
     }
 }
@@ -218,7 +220,7 @@ internal fun StaticMarqueeText(
     textAlign: TextAlign,
     color: Color,
     style: TextStyle,
-    modifier: Modifier = Modifier,
+    modifier: Modifier = Modifier
 ) {
     Text(
         text = text,

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/MarqueeChipTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/MarqueeChipTest.kt
@@ -48,7 +48,7 @@ class MarqueeChipTest : ScreenshotBaseTest(
     private fun runMarqueeTest(text: String) {
         screenshotTestRule.setContent(
             isComponent = true,
-            takeScreenshot = true,
+            takeScreenshot = true
         ) {
             Box(modifier = Modifier.background(Color.Black)) {
                 MarqueeSample(text)

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/MarqueeChipTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/MarqueeChipTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.composables
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.google.android.horologist.screenshots.ScreenshotBaseTest
+import com.google.android.horologist.screenshots.ScreenshotTestRule.Companion.screenshotTestRuleParams
+import org.junit.Test
+
+class MarqueeChipTest : ScreenshotBaseTest(
+    params = screenshotTestRuleParams {
+        record = true
+    }
+) {
+    @Test
+    fun noMarquee() {
+        runMarqueeTest("Sia")
+    }
+
+    @Test
+    fun marquee() {
+        runMarqueeTest("Tikki Tikki Tembo-no Sa Rembo-chari Bari Ruchi-pip Peri Pembo")
+    }
+
+    private fun runMarqueeTest(text: String) {
+        screenshotTestRule.setContent(
+            isComponent = true,
+            takeScreenshot = true,
+        ) {
+            Box(modifier = Modifier.background(Color.Black)) {
+                MarqueeSample(text)
+            }
+        }
+
+        screenshotTestRule.interact {
+            onNodeWithText(text).assertIsDisplayed()
+        }
+    }
+
+    @Composable
+    private fun MarqueeSample(text: String) {
+        MarqueeText(
+            text = text,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .width(192.dp)
+        )
+    }
+}

--- a/composables/src/test/snapshots/images/com.google.android.horologist.composables_MarqueeChipTest_marquee.png
+++ b/composables/src/test/snapshots/images/com.google.android.horologist.composables_MarqueeChipTest_marquee.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:410fb6289d2b9bac4d4020c4e5b48ea403b2564f31660b54530d8a0a42268075
+size 4930

--- a/composables/src/test/snapshots/images/com.google.android.horologist.composables_MarqueeChipTest_noMarquee.png
+++ b/composables/src/test/snapshots/images/com.google.android.horologist.composables_MarqueeChipTest_noMarquee.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09540991b19dc8c2722f4c4c1ad043e172ee6583bc816e6cb2da9c3f0745f3cf
+size 1488


### PR DESCRIPTION
#### WHAT

Improve marquee, use the new basicMarquee modifier.

#### WHY

The current implementation of marquee composes the text twice, although so does this one :(
But this should be a more optimal implementation.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
