### PR TITLE
Add snapshot tests for StandardIcon

### DIFF
--- a/base-ui/api/current.api
+++ b/base-ui/api/current.api
@@ -16,7 +16,7 @@ package com.google.android.horologist.base.ui.components {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void ConfirmationDialog(kotlin.jvm.functions.Function0<kotlin.Unit> onTimeout, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.ColumnScope,kotlin.Unit>? icon, optional androidx.wear.compose.foundation.lazy.ScalingLazyListState scrollState, optional long durationMillis, optional long backgroundColor, optional long contentColor, optional long iconColor, optional androidx.compose.foundation.layout.Arrangement.Vertical verticalArrangement, optional androidx.compose.foundation.layout.PaddingValues contentPadding, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.ColumnScope,kotlin.Unit> content);
   }
 
-  public enum IconRtlMode {
+  @com.google.android.horologist.annotations.ExperimentalHorologistApi public enum IconRtlMode {
     method public static com.google.android.horologist.base.ui.components.IconRtlMode valueOf(String name) throws java.lang.IllegalArgumentException;
     method public static com.google.android.horologist.base.ui.components.IconRtlMode[] values();
     enum_constant public static final com.google.android.horologist.base.ui.components.IconRtlMode Default;
@@ -67,7 +67,7 @@ package com.google.android.horologist.base.ui.components {
   }
 
   public final class StandardIconKt {
-    method @androidx.compose.runtime.Composable public static void StandardIcon(androidx.compose.ui.graphics.vector.ImageVector imageVector, String? contentDescription, optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.base.ui.components.IconRtlMode rtlMode);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void StandardIcon(androidx.compose.ui.graphics.vector.ImageVector imageVector, String? contentDescription, optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.base.ui.components.IconRtlMode rtlMode);
   }
 
   public final class StandardToggleChipKt {

--- a/base-ui/src/main/java/com/google/android/horologist/base/ui/components/StandardIcon.kt
+++ b/base-ui/src/main/java/com/google/android/horologist/base/ui/components/StandardIcon.kt
@@ -23,7 +23,9 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.wear.compose.material.Icon
+import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
+@ExperimentalHorologistApi
 @Composable
 public fun StandardIcon(
     imageVector: ImageVector,
@@ -44,6 +46,7 @@ public fun StandardIcon(
     )
 }
 
+@ExperimentalHorologistApi
 public enum class IconRtlMode {
     Default,
     Mirrored

--- a/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardIconTest.kt
+++ b/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardIconTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.base.ui.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.VolumeDown
+import androidx.compose.ui.unit.LayoutDirection
+import com.google.accompanist.testharness.TestHarness
+import com.google.android.horologist.screenshots.ScreenshotBaseTest
+import org.junit.Test
+
+class StandardIconTest : ScreenshotBaseTest() {
+
+    @Test
+    fun default() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardIcon(
+                imageVector = Icons.Outlined.VolumeDown,
+                contentDescription = "contentDescription"
+            )
+        }
+    }
+
+    @Test
+    fun defaultRtl() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            TestHarness(layoutDirection = LayoutDirection.Rtl) {
+                StandardIcon(
+                    imageVector = Icons.Outlined.VolumeDown,
+                    contentDescription = "contentDescription"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun mirrored() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            StandardIcon(
+                imageVector = Icons.Outlined.VolumeDown,
+                contentDescription = "contentDescription",
+                rtlMode = IconRtlMode.Mirrored
+            )
+        }
+    }
+
+    @Test
+    fun mirroredRtl() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            TestHarness(layoutDirection = LayoutDirection.Rtl) {
+                StandardIcon(
+                    imageVector = Icons.Outlined.VolumeDown,
+                    contentDescription = "contentDescription",
+                    rtlMode = IconRtlMode.Mirrored
+                )
+            }
+        }
+    }
+}

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardIconTest_default.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardIconTest_default.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a160701d630d2a07ff1f1cd15e5bf965f78ceef95d4e9764461f25a01c037b9
+size 554

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardIconTest_defaultRtl.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardIconTest_defaultRtl.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a160701d630d2a07ff1f1cd15e5bf965f78ceef95d4e9764461f25a01c037b9
+size 554

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardIconTest_mirrored.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardIconTest_mirrored.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a160701d630d2a07ff1f1cd15e5bf965f78ceef95d4e9764461f25a01c037b9
+size 554

--- a/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardIconTest_mirroredRtl.png
+++ b/base-ui/src/test/snapshots/images/com.google.android.horologist.base.ui.components_StandardIconTest_mirroredRtl.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3628b990cbbcc7be918887ea1c75c61687a335f6e610025a8de0295a70681163
+size 583


### PR DESCRIPTION
#### WHAT

Add snapshot tests for `StandardIcon`.

#### WHY

In preparation to deprecate and move it to `compose-material`.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
