### PR TITLE
Add rememberVectorPainter to compose-material

### DIFF
--- a/base-ui/api/current.api
+++ b/base-ui/api/current.api
@@ -97,11 +97,11 @@ package com.google.android.horologist.base.ui.util {
   }
 
   public final class AdjustChipHeightToFontScaleKt {
-    method public static androidx.compose.ui.Modifier adjustChipHeightToFontScale(androidx.compose.ui.Modifier, float fontScale, optional float padding);
+    method @Deprecated @com.google.android.horologist.annotations.ExperimentalHorologistApi public static androidx.compose.ui.Modifier adjustChipHeightToFontScale(androidx.compose.ui.Modifier, float fontScale, optional float padding);
   }
 
   public final class RememberVectorPainterKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static androidx.compose.ui.graphics.vector.VectorPainter rememberVectorPainter(androidx.compose.ui.graphics.vector.ImageVector image, long tintColor, optional int tintBlendMode);
+    method @Deprecated @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static androidx.compose.ui.graphics.vector.VectorPainter rememberVectorPainter(androidx.compose.ui.graphics.vector.ImageVector image, long tintColor, optional int tintBlendMode);
   }
 
 }

--- a/base-ui/src/main/java/com/google/android/horologist/base/ui/components/StandardChip.kt
+++ b/base-ui/src/main/java/com/google/android/horologist/base/ui/components/StandardChip.kt
@@ -44,8 +44,8 @@ import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import coil.compose.rememberAsyncImagePainter
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.base.ui.util.adjustChipHeightToFontScale
 import com.google.android.horologist.compose.material.util.DECORATIVE_ELEMENT_CONTENT_DESCRIPTION
+import com.google.android.horologist.compose.material.util.adjustChipHeightToFontScale
 
 /**
  * This composable fulfils the redlines of the following components:

--- a/base-ui/src/main/java/com/google/android/horologist/base/ui/util/AdjustChipHeightToFontScale.kt
+++ b/base-ui/src/main/java/com/google/android/horologist/base/ui/util/AdjustChipHeightToFontScale.kt
@@ -20,8 +20,17 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 /** Adjusts height of the chip as per the font scale. */
+@Deprecated(
+    "Replaced by adjustChipHeightToFontScale in Horologist Material Compose library",
+    replaceWith = ReplaceWith(
+        "adjustChipHeightToFontScale(fontScale, padding)",
+        "com.google.android.horologist.compose.material.util.adjustChipHeightToFontScale"
+    )
+)
+@ExperimentalHorologistApi
 public fun Modifier.adjustChipHeightToFontScale(fontScale: Float, padding: Dp = 0.dp): Modifier =
     if (fontScale > 1.06) {
         this.then(Modifier.height(60.dp + padding))

--- a/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardChipPrimaryTest.kt
+++ b/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardChipPrimaryTest.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.testharness.TestHarness
-import com.google.android.horologist.base.ui.util.rememberVectorPainter
+import com.google.android.horologist.compose.material.util.rememberVectorPainter
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.screenshots.ScreenshotBaseTest
 import org.junit.Test

--- a/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardChipSecondaryTest.kt
+++ b/base-ui/src/test/java/com/google/android/horologist/base/ui/components/StandardChipSecondaryTest.kt
@@ -29,8 +29,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.testharness.TestHarness
-import com.google.android.horologist.base.ui.util.rememberVectorPainter
 import com.google.android.horologist.compose.material.ChipIconWithProgress
+import com.google.android.horologist.compose.material.util.rememberVectorPainter
 import com.google.android.horologist.compose.tools.coil.FakeImageLoader
 import com.google.android.horologist.screenshots.ScreenshotBaseTest
 import org.junit.Test

--- a/compose-material/api/current.api
+++ b/compose-material/api/current.api
@@ -51,5 +51,9 @@ package com.google.android.horologist.compose.material.util {
     method @com.google.android.horologist.annotations.ExperimentalHorologistApi public static androidx.compose.ui.Modifier adjustChipHeightToFontScale(androidx.compose.ui.Modifier, float fontScale, optional float padding);
   }
 
+  public final class RememberVectorPainterKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static androidx.compose.ui.graphics.vector.VectorPainter rememberVectorPainter(androidx.compose.ui.graphics.vector.ImageVector image, long tintColor, optional int tintBlendMode);
+  }
+
 }
 

--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/util/RememberVectorPainter.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/util/RememberVectorPainter.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.base.ui.util
+package com.google.android.horologist.compose.material.util
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.BlendMode
@@ -33,13 +33,6 @@ import com.google.android.horologist.annotations.ExperimentalHorologistApi
  * @param [tintBlendMode] optional BlendMode used in combination with [tintColor], defaults to
  * value defined in [image].
  */
-@Deprecated(
-    "Replaced by rememberVectorPainter in Horologist Material Compose library",
-    replaceWith = ReplaceWith(
-        "rememberVectorPainter(image, tintColor, tintBlendMode)",
-        "com.google.android.horologist.compose.material.util.rememberVectorPainter"
-    )
-)
 @ExperimentalHorologistApi
 @Composable
 public fun rememberVectorPainter(

--- a/media/ui/src/debug/java/com/google/android/horologist/media/ui/components/MediaChipPreview.kt
+++ b/media/ui/src/debug/java/com/google/android/horologist/media/ui/components/MediaChipPreview.kt
@@ -21,7 +21,7 @@ import androidx.compose.material.icons.filled.Album
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.base.ui.util.rememberVectorPainter
+import com.google.android.horologist.compose.material.util.rememberVectorPainter
 import com.google.android.horologist.compose.tools.WearPreview
 import com.google.android.horologist.media.ui.state.model.MediaUiModel
 

--- a/media/ui/src/debug/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChipPreview.kt
+++ b/media/ui/src/debug/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChipPreview.kt
@@ -21,7 +21,7 @@ import androidx.compose.material.icons.filled.FeaturedPlayList
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.android.horologist.base.ui.util.rememberVectorPainter
+import com.google.android.horologist.compose.material.util.rememberVectorPainter
 import com.google.android.horologist.compose.tools.WearPreview
 
 @WearPreview

--- a/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/browse/PlaylistDownloadBrowseScreenPreview.kt
+++ b/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/browse/PlaylistDownloadBrowseScreenPreview.kt
@@ -21,8 +21,8 @@ import androidx.compose.material.icons.filled.FeaturedPlayList
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
-import com.google.android.horologist.base.ui.util.rememberVectorPainter
 import com.google.android.horologist.compose.layout.belowTimeTextPreview
+import com.google.android.horologist.compose.material.util.rememberVectorPainter
 import com.google.android.horologist.media.ui.state.model.PlaylistDownloadUiModel
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
 import com.google.android.horologist.media.ui.uamp.UampTheme

--- a/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenPreview.kt
+++ b/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenPreview.kt
@@ -21,8 +21,8 @@ import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
-import com.google.android.horologist.base.ui.util.rememberVectorPainter
 import com.google.android.horologist.compose.layout.belowTimeTextPreview
+import com.google.android.horologist.compose.material.util.rememberVectorPainter
 import com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
 

--- a/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreenPreview.kt
+++ b/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreenPreview.kt
@@ -23,8 +23,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import com.google.android.horologist.base.ui.components.StandardChip
 import com.google.android.horologist.base.ui.components.StandardChipType
-import com.google.android.horologist.base.ui.util.rememberVectorPainter
 import com.google.android.horologist.compose.layout.belowTimeTextPreview
+import com.google.android.horologist.compose.material.util.rememberVectorPainter
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
 
 @WearPreviewDevices

--- a/media/ui/src/test/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenA11yScreenshotTest.kt
+++ b/media/ui/src/test/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenA11yScreenshotTest.kt
@@ -19,7 +19,7 @@ package com.google.android.horologist.media.ui.screens.entity
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.ui.graphics.Color
-import com.google.android.horologist.base.ui.util.rememberVectorPainter
+import com.google.android.horologist.compose.material.util.rememberVectorPainter
 import com.google.android.horologist.media.ui.PlayerLibraryPreview
 import com.google.android.horologist.media.ui.components.positionedState
 import com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel


### PR DESCRIPTION
#### WHAT

Add `rememberVectorPainter` to `compose-material`.

#### WHY

https://github.com/google/horologist/issues/1324

#### HOW

- Keep components in `base-ui` for few releases, marked as deprecated, suggesting the new library;
- Change the code of the components in `base-ui` and samples to use the ones from `compose-material`;
- Remove previews from `base-ui`, keep the unit tests to check if the usage of `compose-material` is correct;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
