### PR TITLE
Ignore flaky tests

### DIFF
--- a/media/sample/src/androidTest/java/com/google/android/horologist/mediasample/playback/PlaybackServiceTest.kt
+++ b/media/sample/src/androidTest/java/com/google/android/horologist/mediasample/playback/PlaybackServiceTest.kt
@@ -23,9 +23,11 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@Ignore("https://github.com/google/horologist/issues/1191")
 @RunWith(AndroidJUnit4::class)
 @LargeTest
 @HiltAndroidTest


### PR DESCRIPTION
#### WHAT

Ignore flaky tests reported in https://github.com/google/horologist/issues/1191


#### WHY

In order to get green builds in CI until these are fixed.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
