### PR TITLE
Fix links from docs

### DIFF
--- a/docs/auth-composables.md
+++ b/docs/auth-composables.md
@@ -9,22 +9,22 @@ per [architecture overview](auth-overview.md#architecture-overview).
 
 ## Screens
 
-- [SignInPlaceholderScreen](https://google.github.io/horologist/api/auth-composables/com.google.android.horologist.auth.composables.screens/-sign-in-placeholder-screen.html)
+- [SignInPlaceholderScreen](https://google.github.io/horologist/api/auth/composables/com.google.android.horologist.auth.composables.screens/-sign-in-placeholder-screen.html)
 
-- [SelectAccountScreen](https://google.github.io/horologist/api/auth-composables/com.google.android.horologist.auth.composables.screens/-select-account-screen.html)
+- [SelectAccountScreen](https://google.github.io/horologist/api/auth/composables/com.google.android.horologist.auth.composables.screens/-select-account-screen.html)
 
-- [CheckYourPhoneScreen](https://google.github.io/horologist/api/auth-composables/com.google.android.horologist.auth.composables.screens/-check-your-phone-screen.html)
+- [CheckYourPhoneScreen](https://google.github.io/horologist/api/auth/composables/com.google.android.horologist.auth.composables.screens/-check-your-phone-screen.html)
 
 ## Dialogs
 
-- [SignedInConfirmationDialog](https://google.github.io/horologist/api/auth-composables/com.google.android.horologist.auth.composables.dialogs/-signed-in-confirmation-dialog.html)
+- [SignedInConfirmationDialog](https://google.github.io/horologist/api/auth/composables/com.google.android.horologist.auth.composables.dialogs/-signed-in-confirmation-dialog.html)
 
 ## Chips
 
-- [CreateAccountChip](https://google.github.io/horologist/api/auth-composables/com.google.android.horologist.auth.composables.chips/-create-account-chip.html)
+- [CreateAccountChip](https://google.github.io/horologist/api/auth/composables/com.google.android.horologist.auth.composables.chips/-create-account-chip.html)
 
-- [GuestModeChip](https://google.github.io/horologist/api/auth-composables/com.google.android.horologist.auth.composables.chips/-guest-mode-chip.html)
+- [GuestModeChip](https://google.github.io/horologist/api/auth/composables/com.google.android.horologist.auth.composables.chips/-guest-mode-chip.html)
 
-- [OtherOptionsChip](https://google.github.io/horologist/api/auth-composables/com.google.android.horologist.auth.composables.chips/-other-options-chip.html)
+- [OtherOptionsChip](https://google.github.io/horologist/api/auth/composables/com.google.android.horologist.auth.composables.chips/-other-options-chip.html)
 
-- [SignInChip](https://google.github.io/horologist/api/auth-composables/com.google.android.horologist.auth.composables.chips/-sign-in-chip.html)
+- [SignInChip](https://google.github.io/horologist/api/auth/composables/com.google.android.horologist.auth.composables.chips/-sign-in-chip.html)

--- a/docs/auth-data-phone.md
+++ b/docs/auth-data-phone.md
@@ -5,5 +5,5 @@ by the `auth-data` library.
 
 ## [Token sharing](https://developer.android.com/training/wearables/apps/auth-wear#tokens)
 
-- [TokenBundleRepository](https://google.github.io/horologist/api/auth-data-phone/com.google.android.horologist.auth.data.phone.tokenshare/-token-bundle-repository/index.html)
-    - [TokenBundleRepositoryImpl](https://google.github.io/horologist/api/auth-data-phone/com.google.android.horologist.auth.data.phone.tokenshare.impl/-token-bundle-repository-impl/index.html)
+- [TokenBundleRepository](https://google.github.io/horologist/api/auth/data-phone/com.google.android.horologist.auth.data.phone.tokenshare/-token-bundle-repository/index.html)
+    - [TokenBundleRepositoryImpl](https://google.github.io/horologist/api/auth/data-phone/com.google.android.horologist.auth.data.phone.tokenshare.impl/-token-bundle-repository-impl/index.html)

--- a/docs/auth-data.md
+++ b/docs/auth-data.md
@@ -9,27 +9,27 @@ from [auth-ui](auth-ui.md) library, but can be used with your own UI components.
 
 ## [Token sharing](https://developer.android.com/training/wearables/apps/auth-wear#tokens)
 
-- [TokenBundleRepository](https://google.github.io/horologist/api/auth-data/com.google.android.horologist.auth.data.tokenshare/-token-bundle-repository/index.html)
-    - [TokenBundleRepositoryImpl](https://google.github.io/horologist/api/auth-data/com.google.android.horologist.auth.data.tokenshare.impl/-token-bundle-repository-impl/index.html)
+- [TokenBundleRepository](https://google.github.io/horologist/api/auth/data/com.google.android.horologist.auth.data.tokenshare/-token-bundle-repository/index.html)
+    - [TokenBundleRepositoryImpl](https://google.github.io/horologist/api/auth/data/com.google.android.horologist.auth.data.tokenshare.impl/-token-bundle-repository-impl/index.html)
 
 ## [Google Sign-In](https://developer.android.com/training/wearables/apps/auth-wear#Google-Sign-in)
 
-- [GoogleSignInAuthUserRepository](https://google.github.io/horologist/api/auth-data/com.google.android.horologist.auth.data.googlesignin/-google-sign-in-auth-user-repository/index.html)
+- [GoogleSignInAuthUserRepository](https://google.github.io/horologist/api/auth/data/com.google.android.horologist.auth.data.googlesignin/-google-sign-in-auth-user-repository/index.html)
 
 ## [OAuth (PKCE)](https://developer.android.com/training/wearables/apps/auth-wear#pkce)
 
-- [PKCEConfigRepository](https://google.github.io/horologist/api/auth-data/com.google.android.horologist.auth.data.oauth.pkce/-p-k-c-e-config-repository/index.html)
-    - [PKCEConfigRepositoryGoogleImpl](https://google.github.io/horologist/api/auth-data-watch-oauth/com.google.android.horologist.auth.data.watch.oauth.pkce.impl.google/-p-k-c-e-config-repository-google-impl/index.html)
-- [PKCEOAuthCodeRepository](https://google.github.io/horologist/api/auth-data/com.google.android.horologist.auth.data.oauth.pkce/-p-k-c-e-o-auth-code-repository/index.html)
-    - [PKCEOAuthCodeRepositoryImpl](https://google.github.io/horologist/api/auth-data-watch-oauth/com.google.android.horologist.auth.data.watch.oauth.pkce.impl/-p-k-c-e-o-auth-code-repository-impl/index.html)
-- [PKCETokenRepository](https://google.github.io/horologist/api/auth-data/com.google.android.horologist.auth.data.oauth.pkce/-p-k-c-e-token-repository/index.html)
-    - [PKCETokenRepositoryGoogleImpl](https://google.github.io/horologist/api/auth-data-watch-oauth/com.google.android.horologist.auth.data.watch.oauth.pkce.impl.google/-p-k-c-e-token-repository-google-impl/index.html)
+- [PKCEConfigRepository](https://google.github.io/horologist/api/auth/data/com.google.android.horologist.auth.data.oauth.pkce/-p-k-c-e-config-repository/index.html)
+    - [PKCEConfigRepositoryGoogleImpl](https://google.github.io/horologist/api/auth/data-watch-oauth/com.google.android.horologist.auth.data.watch.oauth.pkce.impl.google/-p-k-c-e-config-repository-google-impl/index.html)
+- [PKCEOAuthCodeRepository](https://google.github.io/horologist/api/auth/data/com.google.android.horologist.auth.data.oauth.pkce/-p-k-c-e-o-auth-code-repository/index.html)
+    - [PKCEOAuthCodeRepositoryImpl](https://google.github.io/horologist/api/auth/data-watch-oauth/com.google.android.horologist.auth.data.watch.oauth.pkce.impl/-p-k-c-e-o-auth-code-repository-impl/index.html)
+- [PKCETokenRepository](https://google.github.io/horologist/api/auth/data/com.google.android.horologist.auth.data.oauth.pkce/-p-k-c-e-token-repository/index.html)
+    - [PKCETokenRepositoryGoogleImpl](https://google.github.io/horologist/api/auth/data-watch-oauth/com.google.android.horologist.auth.data.watch.oauth.pkce.impl.google/-p-k-c-e-token-repository-google-impl/index.html)
 
 ## [OAuth (Device Grant)](https://developer.android.com/training/wearables/apps/auth-wear#DAG)
 
-- [DeviceGrantConfigRepository](https://google.github.io/horologist/api/auth-data/com.google.android.horologist.auth.data.oauth.devicegrant/-device-grant-config-repository/index.html)
-    - [DeviceGrantConfigRepositoryDefaultImpl](https://google.github.io/horologist/api/auth-data-watch-oauth/com.google.android.horologist.auth.data.watch.oauth.devicegrant.impl/-device-grant-config-repository-default-impl/index.html)
-- [DeviceGrantTokenRepository](https://google.github.io/horologist/api/auth-data/com.google.android.horologist.auth.data.oauth.devicegrant/-device-grant-token-repository/index.html)
-    - [DeviceGrantTokenRepositoryGoogleImpl](https://google.github.io/horologist/api/auth-data-watch-oauth/com.google.android.horologist.auth.data.watch.oauth.devicegrant.impl.google/-device-grant-token-repository-google-impl/index.html)
-- [DeviceGrantVerificationInfoRepository](https://google.github.io/horologist/api/auth-data/com.google.android.horologist.auth.data.oauth.devicegrant/-device-grant-verification-info-repository/index.html)
-    - [DeviceGrantVerificationInfoRepositoryGoogleImpl](https://google.github.io/horologist/api/auth-data-watch-oauth/com.google.android.horologist.auth.data.watch.oauth.devicegrant.impl.google/-device-grant-verification-info-repository-google-impl/index.html)
+- [DeviceGrantConfigRepository](https://google.github.io/horologist/api/auth/data/com.google.android.horologist.auth.data.oauth.devicegrant/-device-grant-config-repository/index.html)
+    - [DeviceGrantConfigRepositoryDefaultImpl](https://google.github.io/horologist/api/auth/data-watch-oauth/com.google.android.horologist.auth.data.watch.oauth.devicegrant.impl/-device-grant-config-repository-default-impl/index.html)
+- [DeviceGrantTokenRepository](https://google.github.io/horologist/api/auth/data/com.google.android.horologist.auth.data.oauth.devicegrant/-device-grant-token-repository/index.html)
+    - [DeviceGrantTokenRepositoryGoogleImpl](https://google.github.io/horologist/api/auth/data-watch-oauth/com.google.android.horologist.auth.data.watch.oauth.devicegrant.impl.google/-device-grant-token-repository-google-impl/index.html)
+- [DeviceGrantVerificationInfoRepository](https://google.github.io/horologist/api/auth/data/com.google.android.horologist.auth.data.oauth.devicegrant/-device-grant-verification-info-repository/index.html)
+    - [DeviceGrantVerificationInfoRepositoryGoogleImpl](https://google.github.io/horologist/api/auth/data-watch-oauth/com.google.android.horologist.auth.data.watch.oauth.devicegrant.impl.google/-device-grant-verification-info-repository-google-impl/index.html)

--- a/docs/auth-googlesignin-guide.md
+++ b/docs/auth-googlesignin-guide.md
@@ -42,7 +42,7 @@ from [this link](https://developers.google.com/identity/sign-in/android/start-in
 1.  Create a ViewModel
 
     Create your implementation 
-    of [GoogleSignInViewModel](https://google.github.io/horologist/api/auth-ui/com.google.android.horologist.auth.ui.googlesignin.signin/-google-sign-in-view-model/index.html), 
+    of [GoogleSignInViewModel](https://google.github.io/horologist/api/auth/ui/com.google.android.horologist.auth.ui.googlesignin.signin/-google-sign-in-view-model/index.html), 
     passing the `GoogleSignInClient` created:
 
     ```kotlin
@@ -54,7 +54,7 @@ from [this link](https://developers.google.com/identity/sign-in/android/start-in
 1.  Display the screen
 
     Display 
-    the [GoogleSignInScreen](https://google.github.io/horologist/api/auth-ui/com.google.android.horologist.auth.ui.googlesignin.signin/-google-sign-in-screen.html) 
+    the [GoogleSignInScreen](https://google.github.io/horologist/api/auth/ui/com.google.android.horologist.auth.ui.googlesignin.signin/-google-sign-in-screen.html) 
     passing an instance of the `GoogleSignInViewModel` created:
 
     ```koltin

--- a/docs/auth-tokenshare-guide.md
+++ b/docs/auth-tokenshare-guide.md
@@ -104,7 +104,7 @@ your phone and watch apps must:
 1.  Create a `TokenBundleRepository` on the phone project
 
     Create an instance
-    of [TokenBundleRepository](https://google.github.io/horologist/api/auth-data-phone/com.google.android.horologist.auth.data.phone.tokenshare/-token-bundle-repository/index.html)
+    of [TokenBundleRepository](https://google.github.io/horologist/api/auth/data-phone/com.google.android.horologist.auth.data.phone.tokenshare/-token-bundle-repository/index.html)
     on the phone app project:
 
     ```kotlin
@@ -142,7 +142,7 @@ your phone and watch apps must:
 1.  Create a `TokenBundleRepository` on the watch project
 
     Create an instance
-    of [TokenBundleRepository](https://google.github.io/horologist/api/auth-data/com.google.android.horologist.auth.data.tokenshare/-token-bundle-repository/index.html)
+    of [TokenBundleRepository](https://google.github.io/horologist/api/auth/data/com.google.android.horologist.auth.data.tokenshare/-token-bundle-repository/index.html)
     on the watch app project:
 
     ```kotlin

--- a/docs/auth-ui.md
+++ b/docs/auth-ui.md
@@ -13,7 +13,7 @@ they can be your own implementation. Some of the composables might depend on an 
 
 ### Common
 
-#### [SignInPromptScreen](https://google.github.io/horologist/api/auth-ui/com.google.android.horologist.auth.ui.common.screens.prompt/-sign-in-prompt-screen.html)
+#### [SignInPromptScreen](https://google.github.io/horologist/api/auth/ui/com.google.android.horologist.auth.ui.common.screens.prompt/-sign-in-prompt-screen.html)
 
 A screen to prompt users to sign in.
 
@@ -30,7 +30,7 @@ It helps achieve to the following [best practices][best_practices]:
 
 ### Google Sign-In
 
-#### [GoogleSignInScreen](https://google.github.io/horologist/api/auth-ui/com.google.android.horologist.auth.ui.googlesignin.signin/-google-sign-in-screen.html)
+#### [GoogleSignInScreen](https://google.github.io/horologist/api/auth/ui/com.google.android.horologist.auth.ui.googlesignin.signin/-google-sign-in-screen.html)
 
 A screen for
 the [Google Sign-In](https://developer.android.com/training/wearables/apps/auth-wear#Google-Sign-in)
@@ -50,7 +50,7 @@ has to be provided to `GoogleSignInViewModel`.
 
 ### OAuth
 
-#### [PKCESignInScreen](https://google.github.io/horologist/api/auth-ui/com.google.android.horologist.auth.ui.oauth.pkce.signin/-p-k-c-e-sign-in-screen.html)
+#### [PKCESignInScreen](https://google.github.io/horologist/api/auth/ui/com.google.android.horologist.auth.ui.oauth.pkce.signin/-p-k-c-e-sign-in-screen.html)
 
 A screen for
 the [OAuth (PKCE)](https://developer.android.com/training/wearables/apps/auth-wear#pkce)
@@ -64,11 +64,11 @@ authentication flow.
 
 A implementation for the following repositories are required to be provided:
 
-- [PKCEConfigRepository](https://google.github.io/horologist/api/auth-data/com.google.android.horologist.auth.data.oauth.pkce/-p-k-c-e-config-repository/index.html)
-- [PKCEOAuthCodeRepository](https://google.github.io/horologist/api/auth-data/com.google.android.horologist.auth.data.oauth.pkce/-p-k-c-e-o-auth-code-repository/index.html)
-- [PKCETokenRepository](https://google.github.io/horologist/api/auth-data/com.google.android.horologist.auth.data.oauth.pkce/-p-k-c-e-token-repository/index.html)
+- [PKCEConfigRepository](https://google.github.io/horologist/api/auth/data/com.google.android.horologist.auth.data.oauth.pkce/-p-k-c-e-config-repository/index.html)
+- [PKCEOAuthCodeRepository](https://google.github.io/horologist/api/auth/data/com.google.android.horologist.auth.data.oauth.pkce/-p-k-c-e-o-auth-code-repository/index.html)
+- [PKCETokenRepository](https://google.github.io/horologist/api/auth/data/com.google.android.horologist.auth.data.oauth.pkce/-p-k-c-e-token-repository/index.html)
 
-#### [DeviceGrantSignInScreen](https://google.github.io/horologist/api/auth-ui/com.google.android.horologist.auth.ui.oauth.devicegrant.signin/-device-grant-sign-in-screen.html)
+#### [DeviceGrantSignInScreen](https://google.github.io/horologist/api/auth/ui/com.google.android.horologist.auth.ui.oauth.devicegrant.signin/-device-grant-sign-in-screen.html)
 
 A screen for
 the [OAuth (Device Grant)](https://developer.android.com/training/wearables/apps/auth-wear#DAG)
@@ -82,6 +82,6 @@ authentication flow.
 
 A implementation for the following repositories are required to be provided:
 
-- [DeviceGrantConfigRepository](https://google.github.io/horologist/api/auth-data/com.google.android.horologist.auth.data.oauth.devicegrant/-device-grant-config-repository/index.html)
-- [DeviceGrantVerificationInfoRepository](https://google.github.io/horologist/api/auth-data/com.google.android.horologist.auth.data.oauth.devicegrant/-device-grant-verification-info-repository/index.html)
-- [DeviceGrantTokenRepository](https://google.github.io/horologist/api/auth-data/com.google.android.horologist.auth.data.oauth.devicegrant/-device-grant-token-repository/index.html)
+- [DeviceGrantConfigRepository](https://google.github.io/horologist/api/auth/data/com.google.android.horologist.auth.data.oauth.devicegrant/-device-grant-config-repository/index.html)
+- [DeviceGrantVerificationInfoRepository](https://google.github.io/horologist/api/auth/data/com.google.android.horologist.auth.data.oauth.devicegrant/-device-grant-verification-info-repository/index.html)
+- [DeviceGrantTokenRepository](https://google.github.io/horologist/api/auth/data/com.google.android.horologist.auth.data.oauth.devicegrant/-device-grant-token-repository/index.html)


### PR DESCRIPTION
#### WHAT

Fix links from docs.

#### WHY

Links in the project's documentation are broken, e.g. all the links in [auth-data](https://google.github.io/horologist/auth-data/) page;

#### HOW

Fix links from `api/auth-*` to `api/auth/*`. 

This should be reverted if a fix is done in https://github.com/google/horologist/issues/1256 that can keep the previous module names listed in the docs.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [N/A] Run tests
- [N/A] Update metalava's signature text files
