### PR TITLE
Remove asset only used for tests

### DIFF
--- a/tiles/src/debug/res/drawable-mdpi/coil.jpg
+++ b/tiles/src/debug/res/drawable-mdpi/coil.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d1a0bfdfeabf716020a47b6873cb4ebf18cffeda455e40931548c1776ad7dc1b
-size 5975

--- a/tiles/src/test/java/com/google/android/horologist/tiles/ImagesTest.kt
+++ b/tiles/src/test/java/com/google/android/horologist/tiles/ImagesTest.kt
@@ -53,15 +53,15 @@ class ImagesTest {
         runTest {
             val imageLoader = FakeImageLoader {
                 // https://wordpress.org/openverse/image/34896de8-afb0-494c-af63-17b73fc14124/
-                FakeImageLoader.loadSuccessBitmap(context, it, R.drawable.coil)
+                FakeImageLoader.loadSuccessBitmap(context, it, android.R.drawable.ic_delete)
             }
 
-            val imageResource = imageLoader.loadImageResource(context, R.drawable.coil)
+            val imageResource = imageLoader.loadImageResource(context, android.R.drawable.ic_delete)
 
             val inlineResource = imageResource!!.inlineResource!!
             assertThat(inlineResource.format).isEqualTo(ResourceBuilders.IMAGE_FORMAT_RGB_565)
-            assertThat(inlineResource.widthPx).isEqualTo(200)
-            assertThat(inlineResource.heightPx).isEqualTo(134)
+            assertThat(inlineResource.widthPx).isEqualTo(64)
+            assertThat(inlineResource.heightPx).isEqualTo(64)
         }
     }
 
@@ -70,11 +70,11 @@ class ImagesTest {
         runTest {
             val imageLoader = FakeImageLoader {
                 // https://wordpress.org/openverse/image/34896de8-afb0-494c-af63-17b73fc14124/
-                FakeImageLoader.loadErrorBitmap(context, it, R.drawable.coil)
+                FakeImageLoader.loadErrorBitmap(context, it, android.R.drawable.ic_delete)
             }
 
-            val imageResource = imageLoader.loadImageResource(context, R.drawable.coil) {
-                error(R.drawable.coil)
+            val imageResource = imageLoader.loadImageResource(context, android.R.drawable.ic_delete) {
+                error(android.R.drawable.ic_delete)
             }
 
             val inlineResource = imageResource!!.inlineResource!!


### PR DESCRIPTION
#### WHAT

Remove `coil.jpg` asset from `tiles` module.

#### WHY

It was added in the `debug` folder as it is supposed to only be used for unit tests.
The side effect is that it break tasks for `release` build type:

```
> Task :tiles:compileReleaseUnitTestKotlin FAILED
e: file:///horologist/tiles/src/test/java/com/google/android/horologist/tiles/ImagesTest.kt:56:75 Unresolved reference: coil
e: file:///horologist/tiles/src/test/java/com/google/android/horologist/tiles/ImagesTest.kt:59:83 Unresolved reference: coil
e: file:///horologist/tiles/src/test/java/com/google/android/horologist/tiles/ImagesTest.kt:73:73 Unresolved reference: coil
e: file:///horologist/tiles/src/test/java/com/google/android/horologist/tiles/ImagesTest.kt:76:83 Unresolved reference: coil
e: file:///horologist/tiles/src/test/java/com/google/android/horologist/tiles/ImagesTest.kt:77:34 Unresolved reference: coil

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':tiles:compileReleaseUnitTestKotlin'.
> A failure occurred while executing org.jetbrains.kotlin.compilerRunner.GradleCompilerRunnerWithWorkers$GradleKotlinCompilerWorkAction
   > Compilation error. See log for more details
```

#### HOW

Remove `coil.jpg` asset and replace usage in tests from a drawable from the sdk.
Caveat: the test might break in newer versions of the sdk if the asset gets changed.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
