### PR TITLE
Improve StandardToggleChip to handle largest font scale

### DIFF
--- a/base-ui/api/current.api
+++ b/base-ui/api/current.api
@@ -71,7 +71,7 @@ package com.google.android.horologist.base.ui.components {
   }
 
   public final class StandardToggleChipKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void StandardToggleChip(boolean checked, kotlin.jvm.functions.Function1<? super java.lang.Boolean,kotlin.Unit> onCheckedChange, String label, com.google.android.horologist.base.ui.components.StandardToggleChipToggleControl toggleControl, optional androidx.compose.ui.Modifier modifier, optional androidx.compose.ui.graphics.vector.ImageVector? icon, optional String? secondaryLabel, optional androidx.wear.compose.material.ToggleChipColors colors, optional boolean enabled, optional androidx.compose.foundation.interaction.MutableInteractionSource interactionSource);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void StandardToggleChip(boolean checked, kotlin.jvm.functions.Function1<? super java.lang.Boolean,kotlin.Unit> onCheckedChanged, String label, com.google.android.horologist.base.ui.components.StandardToggleChipToggleControl toggleControl, optional androidx.compose.ui.Modifier modifier, optional androidx.compose.ui.graphics.vector.ImageVector? icon, optional String? secondaryLabel, optional androidx.wear.compose.material.ToggleChipColors colors, optional boolean enabled, optional androidx.compose.foundation.interaction.MutableInteractionSource interactionSource);
   }
 
   public enum StandardToggleChipToggleControl {
@@ -106,6 +106,10 @@ package com.google.android.horologist.base.ui.util {
   public final class A11yKt {
     method public static String? getDECORATIVE_ELEMENT_CONTENT_DESCRIPTION();
     property public static final String? DECORATIVE_ELEMENT_CONTENT_DESCRIPTION;
+  }
+
+  public final class AdjustChipHeightToFontScaleKt {
+    method public static androidx.compose.ui.Modifier adjustChipHeightToFontScale(androidx.compose.ui.Modifier, float fontScale, optional float padding);
   }
 
   public final class RememberVectorPainterKt {

--- a/base-ui/build.gradle.kts
+++ b/base-ui/build.gradle.kts
@@ -113,6 +113,7 @@ dependencies {
 
     debugImplementation(libs.compose.ui.test.manifest)
 
+    testImplementation(libs.accompanist.testharness)
     testImplementation(libs.junit)
     testImplementation(libs.androidx.test.ext.ktx)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/StandardToggleChipOverflowPreview.kt
+++ b/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/StandardToggleChipOverflowPreview.kt
@@ -30,7 +30,24 @@ import androidx.compose.ui.tooling.preview.Preview
 fun StandardToggleChipOverflowPreviewWithLongText() {
     StandardToggleChip(
         checked = true,
-        onCheckedChange = { },
+        onCheckedChanged = { },
+        label = "Primary label very very very very very very very very very very very very very very very very very long text",
+        toggleControl = StandardToggleChipToggleControl.Switch
+    )
+}
+
+@Preview(
+    name = "With long text",
+    backgroundColor = 0xff000000,
+    showBackground = true,
+    fontScale = largestFontScale,
+    group = "Largest font scale"
+)
+@Composable
+fun StandardToggleChipOverflowPreviewWithLongTextAndLargestFontScale() {
+    StandardToggleChip(
+        checked = true,
+        onCheckedChanged = { },
         label = "Primary label very very very very very very very very very very very very very very very very very long text",
         toggleControl = StandardToggleChipToggleControl.Switch
     )
@@ -45,7 +62,25 @@ fun StandardToggleChipOverflowPreviewWithLongText() {
 fun StandardToggleChipOverflowPreviewWithIconAndLongText() {
     StandardToggleChip(
         checked = true,
-        onCheckedChange = { },
+        onCheckedChanged = { },
+        label = "Primary label very very very very very very very very very very very very very very very very very long text",
+        toggleControl = StandardToggleChipToggleControl.Switch,
+        icon = Icons.Default.Image
+    )
+}
+
+@Preview(
+    name = "With icon and long text",
+    backgroundColor = 0xff000000,
+    showBackground = true,
+    fontScale = largestFontScale,
+    group = "Largest font scale"
+)
+@Composable
+fun StandardToggleChipOverflowPreviewWithIconAndLongTextAndLargestFontScale() {
+    StandardToggleChip(
+        checked = true,
+        onCheckedChanged = { },
         label = "Primary label very very very very very very very very very very very very very very very very very long text",
         toggleControl = StandardToggleChipToggleControl.Switch,
         icon = Icons.Default.Image
@@ -61,7 +96,25 @@ fun StandardToggleChipOverflowPreviewWithIconAndLongText() {
 fun StandardToggleChipOverflowPreviewWithSecondaryLabelAndLongText() {
     StandardToggleChip(
         checked = true,
-        onCheckedChange = { },
+        onCheckedChanged = { },
+        label = "Primary label very very very very very very very very long text",
+        secondaryLabel = "Secondary label very very very very very very very very very long text",
+        toggleControl = StandardToggleChipToggleControl.Switch
+    )
+}
+
+@Preview(
+    name = "With secondary label and long text",
+    backgroundColor = 0xff000000,
+    showBackground = true,
+    fontScale = largestFontScale,
+    group = "Largest font scale"
+)
+@Composable
+fun StandardToggleChipOverflowPreviewWithSecondaryLabelAndLongTextAndLargestFontScale() {
+    StandardToggleChip(
+        checked = true,
+        onCheckedChanged = { },
         label = "Primary label very very very very very very very very long text",
         secondaryLabel = "Secondary label very very very very very very very very very long text",
         toggleControl = StandardToggleChipToggleControl.Switch
@@ -77,10 +130,31 @@ fun StandardToggleChipOverflowPreviewWithSecondaryLabelAndLongText() {
 fun StandardToggleChipOverflowPreviewWithIconAndSecondaryLabelAndLongText() {
     StandardToggleChip(
         checked = true,
-        onCheckedChange = { },
+        onCheckedChanged = { },
         label = "Primary label very very very very very very very very long text",
         secondaryLabel = "Secondary label very very very very very very very very very long text",
         toggleControl = StandardToggleChipToggleControl.Switch,
         icon = Icons.Default.Image
     )
 }
+
+@Preview(
+    name = "With icon, secondary label and long text",
+    backgroundColor = 0xff000000,
+    showBackground = true,
+    fontScale = largestFontScale,
+    group = "Largest font scale"
+)
+@Composable
+fun StandardToggleChipOverflowPreviewWithIconAndSecondaryLabelAndLongTextAndLargestFontScale() {
+    StandardToggleChip(
+        checked = true,
+        onCheckedChanged = { },
+        label = "Primary label very very very very very very very very long text",
+        secondaryLabel = "Secondary label very very very very very very very very very long text",
+        toggleControl = StandardToggleChipToggleControl.Switch,
+        icon = Icons.Default.Image
+    )
+}
+
+private const val largestFontScale = 1.18f

--- a/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/StandardToggleChipVariantsPreview.kt
+++ b/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/StandardToggleChipVariantsPreview.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.tooling.preview.Preview
 fun StandardToggleChipSwitchPreview() {
     StandardToggleChip(
         checked = true,
-        onCheckedChange = { },
+        onCheckedChanged = { },
         label = "Primary label",
         toggleControl = StandardToggleChipToggleControl.Switch
     )
@@ -43,7 +43,7 @@ fun StandardToggleChipSwitchPreview() {
 fun StandardToggleChipRadioPreview() {
     StandardToggleChip(
         checked = true,
-        onCheckedChange = { },
+        onCheckedChanged = { },
         label = "Primary label",
         toggleControl = StandardToggleChipToggleControl.Radio
     )
@@ -57,9 +57,23 @@ fun StandardToggleChipRadioPreview() {
 fun StandardToggleChipCheckboxPreview() {
     StandardToggleChip(
         checked = true,
-        onCheckedChange = { },
+        onCheckedChanged = { },
         label = "Primary label",
         toggleControl = StandardToggleChipToggleControl.Checkbox
+    )
+}
+
+@Preview(
+    backgroundColor = 0xff000000,
+    showBackground = true
+)
+@Composable
+fun StandardToggleChipUncheckedPreview() {
+    StandardToggleChip(
+        checked = false,
+        onCheckedChanged = { },
+        label = "Primary label",
+        toggleControl = StandardToggleChipToggleControl.Switch
     )
 }
 
@@ -72,7 +86,7 @@ fun StandardToggleChipCheckboxPreview() {
 fun StandardToggleChipWithSecondaryLabel() {
     StandardToggleChip(
         checked = true,
-        onCheckedChange = { },
+        onCheckedChanged = { },
         label = "Primary label",
         toggleControl = StandardToggleChipToggleControl.Switch,
         secondaryLabel = "Secondary label"
@@ -88,7 +102,7 @@ fun StandardToggleChipWithSecondaryLabel() {
 fun StandardToggleChipPreviewWithIcon() {
     StandardToggleChip(
         checked = true,
-        onCheckedChange = { },
+        onCheckedChanged = { },
         label = "Primary label",
         toggleControl = StandardToggleChipToggleControl.Switch,
         icon = Icons.Default.Image
@@ -104,7 +118,7 @@ fun StandardToggleChipPreviewWithIcon() {
 fun StandardToggleChipPreviewWithSecondaryLabelAndIcon() {
     StandardToggleChip(
         checked = true,
-        onCheckedChange = { },
+        onCheckedChanged = { },
         label = "Primary label",
         toggleControl = StandardToggleChipToggleControl.Switch,
         secondaryLabel = "Secondary label"
@@ -120,7 +134,22 @@ fun StandardToggleChipPreviewWithSecondaryLabelAndIcon() {
 fun StandardToggleChipPreviewDisabled() {
     StandardToggleChip(
         checked = true,
-        onCheckedChange = { },
+        onCheckedChanged = { },
+        label = "Primary label",
+        toggleControl = StandardToggleChipToggleControl.Switch,
+        enabled = false
+    )
+}
+
+@Preview(
+    backgroundColor = 0xff000000,
+    showBackground = true
+)
+@Composable
+fun StandardToggleChipUncheckedAndDisabledPreview() {
+    StandardToggleChip(
+        checked = false,
+        onCheckedChanged = { },
         label = "Primary label",
         toggleControl = StandardToggleChipToggleControl.Switch,
         enabled = false

--- a/base-ui/src/main/java/com/google/android/horologist/base/ui/components/StandardToggleChip.kt
+++ b/base-ui/src/main/java/com/google/android/horologist/base/ui/components/StandardToggleChip.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -40,6 +41,7 @@ import androidx.wear.compose.material.ToggleChipDefaults
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.base.ui.R
 import com.google.android.horologist.base.ui.util.DECORATIVE_ELEMENT_CONTENT_DESCRIPTION
+import com.google.android.horologist.base.ui.util.adjustChipHeightToFontScale
 
 /**
  * This composable fulfils the redlines of the following components:
@@ -49,7 +51,7 @@ import com.google.android.horologist.base.ui.util.DECORATIVE_ELEMENT_CONTENT_DES
 @Composable
 public fun StandardToggleChip(
     checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit,
+    onCheckedChanged: (Boolean) -> Unit,
     label: String,
     toggleControl: StandardToggleChipToggleControl,
     modifier: Modifier = Modifier,
@@ -60,14 +62,13 @@ public fun StandardToggleChip(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
 ) {
     val hasSecondaryLabel = secondaryLabel != null
-    val hasIcon = icon != null
 
     val labelParam: (@Composable RowScope.() -> Unit) =
         {
             Text(
                 text = label,
                 modifier = Modifier.fillMaxWidth(),
-                textAlign = if (hasSecondaryLabel || hasIcon) TextAlign.Left else TextAlign.Center,
+                textAlign = TextAlign.Left,
                 overflow = TextOverflow.Ellipsis,
                 maxLines = if (hasSecondaryLabel) 1 else 2
             )
@@ -118,10 +119,12 @@ public fun StandardToggleChip(
 
     ToggleChip(
         checked = checked,
-        onCheckedChange = onCheckedChange,
+        onCheckedChange = onCheckedChanged,
         label = labelParam,
         toggleControl = toggleControlParam,
-        modifier = modifier,
+        modifier = modifier
+            .adjustChipHeightToFontScale(LocalConfiguration.current.fontScale)
+            .fillMaxWidth(),
         appIcon = iconParam,
         secondaryLabel = secondaryLabelParam,
         colors = colors,

--- a/base-ui/src/main/java/com/google/android/horologist/base/ui/util/AdjustChipHeightToFontScale.kt
+++ b/base-ui/src/main/java/com/google/android/horologist/base/ui/util/AdjustChipHeightToFontScale.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.base.ui.util
+
+import androidx.compose.foundation.layout.height
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/** Adjusts height of the chip as per the font scale. */
+public fun Modifier.adjustChipHeightToFontScale(fontScale: Float, padding: Dp = 0.dp): Modifier =
+    if (fontScale > 1.06) {
+        this.then(Modifier.height(60.dp + padding))
+    } else {
+        this
+    }

--- a/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardToggleChipTest.kt
+++ b/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardToggleChipTest.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.materialPath
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
+import com.google.accompanist.testharness.TestHarness
 import com.google.android.horologist.screenshots.ScreenshotBaseTest
 import org.junit.Test
 
@@ -31,7 +32,7 @@ class StandardToggleChipTest : ScreenshotBaseTest() {
         screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
             StandardToggleChip(
                 checked = true,
-                onCheckedChange = { },
+                onCheckedChanged = { },
                 label = "Primary label",
                 toggleControl = StandardToggleChipToggleControl.Switch
             )
@@ -43,7 +44,7 @@ class StandardToggleChipTest : ScreenshotBaseTest() {
         screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
             StandardToggleChip(
                 checked = true,
-                onCheckedChange = { },
+                onCheckedChanged = { },
                 label = "Primary label",
                 toggleControl = StandardToggleChipToggleControl.Radio
             )
@@ -55,9 +56,21 @@ class StandardToggleChipTest : ScreenshotBaseTest() {
         screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
             StandardToggleChip(
                 checked = true,
-                onCheckedChange = { },
+                onCheckedChanged = { },
                 label = "Primary label",
                 toggleControl = StandardToggleChipToggleControl.Checkbox
+            )
+        }
+    }
+
+    @Test
+    fun unchecked() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardToggleChip(
+                checked = false,
+                onCheckedChanged = { },
+                label = "Primary label",
+                toggleControl = StandardToggleChipToggleControl.Switch
             )
         }
     }
@@ -67,7 +80,7 @@ class StandardToggleChipTest : ScreenshotBaseTest() {
         screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
             StandardToggleChip(
                 checked = true,
-                onCheckedChange = { },
+                onCheckedChanged = { },
                 label = "Primary label",
                 toggleControl = StandardToggleChipToggleControl.Switch,
                 secondaryLabel = "Secondary label"
@@ -80,7 +93,7 @@ class StandardToggleChipTest : ScreenshotBaseTest() {
         screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
             StandardToggleChip(
                 checked = true,
-                onCheckedChange = { },
+                onCheckedChanged = { },
                 label = "Primary label",
                 toggleControl = StandardToggleChipToggleControl.Switch,
                 icon = Icons.Default.Image
@@ -93,7 +106,7 @@ class StandardToggleChipTest : ScreenshotBaseTest() {
         screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
             StandardToggleChip(
                 checked = true,
-                onCheckedChange = { },
+                onCheckedChanged = { },
                 label = "Primary label",
                 toggleControl = StandardToggleChipToggleControl.Switch,
                 secondaryLabel = "Secondary label"
@@ -106,7 +119,20 @@ class StandardToggleChipTest : ScreenshotBaseTest() {
         screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
             StandardToggleChip(
                 checked = true,
-                onCheckedChange = { },
+                onCheckedChanged = { },
+                label = "Primary label",
+                toggleControl = StandardToggleChipToggleControl.Switch,
+                enabled = false
+            )
+        }
+    }
+
+    @Test
+    fun uncheckedAndDisabled() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardToggleChip(
+                checked = false,
+                onCheckedChanged = { },
                 label = "Primary label",
                 toggleControl = StandardToggleChipToggleControl.Switch,
                 enabled = false
@@ -119,10 +145,24 @@ class StandardToggleChipTest : ScreenshotBaseTest() {
         screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
             StandardToggleChip(
                 checked = true,
-                onCheckedChange = { },
+                onCheckedChanged = { },
                 label = "Primary label very very very very very very very very very very very very very very very very very long text",
                 toggleControl = StandardToggleChipToggleControl.Switch
             )
+        }
+    }
+
+    @Test
+    fun withLongTextAndLargestFontScale() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            TestHarness(fontScale = largestFontScale) {
+                StandardToggleChip(
+                    checked = true,
+                    onCheckedChanged = { },
+                    label = "Primary label very very very very very very very very very very very very very very very very very long text",
+                    toggleControl = StandardToggleChipToggleControl.Switch
+                )
+            }
         }
     }
 
@@ -131,7 +171,7 @@ class StandardToggleChipTest : ScreenshotBaseTest() {
         screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
             StandardToggleChip(
                 checked = true,
-                onCheckedChange = { },
+                onCheckedChanged = { },
                 label = "Primary label very very very very very very very very very very very very very very very very very long text",
                 toggleControl = StandardToggleChipToggleControl.Switch,
                 icon = Icons.Default.Image
@@ -140,11 +180,26 @@ class StandardToggleChipTest : ScreenshotBaseTest() {
     }
 
     @Test
+    fun withIconAndLongTextAndLargestFontScale() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            TestHarness(fontScale = largestFontScale) {
+                StandardToggleChip(
+                    checked = true,
+                    onCheckedChanged = { },
+                    label = "Primary label very very very very very very very very very very very very very very very very very long text",
+                    toggleControl = StandardToggleChipToggleControl.Switch,
+                    icon = Icons.Default.Image
+                )
+            }
+        }
+    }
+
+    @Test
     fun withSecondaryLabelAndLongText() {
         screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
             StandardToggleChip(
                 checked = true,
-                onCheckedChange = { },
+                onCheckedChanged = { },
                 label = "Primary label very very very very very very very very long text",
                 secondaryLabel = "Secondary label very very very very very very very very very long text",
                 toggleControl = StandardToggleChipToggleControl.Switch
@@ -153,11 +208,26 @@ class StandardToggleChipTest : ScreenshotBaseTest() {
     }
 
     @Test
+    fun withSecondaryLabelAndLongTextAndLargestFontScale() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            TestHarness(fontScale = largestFontScale) {
+                StandardToggleChip(
+                    checked = true,
+                    onCheckedChanged = { },
+                    label = "Primary label very very very very very very very very long text",
+                    secondaryLabel = "Secondary label very very very very very very very very very long text",
+                    toggleControl = StandardToggleChipToggleControl.Switch
+                )
+            }
+        }
+    }
+
+    @Test
     fun withIconAndSecondaryLabelAndLongText() {
         screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
             StandardToggleChip(
                 checked = true,
-                onCheckedChange = { },
+                onCheckedChanged = { },
                 label = "Primary label very very very very very very very very long text",
                 secondaryLabel = "Secondary label very very very very very very very very very long text",
                 toggleControl = StandardToggleChipToggleControl.Switch,
@@ -167,11 +237,27 @@ class StandardToggleChipTest : ScreenshotBaseTest() {
     }
 
     @Test
+    fun withIconAndSecondaryLabelAndLongTextAndLargestFontScale() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            TestHarness(fontScale = largestFontScale) {
+                StandardToggleChip(
+                    checked = true,
+                    onCheckedChanged = { },
+                    label = "Primary label very very very very very very very very long text",
+                    secondaryLabel = "Secondary label very very very very very very very very very long text",
+                    toggleControl = StandardToggleChipToggleControl.Switch,
+                    icon = Icons.Default.Image
+                )
+            }
+        }
+    }
+
+    @Test
     fun usingSmallIcon() {
         screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
             StandardToggleChip(
                 checked = true,
-                onCheckedChange = { },
+                onCheckedChanged = { },
                 label = "Primary label",
                 toggleControl = StandardToggleChipToggleControl.Switch,
                 icon = Icon12dp
@@ -184,7 +270,7 @@ class StandardToggleChipTest : ScreenshotBaseTest() {
         screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
             StandardToggleChip(
                 checked = true,
-                onCheckedChange = { },
+                onCheckedChanged = { },
                 label = "Primary label",
                 toggleControl = StandardToggleChipToggleControl.Switch,
                 icon = Icon32dp
@@ -193,6 +279,7 @@ class StandardToggleChipTest : ScreenshotBaseTest() {
     }
 
     companion object {
+        private const val largestFontScale = 1.18f
 
         private val Icon12dp: ImageVector
             get() = ImageVector.Builder(

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_checkbox.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_checkbox.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:599b78da4510bd81e626d7c994b67cbe10020075499a5312521c529f803bc6fd
-size 19902
+oid sha256:7cbb4af8253db89cef1c873a6e035adf9f94f5f2cc7e23f7745c894d50bd171a
+size 28569

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_disabled.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_disabled.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4a7202ef5ba2fa4f16d7cda85f7847685763d00e53bee9f4083ae5f890302d37
-size 24980
+oid sha256:ebb69988b561faa290040fcdefeaca8501971a10fb0e3293b2f28dccc337350d
+size 34083

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_radio.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_radio.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0a53f14c9f289244fcfc282412c1567489f54802b81b4ae608a96d309b225d29
-size 20599
+oid sha256:53f01b1aba24eb4b52b456fcf983a31177c0c51766c6c08dd1c3e7f652e8d9af
+size 29407

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_switch.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_switch.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:07bc4c1f8a2eff88359a5b025891fb9e7a7a20fa18c747e5e2fde0efc420c5f0
-size 20058
+oid sha256:645f5df2a2cf1c92708a0d617c870307c29acd312fb85ada867fac4a90998a86
+size 28655

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_unchecked.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_unchecked.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c95b0b60e6dd7c63a3f8f130598dff69843bb979ea61f5daf26799667e8604e7
+size 7048

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_uncheckedAndDisabled.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_uncheckedAndDisabled.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba60d008494e1d6aee0784f10e0df02fa18015bedb43bb17b11f1c94a5612392
+size 9411

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_usingLargeIcon.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_usingLargeIcon.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c15debcacd5331d99c8eebc526373c50f7daa0846543e65730bcd7a080efdef5
-size 19721
+oid sha256:6a59286bdc382c3c9d4eb5cdbc8f54ceb114782b11ae494bef45d7fc06238b1c
+size 29023

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_usingSmallIcon.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_usingSmallIcon.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c15debcacd5331d99c8eebc526373c50f7daa0846543e65730bcd7a080efdef5
-size 19721
+oid sha256:6a59286bdc382c3c9d4eb5cdbc8f54ceb114782b11ae494bef45d7fc06238b1c
+size 29023

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withIcon.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withIcon.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5ca9e4a5c14fa84004b872d7c154b48a89d92d7edd145d2d28423ae5a8b334a3
-size 19545
+oid sha256:c0e787eaf469fd5b0a1faae743595588eed1a74031bb45017cf6a5543bd3e4bb
+size 28801

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withIconAndLongTextAndLargestFontScale.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withIconAndLongTextAndLargestFontScale.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c537aff233bd7127a9b72e86ec09b4a8a42e5f655725329f3a66127281d50150
+size 38039

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withIconAndSecondaryLabelAndLongTextAndLargestFontScale.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withIconAndSecondaryLabelAndLongTextAndLargestFontScale.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80de6fb00ded86473f9bf47a4c7834bc79d171ab62767844d3ed8f578ddc1dbd
+size 39370

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withLongText.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withLongText.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cb3fde1dbe43fd84808b06a739686b3e4384debd7ecfedb7c82a418acfd7774b
-size 36888
+oid sha256:d4f69e3a8efa6876771aa1e9906c66f8cd4026dd264afc7dec43242e25ee947b
+size 37274

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withLongTextAndLargestFontScale.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withLongTextAndLargestFontScale.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d8dee4833231c2c53a1c37e2dee99e3bd3ff69b5db1dfe85cb11e9d565ac0b0
+size 40332

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withSecondaryLabel.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withSecondaryLabel.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:26d1578886e9a82050b327bbe9e504e284e7fd79b64d8011a7344eebb0e035bf
-size 23838
+oid sha256:8e84fe572f8c62dea86ff2c8540774cc62a6a9cecf91f6a0a42e1f05de0901c1
+size 32558

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withSecondaryLabelAndIcon.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withSecondaryLabelAndIcon.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:26d1578886e9a82050b327bbe9e504e284e7fd79b64d8011a7344eebb0e035bf
-size 23838
+oid sha256:8e84fe572f8c62dea86ff2c8540774cc62a6a9cecf91f6a0a42e1f05de0901c1
+size 32558

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withSecondaryLabelAndLongTextAndLargestFontScale.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardToggleChipTest_withSecondaryLabelAndLongTextAndLargestFontScale.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c217667441a622f84d8873b5f0bfb8d6d1fa89efb928c94904f04030da040cae
+size 41424

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+accompanist = "0.31.2-alpha"
 androidx-benchmark = "1.2.0-alpha14"
 androidx-complications-data = "1.2.0-alpha08"
 androidx-compose-material = "1.5.0-alpha04"
@@ -60,6 +61,7 @@ versionCatalogUpdate = "0.8.0"
 wearcompose = "1.2.0-alpha10"
 
 [libraries]
+accompanist-testharness = { module = "com.google.accompanist:accompanist-testharness", version.ref = "accompanist" }
 android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "gradlePlugin" }
 android-tools-build-gradle = { module = "com.android.tools.build:gradle", version.ref = "gradlePlugin" }
 androidx-activity = { module = "androidx.activity:activity", version.ref = "androidxActivity" }


### PR DESCRIPTION
#### WHAT

Improve `StandardToggleChip` to handle largest font scale.

![Screenshot 2023-05-16 at 20 23 34](https://github.com/google/horologist/assets/878134/e24e6a87-97bc-4c29-88ba-7439bd633183)


#### WHY

So it won't clip the text when user is using largest font scale.

#### HOW

- Increase the size of the chip when the font scale is bigger than the threshold;
- Add tests and previews with largest font scale;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
