### PR TITLE
Add Button to compose-material

### DIFF
--- a/base-ui/api/current.api
+++ b/base-ui/api/current.api
@@ -24,28 +24,28 @@ package com.google.android.horologist.base.ui.components {
   }
 
   public final class StandardButtonKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void StandardButton(androidx.compose.ui.graphics.vector.ImageVector imageVector, String contentDescription, kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.base.ui.components.StandardButtonType buttonType, optional com.google.android.horologist.base.ui.components.StandardButtonSize buttonSize, optional boolean enabled);
+    method @Deprecated @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void StandardButton(androidx.compose.ui.graphics.vector.ImageVector imageVector, String contentDescription, kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.base.ui.components.StandardButtonType buttonType, optional com.google.android.horologist.base.ui.components.StandardButtonSize buttonSize, optional boolean enabled);
   }
 
-  @com.google.android.horologist.annotations.ExperimentalHorologistApi public enum StandardButtonSize {
-    method public final float getIconSize();
-    method public final float getTapTargetSize();
-    method public static com.google.android.horologist.base.ui.components.StandardButtonSize valueOf(String name) throws java.lang.IllegalArgumentException;
-    method public static com.google.android.horologist.base.ui.components.StandardButtonSize[] values();
+  @Deprecated @com.google.android.horologist.annotations.ExperimentalHorologistApi public enum StandardButtonSize {
+    method @Deprecated public final float getIconSize();
+    method @Deprecated public final float getTapTargetSize();
+    method @Deprecated public static com.google.android.horologist.base.ui.components.StandardButtonSize valueOf(String name) throws java.lang.IllegalArgumentException;
+    method @Deprecated public static com.google.android.horologist.base.ui.components.StandardButtonSize[] values();
     property public final float iconSize;
     property public final float tapTargetSize;
-    enum_constant public static final com.google.android.horologist.base.ui.components.StandardButtonSize Default;
-    enum_constant public static final com.google.android.horologist.base.ui.components.StandardButtonSize ExtraSmall;
-    enum_constant public static final com.google.android.horologist.base.ui.components.StandardButtonSize Large;
-    enum_constant public static final com.google.android.horologist.base.ui.components.StandardButtonSize Small;
+    enum_constant @Deprecated public static final com.google.android.horologist.base.ui.components.StandardButtonSize Default;
+    enum_constant @Deprecated public static final com.google.android.horologist.base.ui.components.StandardButtonSize ExtraSmall;
+    enum_constant @Deprecated public static final com.google.android.horologist.base.ui.components.StandardButtonSize Large;
+    enum_constant @Deprecated public static final com.google.android.horologist.base.ui.components.StandardButtonSize Small;
   }
 
-  @com.google.android.horologist.annotations.ExperimentalHorologistApi public enum StandardButtonType {
-    method public static com.google.android.horologist.base.ui.components.StandardButtonType valueOf(String name) throws java.lang.IllegalArgumentException;
-    method public static com.google.android.horologist.base.ui.components.StandardButtonType[] values();
-    enum_constant public static final com.google.android.horologist.base.ui.components.StandardButtonType IconOnly;
-    enum_constant public static final com.google.android.horologist.base.ui.components.StandardButtonType Primary;
-    enum_constant public static final com.google.android.horologist.base.ui.components.StandardButtonType Secondary;
+  @Deprecated @com.google.android.horologist.annotations.ExperimentalHorologistApi public enum StandardButtonType {
+    method @Deprecated public static com.google.android.horologist.base.ui.components.StandardButtonType valueOf(String name) throws java.lang.IllegalArgumentException;
+    method @Deprecated public static com.google.android.horologist.base.ui.components.StandardButtonType[] values();
+    enum_constant @Deprecated public static final com.google.android.horologist.base.ui.components.StandardButtonType IconOnly;
+    enum_constant @Deprecated public static final com.google.android.horologist.base.ui.components.StandardButtonType Primary;
+    enum_constant @Deprecated public static final com.google.android.horologist.base.ui.components.StandardButtonType Secondary;
   }
 
   public final class StandardChipIconWithProgressKt {

--- a/base-ui/src/main/java/com/google/android/horologist/base/ui/components/AlertDialog.kt
+++ b/base-ui/src/main/java/com/google/android/horologist/base/ui/components/AlertDialog.kt
@@ -29,6 +29,8 @@ import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.dialog.Alert
 import androidx.wear.compose.material.dialog.Dialog
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.compose.material.Button
+import com.google.android.horologist.compose.material.ButtonType
 
 /**
  * This composable fulfils the redlines of the following components:
@@ -93,15 +95,15 @@ internal fun AlertDialogAlert(
             )
         },
         negativeButton = {
-            StandardButton(
+            Button(
                 imageVector = Icons.Default.Close,
                 contentDescription = cancelButtonContentDescription,
                 onClick = onCancelButtonClick,
-                buttonType = StandardButtonType.Secondary
+                buttonType = ButtonType.Secondary
             )
         },
         positiveButton = {
-            StandardButton(
+            Button(
                 imageVector = Icons.Default.Check,
                 contentDescription = okButtonContentDescription,
                 onClick = onOKButtonClick

--- a/base-ui/src/main/java/com/google/android/horologist/base/ui/components/StandardButton.kt
+++ b/base-ui/src/main/java/com/google/android/horologist/base/ui/components/StandardButton.kt
@@ -16,23 +16,29 @@
 
 package com.google.android.horologist.base.ui.components
 
-import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.wear.compose.material.Button
-import androidx.wear.compose.material.ButtonDefaults
-import androidx.wear.compose.material.Icon
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.compose.material.Button
+import com.google.android.horologist.compose.material.ButtonSize
+import com.google.android.horologist.compose.material.ButtonType
 
 /**
  * This composable fulfils the redlines of the following components:
  * - Primary, Secondary or Icon only button - according to [buttonType] value;
  * - Default, Large, Small and Extra Small button - according to [buttonSize] value;
  */
+@Suppress("DEPRECATION")
+@Deprecated(
+    "Replaced by Button in Horologist Material Compose library",
+    replaceWith = ReplaceWith(
+        "Button(imageVector, contentDescription, onClick, modifier, buttonType, buttonSize, enabled)",
+        "com.google.android.horologist.compose.material.Button"
+    )
+)
 @ExperimentalHorologistApi
 @Composable
 public fun StandardButton(
@@ -45,25 +51,32 @@ public fun StandardButton(
     enabled: Boolean = true
 ) {
     Button(
+        imageVector = imageVector,
+        contentDescription = contentDescription,
         onClick = onClick,
-        modifier = modifier.size(buttonSize.tapTargetSize),
-        enabled = enabled,
-        colors = when (buttonType) {
-            StandardButtonType.Primary -> ButtonDefaults.primaryButtonColors()
-            StandardButtonType.Secondary -> ButtonDefaults.secondaryButtonColors()
-            StandardButtonType.IconOnly -> ButtonDefaults.iconButtonColors()
-        }
-    ) {
-        Icon(
-            imageVector = imageVector,
-            contentDescription = contentDescription,
-            modifier = Modifier
-                .size(buttonSize.iconSize)
-                .align(Alignment.Center)
-        )
-    }
+        modifier = modifier,
+        buttonType = when (buttonType) {
+            StandardButtonType.Primary -> ButtonType.Primary
+            StandardButtonType.Secondary -> ButtonType.Secondary
+            StandardButtonType.IconOnly -> ButtonType.IconOnly
+        },
+        buttonSize = when (buttonSize) {
+            StandardButtonSize.Default -> ButtonSize.Default
+            StandardButtonSize.Large -> ButtonSize.Large
+            StandardButtonSize.Small -> ButtonSize.Small
+            StandardButtonSize.ExtraSmall -> ButtonSize.ExtraSmall
+        },
+        enabled = enabled
+    )
 }
 
+@Deprecated(
+    "Replaced by ButtonType in Horologist Material Compose library",
+    replaceWith = ReplaceWith(
+        "ButtonType",
+        "com.google.android.horologist.compose.material.ButtonType"
+    )
+)
 @ExperimentalHorologistApi
 public enum class StandardButtonType {
     Primary,
@@ -71,6 +84,13 @@ public enum class StandardButtonType {
     IconOnly,
 }
 
+@Deprecated(
+    "Replaced by ButtonSize in Horologist Material Compose library",
+    replaceWith = ReplaceWith(
+        "ButtonSize",
+        "com.google.android.horologist.compose.material.ButtonSize"
+    )
+)
 @ExperimentalHorologistApi
 public enum class StandardButtonSize(
     public val iconSize: Dp,

--- a/compose-material/api/current.api
+++ b/compose-material/api/current.api
@@ -1,6 +1,31 @@
 // Signature format: 4.0
 package com.google.android.horologist.compose.material {
 
+  public final class ButtonKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void Button(androidx.compose.ui.graphics.vector.ImageVector imageVector, String contentDescription, kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.compose.material.ButtonType buttonType, optional com.google.android.horologist.compose.material.ButtonSize buttonSize, optional boolean enabled);
+  }
+
+  @com.google.android.horologist.annotations.ExperimentalHorologistApi public enum ButtonSize {
+    method public final float getIconSize();
+    method public final float getTapTargetSize();
+    method public static com.google.android.horologist.compose.material.ButtonSize valueOf(String name) throws java.lang.IllegalArgumentException;
+    method public static com.google.android.horologist.compose.material.ButtonSize[] values();
+    property public final float iconSize;
+    property public final float tapTargetSize;
+    enum_constant public static final com.google.android.horologist.compose.material.ButtonSize Default;
+    enum_constant public static final com.google.android.horologist.compose.material.ButtonSize ExtraSmall;
+    enum_constant public static final com.google.android.horologist.compose.material.ButtonSize Large;
+    enum_constant public static final com.google.android.horologist.compose.material.ButtonSize Small;
+  }
+
+  @com.google.android.horologist.annotations.ExperimentalHorologistApi public enum ButtonType {
+    method public static com.google.android.horologist.compose.material.ButtonType valueOf(String name) throws java.lang.IllegalArgumentException;
+    method public static com.google.android.horologist.compose.material.ButtonType[] values();
+    enum_constant public static final com.google.android.horologist.compose.material.ButtonType IconOnly;
+    enum_constant public static final com.google.android.horologist.compose.material.ButtonType Primary;
+    enum_constant public static final com.google.android.horologist.compose.material.ButtonType Secondary;
+  }
+
   public final class ChipIconWithProgressKt {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void ChipIconWithProgress(optional androidx.compose.ui.Modifier modifier, optional Object? icon, optional boolean largeIcon, optional androidx.compose.ui.graphics.painter.Painter? placeholder, optional long progressIndicatorColor, optional long progressTrackColor);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void ChipIconWithProgress(float progress, optional androidx.compose.ui.Modifier modifier, optional Object? icon, optional boolean largeIcon, optional androidx.compose.ui.graphics.painter.Painter? placeholder, optional long progressIndicatorColor, optional long progressTrackColor);

--- a/compose-material/src/debug/java/com/google/android/horologist/compose/material/ButtonIconOnlyPreview.kt
+++ b/compose-material/src/debug/java/com/google/android/horologist/compose/material/ButtonIconOnlyPreview.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.base.ui.components
+package com.google.android.horologist.compose.material
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -23,59 +23,59 @@ import com.google.android.horologist.compose.tools.WearPreview
 
 @WearPreview
 @Composable
-fun IconOnlyButtonPreview() {
-    StandardButton(
+fun ButtonIconOnlyPreview() {
+    Button(
         imageVector = Icons.Default.Check,
         contentDescription = "contentDescription",
         onClick = { },
-        buttonType = StandardButtonType.IconOnly
+        buttonType = ButtonType.IconOnly
     )
 }
 
 @WearPreview
 @Composable
-fun IconOnlyButtonPreviewLarge() {
-    StandardButton(
+fun ButtonIconOnlyPreviewLarge() {
+    Button(
         imageVector = Icons.Default.Check,
         contentDescription = "contentDescription",
         onClick = { },
-        buttonType = StandardButtonType.IconOnly,
-        buttonSize = StandardButtonSize.Large
+        buttonType = ButtonType.IconOnly,
+        buttonSize = ButtonSize.Large
     )
 }
 
 @WearPreview
 @Composable
-fun IconOnlyButtonPreviewSmall() {
-    StandardButton(
+fun ButtonIconOnlyPreviewSmall() {
+    Button(
         imageVector = Icons.Default.Check,
         contentDescription = "contentDescription",
         onClick = { },
-        buttonType = StandardButtonType.IconOnly,
-        buttonSize = StandardButtonSize.Small
+        buttonType = ButtonType.IconOnly,
+        buttonSize = ButtonSize.Small
     )
 }
 
 @WearPreview
 @Composable
-fun IconOnlyButtonPreviewExtraSmall() {
-    StandardButton(
+fun ButtonIconOnlyPreviewExtraSmall() {
+    Button(
         imageVector = Icons.Default.Check,
         contentDescription = "contentDescription",
         onClick = { },
-        buttonType = StandardButtonType.IconOnly,
-        buttonSize = StandardButtonSize.ExtraSmall
+        buttonType = ButtonType.IconOnly,
+        buttonSize = ButtonSize.ExtraSmall
     )
 }
 
 @WearPreview
 @Composable
-fun IconOnlyButtonPreviewDisabled() {
-    StandardButton(
+fun ButtonIconOnlyPreviewDisabled() {
+    Button(
         imageVector = Icons.Default.Check,
         contentDescription = "contentDescription",
         onClick = { },
-        buttonType = StandardButtonType.IconOnly,
+        buttonType = ButtonType.IconOnly,
         enabled = false
     )
 }

--- a/compose-material/src/debug/java/com/google/android/horologist/compose/material/ButtonPrimaryPreview.kt
+++ b/compose-material/src/debug/java/com/google/android/horologist/compose/material/ButtonPrimaryPreview.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.base.ui.components
+package com.google.android.horologist.compose.material
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -23,8 +23,8 @@ import com.google.android.horologist.compose.tools.WearPreview
 
 @WearPreview
 @Composable
-fun PrimaryButtonPreview() {
-    StandardButton(
+fun ButtonPrimaryPreview() {
+    Button(
         imageVector = Icons.Default.Check,
         contentDescription = "contentDescription",
         onClick = { }
@@ -33,41 +33,41 @@ fun PrimaryButtonPreview() {
 
 @WearPreview
 @Composable
-fun PrimaryButtonPreviewLarge() {
-    StandardButton(
+fun ButtonPrimaryPreviewLarge() {
+    Button(
         imageVector = Icons.Default.Check,
         contentDescription = "contentDescription",
         onClick = { },
-        buttonSize = StandardButtonSize.Large
+        buttonSize = ButtonSize.Large
     )
 }
 
 @WearPreview
 @Composable
-fun PrimaryButtonPreviewSmall() {
-    StandardButton(
+fun ButtonPrimaryPreviewSmall() {
+    Button(
         imageVector = Icons.Default.Check,
         contentDescription = "contentDescription",
         onClick = { },
-        buttonSize = StandardButtonSize.Small
+        buttonSize = ButtonSize.Small
     )
 }
 
 @WearPreview
 @Composable
-fun PrimaryButtonPreviewExtraSmall() {
-    StandardButton(
+fun ButtonPrimaryPreviewExtraSmall() {
+    Button(
         imageVector = Icons.Default.Check,
         contentDescription = "contentDescription",
         onClick = { },
-        buttonSize = StandardButtonSize.ExtraSmall
+        buttonSize = ButtonSize.ExtraSmall
     )
 }
 
 @WearPreview
 @Composable
-fun PrimaryButtonPreviewDisabled() {
-    StandardButton(
+fun ButtonPrimaryPreviewDisabled() {
+    Button(
         imageVector = Icons.Default.Check,
         contentDescription = "contentDescription",
         onClick = { },

--- a/compose-material/src/debug/java/com/google/android/horologist/compose/material/ButtonSecondaryPreview.kt
+++ b/compose-material/src/debug/java/com/google/android/horologist/compose/material/ButtonSecondaryPreview.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.base.ui.components
+package com.google.android.horologist.compose.material
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -23,59 +23,59 @@ import com.google.android.horologist.compose.tools.WearPreview
 
 @WearPreview
 @Composable
-fun SecondaryButtonPreview() {
-    StandardButton(
+fun ButtonSecondaryPreview() {
+    Button(
         imageVector = Icons.Default.Check,
         contentDescription = "contentDescription",
         onClick = { },
-        buttonType = StandardButtonType.Secondary
+        buttonType = ButtonType.Secondary
     )
 }
 
 @WearPreview
 @Composable
-fun SecondaryButtonPreviewLarge() {
-    StandardButton(
+fun ButtonSecondaryPreviewLarge() {
+    Button(
         imageVector = Icons.Default.Check,
         contentDescription = "contentDescription",
         onClick = { },
-        buttonType = StandardButtonType.Secondary,
-        buttonSize = StandardButtonSize.Large
+        buttonType = ButtonType.Secondary,
+        buttonSize = ButtonSize.Large
     )
 }
 
 @WearPreview
 @Composable
-fun SecondaryButtonPreviewSmall() {
-    StandardButton(
+fun ButtonSecondaryPreviewSmall() {
+    Button(
         imageVector = Icons.Default.Check,
         contentDescription = "contentDescription",
         onClick = { },
-        buttonType = StandardButtonType.Secondary,
-        buttonSize = StandardButtonSize.Small
+        buttonType = ButtonType.Secondary,
+        buttonSize = ButtonSize.Small
     )
 }
 
 @WearPreview
 @Composable
-fun SecondaryButtonPreviewExtraSmall() {
-    StandardButton(
+fun ButtonSecondaryPreviewExtraSmall() {
+    Button(
         imageVector = Icons.Default.Check,
         contentDescription = "contentDescription",
         onClick = { },
-        buttonType = StandardButtonType.Secondary,
-        buttonSize = StandardButtonSize.ExtraSmall
+        buttonType = ButtonType.Secondary,
+        buttonSize = ButtonSize.ExtraSmall
     )
 }
 
 @WearPreview
 @Composable
-fun SecondaryButtonPreviewDisabled() {
-    StandardButton(
+fun ButtonSecondaryPreviewDisabled() {
+    Button(
         imageVector = Icons.Default.Check,
         contentDescription = "contentDescription",
         onClick = { },
-        buttonType = StandardButtonType.Secondary,
+        buttonType = ButtonType.Secondary,
         enabled = false
     )
 }

--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/Button.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/Button.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.compose.material
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.Button
+import androidx.wear.compose.material.ButtonDefaults
+import androidx.wear.compose.material.Icon
+import com.google.android.horologist.annotations.ExperimentalHorologistApi
+
+/**
+ * This composable fulfils the redlines of the following components:
+ * - Primary, Secondary or Icon only button - according to [buttonType] value;
+ * - Default, Large, Small and Extra Small button - according to [buttonSize] value;
+ */
+@ExperimentalHorologistApi
+@Composable
+public fun Button(
+    imageVector: ImageVector,
+    contentDescription: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    buttonType: ButtonType = ButtonType.Primary,
+    buttonSize: ButtonSize = ButtonSize.Default,
+    enabled: Boolean = true
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier.size(buttonSize.tapTargetSize),
+        enabled = enabled,
+        colors = when (buttonType) {
+            ButtonType.Primary -> ButtonDefaults.primaryButtonColors()
+            ButtonType.Secondary -> ButtonDefaults.secondaryButtonColors()
+            ButtonType.IconOnly -> ButtonDefaults.iconButtonColors()
+        }
+    ) {
+        Icon(
+            imageVector = imageVector,
+            contentDescription = contentDescription,
+            modifier = Modifier
+                .size(buttonSize.iconSize)
+                .align(Alignment.Center)
+        )
+    }
+}
+
+@ExperimentalHorologistApi
+public enum class ButtonType {
+    Primary,
+    Secondary,
+    IconOnly,
+}
+
+@ExperimentalHorologistApi
+public enum class ButtonSize(
+    public val iconSize: Dp,
+    public val tapTargetSize: Dp
+) {
+    Default(iconSize = 26.dp, tapTargetSize = 52.dp),
+    Large(iconSize = 30.dp, tapTargetSize = 60.dp),
+    Small(iconSize = 24.dp, tapTargetSize = 48.dp),
+    ExtraSmall(iconSize = 24.dp, tapTargetSize = 48.dp),
+}

--- a/compose-material/src/test/java/com/google/android/horologist/compose/material/ButtonTest.kt
+++ b/compose-material/src/test/java/com/google/android/horologist/compose/material/ButtonTest.kt
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-@file:Suppress("DEPRECATION")
-
-package com.google.android.horologist.base.ui.components
+package com.google.android.horologist.compose.material
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -27,18 +25,18 @@ import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.ParameterizedRobolectricTestRunner.Parameters
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
-internal class StandardButtonTest(
+internal class ButtonTest(
     @Suppress("unused") // it's used by junit to display the test name
     private val description: String,
-    private val buttonType: StandardButtonType,
-    private val buttonSize: StandardButtonSize,
+    private val buttonType: ButtonType,
+    private val buttonSize: ButtonSize,
     private val enabled: Boolean
 ) : ScreenshotBaseTest() {
 
     @Test
     fun variants() {
         screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
-            StandardButton(
+            Button(
                 imageVector = Icons.Default.Check,
                 contentDescription = "contentDescription",
                 onClick = { },
@@ -55,92 +53,92 @@ internal class StandardButtonTest(
         fun params() = listOf(
             arrayOf(
                 "Primary Default",
-                StandardButtonType.Primary,
-                StandardButtonSize.Default,
+                ButtonType.Primary,
+                ButtonSize.Default,
                 true
             ),
             arrayOf(
                 "Primary Large",
-                StandardButtonType.Primary,
-                StandardButtonSize.Large,
+                ButtonType.Primary,
+                ButtonSize.Large,
                 true
             ),
             arrayOf(
                 "Primary Small",
-                StandardButtonType.Primary,
-                StandardButtonSize.Small,
+                ButtonType.Primary,
+                ButtonSize.Small,
                 true
             ),
             arrayOf(
                 "Primary ExtraSmall",
-                StandardButtonType.Primary,
-                StandardButtonSize.ExtraSmall,
+                ButtonType.Primary,
+                ButtonSize.ExtraSmall,
                 true
             ),
             arrayOf(
                 "Primary Default Disabled",
-                StandardButtonType.Primary,
-                StandardButtonSize.Default,
+                ButtonType.Primary,
+                ButtonSize.Default,
                 false
             ),
             arrayOf(
                 "Secondary Default",
-                StandardButtonType.Secondary,
-                StandardButtonSize.Default,
+                ButtonType.Secondary,
+                ButtonSize.Default,
                 true
             ),
             arrayOf(
                 "Secondary Large",
-                StandardButtonType.Secondary,
-                StandardButtonSize.Large,
+                ButtonType.Secondary,
+                ButtonSize.Large,
                 true
             ),
             arrayOf(
                 "Secondary Small",
-                StandardButtonType.Secondary,
-                StandardButtonSize.Small,
+                ButtonType.Secondary,
+                ButtonSize.Small,
                 true
             ),
             arrayOf(
                 "Secondary Extra Small",
-                StandardButtonType.Secondary,
-                StandardButtonSize.ExtraSmall,
+                ButtonType.Secondary,
+                ButtonSize.ExtraSmall,
                 true
             ),
             arrayOf(
                 "Secondary Default Disabled",
-                StandardButtonType.Secondary,
-                StandardButtonSize.Default,
+                ButtonType.Secondary,
+                ButtonSize.Default,
                 false
             ),
             arrayOf(
                 "Icon only Default",
-                StandardButtonType.IconOnly,
-                StandardButtonSize.Default,
+                ButtonType.IconOnly,
+                ButtonSize.Default,
                 true
             ),
             arrayOf(
                 "Icon only Large",
-                StandardButtonType.IconOnly,
-                StandardButtonSize.Large,
+                ButtonType.IconOnly,
+                ButtonSize.Large,
                 true
             ),
             arrayOf(
                 "Icon only Small",
-                StandardButtonType.IconOnly,
-                StandardButtonSize.Small,
+                ButtonType.IconOnly,
+                ButtonSize.Small,
                 true
             ),
             arrayOf(
                 "Icon only Extra Small",
-                StandardButtonType.IconOnly,
-                StandardButtonSize.ExtraSmall,
+                ButtonType.IconOnly,
+                ButtonSize.ExtraSmall,
                 true
             ),
             arrayOf(
                 "Icon only Default Disabled",
-                StandardButtonType.IconOnly,
-                StandardButtonSize.Default,
+                ButtonType.IconOnly,
+                ButtonSize.Default,
                 false
             )
         )

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Icon only Default Disabled].png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Icon only Default Disabled].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24b4ba300938f976619bb9c0f001afc51ccf848667c55fc73cc9c6a5081fe2f8
+size 1973

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Icon only Default].png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Icon only Default].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c8a78038485d7b80dfd3c1364f7bdf347ab10b790cc1e355c1783feb445c373
+size 931

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Icon only Extra Small].png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Icon only Extra Small].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:271f33eef4a5d02211c346f0e069fdacd1276f4804d9703b147f7d54c41fc0ac
+size 915

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Icon only Large].png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Icon only Large].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6b943d4733ca054c6817072721a3d9546311a973ee20ab0d5463edd5de32396
+size 901

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Icon only Small].png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Icon only Small].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:271f33eef4a5d02211c346f0e069fdacd1276f4804d9703b147f7d54c41fc0ac
+size 915

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Primary Default Disabled].png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Primary Default Disabled].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60ed348408e12d3ace6142e83bef8b6768630a597146b4cf07defb29229f735a
+size 3100

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Primary Default].png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Primary Default].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3cacfebb96aa9f061dda27c665120bc2bdc669ec6f491eff39dfdd2e1c5a8424
+size 3258

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Primary ExtraSmall].png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Primary ExtraSmall].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd659dd0a0c6a3079d859f1bddc2185377898b5bf4cacb628bac906fc19d5068
+size 3031

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Primary Large].png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Primary Large].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8381409b3b0a5494a05112c118530f36770bebb61b8637106c299bcef02fbe85
+size 3603

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Primary Small].png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Primary Small].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd659dd0a0c6a3079d859f1bddc2185377898b5bf4cacb628bac906fc19d5068
+size 3031

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Secondary Default Disabled].png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Secondary Default Disabled].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:efc7d4d8fb2d4b1ef58bad036a5aefc85d9cf5e701cfb7df84ce1797975e6edc
+size 2830

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Secondary Default].png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Secondary Default].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:efc877136aa9ea0b65fa0e0ae6921981e65011a7207e08b1f5de6b5853ddd5ad
+size 2954

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Secondary Extra Small].png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Secondary Extra Small].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4483e0824ba8f885f021b15d5550e05e18ca4e82d0c5f03f0da8c5abaad3000
+size 2885

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Secondary Large].png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Secondary Large].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73d01aa6521dd94f07736f9c2913419362f66cfee3bbf8aceaf346ce999bf437
+size 3433

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Secondary Small].png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_variants[Secondary Small].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4483e0824ba8f885f021b15d5550e05e18ca4e82d0c5f03f0da8c5abaad3000
+size 2885

--- a/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/EntityScreenPreview.kt
+++ b/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/EntityScreenPreview.kt
@@ -44,9 +44,9 @@ import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
-import com.google.android.horologist.base.ui.components.StandardButton
 import com.google.android.horologist.composables.PlaceholderChip
 import com.google.android.horologist.compose.layout.belowTimeTextPreview
+import com.google.android.horologist.compose.material.Button
 import com.google.android.horologist.compose.material.Chip
 
 @WearPreviewDevices
@@ -79,7 +79,7 @@ fun EntityScreenPreview() {
                     .height(52.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                StandardButton(
+                Button(
                     imageVector = Icons.Default.Favorite,
                     contentDescription = "Favorite",
                     onClick = { },
@@ -88,7 +88,7 @@ fun EntityScreenPreview() {
                         .weight(weight = 0.3F, fill = false)
                 )
 
-                StandardButton(
+                Button(
                     imageVector = Icons.Default.PlaylistPlay,
                     contentDescription = "Play",
                     onClick = { },
@@ -170,7 +170,7 @@ private fun ButtonContentForStatePreview() {
             .height(52.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        StandardButton(
+        Button(
             imageVector = Icons.Default.Download,
             contentDescription = "Download",
             onClick = { },
@@ -179,7 +179,7 @@ private fun ButtonContentForStatePreview() {
                 .weight(weight = 0.3F, fill = false)
         )
 
-        StandardButton(
+        Button(
             imageVector = Icons.Default.Shuffle,
             contentDescription = "Shuffle",
             onClick = { },
@@ -188,7 +188,7 @@ private fun ButtonContentForStatePreview() {
                 .weight(weight = 0.3F, fill = false)
         )
 
-        StandardButton(
+        Button(
             imageVector = Icons.Default.PlayArrow,
             contentDescription = "Play",
             onClick = { },

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreen.kt
@@ -47,7 +47,6 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
-import androidx.wear.compose.material.Button
 import androidx.wear.compose.material.ButtonDefaults
 import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.CircularProgressIndicator
@@ -55,11 +54,11 @@ import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.ProgressIndicatorDefaults
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.base.ui.components.StandardButton
-import com.google.android.horologist.base.ui.components.StandardButtonSize
-import com.google.android.horologist.base.ui.components.StandardButtonType
 import com.google.android.horologist.composables.PlaceholderChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.material.Button
+import com.google.android.horologist.compose.material.ButtonSize
+import com.google.android.horologist.compose.material.ButtonType
 import com.google.android.horologist.compose.material.Chip
 import com.google.android.horologist.compose.material.ChipIconWithProgress
 import com.google.android.horologist.compose.material.ChipType
@@ -307,7 +306,7 @@ private fun ButtonsContent(
                             .weight(weight = 0.3F, fill = false)
                     )
 
-                    StandardButton(
+                    Button(
                         imageVector = Icons.Default.Shuffle,
                         contentDescription = stringResource(id = R.string.horologist_playlist_download_button_shuffle_content_description),
                         onClick = { onShuffleButtonClick(state.collectionModel) },
@@ -315,7 +314,7 @@ private fun ButtonsContent(
                             .weight(weight = 0.3F, fill = false)
                     )
 
-                    StandardButton(
+                    Button(
                         imageVector = Icons.Filled.PlayArrow,
                         contentDescription = stringResource(id = R.string.horologist_playlist_download_button_play_content_description),
                         onClick = { onPlayButtonClick(state.collectionModel) },
@@ -346,10 +345,10 @@ private fun <Collection> FirstButton(
         val label =
             stringResource(id = R.string.horologist_playlist_download_progress_button_cancel_action_label)
 
-        Button(
+        androidx.wear.compose.material.Button(
             onClick = { onCancelDownloadButtonClick(collectionModel) },
             modifier = modifier
-                .size(StandardButtonSize.Default.tapTargetSize)
+                .size(ButtonSize.Default.tapTargetSize)
                 .semantics(mergeDescendants = true) {
                     onClick(label = label, action = null)
                 },
@@ -373,22 +372,22 @@ private fun <Collection> FirstButton(
                 imageVector = Icons.Default.Close,
                 contentDescription = stringResource(id = R.string.horologist_playlist_download_progress_button_cancel_content_description),
                 modifier = Modifier
-                    .size(StandardButtonSize.Default.iconSize)
+                    .size(ButtonSize.Default.iconSize)
                     .align(Alignment.Center)
             )
         }
     } else if (downloadMediaListState == PlaylistDownloadScreenState.Loaded.DownloadMediaListState.Partially) {
-        StandardButton(
+        Button(
             imageVector = Icons.Default.Download,
             contentDescription = stringResource(id = R.string.horologist_playlist_download_button_download_content_description),
             onClick = { onDownloadButtonClick(collectionModel) },
             modifier = modifier,
-            buttonType = StandardButtonType.Secondary
+            buttonType = ButtonType.Secondary
         )
     } else if (downloadMediaListState == PlaylistDownloadScreenState.Loaded.DownloadMediaListState.Fully) {
         val label =
             stringResource(id = R.string.horologist_playlist_download_button_remove_download_action_label)
-        StandardButton(
+        Button(
             imageVector = Icons.Default.DownloadDone,
             contentDescription = stringResource(id = R.string.horologist_playlist_download_button_download_done_content_description),
             onClick = { onDownloadCompletedButtonClick(collectionModel) },
@@ -398,7 +397,7 @@ private fun <Collection> FirstButton(
                     action = null
                 )
             },
-            buttonType = StandardButtonType.Secondary
+            buttonType = ButtonType.Secondary
         )
     } else {
         error("Invalid state to be used with this button")

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistStreamingScreen.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/entity/PlaylistStreamingScreen.kt
@@ -29,9 +29,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.ChipDefaults
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.base.ui.components.StandardButton
 import com.google.android.horologist.composables.PlaceholderChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.material.Button
 import com.google.android.horologist.compose.material.Chip
 import com.google.android.horologist.compose.material.ChipType
 import com.google.android.horologist.media.ui.R
@@ -87,7 +87,7 @@ public fun PlaylistStreamingScreen(
                     .height(52.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                StandardButton(
+                Button(
                     imageVector = Icons.Default.Shuffle,
                     contentDescription = stringResource(id = R.string.horologist_playlist_download_button_shuffle_content_description),
                     onClick = { onShuffleButtonClick() },
@@ -96,7 +96,7 @@ public fun PlaylistStreamingScreen(
                         .weight(weight = 0.3F, fill = false)
                 )
 
-                StandardButton(
+                Button(
                     imageVector = Icons.Filled.PlayArrow,
                     contentDescription = stringResource(id = R.string.horologist_playlist_download_button_play_content_description),
                     onClick = { onPlayButtonClick() },


### PR DESCRIPTION
#### WHAT

Add `Button` to `compose-material`.

#### WHY

https://github.com/google/horologist/issues/1324

#### HOW

- Keep components in `base-ui` for few releases, marked as deprecated, suggesting the new library;
- Change the code of the components in `base-ui` and samples to use the ones from `compose-material`;
- Remove previews from `base-ui`, keep the unit tests to check if the usage of `compose-material` is correct;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
