### PR TITLE
Speed up the playback progress animation

### DIFF
--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/animation/PlaybackProgressAnimation.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/animation/PlaybackProgressAnimation.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.animation
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.SpringSpec
+
+internal object PlaybackProgressAnimation {
+    val PLAYBACK_PROGRESS_ANIMATION_SPEC =
+        SpringSpec(
+            dampingRatio = Spring.DampingRatioNoBouncy,
+            stiffness = 100f,
+            // The default threshold is 0.01, or 1% of the overall progress range, which is quite
+            // large and noticeable.
+            visibilityThreshold = 1 / 1000f
+        )
+}

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/components/animated/AnimatedPlayPauseButton.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/components/animated/AnimatedPlayPauseButton.kt
@@ -51,13 +51,13 @@ import androidx.wear.compose.material.ButtonDefaults
 import androidx.wear.compose.material.CircularProgressIndicator
 import androidx.wear.compose.material.LocalContentAlpha
 import androidx.wear.compose.material.MaterialTheme
-import androidx.wear.compose.material.ProgressIndicatorDefaults
 import com.airbnb.lottie.LottieComposition
 import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.rememberLottieAnimatable
 import com.airbnb.lottie.compose.rememberLottieComposition
 import com.google.android.horologist.audio.ui.components.animated.LocalStaticPreview
 import com.google.android.horologist.media.ui.R
+import com.google.android.horologist.media.ui.animation.PlaybackProgressAnimation.PLAYBACK_PROGRESS_ANIMATION_SPEC
 import com.google.android.horologist.media.ui.components.PlayPauseButton
 import com.google.android.horologist.media.ui.state.ProgressStateHolder
 import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
@@ -236,7 +236,7 @@ private fun animateChangeAsRotation(rotateProgressIndicator: Flow<Unit>): Float 
     }
     val animatedProgressIndicatorRotation by animateFloatAsState(
         targetValue = progressIndicatorRotation,
-        animationSpec = ProgressIndicatorDefaults.ProgressAnimationSpec,
+        animationSpec = PLAYBACK_PROGRESS_ANIMATION_SPEC,
         label = "Progress Indicator Rotation"
     )
     return animatedProgressIndicatorRotation

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/state/ProgressStateHolder.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/state/ProgressStateHolder.kt
@@ -24,9 +24,9 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.withFrameMillis
-import androidx.wear.compose.material.ProgressIndicatorDefaults
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.TimestampProvider
+import com.google.android.horologist.media.ui.animation.PlaybackProgressAnimation.PLAYBACK_PROGRESS_ANIMATION_SPEC
 import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.coroutineScope
@@ -54,7 +54,7 @@ internal class ProgressStateHolder(
             return@coroutineScope
         }
         launch(NonCancellable) {
-            animatable.animateTo(offset, ProgressIndicatorDefaults.ProgressAnimationSpec)
+            animatable.animateTo(offset, PLAYBACK_PROGRESS_ANIMATION_SPEC)
             animatable.snapTo(0f)
         }
     }


### PR DESCRIPTION
#### WHAT
Define a new animation spec to be used for the two playback progress animations in Horologist.

#### WHY
The current next-track rotation animation is too slow.

#### HOW
Create a new animation spec, which uses a higher stiffness value (50 before; 100 after)

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
