### PR TITLE
Avoid rounding the progress to 0 so that the progress does not go away

### DIFF
--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/components/animated/AnimatedPlayPauseButton.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/components/animated/AnimatedPlayPauseButton.kt
@@ -320,13 +320,14 @@ private fun CircularProgressIndicatorFast(
     }
 }
 
-/** Rounds the progress to avoid producing too many UI updates. */
 private fun roundProgress(progress: Float, progressSteps: Int) = if (progress == 0f) {
     0f
 } else {
-    (floor(
-        progress * progressSteps
-    ) / progressSteps).coerceIn(0.001f..1f)
+    (
+        floor(
+            progress * progressSteps
+        ) / progressSteps
+        ).coerceIn(0.001f..1f)
 }
 
 private fun DrawScope.drawCircularIndicator(

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/components/animated/AnimatedPlayPauseButton.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/components/animated/AnimatedPlayPauseButton.kt
@@ -286,7 +286,9 @@ private fun CircularProgressIndicatorFast(
             .focusable()
     ) {
         val backgroundSweep = 360f - ((startAngle - endAngle) % 360 + 360) % 360
-        val progressSweep = backgroundSweep * truncatedProgress.coerceIn(0f..1f)
+        // Coerce the progress, avoiding rounding to 0 so that the progress bar does not disappear.
+        val progressSweep =
+            backgroundSweep * (if (progress.value == 0f) 0f else truncatedProgress.coerceIn(0.001f..1f))
         // Draw a background
         drawCircularIndicator(
             startAngle,

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/components/animated/AnimatedPlayPauseButton.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/components/animated/AnimatedPlayPauseButton.kt
@@ -77,6 +77,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlin.math.floor
 import kotlin.math.min
+import kotlin.math.roundToInt
 
 @Composable
 public fun AnimatedPlayPauseButton(
@@ -271,10 +272,24 @@ private fun CircularProgressIndicatorFast(
     tapTargetSize: DpSize
 ) {
     val progressSteps = with(LocalDensity.current) {
-        tapTargetSize.width.toPx() * Math.PI
+        (tapTargetSize.width.toPx() * Math.PI).roundToInt()
     }
-    val truncatedProgress by remember { derivedStateOf { (floor(progress.value * progressSteps) / progressSteps).toFloat() } }
-    val semanticsProgress by remember { derivedStateOf { (floor(progress.value * 100) / 100) } }
+    val truncatedProgress by remember {
+        derivedStateOf {
+            roundProgress(
+                progress = progress.value,
+                progressSteps = progressSteps
+            )
+        }
+    }
+    val semanticsProgress by remember {
+        derivedStateOf {
+            roundProgress(
+                progress = progress.value,
+                progressSteps = 100
+            )
+        }
+    }
 
     val stroke = with(LocalDensity.current) {
         Stroke(width = strokeWidth.toPx(), cap = StrokeCap.Round)
@@ -286,9 +301,7 @@ private fun CircularProgressIndicatorFast(
             .focusable()
     ) {
         val backgroundSweep = 360f - ((startAngle - endAngle) % 360 + 360) % 360
-        // Coerce the progress, avoiding rounding to 0 so that the progress bar does not disappear.
-        val progressSweep =
-            backgroundSweep * (if (progress.value == 0f) 0f else truncatedProgress.coerceIn(0.001f..1f))
+        val progressSweep = backgroundSweep * truncatedProgress
         // Draw a background
         drawCircularIndicator(
             startAngle,
@@ -305,6 +318,14 @@ private fun CircularProgressIndicatorFast(
             stroke
         )
     }
+}
+
+private fun roundProgress(progress: Float, progressSteps: Int) = if (progress == 0f) {
+    0f
+} else {
+    (floor(
+        progress * progressSteps
+    ) / progressSteps).coerceIn(0.001f..1f)
 }
 
 private fun DrawScope.drawCircularIndicator(

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/components/animated/AnimatedPlayPauseButton.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/components/animated/AnimatedPlayPauseButton.kt
@@ -320,6 +320,7 @@ private fun CircularProgressIndicatorFast(
     }
 }
 
+/** Rounds the progress to avoid producing too many UI updates. */
 private fun roundProgress(progress: Float, progressSteps: Int) = if (progress == 0f) {
     0f
 } else {


### PR DESCRIPTION
#### WHAT
Make sure the drawn progress is at least 0.1% if it was rounded from a non-zero value.

#### WHY
This ensures that the progress bar does not go away if the progress is non-zero bug very small.

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
