### PR TITLE
Replace the deprecated tiles types with their ProtoLayout replacement

### DIFF
--- a/compose-tools/api/current.api
+++ b/compose-tools/api/current.api
@@ -38,11 +38,11 @@ package com.google.android.horologist.compose.tools {
   }
 
   public final class TilePreviewKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void LayoutElementPreview(androidx.wear.tiles.LayoutElementBuilders.LayoutElement element, optional @ColorInt int windowBackgroundColor, optional kotlin.jvm.functions.Function1<? super androidx.wear.tiles.ResourceBuilders.Resources.Builder,kotlin.Unit> tileResourcesFn);
-    method @androidx.compose.runtime.Composable public static void LayoutRootPreview(androidx.wear.tiles.LayoutElementBuilders.LayoutElement root, optional kotlin.jvm.functions.Function1<? super androidx.wear.tiles.ResourceBuilders.Resources.Builder,kotlin.Unit> tileResourcesFn);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void LayoutElementPreview(androidx.wear.protolayout.LayoutElementBuilders.LayoutElement element, optional @ColorInt int windowBackgroundColor, optional kotlin.jvm.functions.Function1<? super androidx.wear.protolayout.ResourceBuilders.Resources.Builder,kotlin.Unit> tileResourcesFn);
+    method @androidx.compose.runtime.Composable public static void LayoutRootPreview(androidx.wear.protolayout.LayoutElementBuilders.LayoutElement root, optional kotlin.jvm.functions.Function1<? super androidx.wear.protolayout.ResourceBuilders.Resources.Builder,kotlin.Unit> tileResourcesFn);
     method @androidx.compose.runtime.Composable public static <T, R> void TileLayoutPreview(T? state, R? resourceState, com.google.android.horologist.tiles.render.TileLayoutRenderer<T,R> renderer);
-    method @androidx.compose.runtime.Composable public static void TilePreview(androidx.wear.tiles.TileBuilders.Tile tile, androidx.wear.tiles.ResourceBuilders.Resources tileResources);
-    method public static androidx.wear.tiles.DeviceParametersBuilders.DeviceParameters buildDeviceParameters(android.content.res.Resources resources);
+    method @androidx.compose.runtime.Composable public static void TilePreview(androidx.wear.tiles.TileBuilders.Tile tile, androidx.wear.protolayout.ResourceBuilders.Resources tileResources);
+    method public static androidx.wear.protolayout.DeviceParametersBuilders.DeviceParameters buildDeviceParameters(android.content.res.Resources resources);
   }
 
   @Deprecated @androidx.compose.ui.tooling.preview.Preview(device=androidx.compose.ui.tooling.preview.Devices.WEAR_OS_LARGE_ROUND, showSystemUi=true, backgroundColor=4278190080L, showBackground=true, group="Devices - Large Round") public @interface WearLargeRoundDevicePreview {

--- a/compose-tools/src/main/java/com/google/android/horologist/compose/tools/TilePreview.kt
+++ b/compose-tools/src/main/java/com/google/android/horologist/compose/tools/TilePreview.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:Suppress("DEPRECATION")
-
 package com.google.android.horologist.compose.tools
 
 import android.content.res.Resources
@@ -29,21 +27,21 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.wear.tiles.ColorBuilders.argb
-import androidx.wear.tiles.DeviceParametersBuilders
-import androidx.wear.tiles.DimensionBuilders.ExpandedDimensionProp
-import androidx.wear.tiles.LayoutElementBuilders
-import androidx.wear.tiles.LayoutElementBuilders.Box
-import androidx.wear.tiles.LayoutElementBuilders.HORIZONTAL_ALIGN_CENTER
-import androidx.wear.tiles.LayoutElementBuilders.LayoutElement
-import androidx.wear.tiles.LayoutElementBuilders.VERTICAL_ALIGN_CENTER
-import androidx.wear.tiles.ModifiersBuilders.Background
-import androidx.wear.tiles.ModifiersBuilders.Modifiers
+import androidx.wear.protolayout.ColorBuilders.argb
+import androidx.wear.protolayout.DeviceParametersBuilders
+import androidx.wear.protolayout.DimensionBuilders.ExpandedDimensionProp
+import androidx.wear.protolayout.LayoutElementBuilders
+import androidx.wear.protolayout.LayoutElementBuilders.Box
+import androidx.wear.protolayout.LayoutElementBuilders.HORIZONTAL_ALIGN_CENTER
+import androidx.wear.protolayout.LayoutElementBuilders.LayoutElement
+import androidx.wear.protolayout.LayoutElementBuilders.VERTICAL_ALIGN_CENTER
+import androidx.wear.protolayout.ModifiersBuilders.Background
+import androidx.wear.protolayout.ModifiersBuilders.Modifiers
+import androidx.wear.protolayout.ResourceBuilders
+import androidx.wear.protolayout.StateBuilders.State
+import androidx.wear.protolayout.TimelineBuilders
 import androidx.wear.tiles.RequestBuilders
-import androidx.wear.tiles.ResourceBuilders
-import androidx.wear.tiles.StateBuilders.State
 import androidx.wear.tiles.TileBuilders
-import androidx.wear.tiles.TimelineBuilders
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.tiles.render.TileLayoutRenderer
 import kotlinx.coroutines.Dispatchers
@@ -89,13 +87,15 @@ public fun TilePreview(
         update = {
             val tileRenderer = androidx.wear.tiles.renderer.TileRenderer(
                 /* uiContext = */ it.context,
-                /* layout = */ tile.timeline?.timelineEntries?.first()?.layout!!,
-                /* resources = */ tileResources,
                 /* loadActionExecutor = */ Dispatchers.IO.asExecutor(),
                 /* loadActionListener = */ {}
             )
 
-            tileRenderer.inflate(it)
+            tileRenderer.inflate(
+                tile.tileTimeline?.timelineEntries?.first()?.layout!!,
+                tileResources,
+                it
+            )
         }
     )
 }
@@ -139,7 +139,7 @@ public fun LayoutRootPreview(
     val tile = remember {
         TileBuilders.Tile.Builder()
             .setResourcesVersion(PERMANENT_RESOURCES_VERSION)
-            .setTimeline(
+            .setTileTimeline(
                 TimelineBuilders.Timeline.Builder().addTimelineEntry(
                     TimelineBuilders.TimelineEntry.Builder()
                         .setLayout(
@@ -160,11 +160,11 @@ public fun LayoutRootPreview(
 internal const val PERMANENT_RESOURCES_VERSION = "0"
 
 private fun requestParams(resources: Resources) =
-    RequestBuilders.TileRequest.Builder().setDeviceParameters(buildDeviceParameters(resources))
-        .setState(State.Builder().build()).build()
+    RequestBuilders.TileRequest.Builder().setDeviceConfiguration(buildDeviceParameters(resources))
+        .setCurrentState(State.Builder().build()).build()
 
 private fun resourceParams(resources: Resources, version: String) =
-    RequestBuilders.ResourcesRequest.Builder().setDeviceParameters(buildDeviceParameters(resources))
+    RequestBuilders.ResourcesRequest.Builder().setDeviceConfiguration(buildDeviceParameters(resources))
         .setVersion(version).build()
 
 public fun buildDeviceParameters(resources: Resources): DeviceParametersBuilders.DeviceParameters {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ androidxTracing = "1.2.0-beta03"
 androidxWear = "1.3.0-alpha05"
 androidxWork = "2.8.1"
 androidxtiles = "1.2.0-alpha04"
+androidxprotolayout = "1.0.0-alpha08"
 annotation = "1.0.1"
 app-cash-turbine = "0.12.3"
 benManes = "0.46.0"
@@ -109,8 +110,8 @@ androidx-tracing-perfetto-binary = { module = "androidx.tracing:tracing-perfetto
 androidx-wear = { module = "androidx.wear:wear", version.ref = "androidxWear" }
 androidx-wear-phone-interactions = { module = "androidx.wear:wear-phone-interactions", version.ref = "androidxPhoneInteractions" }
 androidx-wear-remote-interactions = { module = "androidx.wear:wear-remote-interactions", version.ref = "androidxRemoteInteractions" }
+androidx-wear-protolayout-material = { module = "androidx.wear.protolayout:protolayout-material", version.ref = "androidxprotolayout" }
 androidx-wear-tiles = { module = "androidx.wear.tiles:tiles", version.ref = "androidxtiles" }
-androidx-wear-tiles-material = { module = "androidx.wear.tiles:tiles-material", version.ref = "androidxtiles" }
 androidx-wear-tiles-renderer = { module = "androidx.wear.tiles:tiles-renderer", version.ref = "androidxtiles" }
 androidx-wear-tiles-testing = { module = "androidx.wear.tiles:tiles-testing", version.ref = "androidxtiles" }
 androidx-work-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "androidxWork" }

--- a/media/sample/build.gradle.kts
+++ b/media/sample/build.gradle.kts
@@ -184,7 +184,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.wear.tiles)
-    implementation(libs.androidx.wear.tiles.material)
+    implementation(libs.androidx.wear.protolayout.material)
 
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.datastore)

--- a/media/sample/src/main/java/com/google/android/horologist/mediasample/data/service/tile/MediaCollectionsTileService.kt
+++ b/media/sample/src/main/java/com/google/android/horologist/mediasample/data/service/tile/MediaCollectionsTileService.kt
@@ -22,11 +22,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
-import androidx.wear.tiles.ActionBuilders
-import androidx.wear.tiles.ActionBuilders.AndroidActivity
+import androidx.wear.protolayout.ActionBuilders
+import androidx.wear.protolayout.ActionBuilders.AndroidActivity
+import androidx.wear.protolayout.ResourceBuilders.Resources
 import androidx.wear.tiles.RequestBuilders.ResourcesRequest
 import androidx.wear.tiles.RequestBuilders.TileRequest
-import androidx.wear.tiles.ResourceBuilders.Resources
 import androidx.wear.tiles.TileBuilders.Tile
 import coil.ImageLoader
 import com.google.android.horologist.compose.tools.TileLayoutPreview

--- a/media/ui/api/current.api
+++ b/media/ui/api/current.api
@@ -904,55 +904,55 @@ package com.google.android.horologist.media.ui.state.model {
 package com.google.android.horologist.media.ui.tiles {
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public final class MediaCollectionsTileRenderer extends com.google.android.horologist.tiles.render.SingleTileLayoutRenderer<com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollectionsState,com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.ResourceState> {
-    ctor public MediaCollectionsTileRenderer(android.content.Context context, androidx.wear.tiles.material.Colors materialTheme, boolean debugResourceMode);
-    method public void produceRequestedResources(androidx.wear.tiles.ResourceBuilders.Resources.Builder, com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.ResourceState resourceState, androidx.wear.tiles.DeviceParametersBuilders.DeviceParameters deviceParameters, java.util.List<java.lang.String> resourceIds);
-    method public androidx.wear.tiles.LayoutElementBuilders.LayoutElement renderTile(com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollectionsState state, androidx.wear.tiles.DeviceParametersBuilders.DeviceParameters deviceParameters);
+    ctor public MediaCollectionsTileRenderer(android.content.Context context, androidx.wear.protolayout.material.Colors materialTheme, boolean debugResourceMode);
+    method public void produceRequestedResources(androidx.wear.protolayout.ResourceBuilders.Resources.Builder, com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.ResourceState resourceState, androidx.wear.protolayout.DeviceParametersBuilders.DeviceParameters deviceParameters, java.util.List<java.lang.String> resourceIds);
+    method public androidx.wear.protolayout.LayoutElementBuilders.LayoutElement renderTile(com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollectionsState state, androidx.wear.protolayout.DeviceParametersBuilders.DeviceParameters deviceParameters);
   }
 
   public static final class MediaCollectionsTileRenderer.MediaCollection {
-    ctor public MediaCollectionsTileRenderer.MediaCollection(String name, String artworkId, androidx.wear.tiles.ActionBuilders.Action action);
+    ctor public MediaCollectionsTileRenderer.MediaCollection(String name, String artworkId, androidx.wear.protolayout.ActionBuilders.Action action);
     method public String component1();
     method public String component2();
-    method public androidx.wear.tiles.ActionBuilders.Action component3();
-    method public com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollection copy(String name, String artworkId, androidx.wear.tiles.ActionBuilders.Action action);
-    method public androidx.wear.tiles.ActionBuilders.Action getAction();
+    method public androidx.wear.protolayout.ActionBuilders.Action component3();
+    method public com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollection copy(String name, String artworkId, androidx.wear.protolayout.ActionBuilders.Action action);
+    method public androidx.wear.protolayout.ActionBuilders.Action getAction();
     method public String getArtworkId();
     method public String getName();
-    property public final androidx.wear.tiles.ActionBuilders.Action action;
+    property public final androidx.wear.protolayout.ActionBuilders.Action action;
     property public final String artworkId;
     property public final String name;
   }
 
   public static final class MediaCollectionsTileRenderer.MediaCollectionsState {
-    ctor public MediaCollectionsTileRenderer.MediaCollectionsState(@StringRes int chipName, androidx.wear.tiles.ActionBuilders.Action chipAction, com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollection collection1, com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollection collection2);
+    ctor public MediaCollectionsTileRenderer.MediaCollectionsState(@StringRes int chipName, androidx.wear.protolayout.ActionBuilders.Action chipAction, com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollection collection1, com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollection collection2);
     method public int component1();
-    method public androidx.wear.tiles.ActionBuilders.Action component2();
+    method public androidx.wear.protolayout.ActionBuilders.Action component2();
     method public com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollection component3();
     method public com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollection component4();
-    method public com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollectionsState copy(@StringRes int chipName, androidx.wear.tiles.ActionBuilders.Action chipAction, com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollection collection1, com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollection collection2);
-    method public androidx.wear.tiles.ActionBuilders.Action getChipAction();
+    method public com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollectionsState copy(@StringRes int chipName, androidx.wear.protolayout.ActionBuilders.Action chipAction, com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollection collection1, com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollection collection2);
+    method public androidx.wear.protolayout.ActionBuilders.Action getChipAction();
     method public int getChipName();
     method public com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollection getCollection1();
     method public com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollection getCollection2();
-    property public final androidx.wear.tiles.ActionBuilders.Action chipAction;
+    property public final androidx.wear.protolayout.ActionBuilders.Action chipAction;
     property public final int chipName;
     property public final com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollection collection1;
     property public final com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollection collection2;
   }
 
   public static final class MediaCollectionsTileRenderer.ResourceState {
-    ctor public MediaCollectionsTileRenderer.ResourceState(@DrawableRes int appIcon, java.util.Map<java.lang.String,androidx.wear.tiles.ResourceBuilders.ImageResource> images);
+    ctor public MediaCollectionsTileRenderer.ResourceState(@DrawableRes int appIcon, java.util.Map<java.lang.String,androidx.wear.protolayout.ResourceBuilders.ImageResource> images);
     method public int component1();
-    method public java.util.Map<java.lang.String,androidx.wear.tiles.ResourceBuilders.ImageResource> component2();
-    method public com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.ResourceState copy(@DrawableRes int appIcon, java.util.Map<java.lang.String,androidx.wear.tiles.ResourceBuilders.ImageResource> images);
+    method public java.util.Map<java.lang.String,androidx.wear.protolayout.ResourceBuilders.ImageResource> component2();
+    method public com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.ResourceState copy(@DrawableRes int appIcon, java.util.Map<java.lang.String,androidx.wear.protolayout.ResourceBuilders.ImageResource> images);
     method public int getAppIcon();
-    method public java.util.Map<java.lang.String,androidx.wear.tiles.ResourceBuilders.ImageResource> getImages();
+    method public java.util.Map<java.lang.String,androidx.wear.protolayout.ResourceBuilders.ImageResource> getImages();
     property public final int appIcon;
-    property public final java.util.Map<java.lang.String,androidx.wear.tiles.ResourceBuilders.ImageResource> images;
+    property public final java.util.Map<java.lang.String,androidx.wear.protolayout.ResourceBuilders.ImageResource> images;
   }
 
   public final class ToTileColorsKt {
-    method @com.google.android.horologist.annotations.ExperimentalHorologistApi public static androidx.wear.tiles.material.Colors toTileColors(androidx.wear.compose.material.Colors);
+    method @com.google.android.horologist.annotations.ExperimentalHorologistApi public static androidx.wear.protolayout.material.Colors toTileColors(androidx.wear.compose.material.Colors);
   }
 
 }

--- a/media/ui/build.gradle.kts
+++ b/media/ui/build.gradle.kts
@@ -126,7 +126,7 @@ dependencies {
     implementation(projects.tiles)
     implementation(libs.androidx.complications.datasource.ktx)
     implementation(libs.androidx.wear.tiles)
-    implementation(libs.androidx.wear.tiles.material)
+    implementation(libs.androidx.wear.protolayout.material)
     implementation(libs.compose.ui.util)
     implementation(libs.compose.ui.toolingpreview)
 

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/tiles/MediaCollectionsTileRenderer.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/tiles/MediaCollectionsTileRenderer.kt
@@ -14,29 +14,27 @@
  * limitations under the License.
  */
 
-@file:Suppress("DEPRECATION")
-
 package com.google.android.horologist.media.ui.tiles
 
 import android.content.Context
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.wear.tiles.ActionBuilders
-import androidx.wear.tiles.DeviceParametersBuilders.DeviceParameters
-import androidx.wear.tiles.DimensionBuilders
-import androidx.wear.tiles.DimensionBuilders.ExpandedDimensionProp
-import androidx.wear.tiles.DimensionBuilders.WrappedDimensionProp
-import androidx.wear.tiles.LayoutElementBuilders
-import androidx.wear.tiles.LayoutElementBuilders.Column
-import androidx.wear.tiles.LayoutElementBuilders.Spacer
-import androidx.wear.tiles.ModifiersBuilders.Clickable
-import androidx.wear.tiles.ResourceBuilders.ImageResource
-import androidx.wear.tiles.ResourceBuilders.Resources
-import androidx.wear.tiles.material.Chip
-import androidx.wear.tiles.material.ChipColors
-import androidx.wear.tiles.material.Colors
-import androidx.wear.tiles.material.CompactChip
-import androidx.wear.tiles.material.layouts.PrimaryLayout
+import androidx.wear.protolayout.ActionBuilders
+import androidx.wear.protolayout.DeviceParametersBuilders.DeviceParameters
+import androidx.wear.protolayout.DimensionBuilders
+import androidx.wear.protolayout.DimensionBuilders.ExpandedDimensionProp
+import androidx.wear.protolayout.DimensionBuilders.WrappedDimensionProp
+import androidx.wear.protolayout.LayoutElementBuilders
+import androidx.wear.protolayout.LayoutElementBuilders.Column
+import androidx.wear.protolayout.LayoutElementBuilders.Spacer
+import androidx.wear.protolayout.ModifiersBuilders.Clickable
+import androidx.wear.protolayout.ResourceBuilders.ImageResource
+import androidx.wear.protolayout.ResourceBuilders.Resources
+import androidx.wear.protolayout.material.Chip
+import androidx.wear.protolayout.material.ChipColors
+import androidx.wear.protolayout.material.Colors
+import androidx.wear.protolayout.material.CompactChip
+import androidx.wear.protolayout.material.layouts.PrimaryLayout
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.tiles.render.SingleTileLayoutRenderer
 
@@ -93,7 +91,7 @@ public class MediaCollectionsTileRenderer(
     }
 
     private fun spacer(size: Float) = Spacer.Builder().setHeight(
-        DimensionBuilders.DpProp.Builder().setValue(size).build()
+        DimensionBuilders.DpProp.Builder(size).build()
     ).build()
 
     private fun collectionChip(

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/tiles/ToTileColors.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/tiles/ToTileColors.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:Suppress("DEPRECATION")
-
 package com.google.android.horologist.media.ui.tiles
 
 import androidx.compose.ui.graphics.toArgb
@@ -23,8 +21,8 @@ import androidx.wear.compose.material.Colors
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 @ExperimentalHorologistApi
-public fun Colors.toTileColors(): androidx.wear.tiles.material.Colors {
-    return androidx.wear.tiles.material.Colors(
+public fun Colors.toTileColors(): androidx.wear.protolayout.material.Colors {
+    return androidx.wear.protolayout.material.Colors(
         primary.toArgb(),
         onPrimary.toArgb(),
         surface.toArgb(),

--- a/media/ui/src/test/java/com/google/android/horologist/media/ui/tiles/MediaCollectionsTileTest.kt
+++ b/media/ui/src/test/java/com/google/android/horologist/media/ui/tiles/MediaCollectionsTileTest.kt
@@ -19,7 +19,7 @@ package com.google.android.horologist.media.ui.tiles
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
-import androidx.wear.tiles.ActionBuilders
+import androidx.wear.protolayout.ActionBuilders
 import com.google.android.horologist.compose.tools.TileLayoutPreview
 import com.google.android.horologist.media.ui.R
 import com.google.android.horologist.media.ui.uamp.UampColors

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -159,7 +159,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.wear.tiles)
-    implementation(libs.androidx.wear.tiles.material)
+    implementation(libs.androidx.wear.protolayout.material)
 
     implementation(libs.kotlinx.coroutines.playservices)
     implementation(libs.kotlin.stdlib)

--- a/sample/src/main/java/com/google/android/horologist/sample/tiles/ExampleTileService.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/tiles/ExampleTileService.kt
@@ -18,16 +18,16 @@ package com.google.android.horologist.sample.tiles
 
 import android.content.Context
 import android.os.BatteryManager
-import androidx.wear.tiles.LayoutElementBuilders.Column
-import androidx.wear.tiles.LayoutElementBuilders.HORIZONTAL_ALIGN_CENTER
-import androidx.wear.tiles.LayoutElementBuilders.Layout
-import androidx.wear.tiles.LayoutElementBuilders.LayoutElement
-import androidx.wear.tiles.LayoutElementBuilders.Text
+import androidx.wear.protolayout.LayoutElementBuilders.Column
+import androidx.wear.protolayout.LayoutElementBuilders.HORIZONTAL_ALIGN_CENTER
+import androidx.wear.protolayout.LayoutElementBuilders.Layout
+import androidx.wear.protolayout.LayoutElementBuilders.LayoutElement
+import androidx.wear.protolayout.LayoutElementBuilders.Text
+import androidx.wear.protolayout.ResourceBuilders
+import androidx.wear.protolayout.TimelineBuilders.Timeline
+import androidx.wear.protolayout.TimelineBuilders.TimelineEntry
 import androidx.wear.tiles.RequestBuilders
-import androidx.wear.tiles.ResourceBuilders
 import androidx.wear.tiles.TileBuilders.Tile
-import androidx.wear.tiles.TimelineBuilders.Timeline
-import androidx.wear.tiles.TimelineBuilders.TimelineEntry
 import com.google.android.horologist.tiles.SuspendingTileService
 
 class ExampleTileService : SuspendingTileService() {
@@ -43,7 +43,7 @@ class ExampleTileService : SuspendingTileService() {
     override suspend fun tileRequest(requestParams: RequestBuilders.TileRequest): Tile {
         return Tile.Builder()
             .setResourcesVersion("1")
-            .setTimeline(
+            .setTileTimeline(
                 Timeline.Builder()
                     .addTimelineEntry(
                         TimelineEntry.Builder()

--- a/sample/src/main/java/com/google/android/horologist/tile/SampleTheme.kt
+++ b/sample/src/main/java/com/google/android/horologist/tile/SampleTheme.kt
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-@file:Suppress("DEPRECATION")
-
 package com.google.android.horologist.tile
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
-import androidx.wear.tiles.material.Colors
+import androidx.wear.protolayout.material.Colors
 import com.google.android.horologist.compose.tools.TileLayoutPreview
 import com.google.android.horologist.tiles.preview.ThemePreviewTileRenderer
 

--- a/sample/src/main/java/com/google/android/horologist/tile/SampleTileRenderer.kt
+++ b/sample/src/main/java/com/google/android/horologist/tile/SampleTileRenderer.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:Suppress("DEPRECATION")
-
 package com.google.android.horologist.tile
 
 import android.content.Context
@@ -26,20 +24,20 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
-import androidx.wear.tiles.ColorBuilders.argb
-import androidx.wear.tiles.DeviceParametersBuilders.DeviceParameters
-import androidx.wear.tiles.LayoutElementBuilders
-import androidx.wear.tiles.ModifiersBuilders.Clickable
-import androidx.wear.tiles.ResourceBuilders.ImageResource
-import androidx.wear.tiles.ResourceBuilders.Resources
-import androidx.wear.tiles.material.Button
-import androidx.wear.tiles.material.ButtonColors
-import androidx.wear.tiles.material.ChipColors
-import androidx.wear.tiles.material.CompactChip
-import androidx.wear.tiles.material.Text
-import androidx.wear.tiles.material.Typography
-import androidx.wear.tiles.material.layouts.MultiButtonLayout
-import androidx.wear.tiles.material.layouts.PrimaryLayout
+import androidx.wear.protolayout.ColorBuilders.argb
+import androidx.wear.protolayout.DeviceParametersBuilders.DeviceParameters
+import androidx.wear.protolayout.LayoutElementBuilders
+import androidx.wear.protolayout.ModifiersBuilders.Clickable
+import androidx.wear.protolayout.ResourceBuilders.ImageResource
+import androidx.wear.protolayout.ResourceBuilders.Resources
+import androidx.wear.protolayout.material.Button
+import androidx.wear.protolayout.material.ButtonColors
+import androidx.wear.protolayout.material.ChipColors
+import androidx.wear.protolayout.material.CompactChip
+import androidx.wear.protolayout.material.Text
+import androidx.wear.protolayout.material.Typography
+import androidx.wear.protolayout.material.layouts.MultiButtonLayout
+import androidx.wear.protolayout.material.layouts.PrimaryLayout
 import com.google.android.horologist.compose.tools.LayoutElementPreview
 import com.google.android.horologist.compose.tools.TileLayoutPreview
 import com.google.android.horologist.sample.R

--- a/sample/src/main/java/com/google/android/horologist/tile/SampleTileService.kt
+++ b/sample/src/main/java/com/google/android/horologist/tile/SampleTileService.kt
@@ -16,9 +16,9 @@
 
 package com.google.android.horologist.tile
 
+import androidx.wear.protolayout.ResourceBuilders.Resources
 import androidx.wear.tiles.RequestBuilders.ResourcesRequest
 import androidx.wear.tiles.RequestBuilders.TileRequest
-import androidx.wear.tiles.ResourceBuilders.Resources
 import androidx.wear.tiles.TileBuilders.Tile
 import com.google.android.horologist.logo.R
 import com.google.android.horologist.tiles.SuspendingTileService

--- a/tiles/api/current.api
+++ b/tiles/api/current.api
@@ -7,11 +7,11 @@ package com.google.android.horologist.tiles {
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public abstract class SuspendingTileService extends androidx.wear.tiles.TileService implements androidx.lifecycle.LifecycleOwner {
     ctor public SuspendingTileService();
     method public androidx.lifecycle.Lifecycle getLifecycle();
-    method protected final com.google.common.util.concurrent.ListenableFuture<androidx.wear.tiles.ResourceBuilders.Resources> onResourcesRequest(androidx.wear.tiles.RequestBuilders.ResourcesRequest requestParams);
     method @Deprecated public final void onStart(android.content.Intent? intent, int startId);
     method public final int onStartCommand(android.content.Intent? intent, int flags, int startId);
     method protected final com.google.common.util.concurrent.ListenableFuture<androidx.wear.tiles.TileBuilders.Tile> onTileRequest(androidx.wear.tiles.RequestBuilders.TileRequest requestParams);
-    method public abstract suspend Object? resourcesRequest(androidx.wear.tiles.RequestBuilders.ResourcesRequest requestParams, kotlin.coroutines.Continuation<? super androidx.wear.tiles.ResourceBuilders.Resources>);
+    method protected final com.google.common.util.concurrent.ListenableFuture<androidx.wear.protolayout.ResourceBuilders.Resources> onTileResourcesRequest(androidx.wear.tiles.RequestBuilders.ResourcesRequest requestParams);
+    method public abstract suspend Object? resourcesRequest(androidx.wear.tiles.RequestBuilders.ResourcesRequest requestParams, kotlin.coroutines.Continuation<? super androidx.wear.protolayout.ResourceBuilders.Resources>);
     method public abstract suspend Object? tileRequest(androidx.wear.tiles.RequestBuilders.TileRequest requestParams, kotlin.coroutines.Continuation<? super androidx.wear.tiles.TileBuilders.Tile>);
     property public androidx.lifecycle.Lifecycle lifecycle;
   }
@@ -21,7 +21,7 @@ package com.google.android.horologist.tiles {
 package com.google.android.horologist.tiles.canvas {
 
   public final class CanvasKt {
-    method @RequiresApi(android.os.Build.VERSION_CODES.O) public static androidx.wear.tiles.ResourceBuilders.ImageResource canvasToImageResource(long size, androidx.compose.ui.unit.Density density, kotlin.jvm.functions.Function1<? super androidx.compose.ui.graphics.drawscope.DrawScope,kotlin.Unit> onDraw);
+    method @RequiresApi(android.os.Build.VERSION_CODES.O) public static androidx.wear.protolayout.ResourceBuilders.ImageResource canvasToImageResource(long size, androidx.compose.ui.unit.Density density, kotlin.jvm.functions.Function1<? super androidx.compose.ui.graphics.drawscope.DrawScope,kotlin.Unit> onDraw);
     method public static void drawToBitmap(android.graphics.Bitmap bitmap, androidx.compose.ui.unit.Density density, long size, kotlin.jvm.functions.Function1<? super androidx.compose.ui.graphics.drawscope.DrawScope,kotlin.Unit> onDraw);
   }
 
@@ -78,8 +78,8 @@ package com.google.android.horologist.tiles.complication {
 package com.google.android.horologist.tiles.components {
 
   public final class ComponentsKt {
-    method public static androidx.wear.tiles.ModifiersBuilders.Clickable getNoOpClickable();
-    property public static final androidx.wear.tiles.ModifiersBuilders.Clickable NoOpClickable;
+    method public static androidx.wear.protolayout.ModifiersBuilders.Clickable getNoOpClickable();
+    property public static final androidx.wear.protolayout.ModifiersBuilders.Clickable NoOpClickable;
   }
 
 }
@@ -87,13 +87,13 @@ package com.google.android.horologist.tiles.components {
 package com.google.android.horologist.tiles.images {
 
   public final class DrawableResToImageResourceKt {
-    method public static androidx.wear.tiles.ResourceBuilders.ImageResource drawableResToImageResource(@DrawableRes int id);
+    method public static androidx.wear.protolayout.ResourceBuilders.ImageResource drawableResToImageResource(@DrawableRes int id);
   }
 
   public final class ImagesKt {
     method public static suspend Object? loadImage(coil.ImageLoader, android.content.Context context, Object? data, optional kotlin.jvm.functions.Function1<? super coil.request.ImageRequest.Builder,kotlin.Unit> configurer, optional kotlin.coroutines.Continuation<? super android.graphics.Bitmap>);
-    method public static suspend Object? loadImageResource(coil.ImageLoader, android.content.Context context, Object? data, optional kotlin.jvm.functions.Function1<? super coil.request.ImageRequest.Builder,kotlin.Unit> configurer, optional kotlin.coroutines.Continuation<? super androidx.wear.tiles.ResourceBuilders.ImageResource>);
-    method public static androidx.wear.tiles.ResourceBuilders.ImageResource toImageResource(android.graphics.Bitmap);
+    method public static suspend Object? loadImageResource(coil.ImageLoader, android.content.Context context, Object? data, optional kotlin.jvm.functions.Function1<? super coil.request.ImageRequest.Builder,kotlin.Unit> configurer, optional kotlin.coroutines.Continuation<? super androidx.wear.protolayout.ResourceBuilders.ImageResource>);
+    method public static androidx.wear.protolayout.ResourceBuilders.ImageResource toImageResource(android.graphics.Bitmap);
   }
 
 }
@@ -101,9 +101,9 @@ package com.google.android.horologist.tiles.images {
 package com.google.android.horologist.tiles.preview {
 
   public final class ThemePreviewTileRenderer extends com.google.android.horologist.tiles.render.SingleTileLayoutRenderer<kotlin.Unit,kotlin.Unit> {
-    ctor public ThemePreviewTileRenderer(android.content.Context context, androidx.wear.tiles.material.Colors thisTheme);
-    method public void produceRequestedResources(androidx.wear.tiles.ResourceBuilders.Resources.Builder, kotlin.Unit resourceState, androidx.wear.tiles.DeviceParametersBuilders.DeviceParameters deviceParameters, java.util.List<java.lang.String> resourceIds);
-    method public androidx.wear.tiles.LayoutElementBuilders.LayoutElement renderTile(kotlin.Unit state, androidx.wear.tiles.DeviceParametersBuilders.DeviceParameters deviceParameters);
+    ctor public ThemePreviewTileRenderer(android.content.Context context, androidx.wear.protolayout.material.Colors thisTheme);
+    method public void produceRequestedResources(androidx.wear.protolayout.ResourceBuilders.Resources.Builder, kotlin.Unit resourceState, androidx.wear.protolayout.DeviceParametersBuilders.DeviceParameters deviceParameters, java.util.List<java.lang.String> resourceIds);
+    method public androidx.wear.protolayout.LayoutElementBuilders.LayoutElement renderTile(kotlin.Unit state, androidx.wear.protolayout.DeviceParametersBuilders.DeviceParameters deviceParameters);
   }
 
 }
@@ -115,25 +115,25 @@ package com.google.android.horologist.tiles.render {
     method public abstract suspend Object? createResourcesInput(kotlin.coroutines.Continuation<? super R>);
     method public abstract S createTileRenderer();
     method public abstract suspend Object? createTileState(kotlin.coroutines.Continuation<? super T>);
-    method public suspend Object? resourcesRequest(androidx.wear.tiles.RequestBuilders.ResourcesRequest requestParams, kotlin.coroutines.Continuation<? super androidx.wear.tiles.ResourceBuilders.Resources>);
+    method public suspend Object? resourcesRequest(androidx.wear.tiles.RequestBuilders.ResourcesRequest requestParams, kotlin.coroutines.Continuation<? super androidx.wear.protolayout.ResourceBuilders.Resources>);
     method public suspend Object? tileRequest(androidx.wear.tiles.RequestBuilders.TileRequest requestParams, kotlin.coroutines.Continuation<? super androidx.wear.tiles.TileBuilders.Tile>);
   }
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public abstract class SingleTileLayoutRenderer<T, R> implements com.google.android.horologist.tiles.render.TileLayoutRenderer<T,R> {
     ctor public SingleTileLayoutRenderer(android.content.Context context, optional boolean debugResourceMode);
-    method public androidx.wear.tiles.material.Colors createTheme();
+    method public androidx.wear.protolayout.material.Colors createTheme();
     method public final android.content.Context getContext();
     method public final boolean getDebugResourceMode();
     method public long getFreshnessIntervalMillis();
-    method public final androidx.wear.tiles.material.Colors getTheme();
-    method public final androidx.wear.tiles.ResourceBuilders.Resources produceRequestedResources(R? resourceState, androidx.wear.tiles.RequestBuilders.ResourcesRequest requestParams);
-    method public void produceRequestedResources(androidx.wear.tiles.ResourceBuilders.Resources.Builder, R? resourceState, androidx.wear.tiles.DeviceParametersBuilders.DeviceParameters deviceParameters, java.util.List<java.lang.String> resourceIds);
-    method public abstract androidx.wear.tiles.LayoutElementBuilders.LayoutElement renderTile(T? state, androidx.wear.tiles.DeviceParametersBuilders.DeviceParameters deviceParameters);
+    method public final androidx.wear.protolayout.material.Colors getTheme();
+    method public final androidx.wear.protolayout.ResourceBuilders.Resources produceRequestedResources(R? resourceState, androidx.wear.tiles.RequestBuilders.ResourcesRequest requestParams);
+    method public void produceRequestedResources(androidx.wear.protolayout.ResourceBuilders.Resources.Builder, R? resourceState, androidx.wear.protolayout.DeviceParametersBuilders.DeviceParameters deviceParameters, java.util.List<java.lang.String> resourceIds);
+    method public abstract androidx.wear.protolayout.LayoutElementBuilders.LayoutElement renderTile(T? state, androidx.wear.protolayout.DeviceParametersBuilders.DeviceParameters deviceParameters);
     method public final androidx.wear.tiles.TileBuilders.Tile renderTimeline(T? state, androidx.wear.tiles.RequestBuilders.TileRequest requestParams);
     property public final android.content.Context context;
     property public final boolean debugResourceMode;
     property public long freshnessIntervalMillis;
-    property public final androidx.wear.tiles.material.Colors theme;
+    property public final androidx.wear.protolayout.material.Colors theme;
   }
 
   public final class SingleTileLayoutRendererKt {
@@ -141,7 +141,7 @@ package com.google.android.horologist.tiles.render {
   }
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public interface TileLayoutRenderer<T, R> {
-    method public androidx.wear.tiles.ResourceBuilders.Resources produceRequestedResources(R? resourceState, androidx.wear.tiles.RequestBuilders.ResourcesRequest requestParams);
+    method public androidx.wear.protolayout.ResourceBuilders.Resources produceRequestedResources(R? resourceState, androidx.wear.tiles.RequestBuilders.ResourcesRequest requestParams);
     method public androidx.wear.tiles.TileBuilders.Tile renderTimeline(T? state, androidx.wear.tiles.RequestBuilders.TileRequest requestParams);
   }
 

--- a/tiles/build.gradle.kts
+++ b/tiles/build.gradle.kts
@@ -105,7 +105,7 @@ dependencies {
     implementation(libs.androidx.concurrent.future)
 
     api(libs.androidx.wear.tiles)
-    api(libs.androidx.wear.tiles.material)
+    api(libs.androidx.wear.protolayout.material)
     api(libs.androidx.lifecycle.service)
 
     implementation(libs.coil)

--- a/tiles/src/main/AndroidManifest.xml
+++ b/tiles/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
     <uses-sdk
         android:minSdkVersion="25"
         tools:ignore="GradleOverrides"
-        tools:overrideLibrary="androidx.wear.tiles.material,
+        tools:overrideLibrary="androidx.wear.protolayout.material,
             androidx.wear.tiles.renderer,
             androidx.wear.tiles.testing,
             androidx.wear.watchface.style,

--- a/tiles/src/main/java/com/google/android/horologist/tiles/SuspendingTileService.kt
+++ b/tiles/src/main/java/com/google/android/horologist/tiles/SuspendingTileService.kt
@@ -24,9 +24,9 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ServiceLifecycleDispatcher
 import androidx.lifecycle.lifecycleScope
+import androidx.wear.protolayout.ResourceBuilders.Resources
 import androidx.wear.tiles.RequestBuilders.ResourcesRequest
 import androidx.wear.tiles.RequestBuilders.TileRequest
-import androidx.wear.tiles.ResourceBuilders.Resources
 import androidx.wear.tiles.TileBuilders.Tile
 import androidx.wear.tiles.TileService
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
@@ -75,7 +75,7 @@ public abstract class SuspendingTileService : TileService(), LifecycleOwner {
      */
     public abstract suspend fun tileRequest(requestParams: TileRequest): Tile
 
-    final override fun onResourcesRequest(
+    final override fun onTileResourcesRequest(
         requestParams: ResourcesRequest
     ): ListenableFuture<Resources> = CallbackToFutureAdapter.getFuture { completer ->
         val job = lifecycleScope.launch {

--- a/tiles/src/main/java/com/google/android/horologist/tiles/canvas/Canvas.kt
+++ b/tiles/src/main/java/com/google/android/horologist/tiles/canvas/Canvas.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
-import androidx.wear.tiles.ResourceBuilders.ImageResource
+import androidx.wear.protolayout.ResourceBuilders.ImageResource
 import com.google.android.horologist.tiles.images.toImageResource
 import android.graphics.Canvas as AndroidCanvas
 import androidx.compose.ui.graphics.Canvas as ComposeCanvas

--- a/tiles/src/main/java/com/google/android/horologist/tiles/components/Components.kt
+++ b/tiles/src/main/java/com/google/android/horologist/tiles/components/Components.kt
@@ -16,7 +16,7 @@
 
 package com.google.android.horologist.tiles.components
 
-import androidx.wear.tiles.ModifiersBuilders
+import androidx.wear.protolayout.ModifiersBuilders
 
 /**
  * Simple NoOp clickable for preview use.

--- a/tiles/src/main/java/com/google/android/horologist/tiles/images/DrawableResToImageResource.kt
+++ b/tiles/src/main/java/com/google/android/horologist/tiles/images/DrawableResToImageResource.kt
@@ -17,8 +17,8 @@
 package com.google.android.horologist.tiles.images
 
 import androidx.annotation.DrawableRes
-import androidx.wear.tiles.ResourceBuilders.AndroidImageResourceByResId
-import androidx.wear.tiles.ResourceBuilders.ImageResource
+import androidx.wear.protolayout.ResourceBuilders.AndroidImageResourceByResId
+import androidx.wear.protolayout.ResourceBuilders.ImageResource
 
 /**
  * Load a resource from the res/drawable* directories.

--- a/tiles/src/main/java/com/google/android/horologist/tiles/images/Images.kt
+++ b/tiles/src/main/java/com/google/android/horologist/tiles/images/Images.kt
@@ -19,8 +19,8 @@ package com.google.android.horologist.tiles.images
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
-import androidx.wear.tiles.ResourceBuilders
-import androidx.wear.tiles.ResourceBuilders.ImageResource
+import androidx.wear.protolayout.ResourceBuilders
+import androidx.wear.protolayout.ResourceBuilders.ImageResource
 import coil.ImageLoader
 import coil.request.ImageRequest
 import java.nio.ByteBuffer

--- a/tiles/src/main/java/com/google/android/horologist/tiles/preview/ThemePreviewTileRenderer.kt
+++ b/tiles/src/main/java/com/google/android/horologist/tiles/preview/ThemePreviewTileRenderer.kt
@@ -14,28 +14,26 @@
  * limitations under the License.
  */
 
-@file:Suppress("DEPRECATION")
-
 package com.google.android.horologist.tiles.preview
 
 import android.content.Context
-import androidx.wear.tiles.ColorBuilders
-import androidx.wear.tiles.DeviceParametersBuilders.DeviceParameters
-import androidx.wear.tiles.DimensionBuilders.ExpandedDimensionProp
-import androidx.wear.tiles.LayoutElementBuilders.Box
-import androidx.wear.tiles.LayoutElementBuilders.Column
-import androidx.wear.tiles.LayoutElementBuilders.HORIZONTAL_ALIGN_CENTER
-import androidx.wear.tiles.LayoutElementBuilders.LayoutElement
-import androidx.wear.tiles.LayoutElementBuilders.VERTICAL_ALIGN_CENTER
-import androidx.wear.tiles.ResourceBuilders
-import androidx.wear.tiles.material.Button
-import androidx.wear.tiles.material.ButtonColors
-import androidx.wear.tiles.material.Chip
-import androidx.wear.tiles.material.ChipColors
-import androidx.wear.tiles.material.Colors
-import androidx.wear.tiles.material.CompactChip
-import androidx.wear.tiles.material.Text
-import androidx.wear.tiles.material.Typography
+import androidx.wear.protolayout.ColorBuilders
+import androidx.wear.protolayout.DeviceParametersBuilders.DeviceParameters
+import androidx.wear.protolayout.DimensionBuilders.ExpandedDimensionProp
+import androidx.wear.protolayout.LayoutElementBuilders.Box
+import androidx.wear.protolayout.LayoutElementBuilders.Column
+import androidx.wear.protolayout.LayoutElementBuilders.HORIZONTAL_ALIGN_CENTER
+import androidx.wear.protolayout.LayoutElementBuilders.LayoutElement
+import androidx.wear.protolayout.LayoutElementBuilders.VERTICAL_ALIGN_CENTER
+import androidx.wear.protolayout.ResourceBuilders
+import androidx.wear.protolayout.material.Button
+import androidx.wear.protolayout.material.ButtonColors
+import androidx.wear.protolayout.material.Chip
+import androidx.wear.protolayout.material.ChipColors
+import androidx.wear.protolayout.material.Colors
+import androidx.wear.protolayout.material.CompactChip
+import androidx.wear.protolayout.material.Text
+import androidx.wear.protolayout.material.Typography
 import com.google.android.horologist.tiles.R
 import com.google.android.horologist.tiles.components.NoOpClickable
 import com.google.android.horologist.tiles.images.drawableResToImageResource

--- a/tiles/src/main/java/com/google/android/horologist/tiles/render/RendererPreviewTileService.kt
+++ b/tiles/src/main/java/com/google/android/horologist/tiles/render/RendererPreviewTileService.kt
@@ -16,9 +16,9 @@
 
 package com.google.android.horologist.tiles.render
 
+import androidx.wear.protolayout.ResourceBuilders.Resources
 import androidx.wear.tiles.RequestBuilders.ResourcesRequest
 import androidx.wear.tiles.RequestBuilders.TileRequest
-import androidx.wear.tiles.ResourceBuilders.Resources
 import androidx.wear.tiles.TileBuilders.Tile
 import com.google.android.horologist.tiles.SuspendingTileService
 

--- a/tiles/src/main/java/com/google/android/horologist/tiles/render/SingleTileLayoutRenderer.kt
+++ b/tiles/src/main/java/com/google/android/horologist/tiles/render/SingleTileLayoutRenderer.kt
@@ -14,19 +14,17 @@
  * limitations under the License.
  */
 
-@file:Suppress("DEPRECATION")
-
 package com.google.android.horologist.tiles.render
 
 import android.content.Context
-import androidx.wear.tiles.DeviceParametersBuilders
-import androidx.wear.tiles.LayoutElementBuilders.Layout
-import androidx.wear.tiles.LayoutElementBuilders.LayoutElement
+import androidx.wear.protolayout.DeviceParametersBuilders
+import androidx.wear.protolayout.LayoutElementBuilders.Layout
+import androidx.wear.protolayout.LayoutElementBuilders.LayoutElement
+import androidx.wear.protolayout.ResourceBuilders.Resources
+import androidx.wear.protolayout.TimelineBuilders
+import androidx.wear.protolayout.material.Colors
 import androidx.wear.tiles.RequestBuilders
-import androidx.wear.tiles.ResourceBuilders.Resources
 import androidx.wear.tiles.TileBuilders.Tile
-import androidx.wear.tiles.TimelineBuilders
-import androidx.wear.tiles.material.Colors
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import java.util.UUID
 
@@ -50,7 +48,7 @@ public abstract class SingleTileLayoutRenderer<T, R>(
         state: T,
         requestParams: RequestBuilders.TileRequest
     ): Tile {
-        val rootLayout = renderTile(state, requestParams.deviceParameters!!)
+        val rootLayout = renderTile(state, requestParams.deviceConfiguration)
 
         val singleTileTimeline = TimelineBuilders.Timeline.Builder()
             .addTimelineEntry(
@@ -72,7 +70,7 @@ public abstract class SingleTileLayoutRenderer<T, R>(
                     PERMANENT_RESOURCES_VERSION
                 }
             )
-            .setTimeline(singleTileTimeline)
+            .setTileTimeline(singleTileTimeline)
             .setFreshnessIntervalMillis(freshnessIntervalMillis)
             .build()
     }
@@ -99,7 +97,7 @@ public abstract class SingleTileLayoutRenderer<T, R>(
             .apply {
                 produceRequestedResources(
                     resourceState,
-                    requestParams.deviceParameters!!,
+                    requestParams.deviceConfiguration,
                     requestParams.resourceIds
                 )
             }

--- a/tiles/src/main/java/com/google/android/horologist/tiles/render/TileLayoutRenderer.kt
+++ b/tiles/src/main/java/com/google/android/horologist/tiles/render/TileLayoutRenderer.kt
@@ -16,8 +16,8 @@
 
 package com.google.android.horologist.tiles.render
 
+import androidx.wear.protolayout.ResourceBuilders.Resources
 import androidx.wear.tiles.RequestBuilders
-import androidx.wear.tiles.ResourceBuilders.Resources
 import androidx.wear.tiles.TileBuilders.Tile
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 

--- a/tiles/src/test/java/com/google/android/horologist/tiles/ImagesTest.kt
+++ b/tiles/src/test/java/com/google/android/horologist/tiles/ImagesTest.kt
@@ -21,7 +21,7 @@ package com.google.android.horologist.tiles
 import android.content.Context
 import androidx.test.filters.SmallTest
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.wear.tiles.ResourceBuilders
+import androidx.wear.protolayout.ResourceBuilders
 import com.google.android.horologist.tiles.images.loadImageResource
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/tiles/src/test/java/com/google/android/horologist/tiles/TestTileService.kt
+++ b/tiles/src/test/java/com/google/android/horologist/tiles/TestTileService.kt
@@ -16,16 +16,16 @@
 
 package com.google.android.horologist.tiles
 
-import androidx.wear.tiles.LayoutElementBuilders.Column
-import androidx.wear.tiles.LayoutElementBuilders.HORIZONTAL_ALIGN_CENTER
-import androidx.wear.tiles.LayoutElementBuilders.Layout
-import androidx.wear.tiles.LayoutElementBuilders.LayoutElement
-import androidx.wear.tiles.LayoutElementBuilders.Text
+import androidx.wear.protolayout.LayoutElementBuilders.Column
+import androidx.wear.protolayout.LayoutElementBuilders.HORIZONTAL_ALIGN_CENTER
+import androidx.wear.protolayout.LayoutElementBuilders.Layout
+import androidx.wear.protolayout.LayoutElementBuilders.LayoutElement
+import androidx.wear.protolayout.LayoutElementBuilders.Text
+import androidx.wear.protolayout.ResourceBuilders
+import androidx.wear.protolayout.TimelineBuilders.Timeline
+import androidx.wear.protolayout.TimelineBuilders.TimelineEntry
 import androidx.wear.tiles.RequestBuilders
-import androidx.wear.tiles.ResourceBuilders
 import androidx.wear.tiles.TileBuilders.Tile
-import androidx.wear.tiles.TimelineBuilders.Timeline
-import androidx.wear.tiles.TimelineBuilders.TimelineEntry
 import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.seconds
 
@@ -42,7 +42,7 @@ public class TestTileService : SuspendingTileService() {
 
         return Tile.Builder()
             .setResourcesVersion(FAKE_VERSION)
-            .setTimeline(
+            .setTileTimeline(
                 Timeline.Builder()
                     .addTimelineEntry(
                         TimelineEntry.Builder()


### PR DESCRIPTION
Most of the layout types in androidx.wear.tiles v1.2 library are now moved to androidx.wear.protolayout library. The ones in under androidx.wear.tiles are now marked as `deprecated. 
The changes needed for using the new types are:
- `setTimeline` -> `setTileTimeline`
- `onResoucesRequest` -> `onTileResourcesRequest`
- `getDeviceParameters` -> `getDeviceConfiguration`
- `getState` -> `getCurrentState`