### PR TITLE
Change build compiletests to run on ubuntu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,14 +47,11 @@ jobs:
             **/build/reports/*
 
   compiletests:
-    runs-on: macos-latest
-    timeout-minutes: 50
+    # Skip build if head commit contains 'skip ci'
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
 
-    strategy:
-      # Allow tests to continue on other devices if they fail on one device.
-      fail-fast: false
-      matrix:
-        api-level: [ 30 ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
 
     env:
       TERM: dumb


### PR DESCRIPTION
#### WHAT

Change build `compiletests` to run on ubuntu.

#### WHY

Does not need to run on a mac.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [N/A] Run tests
- [N/A] Update metalava's signature text files
