### PR TITLE
Fix Horologist doc images

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The toolkit includes:
 
 Player Screen | Browse Screen | Entity Screen
 :------------:|:-------------:|:-------------:
-<img src="https://raw.githubusercontent.com/google/horologist/main/docs/media-ui/playerscreen.png" height="120" width="120" > | <img src="https://raw.githubusercontent.com/google/horologist/main/docs/media-ui/browse.png" height="120" width="120" > | <img src="https://raw.githubusercontent.com/google/horologist/main/docs/media-ui/detail.png" height="120" width="120" >
+<img src="https://media.githubusercontent.com/media/google/horologist/main/docs/media-ui/playerscreen.png" height="120" width="120" > | <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/media-ui/browse.png" height="120" width="120" > | <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/media-ui/detail.png" height="120" width="120" >
 
 ## 📅 Composables
 
@@ -30,11 +30,11 @@ High quality prebuilt composables, such as Time and Date pickers.
 
 DatePicker             |  TimePickerWith12HourClock |  TimePicker
 :-------------------------:|:-------------------------:|:-------------------------:
-<img src="https://raw.githubusercontent.com/google/horologist/main/docs/composables/date_picker.png" height="120" width="120" >  |  <img src="https://raw.githubusercontent.com/google/horologist/main/docs/composables/time_12h_picker.png" height="120" width="120"> | <img src="https://raw.githubusercontent.com/google/horologist/main/docs/composables/time_24h_picker.png" height="120" width="120">
+<img src="https://media.githubusercontent.com/media/google/horologist/main/docs/composables/date_picker.png" height="120" width="120" >  |  <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/composables/time_12h_picker.png" height="120" width="120"> | <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/composables/time_24h_picker.png" height="120" width="120">
 
 SegmentedProgressIndicator | SquareSegmentedProgressIndicator
 :----------------------------------------------------------------------------------------------------------------------------------------------:|:-------------------------:
-<img src="https://raw.githubusercontent.com/google/horologist/main/docs/composables/segmented_progress_indicator.png" height="120" width="120"> | <img src="https://raw.githubusercontent.com/google/horologist/main/docs/composables/square_segmented_progress_indicator.png" height="120" width="120">
+<img src="https://media.githubusercontent.com/media/google/horologist/main/docs/composables/segmented_progress_indicator.png" height="120" width="120"> | <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/composables/square_segmented_progress_indicator.png" height="120" width="120">
 
 
 ## 📐 Compose Layout
@@ -45,7 +45,7 @@ Layout related functionality such as a Navigation Aware Scaffold.
 
 |                                                             fillMaxRectangle()                                                             |
 |:------------------------------------------------------------------------------------------------------------------------------------------:|
-| <img src="https://raw.githubusercontent.com/google/horologist/main/docs/compose-layout/fill_max_rectangle.png" height="120" width="120" >  |
+| <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/compose-layout/fill_max_rectangle.png" height="120" width="120" >  |
 
 ## 🔊 Audio and UI
 
@@ -57,7 +57,7 @@ Subscribing to a Flow of changes in audio or output.
 
 |                                                          VolumeScreen                                                          |
 |:------------------------------------------------------------------------------------------------------------------------------:|
-| <img src="https://raw.githubusercontent.com/google/horologist/main/docs/audio-ui/volume_screen.png" height="120" width="120" > |
+| <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/audio-ui/volume_screen.png" height="120" width="120" > |
 
 ## ☰ Tiles
 

--- a/auth/composables/src/main/java/com/google/android/horologist/auth/composables/chips/CreateAccountChip.kt
+++ b/auth/composables/src/main/java/com/google/android/horologist/auth/composables/chips/CreateAccountChip.kt
@@ -30,7 +30,7 @@ import com.google.android.horologist.base.ui.components.StandardChipType
 /**
  * An opinionated [Chip] to represent the "Create account" action.
  *
- * <img src="https://raw.githubusercontent.com/google/horologist/main/docs/auth-composables/create_account_chip.png" height="120" width="120" >
+ * <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/create_account_chip.png" height="120" width="120" >
  */
 @ExperimentalHorologistApi
 @Composable

--- a/auth/composables/src/main/java/com/google/android/horologist/auth/composables/chips/GuestModeChip.kt
+++ b/auth/composables/src/main/java/com/google/android/horologist/auth/composables/chips/GuestModeChip.kt
@@ -30,7 +30,7 @@ import com.google.android.horologist.base.ui.components.StandardChipType
 /**
  * An opinionated [Chip] to represent the "Guest mode" action.
  *
- * <img src="https://raw.githubusercontent.com/google/horologist/main/docs/auth-composables/guest_mode_chip.png" height="120" width="120" >
+ * <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/guest_mode_chip.png" height="120" width="120" >
  *
  * @sample com.google.android.horologist.auth.sample.screens.googlesignin.prompt.GoogleSignInPromptSampleScreen
  */

--- a/auth/composables/src/main/java/com/google/android/horologist/auth/composables/chips/OtherOptionsChip.kt
+++ b/auth/composables/src/main/java/com/google/android/horologist/auth/composables/chips/OtherOptionsChip.kt
@@ -30,7 +30,7 @@ import com.google.android.horologist.base.ui.components.StandardChipType
 /**
  * An opinionated [Chip] to represent the "Other options to authentication" action.
  *
- * <img src="https://raw.githubusercontent.com/google/horologist/main/docs/auth-composables/other_options_chip.png" height="120" width="120" >
+ * <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/other_options_chip.png" height="120" width="120" >
  */
 @ExperimentalHorologistApi
 @Composable

--- a/auth/composables/src/main/java/com/google/android/horologist/auth/composables/chips/SignInChip.kt
+++ b/auth/composables/src/main/java/com/google/android/horologist/auth/composables/chips/SignInChip.kt
@@ -30,7 +30,7 @@ import com.google.android.horologist.base.ui.components.StandardChipType
 /**
  * An opinionated [Chip] to represent the "Sign in" action.
  *
- * <img src="https://raw.githubusercontent.com/google/horologist/main/docs/auth-composables/sign_in_chip.png" height="120" width="120" >
+ * <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/sign_in_chip.png" height="120" width="120" >
  *
  * @sample com.google.android.horologist.auth.sample.screens.googlesignin.prompt.GoogleSignInPromptSampleScreen
  */

--- a/auth/composables/src/main/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialog.kt
+++ b/auth/composables/src/main/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialog.kt
@@ -57,7 +57,7 @@ private const val HORIZONTAL_PADDING_SCREEN_PERCENTAGE = 0.094
 /**
  * A signed in confirmation dialog that can display the name, email and avatar image of the user.
  *
- * <img src="https://raw.githubusercontent.com/google/horologist/main/docs/auth-composables/signed_in_confirmation_dialog.png" height="120" width="120"/>
+ * <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/signed_in_confirmation_dialog.png" height="120" width="120"/>
  */
 @ExperimentalHorologistApi
 @Composable
@@ -87,7 +87,7 @@ public fun SignedInConfirmationDialog(
  * A [SignedInConfirmationDialog] that can display the name, email and avatar image of an
  * [AccountUiModel].
  *
- * <img src="https://raw.githubusercontent.com/google/horologist/main/docs/auth-composables/signed_in_confirmation_dialog.png" height="120" width="120"/>
+ * <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/signed_in_confirmation_dialog.png" height="120" width="120"/>
  */
 @ExperimentalHorologistApi
 @Composable

--- a/auth/composables/src/main/java/com/google/android/horologist/auth/composables/screens/CheckYourPhoneScreen.kt
+++ b/auth/composables/src/main/java/com/google/android/horologist/auth/composables/screens/CheckYourPhoneScreen.kt
@@ -48,7 +48,7 @@ private val progressBarStrokeWidth = 4.dp
 /**
  * A screen to request the user to check their paired phone to proceed.
  *
- * <img src="https://raw.githubusercontent.com/google/horologist/main/docs/auth-composables/check_your_phone_screen.png"  height="120" width="120"/>
+ * <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/check_your_phone_screen.png"  height="120" width="120"/>
  */
 @ExperimentalHorologistApi
 @Composable
@@ -94,7 +94,7 @@ public fun CheckYourPhoneScreen(
  * A screen to request the user to check their paired phone to proceed.
  * It also allows a [message] to be displayed.
  *
- * <img src="https://raw.githubusercontent.com/google/horologist/main/docs/auth-composables/check_your_phone_screen_code.png"  height="120" width="120"/>
+ * <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/check_your_phone_screen_code.png"  height="120" width="120"/>
  */
 @ExperimentalHorologistApi
 @Composable

--- a/auth/composables/src/main/java/com/google/android/horologist/auth/composables/screens/SelectAccountScreen.kt
+++ b/auth/composables/src/main/java/com/google/android/horologist/auth/composables/screens/SelectAccountScreen.kt
@@ -39,7 +39,7 @@ private const val HORIZONTAL_PADDING_SCREEN_PERCENTAGE = 0.052
 /**
  * A screen to display a list of available accounts and to allow the user select one of them.
  *
- * <img src="https://raw.githubusercontent.com/google/horologist/main/docs/auth-composables/select_account_screen.png" height="120" width="120"/>
+ * <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/select_account_screen.png" height="120" width="120"/>
  */
 @ExperimentalHorologistApi
 @Composable

--- a/auth/composables/src/main/java/com/google/android/horologist/auth/composables/screens/SignInPlaceholderScreen.kt
+++ b/auth/composables/src/main/java/com/google/android/horologist/auth/composables/screens/SignInPlaceholderScreen.kt
@@ -47,7 +47,7 @@ private const val HORIZONTAL_PADDING_SCREEN_PERCENTAGE = 0.094
  * A screen to represent a
  * [signing-in process state](https://developer.android.com/training/wearables/design/sign-in#confirmations).
  *
- * <img src="https://raw.githubusercontent.com/google/horologist/main/docs/auth-composables/sign_in_placeholder_screen.png" height="120" width="120"/>
+ * <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/sign_in_placeholder_screen.png" height="120" width="120"/>
  */
 @ExperimentalHorologistApi
 @Composable

--- a/docs/auth-ui.md
+++ b/docs/auth-ui.md
@@ -39,7 +39,7 @@ authentication method.
 It uses different screens from [auth-composables](auth-composables.md) to display the full
 authentication flow.
 
-| <img src="https://raw.githubusercontent.com/google/horologist/main/docs/auth-composables/sign_in_placeholder_screen.png" height="120" width="120" > | <img src="https://raw.githubusercontent.com/google/horologist/main/docs/auth-composables/select_account_screen.png" height="120" width="120" > | <img src="https://raw.githubusercontent.com/google/horologist/main/docs/auth-composables/signed_in_confirmation_dialog.png" height="120" width="120" > |
+| <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/sign_in_placeholder_screen.png" height="120" width="120" > | <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/select_account_screen.png" height="120" width="120" > | <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/signed_in_confirmation_dialog.png" height="120" width="120" > |
 |:---------------------------------------------------------------------------------------------------------------------------------------------------:|:----------------------------------------------------------------------------------------------------------------------------------------------:|:------------------------------------------------------------------------------------------------------------------------------------------------------:|
 
 It relies on
@@ -59,7 +59,7 @@ authentication method.
 It uses different screens from [auth-composables](auth-composables.md) to display the full
 authentication flow.
 
-| <img src="https://raw.githubusercontent.com/google/horologist/main/docs/auth-composables/sign_in_placeholder_screen.png" height="120" width="120" > | <img src="https://raw.githubusercontent.com/google/horologist/main/docs/auth-composables/check_your_phone_screen.png" height="120" width="120" > | <img src="https://raw.githubusercontent.com/google/horologist/main/docs/auth-composables/signed_in_confirmation_dialog.png" height="120" width="120" > |
+| <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/sign_in_placeholder_screen.png" height="120" width="120" > | <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/check_your_phone_screen.png" height="120" width="120" > | <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/signed_in_confirmation_dialog.png" height="120" width="120" > |
 |:---------------------------------------------------------------------------------------------------------------------------------------------------:|:------------------------------------------------------------------------------------------------------------------------------------------------:|:------------------------------------------------------------------------------------------------------------------------------------------------------:|
 
 A implementation for the following repositories are required to be provided:
@@ -77,7 +77,7 @@ authentication method.
 It uses different screens from [auth-composables](auth-composables.md) to display the full
 authentication flow.
 
-| <img src="https://raw.githubusercontent.com/google/horologist/main/docs/auth-composables/sign_in_placeholder_screen.png" height="120" width="120" > | <img src="https://raw.githubusercontent.com/google/horologist/main/docs/auth-composables/check_your_phone_screen_code.png" height="120" width="120" > | <img src="https://raw.githubusercontent.com/google/horologist/main/docs/auth-composables/signed_in_confirmation_dialog.png" height="120" width="120" > |
+| <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/sign_in_placeholder_screen.png" height="120" width="120" > | <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/check_your_phone_screen_code.png" height="120" width="120" > | <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/signed_in_confirmation_dialog.png" height="120" width="120" > |
 |:---------------------------------------------------------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------:|:------------------------------------------------------------------------------------------------------------------------------------------------------:|
 
 A implementation for the following repositories are required to be provided:

--- a/docs/tiles.md
+++ b/docs/tiles.md
@@ -25,7 +25,7 @@ bitmap, and encode as a Tiles InlineImageResource.
 
 ```kotlin
 val imageResource = imageLoader.loadImageResource(applicationContext, 
-    "https://raw.githubusercontent.com/google/horologist/main/docs/media-ui/playerscreen.png") {
+    "https://media.githubusercontent.com/media/google/horologist/main/docs/media-ui/playerscreen.png") {
     // Show a local error image if missing
     error(R.drawable.missingImage)
 }


### PR DESCRIPTION
#### WHAT

Fix Horologist doc images

#### WHY

Broken by making these LFS images

https://raw.githubusercontent.com/google/horologist/main/docs/auth-composables/sign_in_placeholder_screen.png
vs
https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/sign_in_placeholder_screen.png

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
