### PR TITLE
Ensures watch screen is woken up when remote launching apps

### DIFF
--- a/datalayer/api/current.api
+++ b/datalayer/api/current.api
@@ -159,6 +159,10 @@ package com.google.android.horologist.data.apphelper {
     ctor public DataLayerAppHelperService();
     method public abstract com.google.android.horologist.data.apphelper.DataLayerAppHelper getAppHelper();
     property public abstract com.google.android.horologist.data.apphelper.DataLayerAppHelper appHelper;
+    field public static final com.google.android.horologist.data.apphelper.DataLayerAppHelperService.Companion Companion;
+  }
+
+  public static final class DataLayerAppHelperService.Companion {
   }
 
   public final class SurfaceInfoSerializer implements androidx.datastore.core.Serializer<error.NonExistentClass> {

--- a/datalayer/src/main/AndroidManifest.xml
+++ b/datalayer/src/main/AndroidManifest.xml
@@ -23,9 +23,15 @@
         tools:ignore="GradleOverrides" />
 
     <!--
-    Required to be able to identify the companion with NodeClient, via calls to
-    getCompanionPackageForNode().
--->
+        Required in order to very briefly wake up the screen of the device when launching an app /
+        Activity remotely via the AppHelper.
+    -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+    <!--
+        Required to be able to identify the companion with NodeClient, via calls to
+        getCompanionPackageForNode().
+    -->
     <queries>
         <intent>
             <action android:name="com.google.android.gms.wearable.CAPABILITY_CHANGED" />

--- a/datalayer/src/main/java/com/google/android/horologist/data/apphelper/DataLayerAppHelperService.kt
+++ b/datalayer/src/main/java/com/google/android/horologist/data/apphelper/DataLayerAppHelperService.kt
@@ -18,6 +18,7 @@ package com.google.android.horologist.data.apphelper
 
 import android.content.ActivityNotFoundException
 import android.content.Intent
+import android.os.PowerManager
 import android.util.Log
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
@@ -54,7 +55,7 @@ public abstract class DataLayerAppHelperService : WearableListenerService() {
             val intent = this.packageManager.getLaunchIntentForPackage(packageName)
                 ?: return AppHelperResultCode.APP_HELPER_RESULT_ACTIVITY_NOT_FOUND
 
-            startActivity(intent)
+            wakeDeviceAndStartActivity(intent)
         } catch (e: ActivityNotFoundException) {
             Log.w(TAG, "Launch activity not found for : $packageName")
             return AppHelperResultCode.APP_HELPER_RESULT_ACTIVITY_NOT_FOUND
@@ -72,7 +73,7 @@ public abstract class DataLayerAppHelperService : WearableListenerService() {
                 setClassName(activityConfig.packageName, activityConfig.classFullName)
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK
             }
-            startActivity(intent)
+            wakeDeviceAndStartActivity(intent)
         } catch (e: ActivityNotFoundException) {
             Log.w(TAG, "Activity not found: $activityConfig")
             return AppHelperResultCode.APP_HELPER_RESULT_ACTIVITY_NOT_FOUND
@@ -87,5 +88,42 @@ public abstract class DataLayerAppHelperService : WearableListenerService() {
         return runBlocking {
             appHelper.startCompanion(companionConfig.sourceNode)
         }
+    }
+
+    /**
+     * Ensures device is woken (e.g. screen turns on) before Activity launched.
+     */
+    private fun wakeDeviceAndStartActivity(intent: Intent) {
+        wakeDevice()
+        startActivity(intent)
+    }
+
+    /**
+     * Wakes the device, screen turns on.
+     */
+    private fun wakeDevice() {
+        val powerManager = getSystemService(POWER_SERVICE) as PowerManager
+
+        // FULL_WAKE_LOCK and ACQUIRE_CAUSES_WAKEUP are deprecated, but they remain in use as the
+        // approach for achieving screen wakeup across mainstream apps, so are the approach to use
+        // for now.
+        @Suppress("DEPRECATION")
+        val wakeLock = powerManager.newWakeLock(
+            PowerManager.FULL_WAKE_LOCK
+                or PowerManager.ACQUIRE_CAUSES_WAKEUP
+                or PowerManager.ON_AFTER_RELEASE,
+            wakeLockTag
+        )
+
+        // Wakelock timeout should not be required as it is being immediately released but
+        // linting guidance recommends one so setting it nonetheless.
+        wakeLock.acquire(wakeLockTimeoutMs)
+        wakeLock.release()
+    }
+
+    companion object {
+        // Tag format as per recommendations: https://developer.android.com/reference/android/os/PowerManager#newWakeLock(int,%20java.lang.String)
+        private val wakeLockTag = "horologist:apphelper"
+        private val wakeLockTimeoutMs = 1000L
     }
 }


### PR DESCRIPTION
Ensures watch screen is woken up when remote launching apps

#### WHAT

Adds screen wakeup when launching apps / activities via AppHelper

#### WHY

When the screen is off, for example on the watch, then launching an app via `startActivity`, does not wake the screen by default.

#### HOW

Use a wake lock with flags to wake the screen, which is released immediately on being obtained, prior to launching the activity.

#### Checklist :clipboard:
- [ x] Add explicit visibility modifier and explicit return types for public declarations
- [ x] Run spotless check
- [ x] Run tests
- [ x] Update metalava's signature text files
