### PR TITLE
Make sure volume bar is shown when calling setVolume even when going beyond max or min

### DIFF
--- a/media/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeViewModel.kt
+++ b/media/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeViewModel.kt
@@ -124,6 +124,7 @@ public open class VolumeViewModel(
     }
 
     public fun setVolume(volume: Int) {
+        this.userActionEvents.tryEmit(Unit)
         if (volume != volumeRepository.volumeState.value.current) {
             volumeRepository.setVolume(volume)
         }


### PR DESCRIPTION
#### WHAT
Make sure volume bar is shown when calling setVolume even when going beyond max or min

#### WHY


#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
