### PR TITLE
Fix ToggleChip for RTL

### DIFF
--- a/compose-material/api/current.api
+++ b/compose-material/api/current.api
@@ -22,7 +22,7 @@ package com.google.android.horologist.compose.material {
   }
 
   public final class ToggleChipKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void ToggleChip(boolean checked, kotlin.jvm.functions.Function1<? super java.lang.Boolean,kotlin.Unit> onCheckedChanged, String label, com.google.android.horologist.compose.material.ToggleChipToggleControl toggleControl, optional androidx.compose.ui.Modifier modifier, optional androidx.compose.ui.graphics.vector.ImageVector? icon, optional String? secondaryLabel, optional androidx.wear.compose.material.ToggleChipColors colors, optional boolean enabled, optional androidx.compose.foundation.interaction.MutableInteractionSource interactionSource);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void ToggleChip(boolean checked, kotlin.jvm.functions.Function1<? super java.lang.Boolean,kotlin.Unit> onCheckedChanged, String label, com.google.android.horologist.compose.material.ToggleChipToggleControl toggleControl, optional androidx.compose.ui.Modifier modifier, optional androidx.compose.ui.graphics.vector.ImageVector? icon, optional com.google.android.horologist.compose.material.IconRtlMode iconRtlMode, optional String? secondaryLabel, optional androidx.wear.compose.material.ToggleChipColors colors, optional boolean enabled, optional androidx.compose.foundation.interaction.MutableInteractionSource interactionSource);
   }
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public enum ToggleChipToggleControl {

--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/SplitToggleChip.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/SplitToggleChip.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.SplitToggleChip
 import androidx.wear.compose.material.SplitToggleChipColors
@@ -64,7 +63,7 @@ public fun SplitToggleChip(
                 modifier = Modifier.fillMaxWidth(),
                 text = label,
                 color = MaterialTheme.colors.onSurface,
-                textAlign = TextAlign.Left,
+                textAlign = TextAlign.Start,
                 overflow = TextOverflow.Ellipsis,
                 maxLines = if (hasSecondaryLabel) 1 else 2,
                 style = MaterialTheme.typography.button
@@ -97,7 +96,8 @@ public fun SplitToggleChip(
                 } else {
                     R.string.horologist_split_toggle_chip_off_content_description
                 }
-            )
+            ),
+            rtlMode = IconRtlMode.Mirrored
         )
     }
 

--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/ToggleChip.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/ToggleChip.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.wear.compose.material.ChipDefaults
-import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.ToggleChip
@@ -56,6 +55,7 @@ public fun ToggleChip(
     toggleControl: ToggleChipToggleControl,
     modifier: Modifier = Modifier,
     icon: ImageVector? = null,
+    iconRtlMode: IconRtlMode = IconRtlMode.Default,
     secondaryLabel: String? = null,
     colors: ToggleChipColors = ToggleChipDefaults.toggleChipColors(),
     enabled: Boolean = true,
@@ -69,7 +69,7 @@ public fun ToggleChip(
                 text = label,
                 color = MaterialTheme.colors.onSurface,
                 modifier = Modifier.fillMaxWidth(),
-                textAlign = TextAlign.Left,
+                textAlign = TextAlign.Start,
                 overflow = TextOverflow.Ellipsis,
                 maxLines = if (hasSecondaryLabel) 1 else 2,
                 style = MaterialTheme.typography.button
@@ -102,7 +102,8 @@ public fun ToggleChip(
                 } else {
                     R.string.horologist_toggle_chip_off_content_description
                 }
-            )
+            ),
+            rtlMode = IconRtlMode.Mirrored
         )
     }
 
@@ -115,7 +116,8 @@ public fun ToggleChip(
                         contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
                         modifier = Modifier
                             .size(ChipDefaults.IconSize)
-                            .clip(CircleShape)
+                            .clip(CircleShape),
+                        rtlMode = iconRtlMode
                     )
                 }
             }

--- a/compose-material/src/test/java/com/google/android/horologist/compose/material/SplitToggleChipTest.kt
+++ b/compose-material/src/test/java/com/google/android/horologist/compose/material/SplitToggleChipTest.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.horologist.compose.material
 
+import androidx.compose.ui.unit.LayoutDirection
 import com.google.accompanist.testharness.TestHarness
 import com.google.android.horologist.screenshots.ScreenshotBaseTest
 import org.junit.Test
@@ -169,6 +170,22 @@ class SplitToggleChipTest : ScreenshotBaseTest() {
                     onClick = { },
                     toggleControl = ToggleChipToggleControl.Switch,
                     secondaryLabel = "Secondary label very very very very very very very very very long text"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun rtl() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            TestHarness(layoutDirection = LayoutDirection.Rtl) {
+                SplitToggleChip(
+                    checked = true,
+                    onCheckedChanged = { },
+                    label = "Primary label",
+                    onClick = { },
+                    toggleControl = ToggleChipToggleControl.Switch,
+                    secondaryLabel = "Secondary label"
                 )
             }
         }

--- a/compose-material/src/test/java/com/google/android/horologist/compose/material/ToggleChipTest.kt
+++ b/compose-material/src/test/java/com/google/android/horologist/compose/material/ToggleChipTest.kt
@@ -18,8 +18,10 @@ package com.google.android.horologist.compose.material
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.materialPath
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.testharness.TestHarness
 import com.google.android.horologist.screenshots.ScreenshotBaseTest
@@ -276,6 +278,70 @@ class ToggleChipTest : ScreenshotBaseTest() {
                 toggleControl = ToggleChipToggleControl.Switch,
                 icon = Icon32dp
             )
+        }
+    }
+
+    // This test is redundant to "withSecondaryLabelAndIcon" test, but it's added to help compare
+    // with "defaultRtl" test, as it uses a different icon that is easier to see mirrored.
+    @Test
+    fun default() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            ToggleChip(
+                checked = true,
+                onCheckedChanged = { },
+                label = "Primary label",
+                toggleControl = ToggleChipToggleControl.Switch,
+                secondaryLabel = "Secondary label",
+                icon = Icons.Default.PlayArrow
+            )
+        }
+    }
+
+    @Test
+    fun defaultRtl() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            TestHarness(layoutDirection = LayoutDirection.Rtl) {
+                ToggleChip(
+                    checked = true,
+                    onCheckedChanged = { },
+                    label = "Primary label",
+                    toggleControl = ToggleChipToggleControl.Switch,
+                    secondaryLabel = "Secondary label",
+                    icon = Icons.Default.PlayArrow
+                )
+            }
+        }
+    }
+
+    @Test
+    fun mirrored() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            ToggleChip(
+                checked = true,
+                onCheckedChanged = { },
+                label = "Primary label",
+                toggleControl = ToggleChipToggleControl.Switch,
+                secondaryLabel = "Secondary label",
+                icon = Icons.Default.PlayArrow,
+                iconRtlMode = IconRtlMode.Mirrored
+            )
+        }
+    }
+
+    @Test
+    fun mirroredRtl() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            TestHarness(layoutDirection = LayoutDirection.Rtl) {
+                ToggleChip(
+                    checked = true,
+                    onCheckedChanged = { },
+                    label = "Primary label",
+                    toggleControl = ToggleChipToggleControl.Switch,
+                    secondaryLabel = "Secondary label",
+                    icon = Icons.Default.PlayArrow,
+                    iconRtlMode = IconRtlMode.Mirrored
+                )
+            }
         }
     }
 

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_SplitToggleChipTest_rtl.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_SplitToggleChipTest_rtl.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f6ce8b5f0979167c7f34ba584ea6eafbec1865baba42acd387c06ae5acf82da
+size 10810

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ToggleChipTest_default.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ToggleChipTest_default.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:554073c9bb2185042945039d4ec7ce5dad82e7989f031957eb0e78b01241cd2c
+size 33004

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ToggleChipTest_defaultRtl.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ToggleChipTest_defaultRtl.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41663226efa8d3e7b5c83777997fe10fe4c7ad5e1e4a1a3d1dd4864a480f2fd5
+size 34637

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ToggleChipTest_mirrored.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ToggleChipTest_mirrored.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:554073c9bb2185042945039d4ec7ce5dad82e7989f031957eb0e78b01241cd2c
+size 33004

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ToggleChipTest_mirroredRtl.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ToggleChipTest_mirroredRtl.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f5c960cfd85c81de1c388b9b5769c934de1cc03c4e948c1f603b3bdada0a979
+size 34645


### PR DESCRIPTION
#### WHAT

Fix `ToggleChip` and `SplitToggleChip` for RTL.

#### HOW

- Replace `TextAlign` from `Left` to `Start`;
- Use `compose-material`'s `Icon` with `IconRtlMode.Mirrored` for the toggle control;
- Add `iconRtlMode` param to `ToggleChip` to allow icon to also be mirroed;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
