### PR TITLE
Add loadingContent param to SignInPromptScreen

### DIFF
--- a/auth/ui/api/current.api
+++ b/auth/ui/api/current.api
@@ -16,7 +16,7 @@ package com.google.android.horologist.auth.ui.common.logging {
 package com.google.android.horologist.auth.ui.common.screens.prompt {
 
   public final class SignInPromptScreenKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void SignInPromptScreen(String message, kotlin.jvm.functions.Function1<? super com.google.android.horologist.auth.composables.model.AccountUiModel,kotlin.Unit> onAlreadySignedIn, com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, optional androidx.compose.ui.Modifier modifier, optional String title, optional com.google.android.horologist.auth.ui.common.screens.prompt.SignInPromptViewModel viewModel, kotlin.jvm.functions.Function1<? super androidx.wear.compose.foundation.lazy.ScalingLazyListScope,kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void SignInPromptScreen(String message, kotlin.jvm.functions.Function1<? super com.google.android.horologist.auth.composables.model.AccountUiModel,kotlin.Unit> onAlreadySignedIn, com.google.android.horologist.compose.layout.ScalingLazyColumnState columnState, optional androidx.compose.ui.Modifier modifier, optional String title, optional com.google.android.horologist.auth.ui.common.screens.prompt.SignInPromptViewModel viewModel, optional kotlin.jvm.functions.Function0<kotlin.Unit> loadingContent, kotlin.jvm.functions.Function1<? super androidx.wear.compose.foundation.lazy.ScalingLazyListScope,kotlin.Unit> content);
   }
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public abstract sealed class SignInPromptScreenState {

--- a/auth/ui/src/debug/java/com/google/android/horologist/auth/composables/screens/SignInPromptScreenPreview.kt
+++ b/auth/ui/src/debug/java/com/google/android/horologist/auth/composables/screens/SignInPromptScreenPreview.kt
@@ -16,7 +16,10 @@
 
 package com.google.android.horologist.auth.composables.screens
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.wear.compose.material.Text
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import com.google.android.horologist.auth.composables.chips.GuestModeChip
 import com.google.android.horologist.auth.composables.chips.SignInChip
@@ -61,6 +64,37 @@ fun SignInPromptScreenPreviewLoading() {
         onIdleStateObserved = { },
         onAlreadySignedIn = { },
         columnState = belowTimeTextPreview()
+    ) {
+        item {
+            SignInChip(
+                onClick = { },
+                chipType = StandardChipType.Secondary
+            )
+        }
+        item {
+            GuestModeChip(
+                onClick = { },
+                chipType = StandardChipType.Secondary
+            )
+        }
+    }
+}
+
+@WearPreviewDevices
+@Composable
+fun SignInPromptScreenPreviewCustomLoading() {
+    SignInPromptScreen(
+        state = SignInPromptScreenState.Loading,
+        title = "Sign in",
+        message = "Send messages and create chat groups with your friends",
+        onIdleStateObserved = { },
+        onAlreadySignedIn = { },
+        columnState = belowTimeTextPreview(),
+        loadingContent = {
+            Box(contentAlignment = Alignment.Center) {
+                Text("Loading...")
+            }
+        }
     ) {
         item {
             SignInChip(

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptScreen.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptScreen.kt
@@ -65,6 +65,7 @@ public fun SignInPromptScreen(
     modifier: Modifier = Modifier,
     title: String = stringResource(id = R.string.horologist_signin_prompt_title),
     viewModel: SignInPromptViewModel = viewModel(),
+    loadingContent: @Composable () -> Unit = { SignInPlaceholderScreen(modifier = modifier) },
     content: ScalingLazyListScope.() -> Unit
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -76,6 +77,7 @@ public fun SignInPromptScreen(
         onIdleStateObserved = { viewModel.onIdleStateObserved() },
         onAlreadySignedIn = onAlreadySignedIn,
         columnState = columnState,
+        loadingContent = loadingContent,
         modifier = modifier,
         content = content
     )
@@ -90,6 +92,7 @@ internal fun SignInPromptScreen(
     onAlreadySignedIn: (account: AccountUiModel) -> Unit,
     columnState: ScalingLazyColumnState,
     modifier: Modifier = Modifier,
+    loadingContent: @Composable () -> Unit = { SignInPlaceholderScreen(modifier = modifier) },
     content: ScalingLazyListScope.() -> Unit
 ) {
     when (state) {
@@ -98,11 +101,11 @@ internal fun SignInPromptScreen(
                 onIdleStateObserved()
             }
 
-            SignInPlaceholderScreen(modifier = modifier)
+            loadingContent()
         }
 
         SignInPromptScreenState.Loading -> {
-            SignInPlaceholderScreen(modifier = modifier)
+            loadingContent()
         }
 
         is SignInPromptScreenState.SignedIn -> {

--- a/auth/ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptScreenTest.kt
+++ b/auth/ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptScreenTest.kt
@@ -16,18 +16,23 @@
 
 package com.google.android.horologist.auth.ui.common.screens.prompt
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.wear.compose.foundation.lazy.ScalingLazyListScope
+import androidx.wear.compose.material.Text
 import com.google.android.horologist.auth.composables.chips.GuestModeChip
 import com.google.android.horologist.auth.composables.chips.SignInChip
 import com.google.android.horologist.auth.composables.model.AccountUiModel
 import com.google.android.horologist.base.ui.components.StandardChipType
 import com.google.android.horologist.screenshots.ScreenshotBaseTest
-import com.google.android.horologist.screenshots.ScreenshotTestRule
+import com.google.android.horologist.screenshots.ScreenshotTestRule.Companion.screenshotTestRuleParams
 import com.google.android.horologist.test.toolbox.composables.positionedState
 import org.junit.Test
 
 class SignInPromptScreenTest : ScreenshotBaseTest(
-    ScreenshotTestRule.screenshotTestRuleParams {
+    screenshotTestRuleParams {
         screenTimeText = {}
     }
 ) {
@@ -58,6 +63,27 @@ class SignInPromptScreenTest : ScreenshotBaseTest(
                 onIdleStateObserved = { },
                 onAlreadySignedIn = { },
                 columnState = positionedState(0, 0)
+            ) {
+                testContent()
+            }
+        }
+    }
+
+    @Test
+    fun customLoading() {
+        screenshotTestRule.setContent(takeScreenshot = true) {
+            SignInPromptScreen(
+                state = SignInPromptScreenState.Loading,
+                title = "Sign in",
+                message = "Send messages and create chat groups with your friends",
+                onIdleStateObserved = { },
+                onAlreadySignedIn = { },
+                columnState = positionedState(0, 0),
+                loadingContent = {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text("Loading...")
+                    }
+                }
             ) {
                 testContent()
             }

--- a/auth/ui/src/test/snapshots/images/com.google.android.horologist.auth.ui.common.screens.prompt_SignInPromptScreenTest_customLoading.png
+++ b/auth/ui/src/test/snapshots/images/com.google.android.horologist.auth.ui.common.screens.prompt_SignInPromptScreenTest_customLoading.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ee0aad220836811990b89580185301da322166de081668a140dfe9ac520c459
+size 10596


### PR DESCRIPTION
#### WHAT

Add `loadingContent` param to `SignInPromptScreen`.


#### WHY

Allow custom content for the loading state.


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
