### PR TITLE
Add UampColors class to test folder

### DIFF
--- a/media/ui/src/test/java/com/google/android/horologist/media/ui/uamp/UampTheme.kt
+++ b/media/ui/src/test/java/com/google/android/horologist/media/ui/uamp/UampTheme.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.uamp
+
+import androidx.compose.ui.graphics.Color
+import androidx.wear.compose.material.Colors
+
+// This class should have the same values as of UampColors class in:
+// debug/java/com/google/android/horologist/media/ui/uamp/UampTheme.kt
+// Alternatively, this class should be moved to a separated module.
+public val UampColors = Colors(
+    primary = Color(0xFF981F68),
+    primaryVariant = Color(0xFF66003d),
+    secondary = Color(0xFF981F68),
+    error = Color(0xFFE24444),
+    onPrimary = Color.White,
+    onSurfaceVariant = Color(0xFFDADCE0),
+    surface = Color(0xFF303133),
+    onError = Color.Black
+)


### PR DESCRIPTION
#### WHAT

Add `UampColors` class to test folder.

#### WHY

Test classes were using the `UampColors` class from the `debug` folder. 
The side effect is that it breaks tasks for `release` build type:

```
> Task :media:ui:compileReleaseUnitTestKotlin FAILED
e: file:///horologist/media/ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerA11yScreenshotTest.kt:22:47 Unresolved reference: uamp
e: file:///horologist/media/ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerA11yScreenshotTest.kt:85:26 Unresolved reference: UampColors
e: file:///horologist/media/ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerDeviceScreenTest.kt:22:47 Unresolved reference: uamp
e: file:///horologist/media/ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerDeviceScreenTest.kt:81:26 Unresolved reference: UampColors
e: file:///horologist/media/ui/src/test/java/com/google/android/horologist/media/ui/tiles/MediaCollectionsTileTest.kt:25:47 Unresolved reference: uamp
e: file:///horologist/media/ui/src/test/java/com/google/android/horologist/media/ui/tiles/MediaCollectionsTileTest.kt:103:33 Unresolved reference: UampColors


FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':media:ui:compileReleaseUnitTestKotlin'.
> A failure occurred while executing org.jetbrains.kotlin.compilerRunner.GradleCompilerRunnerWithWorkers$GradleKotlinCompilerWorkAction
   > Compilation error. See log for more details
```

#### HOW

Copy `UampColors` class to the test folder, in the same package structure.
Caveat: duplication of the code might cause class definition to not be synced. Alternatively we should place the class in a separate module.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
