### PR TITLE
Split instrumentation tests

### DIFF
--- a/.github/workflows/android_test.yml
+++ b/.github/workflows/android_test.yml
@@ -6,10 +6,11 @@ on:
       - main
     paths-ignore:
       - '**.md'
+  pull_request: # TODO: REMOVE BEFORE MERGING
   workflow_dispatch:
 
 jobs:
-  test:
+  smalltest:
     runs-on: macos-latest
     timeout-minutes: 50
 
@@ -42,7 +43,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
-      - name: Run tests
+      - name: Run small tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
@@ -51,7 +52,7 @@ jobs:
           channel: beta
           arch: ${{ matrix.api-level == 33 && 'x86_64' || 'x86' }}
           emulator-options: -no-window -no-snapshot
-          script: ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=Microbenchmark -x media:benchmark:connectedDebugAndroidTest
+          script: ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.notAnnotation=androidx.test.filters.LargeTest -Pandroid.testInstrumentationRunnerArguments.notAnnotation=androidx.test.filters.MediumTest
 
       - name: Upload logs
         if: always()
@@ -69,3 +70,125 @@ jobs:
             **/build/reports/*
             **/build/outputs/*/connected/*
             **/out/failures/
+
+  mediumlargetest:
+    runs-on: macos-latest
+    timeout-minutes: 50
+
+    strategy:
+      # Allow tests to continue on other devices if they fail on one device.
+      fail-fast: false
+      matrix:
+        api-level: [ 30, 33 ]
+
+    env:
+      TERM: dumb
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          lfs: 'true'
+
+      - name: Install pulseaudio
+        run: brew install pulseaudio
+
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
+      - name: set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Run medium and large tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: android-wear
+          profile: wearos_large_round
+          channel: beta
+          arch: ${{ matrix.api-level == 33 && 'x86_64' || 'x86' }}
+          emulator-options: -no-window -no-snapshot
+          script: ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=androidx.test.filters.LargeTest -Pandroid.testInstrumentationRunnerArguments.annotation=androidx.test.filters.MediumTest
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs-${{ matrix.api-level }}-${{ matrix.shard }}
+          path: logcat.txt
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results-${{ matrix.api-level }}-${{ matrix.shard }}
+          path: |
+            **/build/reports/*
+            **/build/outputs/*/connected/*
+            **/out/failures/
+
+  benchmarktest:
+    runs-on: macos-latest
+    timeout-minutes: 50
+
+    strategy:
+      # Allow tests to continue on other devices if they fail on one device.
+      fail-fast: false
+      matrix:
+        api-level: [ 30, 33 ]
+
+    env:
+      TERM: dumb
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          lfs: 'true'
+
+      - name: Install pulseaudio
+        run: brew install pulseaudio
+
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
+      - name: set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Run benchmark tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: android-wear
+          profile: wearos_large_round
+          channel: beta
+          arch: ${{ matrix.api-level == 33 && 'x86_64' || 'x86' }}
+          emulator-options: -no-window -no-snapshot
+          script: ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.google.android.horologist.media.benchmark.BenchmarkTest -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=Microbenchmark -x media:benchmark:connectedDebugAndroidTest
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs-${{ matrix.api-level }}-${{ matrix.shard }}
+          path: logcat.txt
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results-${{ matrix.api-level }}-${{ matrix.shard }}
+          path: |
+            **/build/reports/*
+            **/build/outputs/*/connected/*
+            **/out/failures/            

--- a/media/benchmark/src/androidTest/java/com/google/android/horologist/media/benchmark/BaselineProfile.kt
+++ b/media/benchmark/src/androidTest/java/com/google/android/horologist/media/benchmark/BaselineProfile.kt
@@ -17,6 +17,7 @@
 package com.google.android.horologist.media.benchmark
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
 import org.junit.runner.RunWith
 
 // This test generates a baseline profile rules file that can be added to the app to configure
@@ -29,6 +30,8 @@ import org.junit.runner.RunWith
 // 3) Add the rules as androidMain/baseline-prof.txt
 // Note that Compose libraries have profile rules already so the main benefit is to add any
 // rules that are specific to classes and methods in your own app and library code.
+@BenchmarkTest
+@LargeTest
 @RunWith(AndroidJUnit4::class)
 class BaselineProfile : BaseMediaBaselineProfile() {
     override val mediaApp: MediaApp = TestMedia.MediaSampleApp

--- a/media/benchmark/src/androidTest/java/com/google/android/horologist/media/benchmark/BenchmarkTest.kt
+++ b/media/benchmark/src/androidTest/java/com/google/android/horologist/media/benchmark/BenchmarkTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalMacrobenchmarkApi::class)
-
 package com.google.android.horologist.media.benchmark
 
-import androidx.benchmark.macro.ExperimentalMacrobenchmarkApi
-import androidx.test.filters.LargeTest
-
-@BenchmarkTest
-@LargeTest
-class PlaybackBenchmark : BasePlaybackBenchmark() {
-    override val mediaApp: MediaApp = TestMedia.MediaSampleApp
-}
+@Retention(AnnotationRetention.RUNTIME)
+@Target(
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.ANNOTATION_CLASS,
+    AnnotationTarget.CLASS
+)
+public annotation class BenchmarkTest

--- a/media/benchmark/src/androidTest/java/com/google/android/horologist/media/benchmark/StartupBenchmark.kt
+++ b/media/benchmark/src/androidTest/java/com/google/android/horologist/media/benchmark/StartupBenchmark.kt
@@ -21,6 +21,7 @@ import androidx.test.filters.LargeTest
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
+@BenchmarkTest
 @LargeTest
 @RunWith(Parameterized::class)
 class StartupBenchmark(


### PR DESCRIPTION
#### WHAT

Split instrumentation tests.

#### WHY

So we can have the potentially flaky ones (medium, large) running in a separated job.


#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
