### PR TITLE
Additional macrobenchmark improvements

### DIFF
--- a/media/benchmark/api/current.api
+++ b/media/benchmark/api/current.api
@@ -5,11 +5,13 @@ package com.google.android.horologist.media.benchmark {
     ctor public BaseMediaBaselineProfile();
     method public suspend Object? checkPlayingState(androidx.media3.session.MediaBrowser mediaController, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method @org.junit.Rule public final androidx.benchmark.macro.junit4.BaselineProfileRule getBaselineRule();
+    method @org.junit.Rule public final androidx.test.rule.GrantPermissionRule getGrantPermissionRule();
     method public abstract com.google.android.horologist.media.benchmark.MediaApp getMediaApp();
     method public void onStartup(androidx.benchmark.macro.MacrobenchmarkScope);
     method @org.junit.Test public final void profile();
     method @org.junit.Before public final void setUp();
     property @org.junit.Rule public final androidx.benchmark.macro.junit4.BaselineProfileRule baselineRule;
+    property @org.junit.Rule public final androidx.test.rule.GrantPermissionRule grantPermissionRule;
     property public abstract com.google.android.horologist.media.benchmark.MediaApp mediaApp;
   }
 
@@ -17,6 +19,7 @@ package com.google.android.horologist.media.benchmark {
     ctor public BasePlaybackBenchmark();
     method public suspend Object? checkPlayingState(androidx.media3.session.MediaBrowser mediaController, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method @org.junit.Rule public final androidx.benchmark.macro.junit4.MacrobenchmarkRule getBenchmarkRule();
+    method @org.junit.Rule public final androidx.test.rule.GrantPermissionRule getGrantPermissionRule();
     method public abstract com.google.android.horologist.media.benchmark.MediaApp getMediaApp();
     method public final com.google.common.util.concurrent.ListenableFuture<androidx.media3.session.MediaBrowser> getMediaControllerFuture();
     method public java.util.List<androidx.benchmark.macro.Metric> metrics();
@@ -24,6 +27,7 @@ package com.google.android.horologist.media.benchmark {
     method public final void setMediaControllerFuture(com.google.common.util.concurrent.ListenableFuture<androidx.media3.session.MediaBrowser>);
     method @org.junit.Test public final void startup();
     property @org.junit.Rule public final androidx.benchmark.macro.junit4.MacrobenchmarkRule benchmarkRule;
+    property @org.junit.Rule public final androidx.test.rule.GrantPermissionRule grantPermissionRule;
     property public abstract com.google.android.horologist.media.benchmark.MediaApp mediaApp;
     property public final com.google.common.util.concurrent.ListenableFuture<androidx.media3.session.MediaBrowser> mediaControllerFuture;
     field public com.google.common.util.concurrent.ListenableFuture<androidx.media3.session.MediaBrowser> mediaControllerFuture;
@@ -67,6 +71,15 @@ package com.google.android.horologist.media.benchmark {
   public final class MediaItems {
     method public androidx.media3.common.MediaItem buildMediaItem(String id, String mediaUri, String? artworkUri, String title, String artist);
     field public static final com.google.android.horologist.media.benchmark.MediaItems INSTANCE;
+  }
+
+}
+
+package com.google.android.horologist.media.benchmark.metrics {
+
+  public final class CompositionMetric extends androidx.benchmark.macro.TraceMetric {
+    ctor public CompositionMetric(String composable);
+    method public java.util.List<androidx.benchmark.macro.Metric.Measurement> getResult(androidx.benchmark.macro.Metric.CaptureInfo captureInfo, androidx.benchmark.perfetto.PerfettoTraceProcessor.Session traceSession);
   }
 
 }

--- a/media/benchmark/src/main/java/com/google/android/horologist/media/benchmark/BaseMediaBaselineProfile.kt
+++ b/media/benchmark/src/main/java/com/google/android/horologist/media/benchmark/BaseMediaBaselineProfile.kt
@@ -16,11 +16,13 @@
 
 package com.google.android.horologist.media.benchmark
 
+import android.Manifest
 import androidx.benchmark.macro.MacrobenchmarkScope
 import androidx.benchmark.macro.junit4.BaselineProfileRule
 import androidx.media3.session.MediaBrowser
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.UiDevice
 import com.google.android.horologist.media.benchmark.MediaControllerHelper.startPlaying
 import com.google.android.horologist.media.benchmark.MediaControllerHelper.stopPlaying
@@ -46,6 +48,8 @@ import kotlin.time.Duration.Companion.seconds
 // rules that are specific to classes and methods in your own app and library code.
 @RunWith(AndroidJUnit4::class)
 public abstract class BaseMediaBaselineProfile {
+    @get:Rule
+    public val grantPermissionRule: GrantPermissionRule = GrantPermissionRule.grant(Manifest.permission.POST_NOTIFICATIONS)
 
     @get:Rule
     public val baselineRule: BaselineProfileRule = BaselineProfileRule()

--- a/media/benchmark/src/main/java/com/google/android/horologist/media/benchmark/BasePlaybackBenchmark.kt
+++ b/media/benchmark/src/main/java/com/google/android/horologist/media/benchmark/BasePlaybackBenchmark.kt
@@ -18,6 +18,7 @@
 
 package com.google.android.horologist.media.benchmark
 
+import android.Manifest
 import androidx.benchmark.macro.CompilationMode
 import androidx.benchmark.macro.ExperimentalMetricApi
 import androidx.benchmark.macro.FrameTimingMetric
@@ -28,6 +29,7 @@ import androidx.benchmark.macro.StartupMode
 import androidx.benchmark.macro.junit4.MacrobenchmarkRule
 import androidx.media3.session.MediaBrowser
 import androidx.test.filters.LargeTest
+import androidx.test.rule.GrantPermissionRule
 import com.google.android.horologist.media.benchmark.MediaControllerHelper.startPlaying
 import com.google.android.horologist.media.benchmark.MediaControllerHelper.stopPlaying
 import com.google.common.util.concurrent.ListenableFuture
@@ -41,6 +43,8 @@ import kotlin.time.Duration.Companion.seconds
 
 @LargeTest
 public abstract class BasePlaybackBenchmark {
+    @get:Rule
+    public val grantPermissionRule: GrantPermissionRule = GrantPermissionRule.grant(Manifest.permission.POST_NOTIFICATIONS)
 
     @get:Rule
     public val benchmarkRule: MacrobenchmarkRule = MacrobenchmarkRule()

--- a/media/benchmark/src/main/java/com/google/android/horologist/media/benchmark/metrics/CompositionMetric.kt
+++ b/media/benchmark/src/main/java/com/google/android/horologist/media/benchmark/metrics/CompositionMetric.kt
@@ -44,7 +44,8 @@ public class CompositionMetric(private val composable: String) : TraceMetric() {
         ).map { it.long("dur") }
 
         return listOf(
-            Measurement("${shortName}RecomposeDurMs",
+            Measurement(
+                "${shortName}RecomposeDurMs",
                 durationsNs.sumOf { it }.nanoseconds.toDouble(DurationUnit.MILLISECONDS)
             ),
             Measurement("${shortName}RecomposeCount", durationsNs.count().toDouble())

--- a/media/benchmark/src/main/java/com/google/android/horologist/media/benchmark/metrics/CompositionMetric.kt
+++ b/media/benchmark/src/main/java/com/google/android/horologist/media/benchmark/metrics/CompositionMetric.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalMetricApi::class, ExperimentalPerfettoTraceProcessorApi::class)
+
+package com.google.android.horologist.media.benchmark.metrics
+
+import androidx.benchmark.macro.ExperimentalMetricApi
+import androidx.benchmark.macro.TraceMetric
+import androidx.benchmark.perfetto.ExperimentalPerfettoTraceProcessorApi
+import androidx.benchmark.perfetto.PerfettoTraceProcessor
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.DurationUnit
+
+public class CompositionMetric(private val composable: String) : TraceMetric() {
+    override fun getResult(
+        captureInfo: CaptureInfo,
+        traceSession: PerfettoTraceProcessor.Session
+    ): List<Measurement> {
+        val shortName = composable.substringAfterLast(".")
+
+        val durationsNs = traceSession.query(
+            """
+                SELECT * FROM slice
+                    INNER JOIN thread_track on slice.track_id = thread_track.id
+                    INNER JOIN thread USING(utid)
+                    INNER JOIN process USING(upid)
+                WHERE process.name LIKE "${captureInfo.targetPackageName}"
+                    AND slice.name LIKE "$composable (%)"
+            """.trimIndent()
+        ).map { it.long("dur") }
+
+        return listOf(
+            Measurement("${shortName}RecomposeDurMs",
+                durationsNs.sumOf { it }.nanoseconds.toDouble(DurationUnit.MILLISECONDS)
+            ),
+            Measurement("${shortName}RecomposeCount", durationsNs.count().toDouble())
+        )
+    }
+}

--- a/media/sample-benchmark/build.gradle.kts
+++ b/media/sample-benchmark/build.gradle.kts
@@ -39,6 +39,7 @@ android {
         targetSdk = 33
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments["androidx.benchmark.fullTracing.enable"] = "true"
     }
 
     buildTypes {

--- a/media/sample-benchmark/src/main/java/com/google/android/horologist/mediasample/benchmark/MarqueeBenchmark.kt
+++ b/media/sample-benchmark/src/main/java/com/google/android/horologist/mediasample/benchmark/MarqueeBenchmark.kt
@@ -33,6 +33,7 @@ import androidx.test.filters.LargeTest
 import com.google.android.horologist.media.benchmark.MediaApp
 import com.google.android.horologist.media.benchmark.MediaControllerHelper
 import com.google.android.horologist.media.benchmark.MediaItems.buildMediaItem
+import com.google.android.horologist.media.benchmark.metrics.CompositionMetric
 import com.google.common.util.concurrent.ListenableFuture
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -152,6 +153,7 @@ class MarqueeBenchmark {
     public open fun metrics(): List<Metric> = listOfNotNull(
         StartupTimingMetric(),
         FrameTimingMetric(),
-        if (includePower) PowerMetric(type = PowerMetric.Type.Battery()) else null
+        if (includePower) PowerMetric(type = PowerMetric.Type.Battery()) else null,
+        CompositionMetric("androidx.compose.foundation.Canvas")
     )
 }


### PR DESCRIPTION
#### WHAT

- use permission rule
- add in compose runtime tracing

```
MarqueeBenchmark_noMarquee
CanvasRecomposeCount   min    55.0,   median    55.0,   max    55.0
CanvasRecomposeDurMs   min     8.3,   median     8.3,   max     8.3
timeToFullDisplayMs   min 1,064.4,   median 1,064.4,   max 1,064.4
timeToInitialDisplayMs   min    68.0,   median    68.0,   max    68.0
frameDurationCpuMs   P50     19.2,   P90     50.4,   P95     87.1,   P99    197.1
```

#### WHY

Debugging compositions in UI

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
