### PR TITLE
Add AlertDialog to compose-material

### DIFF
--- a/base-ui/api/current.api
+++ b/base-ui/api/current.api
@@ -9,7 +9,7 @@ package com.google.android.horologist.base.ui {
 package com.google.android.horologist.base.ui.components {
 
   public final class AlertDialogKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void AlertDialog(String body, kotlin.jvm.functions.Function0<kotlin.Unit> onCancelButtonClick, kotlin.jvm.functions.Function0<kotlin.Unit> onOKButtonClick, boolean showDialog, androidx.wear.compose.foundation.lazy.ScalingLazyListState scalingLazyListState, optional androidx.compose.ui.Modifier modifier, optional String title, optional String okButtonContentDescription, optional String cancelButtonContentDescription);
+    method @Deprecated @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void AlertDialog(String body, kotlin.jvm.functions.Function0<kotlin.Unit> onCancelButtonClick, kotlin.jvm.functions.Function0<kotlin.Unit> onOKButtonClick, boolean showDialog, androidx.wear.compose.foundation.lazy.ScalingLazyListState scalingLazyListState, optional androidx.compose.ui.Modifier modifier, optional String title, optional String okButtonContentDescription, optional String cancelButtonContentDescription);
   }
 
   public final class ConfirmationDialogKt {

--- a/base-ui/src/main/java/com/google/android/horologist/base/ui/components/AlertDialog.kt
+++ b/base-ui/src/main/java/com/google/android/horologist/base/ui/components/AlertDialog.kt
@@ -16,26 +16,23 @@
 
 package com.google.android.horologist.base.ui.components
 
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.wear.compose.foundation.lazy.ScalingLazyListState
-import androidx.wear.compose.material.MaterialTheme
-import androidx.wear.compose.material.Text
-import androidx.wear.compose.material.dialog.Alert
-import androidx.wear.compose.material.dialog.Dialog
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.compose.material.Button
-import com.google.android.horologist.compose.material.ButtonType
 
 /**
  * This composable fulfils the redlines of the following components:
  * - AlertDialog - Title + body + buttons
  */
+@Deprecated(
+    "Replaced by AlertDialog in Horologist Material Compose library",
+    replaceWith = ReplaceWith(
+        "AlertDialog(body, onCancelButtonClick, onOKButtonClick, showDialog, scalingLazyListState, modifier, title, okButtonContentDescription, cancelButtonContentDescription)",
+        "com.google.android.horologist.compose.material.AlertDialog"
+    )
+)
 @ExperimentalHorologistApi
 @Composable
 public fun AlertDialog(
@@ -49,65 +46,15 @@ public fun AlertDialog(
     okButtonContentDescription: String = stringResource(android.R.string.ok),
     cancelButtonContentDescription: String = stringResource(android.R.string.cancel)
 ) {
-    Dialog(
+    com.google.android.horologist.compose.material.AlertDialog(
+        body = body,
+        onCancelButtonClick = onCancelButtonClick,
+        onOKButtonClick = onOKButtonClick,
         showDialog = showDialog,
-        onDismissRequest = onCancelButtonClick,
-        scrollState = scalingLazyListState,
-        modifier = modifier
-    ) {
-        AlertDialogAlert(
-            title = title,
-            body = body,
-            onCancelButtonClick = onCancelButtonClick,
-            onOKButtonClick = onOKButtonClick,
-            okButtonContentDescription = okButtonContentDescription,
-            cancelButtonContentDescription = cancelButtonContentDescription
-        )
-    }
-}
-
-@ExperimentalHorologistApi
-@Composable
-internal fun AlertDialogAlert(
-    title: String,
-    body: String,
-    onCancelButtonClick: () -> Unit,
-    onOKButtonClick: () -> Unit,
-    okButtonContentDescription: String,
-    cancelButtonContentDescription: String
-) {
-    Alert(
-        title = {
-            Text(
-                text = title,
-                color = MaterialTheme.colors.onBackground,
-                textAlign = TextAlign.Center,
-                maxLines = 3,
-                style = MaterialTheme.typography.title3
-            )
-        },
-        content = {
-            Text(
-                text = body,
-                color = MaterialTheme.colors.onBackground,
-                textAlign = TextAlign.Center,
-                style = MaterialTheme.typography.body2
-            )
-        },
-        negativeButton = {
-            Button(
-                imageVector = Icons.Default.Close,
-                contentDescription = cancelButtonContentDescription,
-                onClick = onCancelButtonClick,
-                buttonType = ButtonType.Secondary
-            )
-        },
-        positiveButton = {
-            Button(
-                imageVector = Icons.Default.Check,
-                contentDescription = okButtonContentDescription,
-                onClick = onOKButtonClick
-            )
-        }
+        scalingLazyListState = scalingLazyListState,
+        modifier = modifier,
+        title = title,
+        okButtonContentDescription = okButtonContentDescription,
+        cancelButtonContentDescription = cancelButtonContentDescription
     )
 }

--- a/compose-material/api/current.api
+++ b/compose-material/api/current.api
@@ -1,6 +1,10 @@
 // Signature format: 4.0
 package com.google.android.horologist.compose.material {
 
+  public final class AlertDialogKt {
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void AlertDialog(String body, kotlin.jvm.functions.Function0<kotlin.Unit> onCancelButtonClick, kotlin.jvm.functions.Function0<kotlin.Unit> onOKButtonClick, boolean showDialog, androidx.wear.compose.foundation.lazy.ScalingLazyListState scalingLazyListState, optional androidx.compose.ui.Modifier modifier, optional String title, optional String okButtonContentDescription, optional String cancelButtonContentDescription);
+  }
+
   public final class ButtonKt {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void Button(androidx.compose.ui.graphics.vector.ImageVector imageVector, String contentDescription, kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.compose.material.ButtonType buttonType, optional com.google.android.horologist.compose.material.ButtonSize buttonSize, optional boolean enabled);
   }

--- a/compose-material/src/debug/java/com/google/android/horologist/compose/material/AlertDialogPreview.kt
+++ b/compose-material/src/debug/java/com/google/android/horologist/compose/material/AlertDialogPreview.kt
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.base.ui.components
+package com.google.android.horologist.compose.material
 
 import androidx.compose.runtime.Composable
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 
 @WearPreviewDevices
 @Composable
-fun AlertDialogAlertPreview() {
-    AlertDialogAlert(
+fun AlertDialogPreview() {
+    Alert(
         title = "Title",
         body = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
         onCancelButtonClick = { },
@@ -34,8 +34,8 @@ fun AlertDialogAlertPreview() {
 
 @WearPreviewDevices
 @Composable
-fun AlertDialogAlertWithLongBodyPreview() {
-    AlertDialogAlert(
+fun AlertDialogWithLongBodyPreview() {
+    Alert(
         title = "Title",
         body = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
         onCancelButtonClick = { },

--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/AlertDialog.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/AlertDialog.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.compose.material
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.wear.compose.foundation.lazy.ScalingLazyListState
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
+import androidx.wear.compose.material.dialog.Alert
+import androidx.wear.compose.material.dialog.Dialog
+import com.google.android.horologist.annotations.ExperimentalHorologistApi
+
+/**
+ * This composable fulfils the redlines of the following components:
+ * - AlertDialog - Title + body + buttons
+ */
+@ExperimentalHorologistApi
+@Composable
+public fun AlertDialog(
+    body: String,
+    onCancelButtonClick: () -> Unit,
+    onOKButtonClick: () -> Unit,
+    showDialog: Boolean,
+    scalingLazyListState: ScalingLazyListState,
+    modifier: Modifier = Modifier,
+    title: String = "",
+    okButtonContentDescription: String = stringResource(android.R.string.ok),
+    cancelButtonContentDescription: String = stringResource(android.R.string.cancel)
+) {
+    Dialog(
+        showDialog = showDialog,
+        onDismissRequest = onCancelButtonClick,
+        scrollState = scalingLazyListState,
+        modifier = modifier
+    ) {
+        Alert(
+            title = title,
+            body = body,
+            onCancelButtonClick = onCancelButtonClick,
+            onOKButtonClick = onOKButtonClick,
+            okButtonContentDescription = okButtonContentDescription,
+            cancelButtonContentDescription = cancelButtonContentDescription
+        )
+    }
+}
+
+@ExperimentalHorologistApi
+@Composable
+internal fun Alert(
+    title: String,
+    body: String,
+    onCancelButtonClick: () -> Unit,
+    onOKButtonClick: () -> Unit,
+    okButtonContentDescription: String,
+    cancelButtonContentDescription: String
+) {
+    Alert(
+        title = {
+            Text(
+                text = title,
+                color = MaterialTheme.colors.onBackground,
+                textAlign = TextAlign.Center,
+                maxLines = 3,
+                style = MaterialTheme.typography.title3
+            )
+        },
+        content = {
+            Text(
+                text = body,
+                color = MaterialTheme.colors.onBackground,
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.body2
+            )
+        },
+        negativeButton = {
+            Button(
+                imageVector = Icons.Default.Close,
+                contentDescription = cancelButtonContentDescription,
+                onClick = onCancelButtonClick,
+                buttonType = ButtonType.Secondary
+            )
+        },
+        positiveButton = {
+            Button(
+                imageVector = Icons.Default.Check,
+                contentDescription = okButtonContentDescription,
+                onClick = onOKButtonClick
+            )
+        }
+    )
+}

--- a/media/sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
+++ b/media/sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
@@ -40,8 +40,8 @@ import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.dialog.Alert
 import androidx.wear.compose.material.dialog.Dialog
-import com.google.android.horologist.base.ui.components.AlertDialog
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.material.AlertDialog
 import com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreen
 import com.google.android.horologist.media.ui.screens.entity.PlaylistDownloadScreenState
 import com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel


### PR DESCRIPTION
#### WHAT

Add `AlertDialog` to `compose-material`.

#### WHY

https://github.com/google/horologist/issues/1324

#### HOW

- Keep components in `base-ui` for few releases, marked as deprecated, suggesting the new library;
- Change the code of the components in `base-ui` and samples to use the ones from `compose-material`;
- Remove previews from `base-ui`, keep the unit tests to check if the usage of `compose-material` is correct;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
