### PR TITLE
Fix the worker running under R8 full

### DIFF
--- a/media/sample/proguard-benchmark.pro
+++ b/media/sample/proguard-benchmark.pro
@@ -13,3 +13,7 @@
 
 # https://issuetracker.google.com/issues/144631039
 -keepclassmembers class * extends com.google.protobuf.GeneratedMessageLite { <fields>; }
+
+-keep,allowobfuscation,allowshrinking interface retrofit2.Call
+-keep,allowobfuscation,allowshrinking class retrofit2.Response
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation

--- a/media/sample/proguard-rules.pro
+++ b/media/sample/proguard-rules.pro
@@ -1,2 +1,6 @@
 # https://issuetracker.google.com/issues/144631039
 -keepclassmembers class * extends com.google.protobuf.GeneratedMessageLite { <fields>; }
+
+-keep,allowobfuscation,allowshrinking interface retrofit2.Call
+-keep,allowobfuscation,allowshrinking class retrofit2.Response
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation


### PR DESCRIPTION
#### WHAT

Fix retrofit under release builds.

#### WHY

https://github.com/square/retrofit/issues/3751

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
