### PR TITLE
Ignore flaky tests

### DIFF
--- a/datalayer/src/androidTest/java/com/google/android/horologist/data/WearLocalDataStoreTest.kt
+++ b/datalayer/src/androidTest/java/com/google/android/horologist/data/WearLocalDataStoreTest.kt
@@ -37,10 +37,12 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestName
 
+@Ignore("https://github.com/google/horologist/issues/1191")
 class WearLocalDataStoreTest {
 
     @get:Rule


### PR DESCRIPTION
#### WHAT

Ignore flaky tests reported in https://github.com/google/horologist/issues/1191


#### WHY

In order to get green builds in CI until these are fixed.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
