### PR TITLE
Ignore flaky tests

### DIFF
--- a/network-awareness/core/src/androidTest/java/com/google/android/horologist/networks/NetworkRepositoryTest.kt
+++ b/network-awareness/core/src/androidTest/java/com/google/android/horologist/networks/NetworkRepositoryTest.kt
@@ -34,8 +34,10 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 
+@Ignore("https://github.com/google/horologist/issues/1191")
 @MediumTest
 class NetworkRepositoryTest {
     private lateinit var networkRepository: NetworkRepositoryImpl


### PR DESCRIPTION
#### WHAT

Ignore flaky tests reported in https://github.com/google/horologist/issues/1191


#### WHY

In order to get green builds in CI until these are fixed.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
