### PR TITLE
Add StandardToggleChip

### DIFF
--- a/base-ui/api/current.api
+++ b/base-ui/api/current.api
@@ -70,6 +70,18 @@ package com.google.android.horologist.base.ui.components {
     method @androidx.compose.runtime.Composable public static void StandardIcon(androidx.compose.ui.graphics.vector.ImageVector imageVector, String? contentDescription, optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.base.ui.components.IconRtlMode rtlMode);
   }
 
+  public final class StandardToggleChipKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void StandardToggleChip(boolean checked, kotlin.jvm.functions.Function1<? super java.lang.Boolean,kotlin.Unit> onCheckedChange, String label, com.google.android.horologist.base.ui.components.StandardToggleChipToggleControl toggleControl, optional androidx.compose.ui.Modifier modifier, optional androidx.compose.ui.graphics.vector.ImageVector? icon, optional String? secondaryLabel, optional androidx.wear.compose.material.ToggleChipColors colors, optional boolean enabled, optional androidx.compose.foundation.interaction.MutableInteractionSource interactionSource);
+  }
+
+  public enum StandardToggleChipToggleControl {
+    method public static com.google.android.horologist.base.ui.components.StandardToggleChipToggleControl valueOf(String name) throws java.lang.IllegalArgumentException;
+    method public static com.google.android.horologist.base.ui.components.StandardToggleChipToggleControl[] values();
+    enum_constant public static final com.google.android.horologist.base.ui.components.StandardToggleChipToggleControl Checkbox;
+    enum_constant public static final com.google.android.horologist.base.ui.components.StandardToggleChipToggleControl Radio;
+    enum_constant public static final com.google.android.horologist.base.ui.components.StandardToggleChipToggleControl Switch;
+  }
+
   public final class TitleKt {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void Title(@StringRes int textId, optional androidx.compose.ui.Modifier modifier);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void Title(String text, optional androidx.compose.ui.Modifier modifier);

--- a/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/StandardToggleChipOverflowPreview.kt
+++ b/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/StandardToggleChipOverflowPreview.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.base.ui.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(
+    name = "With long text",
+    backgroundColor = 0xff000000,
+    showBackground = true
+)
+@Composable
+fun StandardToggleChipOverflowPreviewWithLongText() {
+    StandardToggleChip(
+        checked = true,
+        onCheckedChange = { },
+        label = "Primary label very very very very very very very very very very very very very very very very very long text",
+        toggleControl = StandardToggleChipToggleControl.Switch
+    )
+}
+
+@Preview(
+    name = "With icon and long text",
+    backgroundColor = 0xff000000,
+    showBackground = true
+)
+@Composable
+fun StandardToggleChipOverflowPreviewWithIconAndLongText() {
+    StandardToggleChip(
+        checked = true,
+        onCheckedChange = { },
+        label = "Primary label very very very very very very very very very very very very very very very very very long text",
+        toggleControl = StandardToggleChipToggleControl.Switch,
+        icon = Icons.Default.Image
+    )
+}
+
+@Preview(
+    name = "With secondary label and long text",
+    backgroundColor = 0xff000000,
+    showBackground = true
+)
+@Composable
+fun StandardToggleChipOverflowPreviewWithSecondaryLabelAndLongText() {
+    StandardToggleChip(
+        checked = true,
+        onCheckedChange = { },
+        label = "Primary label very very very very very very very very long text",
+        secondaryLabel = "Secondary label very very very very very very very very very long text",
+        toggleControl = StandardToggleChipToggleControl.Switch
+    )
+}
+
+@Preview(
+    name = "With icon, secondary label and long text",
+    backgroundColor = 0xff000000,
+    showBackground = true
+)
+@Composable
+fun StandardToggleChipOverflowPreviewWithIconAndSecondaryLabelAndLongText() {
+    StandardToggleChip(
+        checked = true,
+        onCheckedChange = { },
+        label = "Primary label very very very very very very very very long text",
+        secondaryLabel = "Secondary label very very very very very very very very very long text",
+        toggleControl = StandardToggleChipToggleControl.Switch,
+        icon = Icons.Default.Image
+    )
+}

--- a/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/StandardToggleChipVariantsPreview.kt
+++ b/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/StandardToggleChipVariantsPreview.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.base.ui.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(
+    backgroundColor = 0xff000000,
+    showBackground = true
+)
+@Composable
+fun StandardToggleChipSwitchPreview() {
+    StandardToggleChip(
+        checked = true,
+        onCheckedChange = { },
+        label = "Primary label",
+        toggleControl = StandardToggleChipToggleControl.Switch
+    )
+}
+
+@Preview(
+    backgroundColor = 0xff000000,
+    showBackground = true
+)
+@Composable
+fun StandardToggleChipRadioPreview() {
+    StandardToggleChip(
+        checked = true,
+        onCheckedChange = { },
+        label = "Primary label",
+        toggleControl = StandardToggleChipToggleControl.Radio
+    )
+}
+
+@Preview(
+    backgroundColor = 0xff000000,
+    showBackground = true
+)
+@Composable
+fun StandardToggleChipCheckboxPreview() {
+    StandardToggleChip(
+        checked = true,
+        onCheckedChange = { },
+        label = "Primary label",
+        toggleControl = StandardToggleChipToggleControl.Checkbox
+    )
+}
+
+@Preview(
+    name = "With secondary label",
+    backgroundColor = 0xff000000,
+    showBackground = true
+)
+@Composable
+fun StandardToggleChipWithSecondaryLabel() {
+    StandardToggleChip(
+        checked = true,
+        onCheckedChange = { },
+        label = "Primary label",
+        toggleControl = StandardToggleChipToggleControl.Switch,
+        secondaryLabel = "Secondary label"
+    )
+}
+
+@Preview(
+    name = "With icon",
+    backgroundColor = 0xff000000,
+    showBackground = true
+)
+@Composable
+fun StandardToggleChipPreviewWithIcon() {
+    StandardToggleChip(
+        checked = true,
+        onCheckedChange = { },
+        label = "Primary label",
+        toggleControl = StandardToggleChipToggleControl.Switch,
+        icon = Icons.Default.Image
+    )
+}
+
+@Preview(
+    name = "With secondary label and icon",
+    backgroundColor = 0xff000000,
+    showBackground = true
+)
+@Composable
+fun StandardToggleChipPreviewWithSecondaryLabelAndIcon() {
+    StandardToggleChip(
+        checked = true,
+        onCheckedChange = { },
+        label = "Primary label",
+        toggleControl = StandardToggleChipToggleControl.Switch,
+        secondaryLabel = "Secondary label"
+    )
+}
+
+@Preview(
+    name = "Disabled",
+    backgroundColor = 0xff000000,
+    showBackground = true
+)
+@Composable
+fun StandardToggleChipPreviewDisabled() {
+    StandardToggleChip(
+        checked = true,
+        onCheckedChange = { },
+        label = "Primary label",
+        toggleControl = StandardToggleChipToggleControl.Switch,
+        enabled = false
+    )
+}

--- a/base-ui/src/main/java/com/google/android/horologist/base/ui/components/StandardToggleChip.kt
+++ b/base-ui/src/main/java/com/google/android/horologist/base/ui/components/StandardToggleChip.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.base.ui.components
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.wear.compose.material.ChipDefaults
+import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.Text
+import androidx.wear.compose.material.ToggleChip
+import androidx.wear.compose.material.ToggleChipColors
+import androidx.wear.compose.material.ToggleChipDefaults
+import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.base.ui.R
+import com.google.android.horologist.base.ui.util.DECORATIVE_ELEMENT_CONTENT_DESCRIPTION
+
+/**
+ * This composable fulfils the redlines of the following components:
+ * - Toggle chips
+ */
+@ExperimentalHorologistApi
+@Composable
+public fun StandardToggleChip(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    label: String,
+    toggleControl: StandardToggleChipToggleControl,
+    modifier: Modifier = Modifier,
+    icon: ImageVector? = null,
+    secondaryLabel: String? = null,
+    colors: ToggleChipColors = ToggleChipDefaults.toggleChipColors(),
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
+) {
+    val hasSecondaryLabel = secondaryLabel != null
+    val hasIcon = icon != null
+
+    val labelParam: (@Composable RowScope.() -> Unit) =
+        {
+            Text(
+                text = label,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = if (hasSecondaryLabel || hasIcon) TextAlign.Left else TextAlign.Center,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = if (hasSecondaryLabel) 1 else 2
+            )
+        }
+
+    val secondaryLabelParam: (@Composable RowScope.() -> Unit)? =
+        secondaryLabel?.let {
+            {
+                Text(
+                    text = secondaryLabel,
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 1
+                )
+            }
+        }
+
+    val toggleControlParam: (@Composable () -> Unit) = {
+        Icon(
+            imageVector = when (toggleControl) {
+                StandardToggleChipToggleControl.Switch -> ToggleChipDefaults.switchIcon(checked)
+                StandardToggleChipToggleControl.Radio -> ToggleChipDefaults.radioIcon(checked)
+                StandardToggleChipToggleControl.Checkbox -> ToggleChipDefaults.checkboxIcon(checked)
+            },
+            contentDescription = stringResource(
+                if (checked) {
+                    R.string.horologist_standard_toggle_chip_on_content_description
+                } else {
+                    R.string.horologist_standard_toggle_chip_off_content_description
+                }
+            )
+        )
+    }
+
+    val iconParam: (@Composable BoxScope.() -> Unit)? =
+        icon?.let {
+            {
+                Row {
+                    Icon(
+                        imageVector = icon,
+                        contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
+                        modifier = Modifier
+                            .size(ChipDefaults.IconSize)
+                            .clip(CircleShape)
+                    )
+                }
+            }
+        }
+
+    ToggleChip(
+        checked = checked,
+        onCheckedChange = onCheckedChange,
+        label = labelParam,
+        toggleControl = toggleControlParam,
+        modifier = modifier,
+        appIcon = iconParam,
+        secondaryLabel = secondaryLabelParam,
+        colors = colors,
+        enabled = enabled,
+        interactionSource = interactionSource
+    )
+}
+
+public enum class StandardToggleChipToggleControl {
+    Switch, Radio, Checkbox
+}

--- a/base-ui/src/main/res/values/strings.xml
+++ b/base-ui/src/main/res/values/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2022 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <string description="Content description of the StandardToggleChip. It lets the user know if the toggle is checked or not. [CHAR_LIMIT=NONE]" name="horologist_standard_toggle_chip_on_content_description">On</string>
+    <string description="Content description of the StandardToggleChip. It lets the user know if the toggle is checked or not. [CHAR_LIMIT=NONE]" name="horologist_standard_toggle_chip_off_content_description">Off</string>
+</resources>

--- a/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardToggleChipTest.kt
+++ b/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardToggleChipTest.kt
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.base.ui.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import com.google.android.horologist.screenshots.ScreenshotBaseTest
+import org.junit.Test
+
+class StandardToggleChipTest : ScreenshotBaseTest() {
+
+    @Test
+    fun switch() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardToggleChip(
+                checked = true,
+                onCheckedChange = { },
+                label = "Primary label",
+                toggleControl = StandardToggleChipToggleControl.Switch
+            )
+        }
+    }
+
+    @Test
+    fun radio() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardToggleChip(
+                checked = true,
+                onCheckedChange = { },
+                label = "Primary label",
+                toggleControl = StandardToggleChipToggleControl.Radio
+            )
+        }
+    }
+
+    @Test
+    fun checkbox() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardToggleChip(
+                checked = true,
+                onCheckedChange = { },
+                label = "Primary label",
+                toggleControl = StandardToggleChipToggleControl.Checkbox
+            )
+        }
+    }
+
+    @Test
+    fun withSecondaryLabel() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardToggleChip(
+                checked = true,
+                onCheckedChange = { },
+                label = "Primary label",
+                toggleControl = StandardToggleChipToggleControl.Switch,
+                secondaryLabel = "Secondary label"
+            )
+        }
+    }
+
+    @Test
+    fun withIcon() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardToggleChip(
+                checked = true,
+                onCheckedChange = { },
+                label = "Primary label",
+                toggleControl = StandardToggleChipToggleControl.Switch,
+                icon = Icons.Default.Image
+            )
+        }
+    }
+
+    @Test
+    fun withSecondaryLabelAndIcon() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardToggleChip(
+                checked = true,
+                onCheckedChange = { },
+                label = "Primary label",
+                toggleControl = StandardToggleChipToggleControl.Switch,
+                secondaryLabel = "Secondary label"
+            )
+        }
+    }
+
+    @Test
+    fun disabled() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardToggleChip(
+                checked = true,
+                onCheckedChange = { },
+                label = "Primary label",
+                toggleControl = StandardToggleChipToggleControl.Switch,
+                enabled = false
+            )
+        }
+    }
+
+    @Test
+    fun withLongText() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardToggleChip(
+                checked = true,
+                onCheckedChange = { },
+                label = "Primary label very very very very very very very very very very very very very very very very very long text",
+                toggleControl = StandardToggleChipToggleControl.Switch
+            )
+        }
+    }
+
+    @Test
+    fun withIconAndLongText() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardToggleChip(
+                checked = true,
+                onCheckedChange = { },
+                label = "Primary label very very very very very very very very very very very very very very very very very long text",
+                toggleControl = StandardToggleChipToggleControl.Switch,
+                icon = Icons.Default.Image
+            )
+        }
+    }
+
+    @Test
+    fun withSecondaryLabelAndLongText() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardToggleChip(
+                checked = true,
+                onCheckedChange = { },
+                label = "Primary label very very very very very very very very long text",
+                secondaryLabel = "Secondary label very very very very very very very very very long text",
+                toggleControl = StandardToggleChipToggleControl.Switch
+            )
+        }
+    }
+
+    @Test
+    fun withIconAndSecondaryLabelAndLongText() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardToggleChip(
+                checked = true,
+                onCheckedChange = { },
+                label = "Primary label very very very very very very very very long text",
+                secondaryLabel = "Secondary label very very very very very very very very very long text",
+                toggleControl = StandardToggleChipToggleControl.Switch,
+                icon = Icons.Default.Image
+            )
+        }
+    }
+
+    @Test
+    fun usingSmallIcon() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardToggleChip(
+                checked = true,
+                onCheckedChange = { },
+                label = "Primary label",
+                toggleControl = StandardToggleChipToggleControl.Switch,
+                icon = Icon12dp
+            )
+        }
+    }
+
+    @Test
+    fun usingLargeIcon() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardToggleChip(
+                checked = true,
+                onCheckedChange = { },
+                label = "Primary label",
+                toggleControl = StandardToggleChipToggleControl.Switch,
+                icon = Icon32dp
+            )
+        }
+    }
+
+    companion object {
+
+        private val Icon12dp: ImageVector
+            get() = ImageVector.Builder(
+                name = "Icon Small",
+                defaultWidth = 12f.dp,
+                defaultHeight = 12f.dp,
+                viewportWidth = 12f,
+                viewportHeight = 12f
+            )
+                .materialPath {
+                    horizontalLineToRelative(12.0f)
+                    verticalLineToRelative(12.0f)
+                    horizontalLineTo(0.0f)
+                    close()
+                }
+                .build()
+
+        private val Icon32dp: ImageVector
+            get() = ImageVector.Builder(
+                name = "Icon Large",
+                defaultWidth = 32f.dp,
+                defaultHeight = 32f.dp,
+                viewportWidth = 32f,
+                viewportHeight = 32f
+            )
+                .materialPath {
+                    horizontalLineToRelative(32.0f)
+                    verticalLineToRelative(32.0f)
+                    horizontalLineTo(0.0f)
+                    close()
+                }
+                .build()
+    }
+}

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_checkbox.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_checkbox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:599b78da4510bd81e626d7c994b67cbe10020075499a5312521c529f803bc6fd
+size 19902

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_disabled.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_disabled.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a7202ef5ba2fa4f16d7cda85f7847685763d00e53bee9f4083ae5f890302d37
+size 24980

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_radio.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_radio.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a53f14c9f289244fcfc282412c1567489f54802b81b4ae608a96d309b225d29
+size 20599

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_switch.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_switch.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07bc4c1f8a2eff88359a5b025891fb9e7a7a20fa18c747e5e2fde0efc420c5f0
+size 20058

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_usingLargeIcon.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_usingLargeIcon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c15debcacd5331d99c8eebc526373c50f7daa0846543e65730bcd7a080efdef5
+size 19721

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_usingSmallIcon.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_usingSmallIcon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c15debcacd5331d99c8eebc526373c50f7daa0846543e65730bcd7a080efdef5
+size 19721

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withIcon.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withIcon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ca9e4a5c14fa84004b872d7c154b48a89d92d7edd145d2d28423ae5a8b334a3
+size 19545

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withIconAndLongText.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withIconAndLongText.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3a0312ea3f36c27fe74cec071aac2ffc7a4afbc3f654f18eed87a0790f1f718
+size 35102

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withIconAndSecondaryLabelAndLongText.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withIconAndSecondaryLabelAndLongText.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c80e01d8b329a9fa88a874beed003e9992a32774f5eac14c323a82558715cbbb
+size 36025

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withLongText.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withLongText.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb3fde1dbe43fd84808b06a739686b3e4384debd7ecfedb7c82a418acfd7774b
+size 36888

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withSecondaryLabel.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withSecondaryLabel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26d1578886e9a82050b327bbe9e504e284e7fd79b64d8011a7344eebb0e035bf
+size 23838

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withSecondaryLabelAndIcon.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withSecondaryLabelAndIcon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26d1578886e9a82050b327bbe9e504e284e7fd79b64d8011a7344eebb0e035bf
+size 23838

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withSecondaryLabelAndLongText.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withSecondaryLabelAndLongText.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a2714ebf02cddbc05c3e2e327ece8357526f3bbf5342441ebdcd747fbb0ac3f
+size 37805


### PR DESCRIPTION
#### WHAT

Add `StandardToggleChip`.

Variants preview:
<img width="541" alt="Screenshot 2023-05-16 at 17 47 31" src="https://github.com/google/horologist/assets/878134/0313638c-5b5b-4758-840e-c9b71da45f7b">

Overflow preview:
<img width="798" alt="Screenshot 2023-05-16 at 17 48 16" src="https://github.com/google/horologist/assets/878134/052ce99a-f983-4ee1-9dcf-442bbda751ba">


#### WHY

In order to have our base building blocks aligned with specs in Figma.

#### HOW

- Add implementation;
- Add previews in the debug folder;
- Add snapshot tests;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
