### PR TITLE
Add Coroutines Guava dependency to Tiles module

### DIFF
--- a/tiles/build.gradle.kts
+++ b/tiles/build.gradle.kts
@@ -107,6 +107,7 @@ dependencies {
     api(libs.androidx.wear.tiles)
     api(libs.androidx.wear.protolayout.material)
     api(libs.androidx.lifecycle.service)
+    api(libs.kotlinx.coroutines.guava) // it is part of SuspendingTileService API
 
     implementation(libs.coil)
     implementation(libs.wearcompose.foundation)


### PR DESCRIPTION
#### WHAT

Add `kotlinx-coroutines-guava` dependency to `tiles` module.

#### WHY

In order to avoid issues like reported in https://github.com/google/horologist/issues/1320

#### HOW

Add dependency with `api` configuration.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
