### PR TITLE
Add Title to compose-material

### DIFF
--- a/auth/composables/src/main/java/com/google/android/horologist/auth/composables/screens/SelectAccountScreen.kt
+++ b/auth/composables/src/main/java/com/google/android/horologist/auth/composables/screens/SelectAccountScreen.kt
@@ -30,9 +30,9 @@ import com.google.android.horologist.auth.composables.R
 import com.google.android.horologist.auth.composables.model.AccountUiModel
 import com.google.android.horologist.base.ui.components.StandardChip
 import com.google.android.horologist.base.ui.components.StandardChipType
-import com.google.android.horologist.base.ui.components.Title
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.material.Title
 
 private const val HORIZONTAL_PADDING_SCREEN_PERCENTAGE = 0.052
 
@@ -60,7 +60,7 @@ public fun SelectAccountScreen(
             .padding(horizontal = horizontalPadding),
         columnState = columnState
     ) {
-        item { Title(text = title, modifier = Modifier.padding(bottom = 8.dp)) }
+        item { Title(title, Modifier.padding(bottom = 8.dp)) }
 
         items(accounts.size) { index ->
             val account = accounts[index]

--- a/auth/sample/wear/src/main/java/com/google/android/horologist/auth/sample/screens/MainScreen.kt
+++ b/auth/sample/wear/src/main/java/com/google/android/horologist/auth/sample/screens/MainScreen.kt
@@ -26,11 +26,11 @@ import com.google.android.horologist.auth.sample.R
 import com.google.android.horologist.auth.sample.Screen
 import com.google.android.horologist.base.ui.components.StandardChip
 import com.google.android.horologist.base.ui.components.StandardChipType
-import com.google.android.horologist.base.ui.components.Title
 import com.google.android.horologist.composables.SectionedList
 import com.google.android.horologist.composables.SectionedListScope
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.layout.belowTimeTextPreview
+import com.google.android.horologist.compose.material.Title
 
 @Composable
 fun MainScreen(
@@ -65,7 +65,7 @@ private fun SectionedListScope.pkceSection(navigateToRoute: (String) -> Unit) {
         )
     ) {
         header {
-            Title(stringResource(id = R.string.auth_menu_oauth_pkce_header))
+            Title(stringResource(id = R.string.auth_menu_oauth_pkce_header), Modifier)
         }
         loaded { (textId, route) ->
             StandardChip(

--- a/auth/sample/wear/src/main/java/com/google/android/horologist/auth/sample/screens/common/streamline/StreamlineSignInMenuScreen.kt
+++ b/auth/sample/wear/src/main/java/com/google/android/horologist/auth/sample/screens/common/streamline/StreamlineSignInMenuScreen.kt
@@ -26,9 +26,9 @@ import com.google.android.horologist.auth.sample.R
 import com.google.android.horologist.auth.sample.Screen
 import com.google.android.horologist.base.ui.components.StandardChip
 import com.google.android.horologist.base.ui.components.StandardChipType
-import com.google.android.horologist.base.ui.components.Title
 import com.google.android.horologist.composables.SectionedList
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.material.Title
 
 @Composable
 fun StreamlineSignInMenuScreen(
@@ -60,7 +60,10 @@ fun StreamlineSignInMenuScreen(
             )
         ) {
             header {
-                Title(stringResource(id = R.string.common_screens_streamline_sign_in_header))
+                Title(
+                    stringResource(id = R.string.common_screens_streamline_sign_in_header),
+                    Modifier
+                )
             }
             loaded { (textId, route, mode) ->
                 StandardChip(

--- a/auth/sample/wear/src/main/java/com/google/android/horologist/auth/sample/screens/tokenshare/customkey/TokenShareCustomKeyScreen.kt
+++ b/auth/sample/wear/src/main/java/com/google/android/horologist/auth/sample/screens/tokenshare/customkey/TokenShareCustomKeyScreen.kt
@@ -31,9 +31,9 @@ import androidx.wear.compose.material.Text
 import com.google.android.horologist.auth.sample.R
 import com.google.android.horologist.base.ui.components.StandardChip
 import com.google.android.horologist.base.ui.components.StandardChipType
-import com.google.android.horologist.base.ui.components.Title
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.material.Title
 
 @Composable
 fun TokenShareCustomKeyScreen(
@@ -48,7 +48,7 @@ fun TokenShareCustomKeyScreen(
         modifier = modifier.fillMaxSize()
     ) {
         item {
-            Title(textId = R.string.token_share_custom_key_title)
+            Title(R.string.token_share_custom_key_title, Modifier)
         }
         item {
             Text(

--- a/auth/sample/wear/src/main/java/com/google/android/horologist/auth/sample/screens/tokenshare/defaultkey/TokenShareDefaultKeyScreen.kt
+++ b/auth/sample/wear/src/main/java/com/google/android/horologist/auth/sample/screens/tokenshare/defaultkey/TokenShareDefaultKeyScreen.kt
@@ -31,9 +31,9 @@ import androidx.wear.compose.material.Text
 import com.google.android.horologist.auth.sample.R
 import com.google.android.horologist.base.ui.components.StandardChip
 import com.google.android.horologist.base.ui.components.StandardChipType
-import com.google.android.horologist.base.ui.components.Title
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.material.Title
 
 @Composable
 fun TokenShareDefaultKeyScreen(
@@ -48,7 +48,7 @@ fun TokenShareDefaultKeyScreen(
         modifier = modifier.fillMaxSize()
     ) {
         item {
-            Title(textId = R.string.token_share_default_key_title)
+            Title(R.string.token_share_default_key_title, Modifier)
         }
         item {
             Text(

--- a/auth/ui/build.gradle.kts
+++ b/auth/ui/build.gradle.kts
@@ -110,6 +110,7 @@ dependencies {
     api(libs.wearcompose.foundation)
 
     implementation(projects.baseUi)
+    implementation(projects.composeMaterial)
 
     implementation(libs.androidx.activity)
     implementation(libs.androidx.activity.compose)

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptScreen.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptScreen.kt
@@ -33,9 +33,9 @@ import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.auth.composables.R
 import com.google.android.horologist.auth.composables.model.AccountUiModel
 import com.google.android.horologist.auth.composables.screens.SignInPlaceholderScreen
-import com.google.android.horologist.base.ui.components.Title
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.material.Title
 
 /**
  * A screen to prompt users to sign in.
@@ -119,7 +119,7 @@ internal fun SignInPromptScreen(
                 columnState = columnState,
                 modifier = modifier
             ) {
-                item { Title(text = title) }
+                item { Title(title, Modifier) }
                 item {
                     Text(
                         text = message,

--- a/base-ui/api/current.api
+++ b/base-ui/api/current.api
@@ -83,8 +83,8 @@ package com.google.android.horologist.base.ui.components {
   }
 
   public final class TitleKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void Title(@StringRes int textId, optional androidx.compose.ui.Modifier modifier);
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void Title(String text, optional androidx.compose.ui.Modifier modifier);
+    method @Deprecated @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void Title(@StringRes int textId, optional androidx.compose.ui.Modifier modifier);
+    method @Deprecated @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void Title(String text, optional androidx.compose.ui.Modifier modifier);
   }
 
 }

--- a/compose-material/api/current.api
+++ b/compose-material/api/current.api
@@ -5,6 +5,11 @@ package com.google.android.horologist.compose.material {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void SplitToggleChip(boolean checked, kotlin.jvm.functions.Function1<? super java.lang.Boolean,kotlin.Unit> onCheckedChanged, String label, kotlin.jvm.functions.Function0<kotlin.Unit> onClick, com.google.android.horologist.compose.material.ToggleChipToggleControl toggleControl, optional androidx.compose.ui.Modifier modifier, optional String? secondaryLabel, optional androidx.wear.compose.material.SplitToggleChipColors colors, optional boolean enabled, optional androidx.compose.foundation.interaction.MutableInteractionSource checkedInteractionSource, optional androidx.compose.foundation.interaction.MutableInteractionSource clickInteractionSource);
   }
 
+  public final class TitleKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void Title(@StringRes int textId, optional androidx.compose.ui.Modifier modifier);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void Title(String text, optional androidx.compose.ui.Modifier modifier);
+  }
+
   public final class ToggleChipKt {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void ToggleChip(boolean checked, kotlin.jvm.functions.Function1<? super java.lang.Boolean,kotlin.Unit> onCheckedChanged, String label, com.google.android.horologist.compose.material.ToggleChipToggleControl toggleControl, optional androidx.compose.ui.Modifier modifier, optional androidx.compose.ui.graphics.vector.ImageVector? icon, optional String? secondaryLabel, optional androidx.wear.compose.material.ToggleChipColors colors, optional boolean enabled, optional androidx.compose.foundation.interaction.MutableInteractionSource interactionSource);
   }

--- a/compose-material/src/debug/java/com/google/android/horologist/compose/material/TitlePreview.kt
+++ b/compose-material/src/debug/java/com/google/android/horologist/compose/material/TitlePreview.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.base.ui.components
+package com.google.android.horologist.compose.material
 
 import androidx.compose.runtime.Composable
 import com.google.android.horologist.compose.tools.WearPreview

--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/Title.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/Title.kt
@@ -14,25 +14,23 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.base.ui.components
+package com.google.android.horologist.compose.material
 
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 /**
  * An alternative function to [Title] that allows a string resource id to be passed as text.
  */
-@Suppress("DEPRECATION")
-@Deprecated(
-    "Replaced by Title in Horologist Material Compose library",
-    replaceWith = ReplaceWith(
-        "Title(textId, modifier)",
-        "com.google.android.horologist.compose.material.Title"
-    )
-)
 @ExperimentalHorologistApi
 @Composable
 public fun Title(
@@ -49,21 +47,18 @@ public fun Title(
  * This composable fulfils the redlines of the following components:
  * - Primary title;
  */
-@Deprecated(
-    "Replaced by Title in Horologist Material Compose library",
-    replaceWith = ReplaceWith(
-        "Title(text, modifier)",
-        "com.google.android.horologist.compose.material.Title"
-    )
-)
 @ExperimentalHorologistApi
 @Composable
 public fun Title(
     text: String,
     modifier: Modifier = Modifier
 ) {
-    com.google.android.horologist.compose.material.Title(
+    Text(
         text = text,
-        modifier = modifier
+        modifier = modifier.semantics { heading() },
+        textAlign = TextAlign.Center,
+        overflow = TextOverflow.Ellipsis,
+        maxLines = 3,
+        style = MaterialTheme.typography.title3
     )
 }

--- a/compose-material/src/test/java/com/google/android/horologist/compose/material/TitleComposeTest.kt
+++ b/compose-material/src/test/java/com/google/android/horologist/compose/material/TitleComposeTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.base.ui.components
+package com.google.android.horologist.compose.material
 
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.SemanticsProperties

--- a/compose-material/src/test/java/com/google/android/horologist/compose/material/TitleTest.kt
+++ b/compose-material/src/test/java/com/google/android/horologist/compose/material/TitleTest.kt
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-@file:Suppress("DEPRECATION")
-
-package com.google.android.horologist.base.ui.components
+package com.google.android.horologist.compose.material
 
 import com.google.android.horologist.screenshots.ScreenshotBaseTest
 import org.junit.Test

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_TitleTest_default.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_TitleTest_default.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2f2e0aecc1f5db71ff8ae66ede2cfe164baf3e7a644a3e650b78f110cf5f6c2
+size 1413

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_TitleTest_withVeryLongText.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_TitleTest_withVeryLongText.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14dff6ba341fba872cc8b15e17f1d58a86cd1bfc39ab4b718f5c86cb8312e29b
+size 10428

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreen.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreen.kt
@@ -29,11 +29,11 @@ import androidx.wear.compose.material.Text
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.base.ui.components.StandardChip
 import com.google.android.horologist.base.ui.components.StandardChipType
-import com.google.android.horologist.base.ui.components.Title
 import com.google.android.horologist.composables.Section
 import com.google.android.horologist.composables.SectionContentScope
 import com.google.android.horologist.composables.SectionedList
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.material.Title
 import com.google.android.horologist.media.ui.R
 import com.google.android.horologist.media.ui.state.model.PlaylistDownloadUiModel
 
@@ -145,8 +145,8 @@ public class BrowseScreenScope {
                 state = Section.State.Loaded(buttons),
                 headerContent = {
                     Title(
-                        textId = R.string.horologist_browse_library_playlists,
-                        modifier = if (firstSectionAdded) {
+                        R.string.horologist_browse_library_playlists,
+                        if (firstSectionAdded) {
                             Modifier.padding(bottom = 8.dp)
                         } else {
                             Modifier.padding(top = 8.dp, bottom = 8.dp)

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/EntityScreen.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/EntityScreen.kt
@@ -23,9 +23,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.foundation.lazy.ScalingLazyListScope
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.base.ui.components.Title
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.material.Title
 
 /**
  * A screen that displays a media collection and allow actions to be taken on it.
@@ -161,5 +161,5 @@ public fun DefaultEntityScreenHeader(
     title: String,
     modifier: Modifier = Modifier
 ) {
-    Title(text = title, modifier = modifier.padding(bottom = 12.dp))
+    Title(title, modifier.padding(bottom = 12.dp))
 }

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreen.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreen.kt
@@ -26,11 +26,11 @@ import androidx.wear.compose.material.ChipDefaults
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.base.ui.components.StandardChip
 import com.google.android.horologist.base.ui.components.StandardChipType
-import com.google.android.horologist.base.ui.components.Title
 import com.google.android.horologist.composables.PlaceholderChip
 import com.google.android.horologist.composables.Section
 import com.google.android.horologist.composables.SectionedList
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.material.Title
 import com.google.android.horologist.media.ui.R
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
 
@@ -74,8 +74,8 @@ public fun <T> PlaylistsScreen(
         section(state = sectionState) {
             header {
                 Title(
-                    textId = R.string.horologist_browse_playlist_title,
-                    modifier = Modifier.padding(bottom = 12.dp)
+                    R.string.horologist_browse_playlist_title,
+                    Modifier.padding(bottom = 12.dp)
                 )
             }
 

--- a/sample/src/main/java/com/google/android/horologist/rotary/RotaryScrollMenuList.kt
+++ b/sample/src/main/java/com/google/android/horologist/rotary/RotaryScrollMenuList.kt
@@ -58,9 +58,9 @@ import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.CompactChip
 import androidx.wear.compose.material.Text
-import com.google.android.horologist.base.ui.components.Title
 import com.google.android.horologist.composables.SectionedList
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.material.Title
 import com.google.android.horologist.compose.rotaryinput.rememberDisabledHaptic
 import com.google.android.horologist.compose.rotaryinput.rememberRotaryHapticHandler
 import com.google.android.horologist.compose.rotaryinput.rotaryWithFling
@@ -99,8 +99,8 @@ fun RotaryMenuScreen(
         ) {
             header {
                 Title(
-                    text = stringResource(R.string.rotarymenu_scroll),
-                    modifier = Modifier.padding(vertical = 8.dp)
+                    stringResource(R.string.rotarymenu_scroll),
+                    Modifier.padding(vertical = 8.dp)
                 )
             }
 

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/SectionedListMenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/SectionedListMenuScreen.kt
@@ -26,9 +26,9 @@ import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Text
-import com.google.android.horologist.base.ui.components.Title
 import com.google.android.horologist.composables.SectionedList
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.material.Title
 import com.google.android.horologist.sample.R
 import com.google.android.horologist.sample.Screen
 
@@ -60,8 +60,8 @@ fun SectionedListMenuScreen(
         ) {
             header {
                 Title(
-                    text = stringResource(R.string.sectionedlist_samples_title),
-                    modifier = Modifier.padding(vertical = 8.dp)
+                    stringResource(R.string.sectionedlist_samples_title),
+                    Modifier.padding(vertical = 8.dp)
                 )
             }
 

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/expandable/SectionedListExpandableScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/expandable/SectionedListExpandableScreen.kt
@@ -44,13 +44,13 @@ import androidx.wear.compose.material.Text
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import com.google.android.horologist.base.ui.components.StandardChip
 import com.google.android.horologist.base.ui.components.StandardChipType
-import com.google.android.horologist.base.ui.components.Title
 import com.google.android.horologist.composables.Section
 import com.google.android.horologist.composables.SectionContentScope
 import com.google.android.horologist.composables.SectionedList
 import com.google.android.horologist.composables.SectionedListScope
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.layout.belowTimeTextPreview
+import com.google.android.horologist.compose.material.Title
 import com.google.android.horologist.compose.material.util.DECORATIVE_ELEMENT_CONTENT_DESCRIPTION
 import com.google.android.horologist.sample.R
 
@@ -91,8 +91,8 @@ fun SectionedListExpandableScreen(
         section {
             loaded {
                 Title(
-                    text = stringResource(R.string.sectionedlist_my_tasks),
-                    modifier = Modifier.padding(vertical = 8.dp)
+                    stringResource(R.string.sectionedlist_my_tasks),
+                    Modifier.padding(vertical = 8.dp)
                 )
             }
         }

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/stateful/SectionedListStatefulScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/stateful/SectionedListStatefulScreen.kt
@@ -47,13 +47,13 @@ import androidx.wear.compose.material.Text
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import com.google.android.horologist.base.ui.components.StandardChip
 import com.google.android.horologist.base.ui.components.StandardChipType
-import com.google.android.horologist.base.ui.components.Title
 import com.google.android.horologist.composables.PlaceholderChip
 import com.google.android.horologist.composables.Section
 import com.google.android.horologist.composables.SectionedList
 import com.google.android.horologist.composables.SectionedListScope
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.layout.belowTimeTextPreview
+import com.google.android.horologist.compose.material.Title
 import com.google.android.horologist.compose.material.util.DECORATIVE_ELEMENT_CONTENT_DESCRIPTION
 import com.google.android.horologist.sample.R
 import com.google.android.horologist.sectionedlist.stateful.SectionedListStatefulScreenViewModel.Recommendation
@@ -118,8 +118,8 @@ private fun SectionedListScope.recommendationsSection(
     section(recommendationsState) {
         header {
             Title(
-                text = stringResource(id = R.string.sectionedlist_recommendations_title),
-                modifier = Modifier.padding(vertical = 8.dp)
+                stringResource(id = R.string.sectionedlist_recommendations_title),
+                Modifier.padding(vertical = 8.dp)
             )
         }
 

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/stateless/SectionedListStatelessScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/stateless/SectionedListStatelessScreen.kt
@@ -32,11 +32,11 @@ import androidx.compose.ui.unit.dp
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import com.google.android.horologist.base.ui.components.StandardChip
 import com.google.android.horologist.base.ui.components.StandardChipType
-import com.google.android.horologist.base.ui.components.Title
 import com.google.android.horologist.composables.SectionedList
 import com.google.android.horologist.composables.SectionedListScope
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.layout.belowTimeTextPreview
+import com.google.android.horologist.compose.material.Title
 import com.google.android.horologist.sample.R
 
 @Composable
@@ -88,8 +88,8 @@ private fun SectionedListScope.recommendationsSection() {
     ) {
         header {
             Title(
-                text = stringResource(id = R.string.sectionedlist_recommendations_title),
-                modifier = Modifier.padding(vertical = 8.dp)
+                stringResource(id = R.string.sectionedlist_recommendations_title),
+                Modifier.padding(vertical = 8.dp)
             )
         }
 


### PR DESCRIPTION
#### WHAT

Add `Title` to `compose-material`.

#### WHY

https://github.com/google/horologist/issues/1324

#### HOW

- Keep components in `base-ui` for few releases, marked as deprecated, suggesting the new library;
- Change the code of the components in `base-ui` and samples to use the ones from `compose-material`;
- Remove previews from `base-ui`, keep the unit tests to check if the usage of `compose-material` is correct;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
