### PR TITLE
Fix docs publishing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -201,6 +201,12 @@ subprojects {
                 // Remove composable previews from docs
                 suppressedFiles.from(file("src/debug/java"))
             }
+
+            // Workaround for https://github.com/Kotlin/dokka/issues/2954
+            if (project.plugins.hasPlugin("org.jetbrains.kotlin.kapt")) {
+                dependsOn("kaptDebugKotlin")
+                dependsOn("kaptReleaseKotlin")
+            }
         }
         if (plugins.hasPlugin("com.android.library")) {
             configure<com.android.build.gradle.LibraryExtension> {


### PR DESCRIPTION
#### WHAT

Fix docs publishing

#### WHY

            // Workaround for https://github.com/Kotlin/dokka/issues/2954

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
