### PR TITLE
Fix release builds on AGP 8.0

### DIFF
--- a/auth-sample-wear/proguard-rules.pro
+++ b/auth-sample-wear/proguard-rules.pro
@@ -1,0 +1,10 @@
+# https://issuetracker.google.com/issues/144631039
+-keepclassmembers class * extends com.google.protobuf.GeneratedMessageLite { <fields>; }
+
+# https://github.com/square/okhttp/blob/master/okhttp/src/jvmMain/resources/META-INF/proguard/okhttp3.pro
+
+# OkHttp platform used only on JVM and when Conscrypt and other security providers are available.
+-dontwarn okhttp3.internal.platform.**
+-dontwarn org.conscrypt.**
+-dontwarn org.bouncycastle.**
+-dontwarn org.openjsse.**

--- a/media-sample/proguard-benchmark.pro
+++ b/media-sample/proguard-benchmark.pro
@@ -10,3 +10,14 @@
 # When generating the baseline profile we want the proper names of
 # the methods and classes
 -dontobfuscate
+
+# https://issuetracker.google.com/issues/144631039
+-keepclassmembers class * extends com.google.protobuf.GeneratedMessageLite { <fields>; }
+
+# https://github.com/square/okhttp/blob/master/okhttp/src/jvmMain/resources/META-INF/proguard/okhttp3.pro
+
+# OkHttp platform used only on JVM and when Conscrypt and other security providers are available.
+-dontwarn okhttp3.internal.platform.**
+-dontwarn org.conscrypt.**
+-dontwarn org.bouncycastle.**
+-dontwarn org.openjsse.**

--- a/media-sample/proguard-rules.pro
+++ b/media-sample/proguard-rules.pro
@@ -1,2 +1,10 @@
 # https://issuetracker.google.com/issues/144631039
 -keepclassmembers class * extends com.google.protobuf.GeneratedMessageLite { <fields>; }
+
+# https://github.com/square/okhttp/blob/master/okhttp/src/jvmMain/resources/META-INF/proguard/okhttp3.pro
+
+# OkHttp platform used only on JVM and when Conscrypt and other security providers are available.
+-dontwarn okhttp3.internal.platform.**
+-dontwarn org.conscrypt.**
+-dontwarn org.bouncycastle.**
+-dontwarn org.openjsse.**


### PR DESCRIPTION
#### WHAT

Fix release builds on AGP 8.0

#### WHY

AGP 8.0 is stricter and needs these fixes of OkHttp 4.11 (does not exist) or 5.0-alpha

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
