### PR TITLE
Add onRouteChanged SystemAudioRepository MediaRouter callback

### DIFF
--- a/media/audio/src/main/java/com/google/android/horologist/audio/SystemAudioRepository.kt
+++ b/media/audio/src/main/java/com/google/android/horologist/audio/SystemAudioRepository.kt
@@ -71,6 +71,10 @@ public class SystemAudioRepository(
             update()
         }
 
+        override fun onRouteChanged(router: MediaRouter, route: RouteInfo) {
+            update()
+        }
+
         override fun onRouteVolumeChanged(router: MediaRouter, route: RouteInfo) {
             mediaRouter.fixInconsistency()
             _volume.value = mediaRouter.volume


### PR DESCRIPTION
#### WHAT
Add onRouteChanged SystemAudioRepository MediaRouter callback

#### WHY
Transfers between Bluetooth routes are signalled by `onRouteChanged()`, rather than `onRouteSelected()`