### PR TITLE
Expose tile version and state

### DIFF
--- a/media/ui/api/current.api
+++ b/media/ui/api/current.api
@@ -905,7 +905,7 @@ package com.google.android.horologist.media.ui.tiles {
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public final class MediaCollectionsTileRenderer extends com.google.android.horologist.tiles.render.SingleTileLayoutRenderer<com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollectionsState,com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.ResourceState> {
     ctor public MediaCollectionsTileRenderer(android.content.Context context, androidx.wear.protolayout.material.Colors materialTheme, boolean debugResourceMode);
-    method public String getVersionForTile(com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollectionsState state);
+    method public String getResourcesVersionForTileState(com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollectionsState state);
     method public void produceRequestedResources(androidx.wear.protolayout.ResourceBuilders.Resources.Builder, com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.ResourceState resourceState, androidx.wear.protolayout.DeviceParametersBuilders.DeviceParameters deviceParameters, java.util.List<java.lang.String> resourceIds);
     method public androidx.wear.protolayout.LayoutElementBuilders.LayoutElement renderTile(com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollectionsState state, androidx.wear.protolayout.DeviceParametersBuilders.DeviceParameters deviceParameters);
   }

--- a/media/ui/api/current.api
+++ b/media/ui/api/current.api
@@ -905,6 +905,7 @@ package com.google.android.horologist.media.ui.tiles {
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public final class MediaCollectionsTileRenderer extends com.google.android.horologist.tiles.render.SingleTileLayoutRenderer<com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollectionsState,com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.ResourceState> {
     ctor public MediaCollectionsTileRenderer(android.content.Context context, androidx.wear.protolayout.material.Colors materialTheme, boolean debugResourceMode);
+    method public String getVersionForTile(com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollectionsState state);
     method public void produceRequestedResources(androidx.wear.protolayout.ResourceBuilders.Resources.Builder, com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.ResourceState resourceState, androidx.wear.protolayout.DeviceParametersBuilders.DeviceParameters deviceParameters, java.util.List<java.lang.String> resourceIds);
     method public androidx.wear.protolayout.LayoutElementBuilders.LayoutElement renderTile(com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer.MediaCollectionsState state, androidx.wear.protolayout.DeviceParametersBuilders.DeviceParameters deviceParameters);
   }

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/tiles/MediaCollectionsTileRenderer.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/tiles/MediaCollectionsTileRenderer.kt
@@ -90,6 +90,10 @@ public class MediaCollectionsTileRenderer(
             ).build()
     }
 
+    override fun getVersionForTile(state: MediaCollectionsState): String {
+        return state.collection1.artworkId + ":" + state.collection2.artworkId
+    }
+
     private fun spacer(size: Float) = Spacer.Builder().setHeight(
         DimensionBuilders.DpProp.Builder(size).build()
     ).build()

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/tiles/MediaCollectionsTileRenderer.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/tiles/MediaCollectionsTileRenderer.kt
@@ -90,7 +90,7 @@ public class MediaCollectionsTileRenderer(
             ).build()
     }
 
-    override fun getVersionForTile(state: MediaCollectionsState): String {
+    override fun getResourcesVersionForTileState(state: MediaCollectionsState): String {
         return state.collection1.artworkId + ":" + state.collection2.artworkId
     }
 

--- a/tiles/api/current.api
+++ b/tiles/api/current.api
@@ -121,11 +121,13 @@ package com.google.android.horologist.tiles.render {
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public abstract class SingleTileLayoutRenderer<T, R> implements com.google.android.horologist.tiles.render.TileLayoutRenderer<T,R> {
     ctor public SingleTileLayoutRenderer(android.content.Context context, optional boolean debugResourceMode);
+    method public androidx.wear.protolayout.StateBuilders.State createState();
     method public androidx.wear.protolayout.material.Colors createTheme();
     method public final android.content.Context getContext();
     method public final boolean getDebugResourceMode();
     method public long getFreshnessIntervalMillis();
     method public final androidx.wear.protolayout.material.Colors getTheme();
+    method public String getVersionForTile(T? state);
     method public final androidx.wear.protolayout.ResourceBuilders.Resources produceRequestedResources(R? resourceState, androidx.wear.tiles.RequestBuilders.ResourcesRequest requestParams);
     method public void produceRequestedResources(androidx.wear.protolayout.ResourceBuilders.Resources.Builder, R? resourceState, androidx.wear.protolayout.DeviceParametersBuilders.DeviceParameters deviceParameters, java.util.List<java.lang.String> resourceIds);
     method public abstract androidx.wear.protolayout.LayoutElementBuilders.LayoutElement renderTile(T? state, androidx.wear.protolayout.DeviceParametersBuilders.DeviceParameters deviceParameters);

--- a/tiles/api/current.api
+++ b/tiles/api/current.api
@@ -127,7 +127,7 @@ package com.google.android.horologist.tiles.render {
     method public final boolean getDebugResourceMode();
     method public long getFreshnessIntervalMillis();
     method public final androidx.wear.protolayout.material.Colors getTheme();
-    method public String getVersionForTile(T? state);
+    method public String getResourcesVersionForTileState(T? state);
     method public final androidx.wear.protolayout.ResourceBuilders.Resources produceRequestedResources(R? resourceState, androidx.wear.tiles.RequestBuilders.ResourcesRequest requestParams);
     method public void produceRequestedResources(androidx.wear.protolayout.ResourceBuilders.Resources.Builder, R? resourceState, androidx.wear.protolayout.DeviceParametersBuilders.DeviceParameters deviceParameters, java.util.List<java.lang.String> resourceIds);
     method public abstract androidx.wear.protolayout.LayoutElementBuilders.LayoutElement renderTile(T? state, androidx.wear.protolayout.DeviceParametersBuilders.DeviceParameters deviceParameters);

--- a/tiles/src/main/java/com/google/android/horologist/tiles/render/SingleTileLayoutRenderer.kt
+++ b/tiles/src/main/java/com/google/android/horologist/tiles/render/SingleTileLayoutRenderer.kt
@@ -21,6 +21,8 @@ import androidx.wear.protolayout.DeviceParametersBuilders
 import androidx.wear.protolayout.LayoutElementBuilders.Layout
 import androidx.wear.protolayout.LayoutElementBuilders.LayoutElement
 import androidx.wear.protolayout.ResourceBuilders.Resources
+import androidx.wear.protolayout.StateBuilders
+import androidx.wear.protolayout.StateBuilders.State
 import androidx.wear.protolayout.TimelineBuilders
 import androidx.wear.protolayout.material.Colors
 import androidx.wear.tiles.RequestBuilders
@@ -67,13 +69,16 @@ public abstract class SingleTileLayoutRenderer<T, R>(
                 if (debugResourceMode) {
                     UUID.randomUUID().toString()
                 } else {
-                    PERMANENT_RESOURCES_VERSION
+                    getVersionForTile(state)
                 }
             )
+            .setState(createState())
             .setTileTimeline(singleTileTimeline)
             .setFreshnessIntervalMillis(freshnessIntervalMillis)
             .build()
     }
+
+    open fun getVersionForTile(state: T) = PERMANENT_RESOURCES_VERSION
 
     /**
      * Create a material theme that should be applied to all components.
@@ -113,6 +118,8 @@ public abstract class SingleTileLayoutRenderer<T, R>(
         resourceIds: MutableList<String>
     ) {
     }
+
+    open fun createState(): State = State.Builder().build()
 }
 
 /**

--- a/tiles/src/main/java/com/google/android/horologist/tiles/render/SingleTileLayoutRenderer.kt
+++ b/tiles/src/main/java/com/google/android/horologist/tiles/render/SingleTileLayoutRenderer.kt
@@ -21,7 +21,6 @@ import androidx.wear.protolayout.DeviceParametersBuilders
 import androidx.wear.protolayout.LayoutElementBuilders.Layout
 import androidx.wear.protolayout.LayoutElementBuilders.LayoutElement
 import androidx.wear.protolayout.ResourceBuilders.Resources
-import androidx.wear.protolayout.StateBuilders
 import androidx.wear.protolayout.StateBuilders.State
 import androidx.wear.protolayout.TimelineBuilders
 import androidx.wear.protolayout.material.Colors
@@ -78,7 +77,7 @@ public abstract class SingleTileLayoutRenderer<T, R>(
             .build()
     }
 
-    open fun getVersionForTile(state: T) = PERMANENT_RESOURCES_VERSION
+    public open fun getVersionForTile(state: T): String = PERMANENT_RESOURCES_VERSION
 
     /**
      * Create a material theme that should be applied to all components.
@@ -119,7 +118,7 @@ public abstract class SingleTileLayoutRenderer<T, R>(
     ) {
     }
 
-    open fun createState(): State = State.Builder().build()
+    public open fun createState(): State = State.Builder().build()
 }
 
 /**

--- a/tiles/src/main/java/com/google/android/horologist/tiles/render/SingleTileLayoutRenderer.kt
+++ b/tiles/src/main/java/com/google/android/horologist/tiles/render/SingleTileLayoutRenderer.kt
@@ -68,7 +68,7 @@ public abstract class SingleTileLayoutRenderer<T, R>(
                 if (debugResourceMode) {
                     UUID.randomUUID().toString()
                 } else {
-                    getVersionForTile(state)
+                    getResourcesVersionForTileState(state)
                 }
             )
             .setState(createState())
@@ -77,7 +77,7 @@ public abstract class SingleTileLayoutRenderer<T, R>(
             .build()
     }
 
-    public open fun getVersionForTile(state: T): String = PERMANENT_RESOURCES_VERSION
+    public open fun getResourcesVersionForTileState(state: T): String = PERMANENT_RESOURCES_VERSION
 
     /**
      * Create a material theme that should be applied to all components.


### PR DESCRIPTION
#### WHAT

Expose tile version and state.

#### WHY

Allow apps to override the version based on the State, such as included image ids.  Also expose the Tile `State` to allow apps to override State only.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
