### PR TITLE
Add base-ui to the list of modules for translation

### DIFF
--- a/localization.bzl
+++ b/localization.bzl
@@ -3,6 +3,7 @@ List of files that are part of the automated translation pipeline
 """
 localized_files = [
     "auth/composables/src/main/res/values/strings.xml",
+    "base-ui/src/main/res/values/strings.xml",
     "composables/src/main/res/values/strings.xml",
     "media/audio-ui/src/main/res/values/strings.xml",
     "media/ui/src/main/res/values/strings.xml",


### PR DESCRIPTION
#### WHAT

Add `base-ui` to the list of modules for translation.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [N/A] Run tests
- [N/A] Update metalava's signature text files
