### PR TITLE
Add ChipIconWithProgress to compose-material

### DIFF
--- a/base-ui/api/current.api
+++ b/base-ui/api/current.api
@@ -49,8 +49,8 @@ package com.google.android.horologist.base.ui.components {
   }
 
   public final class StandardChipIconWithProgressKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void StandardChipIconWithProgress(optional androidx.compose.ui.Modifier modifier, optional Object? icon, optional boolean largeIcon, optional androidx.compose.ui.graphics.painter.Painter? placeholder, optional long progressIndicatorColor, optional long progressTrackColor);
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void StandardChipIconWithProgress(float progress, optional androidx.compose.ui.Modifier modifier, optional Object? icon, optional boolean largeIcon, optional androidx.compose.ui.graphics.painter.Painter? placeholder, optional long progressIndicatorColor, optional long progressTrackColor);
+    method @Deprecated @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void StandardChipIconWithProgress(optional androidx.compose.ui.Modifier modifier, optional Object? icon, optional boolean largeIcon, optional androidx.compose.ui.graphics.painter.Painter? placeholder, optional long progressIndicatorColor, optional long progressTrackColor);
+    method @Deprecated @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void StandardChipIconWithProgress(float progress, optional androidx.compose.ui.Modifier modifier, optional Object? icon, optional boolean largeIcon, optional androidx.compose.ui.graphics.painter.Painter? placeholder, optional long progressIndicatorColor, optional long progressTrackColor);
   }
 
   public final class StandardChipKt {

--- a/base-ui/src/main/java/com/google/android/horologist/base/ui/components/StandardChipIconWithProgress.kt
+++ b/base-ui/src/main/java/com/google/android/horologist/base/ui/components/StandardChipIconWithProgress.kt
@@ -16,30 +16,13 @@
 
 package com.google.android.horologist.base.ui.components
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.unit.dp
-import androidx.wear.compose.material.ChipDefaults
-import androidx.wear.compose.material.CircularProgressIndicator
-import androidx.wear.compose.material.Icon
-import androidx.wear.compose.material.LocalContentAlpha
 import androidx.wear.compose.material.MaterialTheme
-import coil.compose.rememberAsyncImagePainter
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.compose.material.util.DECORATIVE_ELEMENT_CONTENT_DESCRIPTION
-
-private val indicatorPadding = 8.dp
-private val progressBarStrokeWidth = 2.dp
+import com.google.android.horologist.compose.material.ChipIconWithProgress
 
 /**
  * A default icon implementation to be used with a [StandardChip] that accepts an icon as slot.
@@ -53,6 +36,13 @@ private val progressBarStrokeWidth = 2.dp
  * @param progressIndicatorColor The color of the progress indicator that is around the icon.
  * @param progressTrackColor The color of the background for the progress indicator.
  */
+@Deprecated(
+    "Replaced by ChipIconWithProgress in Horologist Material Compose library",
+    replaceWith = ReplaceWith(
+        "ChipIconWithProgress(modifier, icon, largeIcon, placeholder, progressIndicatorColor, progressTrackColor)",
+        "com.google.android.horologist.compose.material.ChipIconWithProgress"
+    )
+)
 @ExperimentalHorologistApi
 @Composable
 public fun StandardChipIconWithProgress(
@@ -63,14 +53,13 @@ public fun StandardChipIconWithProgress(
     progressIndicatorColor: Color = MaterialTheme.colors.primary,
     progressTrackColor: Color = MaterialTheme.colors.onSurface.copy(alpha = 0.10f)
 ) {
-    StandardChipIconWithProgressInternal(
-        progress = null,
+    ChipIconWithProgress(
+        modifier = modifier,
         icon = icon,
         largeIcon = largeIcon,
         placeholder = placeholder,
         progressIndicatorColor = progressIndicatorColor,
-        progressTrackColor = progressTrackColor,
-        modifier = modifier
+        progressTrackColor = progressTrackColor
     )
 }
 
@@ -88,6 +77,13 @@ public fun StandardChipIconWithProgress(
  * @param progressIndicatorColor The color of the progress indicator that is around the icon.
  * @param progressTrackColor The color of the background for the progress indicator.
  */
+@Deprecated(
+    "Replaced by ChipIconWithProgress in Horologist Material Compose library",
+    replaceWith = ReplaceWith(
+        "ChipIconWithProgress(progress, modifier, icon, largeIcon, placeholder, progressIndicatorColor, progressTrackColor)",
+        "com.google.android.horologist.compose.material.ChipIconWithProgress"
+    )
+)
 @ExperimentalHorologistApi
 @Composable
 public fun StandardChipIconWithProgress(
@@ -99,83 +95,13 @@ public fun StandardChipIconWithProgress(
     progressIndicatorColor: Color = MaterialTheme.colors.primary,
     progressTrackColor: Color = MaterialTheme.colors.onSurface.copy(alpha = 0.10f)
 ) {
-    StandardChipIconWithProgressInternal(
+    ChipIconWithProgress(
         progress = progress,
+        modifier = modifier,
         icon = icon,
         largeIcon = largeIcon,
         placeholder = placeholder,
         progressIndicatorColor = progressIndicatorColor,
-        progressTrackColor = progressTrackColor,
-        modifier = modifier
+        progressTrackColor = progressTrackColor
     )
-}
-
-@Composable
-private fun StandardChipIconWithProgressInternal(
-    progress: Float?,
-    icon: Any?,
-    largeIcon: Boolean,
-    placeholder: Painter?,
-    progressIndicatorColor: Color,
-    progressTrackColor: Color,
-    modifier: Modifier = Modifier
-) {
-    val iconSize = if (largeIcon) {
-        ChipDefaults.LargeIconSize
-    } else {
-        ChipDefaults.IconSize
-    }
-
-    Box(
-        modifier = modifier
-            .size(iconSize)
-            .clip(CircleShape)
-    ) {
-        if (progress != null) {
-            CircularProgressIndicator(
-                modifier = modifier
-                    .size(iconSize - progressBarStrokeWidth + indicatorPadding),
-                indicatorColor = progressIndicatorColor,
-                trackColor = progressTrackColor,
-                progress = progress / 100,
-                strokeWidth = progressBarStrokeWidth
-            )
-        } else {
-            CircularProgressIndicator(
-                modifier = modifier
-                    .size(iconSize - progressBarStrokeWidth + indicatorPadding),
-                indicatorColor = progressIndicatorColor,
-                trackColor = progressTrackColor,
-                strokeWidth = progressBarStrokeWidth
-            )
-        }
-
-        when (icon) {
-            is ImageVector -> {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
-                    modifier = Modifier
-                        .align(Alignment.Center)
-                        .size(iconSize - indicatorPadding)
-                        .clip(CircleShape)
-                )
-            }
-            else -> {
-                Image(
-                    painter = rememberAsyncImagePainter(
-                        model = icon,
-                        placeholder = placeholder
-                    ),
-                    contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
-                    modifier = Modifier
-                        .align(Alignment.Center)
-                        .size(iconSize - indicatorPadding)
-                        .clip(CircleShape),
-                    contentScale = ContentScale.Crop,
-                    alpha = LocalContentAlpha.current
-                )
-            }
-        }
-    }
 }

--- a/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardChipSecondaryTest.kt
+++ b/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardChipSecondaryTest.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.testharness.TestHarness
 import com.google.android.horologist.base.ui.util.rememberVectorPainter
+import com.google.android.horologist.compose.material.ChipIconWithProgress
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.screenshots.ScreenshotBaseTest
 import org.junit.Test
@@ -246,7 +247,7 @@ class StandardChipSecondaryTest : ScreenshotBaseTest() {
                 label = "Primary label",
                 onClick = { },
                 icon = {
-                    StandardChipIconWithProgress(
+                    ChipIconWithProgress(
                         progress = 75f,
                         icon = Icon48dp,
                         largeIcon = true

--- a/compose-material/api/current.api
+++ b/compose-material/api/current.api
@@ -1,6 +1,11 @@
 // Signature format: 4.0
 package com.google.android.horologist.compose.material {
 
+  public final class ChipIconWithProgressKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void ChipIconWithProgress(optional androidx.compose.ui.Modifier modifier, optional Object? icon, optional boolean largeIcon, optional androidx.compose.ui.graphics.painter.Painter? placeholder, optional long progressIndicatorColor, optional long progressTrackColor);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void ChipIconWithProgress(float progress, optional androidx.compose.ui.Modifier modifier, optional Object? icon, optional boolean largeIcon, optional androidx.compose.ui.graphics.painter.Painter? placeholder, optional long progressIndicatorColor, optional long progressTrackColor);
+  }
+
   public final class IconKt {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void Icon(androidx.compose.ui.graphics.vector.ImageVector imageVector, String? contentDescription, optional androidx.compose.ui.Modifier modifier, optional long tint, optional com.google.android.horologist.compose.material.IconRtlMode rtlMode);
   }

--- a/compose-material/src/debug/java/com/google/android/horologist/compose/material/ChipIconWithProgressPreview.kt
+++ b/compose-material/src/debug/java/com/google/android/horologist/compose/material/ChipIconWithProgressPreview.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.base.ui.components
+package com.google.android.horologist.compose.material
 
 import androidx.compose.material.icons.materialPath
 import androidx.compose.runtime.Composable
@@ -24,35 +24,32 @@ import androidx.compose.ui.unit.dp
 
 @Preview(
     name = "Standard",
-    group = "Variants",
     backgroundColor = 0xff000000,
     showBackground = true
 )
 @Composable
-fun StandardChipIconWithProgressPreview() {
-    StandardChipIconWithProgress()
+fun ChipIconWithProgressPreview() {
+    ChipIconWithProgress()
 }
 
 @Preview(
     name = "With 75 percent download complete",
-    group = "Variants",
     backgroundColor = 0xff000000,
     showBackground = true
 )
 @Composable
-fun StandardChipIconWithProgressInProgressPreview() {
-    StandardChipIconWithProgress(progress = 75f)
+fun ChipIconWithProgressInProgressPreview() {
+    ChipIconWithProgress(progress = 75f)
 }
 
 @Preview(
     name = "With 75 percent download complete with large icon",
-    group = "Variants",
     backgroundColor = 0xff000000,
     showBackground = true
 )
 @Composable
-fun StandardChipIconWithProgressInProgressLargeIconPreview() {
-    StandardChipIconWithProgress(
+fun ChipIconWithProgressInProgressLargeIconPreview() {
+    ChipIconWithProgress(
         progress = 75f,
         icon = Icon48dp,
         largeIcon = true
@@ -61,24 +58,22 @@ fun StandardChipIconWithProgressInProgressLargeIconPreview() {
 
 @Preview(
     name = "With 75 percent download complete with medium icon",
-    group = "Variants",
     backgroundColor = 0xff000000,
     showBackground = true
 )
 @Composable
-fun StandardChipIconWithProgressInProgressMediumIconPreview() {
-    StandardChipIconWithProgress(progress = 75f, icon = Icon32dp)
+fun ChipIconWithProgressInProgressMediumIconPreview() {
+    ChipIconWithProgress(progress = 75f, icon = Icon32dp)
 }
 
 @Preview(
     name = "With 75 percent download complete with small icon",
-    group = "Variants",
     backgroundColor = 0xff000000,
     showBackground = true
 )
 @Composable
-fun StandardChipIconWithProgressInProgressSmallIconPreview() {
-    StandardChipIconWithProgress(progress = 75f, icon = Icon12dp)
+fun ChipIconWithProgressInProgressSmallIconPreview() {
+    ChipIconWithProgress(progress = 75f, icon = Icon12dp)
 }
 
 private val Icon12dp: ImageVector

--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/ChipIconWithProgress.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/ChipIconWithProgress.kt
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.compose.material
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.ChipDefaults
+import androidx.wear.compose.material.CircularProgressIndicator
+import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.LocalContentAlpha
+import androidx.wear.compose.material.MaterialTheme
+import coil.compose.rememberAsyncImagePainter
+import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.compose.material.util.DECORATIVE_ELEMENT_CONTENT_DESCRIPTION
+
+private val indicatorPadding = 8.dp
+private val progressBarStrokeWidth = 2.dp
+
+/**
+ * A default icon implementation to be used with a [Chip] that accepts an icon as slot.
+ * This implementation displays an icon with a circular progress indicator around it.
+ * The progress indicator is in an indeterminate state and spins indefinitely.
+ *
+ * @param modifier [Modifier] to apply to this layout node.
+ * @param icon Image or icon to be displayed in the center of this view.
+ * @param largeIcon True if it should display the icon with in a large size.
+ * @param placeholder A [Painter] that is displayed while the icon image is loading.
+ * @param progressIndicatorColor The color of the progress indicator that is around the icon.
+ * @param progressTrackColor The color of the background for the progress indicator.
+ */
+@ExperimentalHorologistApi
+@Composable
+public fun ChipIconWithProgress(
+    modifier: Modifier = Modifier,
+    icon: Any? = null,
+    largeIcon: Boolean = false,
+    placeholder: Painter? = null,
+    progressIndicatorColor: Color = MaterialTheme.colors.primary,
+    progressTrackColor: Color = MaterialTheme.colors.onSurface.copy(alpha = 0.10f)
+) {
+    ChipIconWithProgressInternal(
+        progress = null,
+        icon = icon,
+        largeIcon = largeIcon,
+        placeholder = placeholder,
+        progressIndicatorColor = progressIndicatorColor,
+        progressTrackColor = progressTrackColor,
+        modifier = modifier
+    )
+}
+
+/**
+ * A default icon implementation to be used with a [Chip] that accepts an icon as slot.
+ * This implementation displays an icon with a circular progress indicator around it.
+ * The progress indicator express the proportion of completion of an ongoing task.
+ *
+ * @param progress The progress of this progress indicator where 0.0 represents no progress and 1.0
+ * represents completion. Values outside of this range are coerced into the range 0..1.
+ * @param modifier [Modifier] to apply to this layout node.
+ * @param icon Image or icon to be displayed in the center of this view.
+ * @param largeIcon True if it should display the icon with in a large size.
+ * @param placeholder A [Painter] that is displayed while the icon image is loading.
+ * @param progressIndicatorColor The color of the progress indicator that is around the icon.
+ * @param progressTrackColor The color of the background for the progress indicator.
+ */
+@ExperimentalHorologistApi
+@Composable
+public fun ChipIconWithProgress(
+    progress: Float,
+    modifier: Modifier = Modifier,
+    icon: Any? = null,
+    largeIcon: Boolean = false,
+    placeholder: Painter? = null,
+    progressIndicatorColor: Color = MaterialTheme.colors.primary,
+    progressTrackColor: Color = MaterialTheme.colors.onSurface.copy(alpha = 0.10f)
+) {
+    ChipIconWithProgressInternal(
+        progress = progress,
+        icon = icon,
+        largeIcon = largeIcon,
+        placeholder = placeholder,
+        progressIndicatorColor = progressIndicatorColor,
+        progressTrackColor = progressTrackColor,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun ChipIconWithProgressInternal(
+    progress: Float?,
+    icon: Any?,
+    largeIcon: Boolean,
+    placeholder: Painter?,
+    progressIndicatorColor: Color,
+    progressTrackColor: Color,
+    modifier: Modifier = Modifier
+) {
+    val iconSize = if (largeIcon) {
+        ChipDefaults.LargeIconSize
+    } else {
+        ChipDefaults.IconSize
+    }
+
+    Box(
+        modifier = modifier
+            .size(iconSize)
+            .clip(CircleShape)
+    ) {
+        if (progress != null) {
+            CircularProgressIndicator(
+                modifier = modifier
+                    .size(iconSize - progressBarStrokeWidth + indicatorPadding),
+                indicatorColor = progressIndicatorColor,
+                trackColor = progressTrackColor,
+                progress = progress / 100,
+                strokeWidth = progressBarStrokeWidth
+            )
+        } else {
+            CircularProgressIndicator(
+                modifier = modifier
+                    .size(iconSize - progressBarStrokeWidth + indicatorPadding),
+                indicatorColor = progressIndicatorColor,
+                trackColor = progressTrackColor,
+                strokeWidth = progressBarStrokeWidth
+            )
+        }
+
+        when (icon) {
+            is ImageVector -> {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .size(iconSize - indicatorPadding)
+                        .clip(CircleShape)
+                )
+            }
+            else -> {
+                Image(
+                    painter = rememberAsyncImagePainter(
+                        model = icon,
+                        placeholder = placeholder
+                    ),
+                    contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .size(iconSize - indicatorPadding)
+                        .clip(CircleShape),
+                    contentScale = ContentScale.Crop,
+                    alpha = LocalContentAlpha.current
+                )
+            }
+        }
+    }
+}

--- a/compose-material/src/test/java/com/google/android/horologist/compose/material/ChipIconWithProgressTest.kt
+++ b/compose-material/src/test/java/com/google/android/horologist/compose/material/ChipIconWithProgressTest.kt
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-@file:Suppress("DEPRECATION")
-
-package com.google.android.horologist.base.ui.components
+package com.google.android.horologist.compose.material
 
 import androidx.compose.material.icons.materialPath
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -25,7 +23,7 @@ import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.screenshots.ScreenshotBaseTest
 import org.junit.Test
 
-class StandardChipIconWithProgressTest : ScreenshotBaseTest() {
+class ChipIconWithProgressTest : ScreenshotBaseTest() {
 
     @Test
     fun default() {
@@ -34,28 +32,28 @@ class StandardChipIconWithProgressTest : ScreenshotBaseTest() {
             takeScreenshot = true,
             fakeImageLoader = FakeImageLoader.NotFound
         ) {
-            StandardChipIconWithProgress(progress = 75f)
+            ChipIconWithProgress(progress = 75f)
         }
     }
 
     @Test
     fun withProgressSmallIcon() {
         screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
-            StandardChipIconWithProgress(progress = 75f, icon = Icon12dp)
+            ChipIconWithProgress(progress = 75f, icon = Icon12dp)
         }
     }
 
     @Test
     fun withProgressMediumIcon() {
         screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
-            StandardChipIconWithProgress(progress = 75f, icon = Icon32dp)
+            ChipIconWithProgress(progress = 75f, icon = Icon32dp)
         }
     }
 
     @Test
     fun withProgressLargeIcon() {
         screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
-            StandardChipIconWithProgress(
+            ChipIconWithProgress(
                 progress = 75f,
                 icon = Icon48dp,
                 largeIcon = true

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ChipIconWithProgressTest_default.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ChipIconWithProgressTest_default.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9bc432007f67d516d33f123c3164b8c13d47b1ca436b841603ecc5eee7fce379
+size 2106

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ChipIconWithProgressTest_withProgressLargeIcon.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ChipIconWithProgressTest_withProgressLargeIcon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74a6abedd250093a384d8905b221d9b7ad8e9efd18f8f82d8f07594e5081b7c7
+size 3871

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ChipIconWithProgressTest_withProgressMediumIcon.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ChipIconWithProgressTest_withProgressMediumIcon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7570c92c43ebb0d89dd41a419851060406179bc77b0840665a03d81282c18a0c
+size 2639

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ChipIconWithProgressTest_withProgressSmallIcon.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ChipIconWithProgressTest_withProgressSmallIcon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7570c92c43ebb0d89dd41a419851060406179bc77b0840665a03d81282c18a0c
+size 2639

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
@@ -59,10 +59,10 @@ import com.google.android.horologist.base.ui.components.StandardButton
 import com.google.android.horologist.base.ui.components.StandardButtonSize
 import com.google.android.horologist.base.ui.components.StandardButtonType
 import com.google.android.horologist.base.ui.components.StandardChip
-import com.google.android.horologist.base.ui.components.StandardChipIconWithProgress
 import com.google.android.horologist.base.ui.components.StandardChipType
 import com.google.android.horologist.composables.PlaceholderChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.material.ChipIconWithProgress
 import com.google.android.horologist.media.ui.R
 import com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState.Loaded.DownloadsProgress
 import com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel
@@ -199,7 +199,7 @@ private fun MediaContent(
                                 animationSpec = ProgressIndicatorDefaults.ProgressAnimationSpec
                             )
 
-                            StandardChipIconWithProgress(
+                            ChipIconWithProgress(
                                 progress = progress,
                                 modifier = Modifier.clearAndSetSemantics { },
                                 icon = downloadMediaUiModel.artworkUri,
@@ -211,7 +211,7 @@ private fun MediaContent(
 
                     is DownloadMediaUiModel.Progress.Waiting -> {
                         {
-                            StandardChipIconWithProgress(
+                            ChipIconWithProgress(
                                 modifier = Modifier.clearAndSetSemantics { },
                                 icon = downloadMediaUiModel.artworkUri,
                                 largeIcon = true,


### PR DESCRIPTION
#### WHAT

Add `ChipIconWithProgress` to `compose-material`.

#### WHY

https://github.com/google/horologist/issues/1324

#### HOW

- Keep components in `base-ui` for few releases, marked as deprecated, suggesting the new library;
- Change the code of the components in `base-ui` and samples to use the ones from `compose-material`;
- Remove previews from `base-ui`, keep the unit tests to check if the usage of `compose-material` is correct;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
