### PR TITLE
Avoid automatic navigation on Benchmark tests

### DIFF
--- a/media-sample-benchmark/src/main/java/com/google/android/horologist/mediasample/benchmark/MarqueeBenchmark.kt
+++ b/media-sample-benchmark/src/main/java/com/google/android/horologist/mediasample/benchmark/MarqueeBenchmark.kt
@@ -16,9 +16,8 @@
 
 package com.google.android.horologist.mediasample.benchmark
 
-import android.content.Intent
-import android.net.Uri
 import androidx.benchmark.macro.CompilationMode
+import androidx.benchmark.macro.FrameTimingMetric
 import androidx.benchmark.macro.Metric
 import androidx.benchmark.macro.StartupMode
 import androidx.benchmark.macro.StartupTimingMetric
@@ -61,7 +60,7 @@ class MarqueeBenchmark {
             mediaControllerFuture.get()
         }
     ) {
-        startActivityAndWait(Intent(Intent.ACTION_VIEW, Uri.parse("uamp://uamp/player?page=0")))
+        startActivityAndWait()
 
         val mediaController = mediaControllerFuture.get()
 
@@ -75,8 +74,8 @@ class MarqueeBenchmark {
     }
 
     public open fun metrics(): List<Metric> = listOf(
-        StartupTimingMetric()
-//        FrameTimingMetric(),
+        StartupTimingMetric(),
+        FrameTimingMetric(),
 //        PowerMetric(type = PowerMetric.Type.Energy()),
     )
 }

--- a/media-sample/build.gradle.kts
+++ b/media-sample/build.gradle.kts
@@ -54,6 +54,8 @@ android {
         debug {
             applicationIdSuffix = ".debug"
             manifestPlaceholders["schemeSuffix"] = "-debug"
+
+            buildConfigField("boolean", "BENCHMARK", "false")
         }
         release {
             manifestPlaceholders["schemeSuffix"] = ""
@@ -66,6 +68,8 @@ android {
             )
 
             signingConfig = signingConfigs.getByName("debug")
+
+            buildConfigField("boolean", "BENCHMARK", "false")
         }
         create("benchmark") {
             initWith(buildTypes.getByName("release"))
@@ -80,6 +84,8 @@ android {
             )
 
             matchingFallbacks.add("release")
+
+            buildConfigField("boolean", "BENCHMARK", "true")
         }
     }
 

--- a/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
+++ b/media-sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
@@ -40,6 +40,7 @@ import com.google.android.horologist.media.ui.navigation.MediaNavController.navi
 import com.google.android.horologist.media.ui.navigation.MediaNavController.navigateToSettings
 import com.google.android.horologist.media.ui.navigation.MediaNavController.navigateToVolume
 import com.google.android.horologist.media.ui.navigation.MediaPlayerScaffold
+import com.google.android.horologist.mediasample.BuildConfig
 import com.google.android.horologist.mediasample.ui.auth.prompt.GoogleSignInPromptScreen
 import com.google.android.horologist.mediasample.ui.auth.signin.UampGoogleSignInViewModel
 import com.google.android.horologist.mediasample.ui.auth.signout.GoogleSignOutScreen
@@ -254,28 +255,38 @@ fun UampWearApp(
         )
     }
 
-    LaunchedEffect(Unit) {
-        val collectionId = intent.getAndRemoveKey(MediaActivity.CollectionKey)
-        val mediaId = intent.getAndRemoveKey(MediaActivity.MediaIdKey)
-        val position = intent.getAndRemoveKey(MediaActivity.PositionKey)
+    if (!BuildConfig.BENCHMARK) {
+        LaunchedEffect(Unit) {
+            startupNavigation(intent, appViewModel, navController)
+        }
+    }
+}
 
-        if (collectionId != null) {
-            if (position != null) {
-                appViewModel.playItems(mediaId, collectionId, position.toLong())
-            } else {
-                appViewModel.playItems(mediaId, collectionId, 0)
-            }
+private suspend fun startupNavigation(
+    intent: Intent,
+    appViewModel: MediaPlayerAppViewModel,
+    navController: NavHostController
+) {
+    val collectionId = intent.getAndRemoveKey(MediaActivity.CollectionKey)
+    val mediaId = intent.getAndRemoveKey(MediaActivity.MediaIdKey)
+    val position = intent.getAndRemoveKey(MediaActivity.PositionKey)
+
+    if (collectionId != null) {
+        if (position != null) {
+            appViewModel.playItems(mediaId, collectionId, position.toLong())
         } else {
-            appViewModel.startupSetup(navigateToLibrary = {
-                navController.navigateToLibrary()
-            })
+            appViewModel.playItems(mediaId, collectionId, 0)
         }
+    } else {
+        appViewModel.startupSetup(navigateToLibrary = {
+            navController.navigateToLibrary()
+        })
+    }
 
-        if (appViewModel.shouldShowLoginPrompt()) {
-            // Allow screen to settle so it feels like a distinct step
-            delay(200)
-            navController.navigateToGoogleSignInPrompt()
-        }
+    if (appViewModel.shouldShowLoginPrompt()) {
+        // Allow screen to settle so it feels like a distinct step
+        delay(200)
+        navController.navigateToGoogleSignInPrompt()
     }
 }
 


### PR DESCRIPTION
#### WHAT

Avoid automatic navigation on Benchmark tests

#### WHY

Want to be able to launch to a particular screen and stay there

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
