### PR TITLE
Add StandardSplitToggleChip

### DIFF
--- a/base-ui/api/current.api
+++ b/base-ui/api/current.api
@@ -6,6 +6,18 @@ package com.google.android.horologist.base.ui {
 
 }
 
+package com.google.android.horologist.base.ui.common {
+
+  public enum StandardToggleChipToggleControl {
+    method public static com.google.android.horologist.base.ui.common.StandardToggleChipToggleControl valueOf(String name) throws java.lang.IllegalArgumentException;
+    method public static com.google.android.horologist.base.ui.common.StandardToggleChipToggleControl[] values();
+    enum_constant public static final com.google.android.horologist.base.ui.common.StandardToggleChipToggleControl Checkbox;
+    enum_constant public static final com.google.android.horologist.base.ui.common.StandardToggleChipToggleControl Radio;
+    enum_constant public static final com.google.android.horologist.base.ui.common.StandardToggleChipToggleControl Switch;
+  }
+
+}
+
 package com.google.android.horologist.base.ui.components {
 
   public final class AlertDialogKt {
@@ -70,16 +82,12 @@ package com.google.android.horologist.base.ui.components {
     method @androidx.compose.runtime.Composable public static void StandardIcon(androidx.compose.ui.graphics.vector.ImageVector imageVector, String? contentDescription, optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.base.ui.components.IconRtlMode rtlMode);
   }
 
-  public final class StandardToggleChipKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void StandardToggleChip(boolean checked, kotlin.jvm.functions.Function1<? super java.lang.Boolean,kotlin.Unit> onCheckedChanged, String label, com.google.android.horologist.base.ui.components.StandardToggleChipToggleControl toggleControl, optional androidx.compose.ui.Modifier modifier, optional androidx.compose.ui.graphics.vector.ImageVector? icon, optional String? secondaryLabel, optional androidx.wear.compose.material.ToggleChipColors colors, optional boolean enabled, optional androidx.compose.foundation.interaction.MutableInteractionSource interactionSource);
+  public final class StandardSplitToggleChipKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void StandardSplitToggleChip(boolean checked, kotlin.jvm.functions.Function1<? super java.lang.Boolean,kotlin.Unit> onCheckedChanged, String label, kotlin.jvm.functions.Function0<kotlin.Unit> onClick, com.google.android.horologist.base.ui.common.StandardToggleChipToggleControl toggleControl, optional androidx.compose.ui.Modifier modifier, optional String? secondaryLabel, optional androidx.wear.compose.material.SplitToggleChipColors colors, optional boolean enabled, optional androidx.compose.foundation.interaction.MutableInteractionSource checkedInteractionSource, optional androidx.compose.foundation.interaction.MutableInteractionSource clickInteractionSource);
   }
 
-  public enum StandardToggleChipToggleControl {
-    method public static com.google.android.horologist.base.ui.components.StandardToggleChipToggleControl valueOf(String name) throws java.lang.IllegalArgumentException;
-    method public static com.google.android.horologist.base.ui.components.StandardToggleChipToggleControl[] values();
-    enum_constant public static final com.google.android.horologist.base.ui.components.StandardToggleChipToggleControl Checkbox;
-    enum_constant public static final com.google.android.horologist.base.ui.components.StandardToggleChipToggleControl Radio;
-    enum_constant public static final com.google.android.horologist.base.ui.components.StandardToggleChipToggleControl Switch;
+  public final class StandardToggleChipKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void StandardToggleChip(boolean checked, kotlin.jvm.functions.Function1<? super java.lang.Boolean,kotlin.Unit> onCheckedChanged, String label, com.google.android.horologist.base.ui.common.StandardToggleChipToggleControl toggleControl, optional androidx.compose.ui.Modifier modifier, optional androidx.compose.ui.graphics.vector.ImageVector? icon, optional String? secondaryLabel, optional androidx.wear.compose.material.ToggleChipColors colors, optional boolean enabled, optional androidx.compose.foundation.interaction.MutableInteractionSource interactionSource);
   }
 
   public final class TitleKt {

--- a/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/StandardSplitToggleChipOverflowPreview.kt
+++ b/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/StandardSplitToggleChipOverflowPreview.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.base.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.google.android.horologist.base.ui.common.StandardToggleChipToggleControl
+import com.google.android.horologist.base.ui.utils.FontScaleUtils.largestFontScale
+
+@Preview(
+    name = "With long text",
+    backgroundColor = 0xff000000,
+    showBackground = true
+)
+@Composable
+fun StandardSplitToggleChipOverflowPreviewWithLongText() {
+    StandardSplitToggleChip(
+        checked = true,
+        onCheckedChanged = { },
+        label = "Primary label very very very very very very very very very very very very very very very very very long text",
+        onClick = { },
+        toggleControl = StandardToggleChipToggleControl.Switch
+    )
+}
+
+@Preview(
+    name = "With long text",
+    backgroundColor = 0xff000000,
+    showBackground = true,
+    fontScale = largestFontScale,
+    group = "Largest font scale"
+)
+@Composable
+fun StandardSplitToggleChipOverflowPreviewWithLongTextAndLargestFontScale() {
+    StandardSplitToggleChip(
+        checked = true,
+        onCheckedChanged = { },
+        label = "Primary label very very very very very very very very very very very very very very very very very long text",
+        onClick = { },
+        toggleControl = StandardToggleChipToggleControl.Switch
+    )
+}
+
+@Preview(
+    name = "With secondary label and long text",
+    backgroundColor = 0xff000000,
+    showBackground = true
+)
+@Composable
+fun StandardSplitToggleChipOverflowPreviewWithSecondaryLabelAndLongText() {
+    StandardSplitToggleChip(
+        checked = true,
+        onCheckedChanged = { },
+        label = "Primary label very very very very very very very very long text",
+        onClick = { },
+        toggleControl = StandardToggleChipToggleControl.Switch,
+        secondaryLabel = "Secondary label very very very very very very very very very long text"
+    )
+}
+
+@Preview(
+    name = "With secondary label and long text",
+    backgroundColor = 0xff000000,
+    showBackground = true,
+    fontScale = largestFontScale,
+    group = "Largest font scale"
+)
+@Composable
+fun StandardSplitToggleChipOverflowPreviewWithSecondaryLabelAndLongTextAndLargestFontScale() {
+    StandardSplitToggleChip(
+        checked = true,
+        onCheckedChanged = { },
+        label = "Primary label very very very very very very very very long text",
+        onClick = { },
+        toggleControl = StandardToggleChipToggleControl.Switch,
+        secondaryLabel = "Secondary label very very very very very very very very very long text"
+    )
+}

--- a/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/StandardSplitToggleChipVariantsPreview.kt
+++ b/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/StandardSplitToggleChipVariantsPreview.kt
@@ -16,8 +16,6 @@
 
 package com.google.android.horologist.base.ui.components
 
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Image
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import com.google.android.horologist.base.ui.common.StandardToggleChipToggleControl
@@ -27,11 +25,12 @@ import com.google.android.horologist.base.ui.common.StandardToggleChipToggleCont
     showBackground = true
 )
 @Composable
-fun StandardToggleChipSwitchPreview() {
-    StandardToggleChip(
+fun StandardSplitToggleChipSwitchPreview() {
+    StandardSplitToggleChip(
         checked = true,
         onCheckedChanged = { },
         label = "Primary label",
+        onClick = { },
         toggleControl = StandardToggleChipToggleControl.Switch
     )
 }
@@ -41,11 +40,12 @@ fun StandardToggleChipSwitchPreview() {
     showBackground = true
 )
 @Composable
-fun StandardToggleChipRadioPreview() {
-    StandardToggleChip(
+fun StandardSplitToggleChipRadioPreview() {
+    StandardSplitToggleChip(
         checked = true,
         onCheckedChanged = { },
         label = "Primary label",
+        onClick = { },
         toggleControl = StandardToggleChipToggleControl.Radio
     )
 }
@@ -55,11 +55,12 @@ fun StandardToggleChipRadioPreview() {
     showBackground = true
 )
 @Composable
-fun StandardToggleChipCheckboxPreview() {
-    StandardToggleChip(
+fun StandardSplitToggleChipCheckboxPreview() {
+    StandardSplitToggleChip(
         checked = true,
         onCheckedChanged = { },
         label = "Primary label",
+        onClick = { },
         toggleControl = StandardToggleChipToggleControl.Checkbox
     )
 }
@@ -69,11 +70,12 @@ fun StandardToggleChipCheckboxPreview() {
     showBackground = true
 )
 @Composable
-fun StandardToggleChipUncheckedPreview() {
-    StandardToggleChip(
+fun StandardSplitToggleChipUncheckedPreview() {
+    StandardSplitToggleChip(
         checked = false,
         onCheckedChanged = { },
         label = "Primary label",
+        onClick = { },
         toggleControl = StandardToggleChipToggleControl.Switch
     )
 }
@@ -84,46 +86,14 @@ fun StandardToggleChipUncheckedPreview() {
     showBackground = true
 )
 @Composable
-fun StandardToggleChipWithSecondaryLabel() {
-    StandardToggleChip(
+fun StandardSplitToggleChipWithSecondaryLabel() {
+    StandardSplitToggleChip(
         checked = true,
         onCheckedChanged = { },
         label = "Primary label",
+        onClick = { },
         toggleControl = StandardToggleChipToggleControl.Switch,
         secondaryLabel = "Secondary label"
-    )
-}
-
-@Preview(
-    name = "With icon",
-    backgroundColor = 0xff000000,
-    showBackground = true
-)
-@Composable
-fun StandardToggleChipPreviewWithIcon() {
-    StandardToggleChip(
-        checked = true,
-        onCheckedChanged = { },
-        label = "Primary label",
-        toggleControl = StandardToggleChipToggleControl.Switch,
-        icon = Icons.Default.Image
-    )
-}
-
-@Preview(
-    name = "With secondary label and icon",
-    backgroundColor = 0xff000000,
-    showBackground = true
-)
-@Composable
-fun StandardToggleChipPreviewWithSecondaryLabelAndIcon() {
-    StandardToggleChip(
-        checked = true,
-        onCheckedChanged = { },
-        label = "Primary label",
-        toggleControl = StandardToggleChipToggleControl.Switch,
-        secondaryLabel = "Secondary label",
-        icon = Icons.Default.Image
     )
 }
 
@@ -133,11 +103,12 @@ fun StandardToggleChipPreviewWithSecondaryLabelAndIcon() {
     showBackground = true
 )
 @Composable
-fun StandardToggleChipPreviewDisabled() {
-    StandardToggleChip(
+fun StandardSplitToggleChipPreviewDisabled() {
+    StandardSplitToggleChip(
         checked = true,
         onCheckedChanged = { },
         label = "Primary label",
+        onClick = { },
         toggleControl = StandardToggleChipToggleControl.Switch,
         enabled = false
     )
@@ -148,11 +119,12 @@ fun StandardToggleChipPreviewDisabled() {
     showBackground = true
 )
 @Composable
-fun StandardToggleChipUncheckedAndDisabledPreview() {
-    StandardToggleChip(
+fun StandardSplitToggleChipUncheckedAndDisabledPreview() {
+    StandardSplitToggleChip(
         checked = false,
         onCheckedChanged = { },
         label = "Primary label",
+        onClick = { },
         toggleControl = StandardToggleChipToggleControl.Switch,
         enabled = false
     )

--- a/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/StandardToggleChipOverflowPreview.kt
+++ b/base-ui/src/debug/java/com/google/android/horologist/base/ui/components/StandardToggleChipOverflowPreview.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import com.google.android.horologist.base.ui.common.StandardToggleChipToggleControl
 import com.google.android.horologist.base.ui.utils.FontScaleUtils.largestFontScale
 
 @Preview(

--- a/base-ui/src/main/java/com/google/android/horologist/base/ui/common/StandardToggleChipToggleControl.kt
+++ b/base-ui/src/main/java/com/google/android/horologist/base/ui/common/StandardToggleChipToggleControl.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.base.ui.common
+
+public enum class StandardToggleChipToggleControl {
+    Switch, Radio, Checkbox
+}

--- a/base-ui/src/main/java/com/google/android/horologist/base/ui/components/StandardSplitToggleChip.kt
+++ b/base-ui/src/main/java/com/google/android/horologist/base/ui/components/StandardSplitToggleChip.kt
@@ -18,59 +18,54 @@ package com.google.android.horologist.base.ui.components
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.BoxScope
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.SplitToggleChip
+import androidx.wear.compose.material.SplitToggleChipColors
 import androidx.wear.compose.material.Text
-import androidx.wear.compose.material.ToggleChip
-import androidx.wear.compose.material.ToggleChipColors
 import androidx.wear.compose.material.ToggleChipDefaults
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.base.ui.R
 import com.google.android.horologist.base.ui.common.StandardToggleChipToggleControl
-import com.google.android.horologist.base.ui.util.DECORATIVE_ELEMENT_CONTENT_DESCRIPTION
 import com.google.android.horologist.base.ui.util.adjustChipHeightToFontScale
 
 /**
  * This composable fulfils the redlines of the following components:
- * - Toggle chips
+ * - SplitToggle chips
  */
+
 @ExperimentalHorologistApi
 @Composable
-public fun StandardToggleChip(
+public fun StandardSplitToggleChip(
     checked: Boolean,
     onCheckedChanged: (Boolean) -> Unit,
     label: String,
+    onClick: () -> Unit,
     toggleControl: StandardToggleChipToggleControl,
     modifier: Modifier = Modifier,
-    icon: ImageVector? = null,
     secondaryLabel: String? = null,
-    colors: ToggleChipColors = ToggleChipDefaults.toggleChipColors(),
+    colors: SplitToggleChipColors = ToggleChipDefaults.splitToggleChipColors(),
     enabled: Boolean = true,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
+    checkedInteractionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    clickInteractionSource: MutableInteractionSource = remember { MutableInteractionSource() }
 ) {
     val hasSecondaryLabel = secondaryLabel != null
 
     val labelParam: (@Composable RowScope.() -> Unit) =
         {
             Text(
+                modifier = Modifier.fillMaxWidth(),
                 text = label,
                 color = MaterialTheme.colors.onSurface,
-                modifier = Modifier.fillMaxWidth(),
                 textAlign = TextAlign.Left,
                 overflow = TextOverflow.Ellipsis,
                 maxLines = if (hasSecondaryLabel) 1 else 2,
@@ -91,7 +86,7 @@ public fun StandardToggleChip(
             }
         }
 
-    val toggleControlParam: (@Composable () -> Unit) = {
+    val toggleControlParam: (@Composable BoxScope.() -> Unit) = {
         Icon(
             imageVector = when (toggleControl) {
                 StandardToggleChipToggleControl.Switch -> ToggleChipDefaults.switchIcon(checked)
@@ -100,41 +95,27 @@ public fun StandardToggleChip(
             },
             contentDescription = stringResource(
                 if (checked) {
-                    R.string.horologist_standard_toggle_chip_on_content_description
+                    R.string.horologist_standard_split_toggle_chip_on_content_description
                 } else {
-                    R.string.horologist_standard_toggle_chip_off_content_description
+                    R.string.horologist_standard_split_toggle_chip_off_content_description
                 }
             )
         )
     }
 
-    val iconParam: (@Composable BoxScope.() -> Unit)? =
-        icon?.let {
-            {
-                Row {
-                    Icon(
-                        imageVector = icon,
-                        contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
-                        modifier = Modifier
-                            .size(ChipDefaults.IconSize)
-                            .clip(CircleShape)
-                    )
-                }
-            }
-        }
-
-    ToggleChip(
+    SplitToggleChip(
         checked = checked,
         onCheckedChange = onCheckedChanged,
         label = labelParam,
+        onClick = onClick,
         toggleControl = toggleControlParam,
         modifier = modifier
             .adjustChipHeightToFontScale(LocalConfiguration.current.fontScale)
             .fillMaxWidth(),
-        appIcon = iconParam,
         secondaryLabel = secondaryLabelParam,
         colors = colors,
         enabled = enabled,
-        interactionSource = interactionSource
+        checkedInteractionSource = checkedInteractionSource,
+        clickInteractionSource = clickInteractionSource
     )
 }

--- a/base-ui/src/main/res/values/strings.xml
+++ b/base-ui/src/main/res/values/strings.xml
@@ -17,4 +17,7 @@
 <resources>
     <string description="Content description of the StandardToggleChip. It lets the user know if the toggle is checked or not. [CHAR_LIMIT=NONE]" name="horologist_standard_toggle_chip_on_content_description">On</string>
     <string description="Content description of the StandardToggleChip. It lets the user know if the toggle is checked or not. [CHAR_LIMIT=NONE]" name="horologist_standard_toggle_chip_off_content_description">Off</string>
+
+    <string description="Content description of the StandardSplitToggleChip. It lets the user know if the toggle is checked or not. [CHAR_LIMIT=NONE]" name="horologist_standard_split_toggle_chip_on_content_description">On</string>
+    <string description="Content description of the StandardSplitToggleChip. It lets the user know if the toggle is checked or not. [CHAR_LIMIT=NONE]" name="horologist_standard_split_toggle_chip_off_content_description">Off</string>
 </resources>

--- a/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardSplitToggleChipTest.kt
+++ b/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardSplitToggleChipTest.kt
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.base.ui.components
+
+import com.google.accompanist.testharness.TestHarness
+import com.google.android.horologist.base.ui.common.StandardToggleChipToggleControl
+import com.google.android.horologist.screenshots.ScreenshotBaseTest
+import org.junit.Test
+
+class StandardSplitToggleChipTest : ScreenshotBaseTest() {
+
+    @Test
+    fun switch() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardSplitToggleChip(
+                checked = true,
+                onCheckedChanged = { },
+                label = "Primary label",
+                onClick = { },
+                toggleControl = StandardToggleChipToggleControl.Switch
+            )
+        }
+    }
+
+    @Test
+    fun radio() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardSplitToggleChip(
+                checked = true,
+                onCheckedChanged = { },
+                label = "Primary label",
+                onClick = { },
+                toggleControl = StandardToggleChipToggleControl.Radio
+            )
+        }
+    }
+
+    @Test
+    fun checkbox() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardSplitToggleChip(
+                checked = true,
+                onCheckedChanged = { },
+                label = "Primary label",
+                onClick = { },
+                toggleControl = StandardToggleChipToggleControl.Checkbox
+            )
+        }
+    }
+
+    @Test
+    fun unchecked() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardSplitToggleChip(
+                checked = false,
+                onCheckedChanged = { },
+                label = "Primary label",
+                onClick = { },
+                toggleControl = StandardToggleChipToggleControl.Switch
+            )
+        }
+    }
+
+    @Test
+    fun withSecondaryLabel() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardSplitToggleChip(
+                checked = true,
+                onCheckedChanged = { },
+                label = "Primary label",
+                onClick = { },
+                toggleControl = StandardToggleChipToggleControl.Switch,
+                secondaryLabel = "Secondary label"
+            )
+        }
+    }
+
+    @Test
+    fun disabled() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardSplitToggleChip(
+                checked = true,
+                onCheckedChanged = { },
+                label = "Primary label",
+                onClick = { },
+                toggleControl = StandardToggleChipToggleControl.Switch,
+                enabled = false
+            )
+        }
+    }
+
+    @Test
+    fun uncheckedAndDisabled() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardSplitToggleChip(
+                checked = false,
+                onCheckedChanged = { },
+                label = "Primary label",
+                onClick = { },
+                toggleControl = StandardToggleChipToggleControl.Switch,
+                enabled = false
+            )
+        }
+    }
+
+    @Test
+    fun withLongText() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardSplitToggleChip(
+                checked = true,
+                onCheckedChanged = { },
+                label = "Primary label very very very very very very very very very very very very very very very very very long text",
+                onClick = { },
+                toggleControl = StandardToggleChipToggleControl.Switch
+            )
+        }
+    }
+
+    @Test
+    fun withLongTextAndLargestFontScale() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            TestHarness(fontScale = largestFontScale) {
+                StandardSplitToggleChip(
+                    checked = true,
+                    onCheckedChanged = { },
+                    label = "Primary label very very very very very very very very very very very very very very very very very long text",
+                    onClick = { },
+                    toggleControl = StandardToggleChipToggleControl.Switch
+                )
+            }
+        }
+    }
+
+    @Test
+    fun withSecondaryLabelAndLongText() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardSplitToggleChip(
+                checked = true,
+                onCheckedChanged = { },
+                label = "Primary label very very very very very very very very long text",
+                onClick = { },
+                toggleControl = StandardToggleChipToggleControl.Switch,
+                secondaryLabel = "Secondary label very very very very very very very very very long text"
+            )
+        }
+    }
+
+    @Test
+    fun withSecondaryLabelAndLongTextAndLargestFontScale() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            TestHarness(fontScale = largestFontScale) {
+                StandardSplitToggleChip(
+                    checked = true,
+                    onCheckedChanged = { },
+                    label = "Primary label very very very very very very very very long text",
+                    onClick = { },
+                    toggleControl = StandardToggleChipToggleControl.Switch,
+                    secondaryLabel = "Secondary label very very very very very very very very very long text"
+                )
+            }
+        }
+    }
+
+    companion object {
+        private const val largestFontScale = 1.18f
+    }
+}

--- a/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardToggleChipTest.kt
+++ b/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardToggleChipTest.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.materialPath
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.testharness.TestHarness
+import com.google.android.horologist.base.ui.common.StandardToggleChipToggleControl
 import com.google.android.horologist.screenshots.ScreenshotBaseTest
 import org.junit.Test
 

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardSplitToggleChipTest_checkbox.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardSplitToggleChipTest_checkbox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f02d4547469cb0528b59f77443f607e1936a7cb10fe6a287b79fcd56546aa7b
+size 6850

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardSplitToggleChipTest_disabled.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardSplitToggleChipTest_disabled.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6aaaf81696ca84c785cb9318bb4ad9a5bde022baeab12f5b53e5843e4e0bc8f1
+size 7541

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardSplitToggleChipTest_radio.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardSplitToggleChipTest_radio.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:859733732ece72c481a3aaf5f42ead08d37fbef6a0e30917840995005a953328
+size 8113

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardSplitToggleChipTest_switch.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardSplitToggleChipTest_switch.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d464427c64b16c7846f22f362cd34f80c921ac02bc1d2b0e29c5fb3c3487f27
+size 7207

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardSplitToggleChipTest_unchecked.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardSplitToggleChipTest_unchecked.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b451b15f4d88f5402e571a57805628ee152a51ace55635b1ac9238d04dcf7aac
+size 7180

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardSplitToggleChipTest_uncheckedAndDisabled.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardSplitToggleChipTest_uncheckedAndDisabled.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c474a69a2e3298fb26e7e253c8c882aa314c055ad935a199bc712e16fe6d691
+size 7478

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardSplitToggleChipTest_withLongText.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardSplitToggleChipTest_withLongText.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0405c2c4406b00d790184f14f7cbef6d5d308e885389c4eda8ddb83bc80aec69
+size 9899

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardSplitToggleChipTest_withLongTextAndLargestFontScale.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardSplitToggleChipTest_withLongTextAndLargestFontScale.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33dc37c6326d5e50feeb69660840bb6a02103b68ac1c3633802672a502f9c4d3
+size 11243

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardSplitToggleChipTest_withSecondaryLabel.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardSplitToggleChipTest_withSecondaryLabel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7cda592bc176d21a4a490f171721994c97ced9373adddd9ce1a79ffaa9c54fd
+size 10785

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardSplitToggleChipTest_withSecondaryLabelAndLongText.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardSplitToggleChipTest_withSecondaryLabelAndLongText.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a296910f7e633817b953535932a22a8c33dbf575f595df3fce372c3818a83b87
+size 12332

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardSplitToggleChipTest_withSecondaryLabelAndLongTextAndLargestFontScale.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardSplitToggleChipTest_withSecondaryLabelAndLongTextAndLargestFontScale.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50620aaaf2f67d36df90887ff26bca7461bff206c74885ad86af830275217dcf
+size 13972


### PR DESCRIPTION
#### WHAT

- Added StandardSplitToggleChip component

#### WHY

- resolves https://github.com/google/horologist/issues/1318

#### HOW

- Implemented StandardSplitToggleChip, similar to StandardToggleChip
- Added previews to debug folder
- Added snapshot tests

#### Screenshots

**Variants preview**:

![image](https://github.com/google/horologist/assets/14975738/80f14e8d-ef38-4c2e-bf33-2601fc191b15)

Overflow preview:

![image](https://github.com/google/horologist/assets/14975738/c2d1af7e-4562-4be2-b583-8f94914513a4)


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
