### PR TITLE
Disable macrobenchmark in CI

### DIFF
--- a/.github/workflows/android_test.yml
+++ b/.github/workflows/android_test.yml
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - '**.md'
   workflow_dispatch:
+  pull_request:
 
 jobs:
   test:
@@ -49,11 +50,7 @@ jobs:
           target: android-wear
           profile: wear_round_454
           emulator-options: -no-window -no-snapshot
-          script: |
-            ./gradlew connectedDebugAndroidTest \
-            -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=Microbenchmark \
-            -x media:benchmark:connectedDebugAndroidTest \
-            -x media:sample-benchmark:connectedDebugAndroidTest
+          script: ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=Microbenchmark -x media:benchmark:connectedDebugAndroidTest -x media:sample-benchmark:connectedDebugAndroidTest
 
       - name: Upload logs
         if: always()

--- a/.github/workflows/android_test.yml
+++ b/.github/workflows/android_test.yml
@@ -51,7 +51,7 @@ jobs:
           target: android-wear
           profile: wear_round_454
           emulator-options: -no-window -no-snapshot
-          script: ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=Microbenchmark -x media:benchmark:connectedDebugAndroidTest -x media:sample-benchmark:connectedDebugAndroidTest
+          script: ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=Microbenchmark -x media:benchmark:connectedDebugAndroidTest
 
       - name: Upload logs
         if: always()

--- a/.github/workflows/android_test.yml
+++ b/.github/workflows/android_test.yml
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - '**.md'
   workflow_dispatch:
+  # TODO remove
   pull_request:
 
 jobs:

--- a/.github/workflows/android_test.yml
+++ b/.github/workflows/android_test.yml
@@ -7,8 +7,6 @@ on:
     paths-ignore:
       - '**.md'
   workflow_dispatch:
-  # TODO remove
-  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
#### WHAT

Disable macrobenchmark in CI

#### WHY

Used for performance testing, not CI with emulators.

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
