### PR TITLE
Archive snapshot delta images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,7 @@ jobs:
             **/build/test-results/*
             **/build/reports/*
             **/out/*
+            /home/runner/work/horologist/horologist/base-ui/out/*
 
   compiletests:
     # Skip build if head commit contains 'skip ci'

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardButtonTest_variants[Icon only Default Disabled].png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardButtonTest_variants[Icon only Default Disabled].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ca0f5d0800d0e085f1e7dc34cd800c95ece7330862deb6c0368f46440948419e
-size 1991
+oid sha256:422f61aac85355321f2db438a515aedf7c79056edf9c49b94c0099579514f59f
+size 779


### PR DESCRIPTION
#### WHAT

Archive snapshot diff output folder.

#### WHY

So we can download and see the differences.

Last attempt did not work: https://github.com/google/horologist/pull/1334

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [N/A] Run tests
- [N/A] Update metalava's signature text files
