### PR TITLE
Fix dependencies of compose-layout

### DIFF
--- a/compose-layout/build.gradle.kts
+++ b/compose-layout/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
     id("org.jetbrains.dokka")
     id("org.jetbrains.kotlin.kapt")
     id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.dependencyAnalysis)
     kotlin("android")
 }
 
@@ -90,33 +91,56 @@ metalava {
 dependencies {
     api(projects.annotations)
 
+    api(libs.androidx.lifecycle.common)
+    api(libs.androidx.lifecycle.viewmodel)
+    api(libs.androidx.lifecycle.viewmodel.savedstate)
+    api(libs.androidx.navigation.common)
+    api(libs.androidx.navigation.runtime)
+    api(libs.androidx.paging)
+    api(libs.compose.foundation.foundation)
+    api(libs.compose.foundation.foundation.layout)
+    api(libs.compose.runtime)
+    api(libs.compose.ui)
     api(libs.wearcompose.material)
     api(libs.wearcompose.foundation)
     api(libs.wearcompose.navigation)
 
-    api(libs.androidx.lifecycle.runtime.compose)
-    api(libs.androidx.paging)
-
-    implementation(libs.kotlin.stdlib)
-    implementation(libs.compose.ui.tooling)
-    implementation(libs.compose.ui.util)
-    implementation(libs.androidx.wear)
+    implementation(libs.androidx.core)
+    implementation(libs.androidx.lifecycle.runtime)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
-    implementation(libs.compose.ui.toolingpreview)
+    implementation(libs.compose.animation)
+    implementation(libs.compose.runtime.saveable)
+    implementation(libs.compose.ui.graphics)
+    implementation(libs.compose.ui.text)
+    implementation(libs.compose.ui.unit)
+    implementation(libs.compose.ui.util)
+    implementation(libs.kotlin.stdlib)
 
-    implementation(libs.androidx.navigation.compose)
-    implementation(libs.androidx.navigation.ui.ktx)
+    debugApi(libs.kotlinx.coroutines.core)
+    debugApi(libs.wearcompose.tooling)
 
-    debugImplementation(libs.compose.ui.tooling)
-    debugImplementation(projects.composeTools)
-    debugImplementation(libs.androidx.activity.compose)
-    debugImplementation(libs.compose.ui.test.manifest)
+    debugRuntimeOnly(libs.compose.ui.test.manifest)
 
-    testImplementation(libs.junit)
-    testImplementation(libs.truth)
+    releaseApi(libs.kotlinx.coroutines.core)
+
+    testImplementation(libs.androidx.test.runner)
+    testImplementation(libs.compose.ui.geometry)
     testImplementation(libs.compose.ui.test.junit4)
-    testImplementation(libs.espresso.core)
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.robolectric)
+    testImplementation(libs.robolectric.annotations)
+    testImplementation(libs.truth)
+}
+
+dependencyAnalysis {
+    issues {
+        onAny {
+            severity("fail")
+            exclude(":annotations") // bug: reported as unused
+        }
+    }
 }
 
 apply(plugin = "com.vanniktech.maven.publish")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,6 +90,7 @@ androidx-lifecycle-testing = { module = "androidx.lifecycle:lifecycle-runtime-te
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidxLifecycle" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
 androidx-lifecycle-viewmodelktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidxLifecycle" }
+androidx-lifecycle-viewmodel-savedstate = { module = "androidx.lifecycle:lifecycle-viewmodel-savedstate", version.ref = "androidxLifecycle" }
 androidx-media3-common = { module = "androidx.media3:media3-common", version.ref = "androidx-media3" }
 androidx-media3-datasourceokhttp = { module = "androidx.media3:media3-datasource-okhttp", version.ref = "androidx-media3" }
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "androidx-media3" }
@@ -102,9 +103,11 @@ androidx-media3-testutils = { module = "androidx.media3:media3-test-utils", vers
 androidx-media3-testutils-robolectric = { module = "androidx.media3:media3-test-utils-robolectric", version.ref = "androidx-media3" }
 androidx-mediarouter = "androidx.mediarouter:mediarouter:1.4.0"
 androidx-metrics-performance = "androidx.metrics:metrics-performance:1.0.0-alpha04"
+androidx-navigation-common = { module = "androidx.navigation:navigation-common", version.ref = "androidxNavigation" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidxNavigation" }
-androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidxNavigation" }
+androidx-navigation-runtime = { module = "androidx.navigation:navigation-runtime", version.ref = "androidxNavigation" }
 androidx-navigation-testing = { module = "androidx.navigation:navigation-testing", version.ref = "androidxNavigation" }
+androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidxNavigation" }
 androidx-paging = "androidx.paging:paging-compose:1.0.0-alpha20"
 androidx-palette-ktx = "androidx.palette:palette-ktx:1.0.0"
 androidx-runtime-tracing = { module = "androidx.compose.runtime:runtime-tracing", version.ref = "runtimeTracing" }
@@ -113,6 +116,7 @@ androidx-test-espressocore = { module = "androidx.test.espresso:espresso-core", 
 androidx-test-ext = { module = "androidx.test.ext:junit", version.ref = "androidx-test-ext" }
 androidx-test-ext-ktx = { module = "androidx.test.ext:junit-ktx", version.ref = "androidx-test-ext" }
 androidx-test-rules = "androidx.test:rules:1.5.0"
+androidx-test-runner = "androidx.test:runner:1.6.0-alpha01"
 androidx-test-uiautomator = "androidx.test.uiautomator:uiautomator:2.2.0"
 androidx-tracing-ktx = { module = "androidx.tracing:tracing-ktx", version.ref = "androidxTracing" }
 androidx-tracing-perfetto = { module = "androidx.tracing:tracing-perfetto", version.ref = "androidx-tracingPerfetto" }
@@ -132,13 +136,16 @@ coil-svg = { module = "io.coil-kt:coil-svg", version.ref = "io-coil-kt" }
 com-squareup-okhttp3-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "com-squareup-okhttp3" }
 com-squareup-okhttp3-okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "com-squareup-okhttp3" }
 compose-bom = "androidx.compose:compose-bom:2023.05.01"
+compose-animation = { module = "androidx.compose.animation:animation-core", version.ref = "androidx-compose-material" }
 compose-foundation-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidx-compose-material" }
 compose-foundation-foundation-layout = { module = "androidx.compose.foundation:foundation-layout", version.ref = "androidx-compose-material" }
 compose-material-iconscore = { module = "androidx.compose.material:material-icons-core", version.ref = "androidx-compose-material" }
 compose-material-iconsext = { module = "androidx.compose.material:material-icons-extended", version.ref = "androidx-compose-material" }
 compose-material3 = { module = "androidx.compose.material3:material3" }
 compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
+compose-runtime-saveable = { module = "androidx.compose.runtime:runtime-saveable", version.ref = "compose" }
 compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
+compose-ui-geometry = { module = "androidx.compose.ui:ui-geometry", version.ref = "compose" }
 compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics", version.ref = "compose" }
 compose-ui-test = { module = "androidx.compose.ui:ui-test", version.ref = "compose" }
 compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
@@ -182,6 +189,7 @@ protobuf-kotlin-lite = { module = "com.google.protobuf:protobuf-kotlin-lite", ve
 retrofit2-convertermoshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "com-squareup-retrofit2" }
 retrofit2-retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "com-squareup-retrofit2" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "org-robolectric" }
+robolectric-annotations = { module = "org.robolectric:annotations", version.ref = "org-robolectric" }
 robolectric-shadows = { module = "org.robolectric:shadows-framework", version.ref = "org-robolectric" }
 room-common = { module = "androidx.room:room-common", version.ref = "room" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }

--- a/media/sample/build.gradle.kts
+++ b/media/sample/build.gradle.kts
@@ -181,6 +181,7 @@ dependencies {
 
     implementation(libs.androidx.corektx)
     implementation(libs.androidx.lifecycle.runtime)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.wear.tiles)

--- a/media/ui/build.gradle.kts
+++ b/media/ui/build.gradle.kts
@@ -112,6 +112,7 @@ dependencies {
     implementation(libs.kotlin.stdlib)
     implementation(libs.androidx.wear)
     implementation(libs.androidx.lifecycle.runtime)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodelktx)
     api(libs.wearcompose.material)
     api(libs.wearcompose.foundation)

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -156,6 +156,7 @@ dependencies {
 
     implementation(libs.androidx.corektx)
     implementation(libs.androidx.lifecycle.runtime)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.wear.tiles)


### PR DESCRIPTION
#### WHAT

Fix dependencies of `compose-layout` module.

> **Warning**
> Projects that were using `compose-layout` for intransitive dependencies, like `collectAsStateWithLifecycle`, will need to add `androidx.lifecycle:lifecycle-runtime-compose` as dependency.

#### WHY

Follow up on https://github.com/google/horologist/issues/1106

#### HOW

- Run task from [dependency analysis](https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin) plugin and address issues;

- Change configuration of the sub project to fail in case of any issues;

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
