### PR TITLE
Add the start of a Marquee Benchmark

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,8 @@ androidx-datastore = "1.0.0"
 androidx-health-services = "1.0.0-beta03"
 androidx-hilt = "1.0.0"
 androidx-media3 = "1.0.0"
+androidx-tracingPerfettoBinary = "1.0.0-alpha14"
+androidx-tracingPerfetto = "1.0.0-alpha14"
 androidx-wear-watchface = "1.2.0-alpha07"
 androidxActivity = "1.7.0"
 androidxCore = "1.10.0"
@@ -100,6 +102,8 @@ androidx-test-ext-ktx = "androidx.test.ext:junit-ktx:1.1.5"
 androidx-test-rules = "androidx.test:rules:1.5.0"
 androidx-test-uiautomator = "androidx.test.uiautomator:uiautomator:2.2.0"
 androidx-tracing-ktx = { module = "androidx.tracing:tracing-ktx", version.ref = "androidxTracing" }
+androidx-tracing-perfetto-binary = { module = "androidx.tracing:tracing-perfetto-binary", version.ref = "androidx-tracingPerfettoBinary" }
+androidx-tracing-perfetto = { module = "androidx.tracing:tracing-perfetto", version.ref = "androidx-tracingPerfetto" }
 androidx-wear = { module = "androidx.wear:wear", version.ref = "androidxWear" }
 androidx-wear-phone-interactions = { module = "androidx.wear:wear-phone-interactions", version.ref = "androidxPhoneInteractions" }
 androidx-wear-remote-interactions = { module = "androidx.wear:wear-remote-interactions", version.ref = "androidxRemoteInteractions" }

--- a/media-sample-benchmark/src/main/java/com/google/android/horologist/mediasample/benchmark/MarqueeBenchmark.kt
+++ b/media-sample-benchmark/src/main/java/com/google/android/horologist/mediasample/benchmark/MarqueeBenchmark.kt
@@ -46,7 +46,8 @@ class MarqueeBenchmark {
     public lateinit var mediaControllerFuture: ListenableFuture<MediaBrowser>
 
     @Test
-    public fun startup(): Unit = benchmarkRule.measureRepeated(packageName = mediaApp.packageName,
+    public fun startup(): Unit = benchmarkRule.measureRepeated(
+        packageName = mediaApp.packageName,
         metrics = metrics(),
         compilationMode = CompilationMode.Partial(),
         iterations = 3,

--- a/media-sample-benchmark/src/main/java/com/google/android/horologist/mediasample/benchmark/MarqueeBenchmark.kt
+++ b/media-sample-benchmark/src/main/java/com/google/android/horologist/mediasample/benchmark/MarqueeBenchmark.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.benchmark
+
+import android.content.Intent
+import android.net.Uri
+import androidx.benchmark.macro.CompilationMode
+import androidx.benchmark.macro.Metric
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.StartupTimingMetric
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.media3.session.MediaBrowser
+import androidx.test.filters.LargeTest
+import com.google.android.horologist.media.benchmark.MediaApp
+import com.google.android.horologist.media.benchmark.MediaControllerHelper
+import com.google.common.util.concurrent.ListenableFuture
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import kotlin.time.Duration.Companion.seconds
+
+@LargeTest
+class MarqueeBenchmark {
+    val mediaApp: MediaApp = TestMedia.MediaSampleApp
+
+    @get:Rule
+    public val benchmarkRule: MacrobenchmarkRule = MacrobenchmarkRule()
+
+    public lateinit var mediaControllerFuture: ListenableFuture<MediaBrowser>
+
+    @Test
+    public fun startup(): Unit = benchmarkRule.measureRepeated(
+        packageName = mediaApp.packageName,
+        metrics = metrics(),
+        compilationMode = CompilationMode.Partial(),
+        iterations = 3,
+        startupMode = StartupMode.WARM,
+        setupBlock = {
+            mediaControllerFuture = MediaControllerHelper.lookupController(
+                mediaApp.playerComponentName
+            )
+
+            // Wait for service
+            mediaControllerFuture.get()
+        }
+    ) {
+        startActivityAndWait(Intent(Intent.ACTION_VIEW, Uri.parse("uamp://uamp/player?page=0")))
+
+        val mediaController = mediaControllerFuture.get()
+
+        mediaController.setMediaItem(TestMedia.Intro)
+
+        runBlocking {
+            delay(15.seconds)
+        }
+    }
+
+    public open fun metrics(): List<Metric> = listOf(
+        StartupTimingMetric()
+//        FrameTimingMetric(),
+//        PowerMetric(type = PowerMetric.Type.Energy()),
+    )
+}

--- a/media-sample-benchmark/src/main/java/com/google/android/horologist/mediasample/benchmark/MarqueeBenchmark.kt
+++ b/media-sample-benchmark/src/main/java/com/google/android/horologist/mediasample/benchmark/MarqueeBenchmark.kt
@@ -28,8 +28,10 @@ import androidx.test.filters.LargeTest
 import com.google.android.horologist.media.benchmark.MediaApp
 import com.google.android.horologist.media.benchmark.MediaControllerHelper
 import com.google.common.util.concurrent.ListenableFuture
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import org.junit.Rule
 import org.junit.Test
 import kotlin.time.Duration.Companion.seconds
@@ -44,8 +46,7 @@ class MarqueeBenchmark {
     public lateinit var mediaControllerFuture: ListenableFuture<MediaBrowser>
 
     @Test
-    public fun startup(): Unit = benchmarkRule.measureRepeated(
-        packageName = mediaApp.packageName,
+    public fun startup(): Unit = benchmarkRule.measureRepeated(packageName = mediaApp.packageName,
         metrics = metrics(),
         compilationMode = CompilationMode.Partial(),
         iterations = 3,
@@ -63,9 +64,11 @@ class MarqueeBenchmark {
 
         val mediaController = mediaControllerFuture.get()
 
-        mediaController.setMediaItem(TestMedia.Intro)
-
         runBlocking {
+            withContext(Dispatchers.Main) {
+                mediaController.setMediaItem(TestMedia.Intro)
+            }
+
             delay(15.seconds)
         }
     }

--- a/media-sample/build.gradle.kts
+++ b/media-sample/build.gradle.kts
@@ -181,6 +181,9 @@ dependencies {
     implementation(libs.androidx.datastore)
     implementation(libs.protobuf.kotlin.lite)
 
+    add("benchmarkImplementation", libs.androidx.tracing.perfetto)
+    add("benchmarkImplementation", libs.androidx.tracing.perfetto.binary)
+
     implementation(libs.androidx.complications.datasource.ktx)
 
     implementation(libs.coil)

--- a/media-sample/proguard-benchmark.pro
+++ b/media-sample/proguard-benchmark.pro
@@ -10,3 +10,14 @@
 # When generating the baseline profile we want the proper names of
 # the methods and classes
 -dontobfuscate
+
+# https://issuetracker.google.com/issues/144631039
+-keepclassmembers class * extends com.google.protobuf.GeneratedMessageLite { <fields>; }
+
+# https://github.com/square/okhttp/blob/master/okhttp/src/jvmMain/resources/META-INF/proguard/okhttp3.pro
+
+# OkHttp platform used only on JVM and when Conscrypt and other security providers are available.
+-dontwarn okhttp3.internal.platform.**
+-dontwarn org.conscrypt.**
+-dontwarn org.bouncycastle.**
+-dontwarn org.openjsse.**


### PR DESCRIPTION
#### WHAT

Add the start of a Marquee Benchmark

#### WHY

Get some tracing of marquee before and after changes.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
