### PR TITLE
Add permission for Bluetooth Settings launching

### DIFF
--- a/media/audio/src/main/AndroidManifest.xml
+++ b/media/audio/src/main/AndroidManifest.xml
@@ -18,5 +18,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.google.android.horologist.audio">
 
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+
     <uses-sdk android:minSdkVersion="25" tools:ignore="GradleOverrides" />
 </manifest>


### PR DESCRIPTION
#### WHAT

Add permission for Bluetooth Settings launching

#### WHY

Some devices may require this for launching the bluetooth output switcher. 

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
