### PR TITLE
Increase timeout of nightly builds

### DIFF
--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
#### WHAT

Increase timeout of nightly builds.

#### WHY

Builds are failing with:

```
The job running on runner GitHub Actions 100 has exceeded the maximum execution time of 30 minutes.
```

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [N/A] Run tests
- [N/A] Update metalava's signature text files
