### PR TITLE
Improve documentation of compose-material

### DIFF
--- a/base-ui/README.md
+++ b/base-ui/README.md
@@ -1,3 +1,3 @@
 # Base UI module
 
-This module contains the base UI components implemented as per our Figma redlines.
+This module is deprecated, `compose-material` should be used instead.

--- a/base-ui/src/main/java/com/google/android/horologist/base/ui/components/AlertDialog.kt
+++ b/base-ui/src/main/java/com/google/android/horologist/base/ui/components/AlertDialog.kt
@@ -47,7 +47,7 @@ public fun AlertDialog(
     cancelButtonContentDescription: String = stringResource(android.R.string.cancel)
 ) {
     com.google.android.horologist.compose.material.AlertDialog(
-        body = body,
+        message = body,
         onCancelButtonClick = onCancelButtonClick,
         onOKButtonClick = onOKButtonClick,
         showDialog = showDialog,

--- a/base-ui/src/main/java/com/google/android/horologist/base/ui/components/StandardChip.kt
+++ b/base-ui/src/main/java/com/google/android/horologist/base/ui/components/StandardChip.kt
@@ -131,7 +131,7 @@ public fun StandardChip(
     enabled: Boolean = true
 ) {
     Chip(
-        labelId = labelId,
+        label = stringResource(id = labelId),
         onClick = onClick,
         modifier = modifier,
         secondaryLabel = secondaryLabel,

--- a/compose-material/api/current.api
+++ b/compose-material/api/current.api
@@ -2,7 +2,7 @@
 package com.google.android.horologist.compose.material {
 
   public final class AlertDialogKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void AlertDialog(String body, kotlin.jvm.functions.Function0<kotlin.Unit> onCancelButtonClick, kotlin.jvm.functions.Function0<kotlin.Unit> onOKButtonClick, boolean showDialog, androidx.wear.compose.foundation.lazy.ScalingLazyListState scalingLazyListState, optional androidx.compose.ui.Modifier modifier, optional String title, optional String okButtonContentDescription, optional String cancelButtonContentDescription);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void AlertDialog(String message, kotlin.jvm.functions.Function0<kotlin.Unit> onCancelButtonClick, kotlin.jvm.functions.Function0<kotlin.Unit> onOKButtonClick, boolean showDialog, androidx.wear.compose.foundation.lazy.ScalingLazyListState scalingLazyListState, optional androidx.compose.ui.Modifier modifier, optional String title, optional String okButtonContentDescription, optional String cancelButtonContentDescription);
   }
 
   public final class ButtonKt {
@@ -37,8 +37,8 @@ package com.google.android.horologist.compose.material {
 
   public final class ChipKt {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void Chip(String label, kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional String? secondaryLabel, optional Object? icon, optional boolean largeIcon, optional androidx.compose.ui.graphics.painter.Painter? placeholder, optional com.google.android.horologist.compose.material.ChipType chipType, optional boolean enabled);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void Chip(@StringRes int labelId, kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional @StringRes Integer? secondaryLabel, optional Object? icon, optional boolean largeIcon, optional androidx.compose.ui.graphics.painter.Painter? placeholder, optional com.google.android.horologist.compose.material.ChipType chipType, optional boolean enabled);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void Chip(String label, kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional String? secondaryLabel, optional kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.BoxScope,kotlin.Unit>? icon, optional boolean largeIcon, optional com.google.android.horologist.compose.material.ChipType chipType, optional boolean enabled);
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void Chip(@StringRes int labelId, kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional String? secondaryLabel, optional Object? icon, optional boolean largeIcon, optional androidx.compose.ui.graphics.painter.Painter? placeholder, optional com.google.android.horologist.compose.material.ChipType chipType, optional boolean enabled);
   }
 
   public enum ChipType {

--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/AlertDialog.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/AlertDialog.kt
@@ -31,13 +31,15 @@ import androidx.wear.compose.material.dialog.Dialog
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 /**
- * This composable fulfils the redlines of the following components:
- * - AlertDialog - Title + body + buttons
+ * This component is an alternative to [Alert], providing the following:
+ * - a convenient way of passing a title and a message;
+ * - default positive and negative buttons;
+ * - wrapped in a [Dialog];
  */
 @ExperimentalHorologistApi
 @Composable
 public fun AlertDialog(
-    body: String,
+    message: String,
     onCancelButtonClick: () -> Unit,
     onOKButtonClick: () -> Unit,
     showDialog: Boolean,
@@ -55,7 +57,7 @@ public fun AlertDialog(
     ) {
         Alert(
             title = title,
-            body = body,
+            body = message,
             onCancelButtonClick = onCancelButtonClick,
             onOKButtonClick = onOKButtonClick,
             okButtonContentDescription = okButtonContentDescription,

--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/Button.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/Button.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,9 @@ import androidx.wear.compose.material.Icon
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 /**
- * This composable fulfils the redlines of the following components:
- * - Primary, Secondary or Icon only button - according to [buttonType] value;
- * - Default, Large, Small and Extra Small button - according to [buttonSize] value;
+ * This component is an alternative to [Button], providing the following:
+ * - a convenient way of providing an icon and choosing its size from a range of sizes recommended
+ * by the Wear guidelines;
  */
 @ExperimentalHorologistApi
 @Composable

--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/Chip.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/Chip.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,10 +48,10 @@ import com.google.android.horologist.compose.material.util.DECORATIVE_ELEMENT_CO
 import com.google.android.horologist.compose.material.util.adjustChipHeightToFontScale
 
 /**
- * This composable fulfils the redlines of the following components:
- * - Primary or Secondary chip - according to [chipType] value;
- * - Standard chip - when [largeIcon] value is `false`;
- * - Chip with small or large avatar - according to [largeIcon] value;
+ * This component is an alternative to [Chip], providing the following:
+ * - a convenient way of providing a label and a secondary label;
+ * - a convenient way of providing an icon and a placeholder, and choosing their size based on the
+ * sizes recommended by the Wear guidelines;
  */
 @ExperimentalHorologistApi
 @Composable
@@ -121,7 +121,40 @@ public fun Chip(
 }
 
 /**
- * An implementation of [Chip] allowing full customization of the icon displayed.
+ * This component is an alternative to [Chip], providing the following:
+ * - a convenient way of providing a label and a secondary label;
+ * - a convenient way of providing an icon and a placeholder, and choosing their size based on the
+ * sizes recommended by the Wear guidelines;
+ */
+@ExperimentalHorologistApi
+@Composable
+public fun Chip(
+    @StringRes labelId: Int,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    @StringRes secondaryLabel: Int? = null,
+    icon: Any? = null,
+    largeIcon: Boolean = false,
+    placeholder: Painter? = null,
+    chipType: ChipType = ChipType.Primary,
+    enabled: Boolean = true
+) {
+    Chip(
+        label = stringResource(id = labelId),
+        onClick = onClick,
+        modifier = modifier,
+        secondaryLabel = secondaryLabel?.let { stringResource(id = it) },
+        icon = icon,
+        largeIcon = largeIcon,
+        placeholder = placeholder,
+        chipType = chipType,
+        enabled = enabled
+    )
+}
+
+/**
+ * This component is an alternative to [Chip], providing the following:
+ * - a convenient way of providing a label and a secondary label;
  */
 @ExperimentalHorologistApi
 @Composable
@@ -196,35 +229,6 @@ public fun Chip(
         },
         enabled = enabled,
         contentPadding = contentPadding
-    )
-}
-
-/**
- * An alternative function to [Chip] that allows a string resource id to be passed as label.
- */
-@ExperimentalHorologistApi
-@Composable
-public fun Chip(
-    @StringRes labelId: Int,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    secondaryLabel: String? = null,
-    icon: Any? = null,
-    largeIcon: Boolean = false,
-    placeholder: Painter? = null,
-    chipType: ChipType = ChipType.Primary,
-    enabled: Boolean = true
-) {
-    Chip(
-        label = stringResource(id = labelId),
-        onClick = onClick,
-        modifier = modifier,
-        secondaryLabel = secondaryLabel,
-        icon = icon,
-        largeIcon = largeIcon,
-        placeholder = placeholder,
-        chipType = chipType,
-        enabled = enabled
     )
 }
 

--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/Icon.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/Icon.kt
@@ -28,6 +28,10 @@ import androidx.wear.compose.material.LocalContentAlpha
 import androidx.wear.compose.material.LocalContentColor
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
+/**
+ * This component is an alternative to [Icon], providing the following:
+ * - a convenient way of setting the icon to be mirrored in RTL mode;
+ */
 @ExperimentalHorologistApi
 @Composable
 public fun Icon(

--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/SplitToggleChip.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/SplitToggleChip.kt
@@ -36,10 +36,10 @@ import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.material.util.adjustChipHeightToFontScale
 
 /**
- * This composable fulfils the redlines of the following components:
- * - SplitToggle chips
+ * This component is an alternative to [SplitToggleChip], providing the following:
+ * - a convenient way of providing a label and a secondary label;
+ * - a convenient way of choosing the toggle control;
  */
-
 @ExperimentalHorologistApi
 @Composable
 public fun SplitToggleChip(

--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/Title.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/Title.kt
@@ -29,7 +29,7 @@ import androidx.wear.compose.material.Text
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 /**
- * An alternative function to [Title] that allows a string resource id to be passed as text.
+ * A title heading to group and identify items.
  */
 @ExperimentalHorologistApi
 @Composable
@@ -44,8 +44,7 @@ public fun Title(
 }
 
 /**
- * This composable fulfils the redlines of the following components:
- * - Primary title;
+ * A title heading to group and identify items.
  */
 @ExperimentalHorologistApi
 @Composable

--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/ToggleChip.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/ToggleChip.kt
@@ -43,8 +43,10 @@ import com.google.android.horologist.compose.material.util.DECORATIVE_ELEMENT_CO
 import com.google.android.horologist.compose.material.util.adjustChipHeightToFontScale
 
 /**
- * This composable fulfils the redlines of the following components:
- * - Toggle chips
+ * This component is an alternative to [ToggleChip], providing the following:
+ * - a convenient way of providing a label and a secondary label;
+ * - a convenient way of choosing the toggle control;
+ * - a convenient way of providing an icon and setting the icon to be mirrored in RTL mode;
  */
 @ExperimentalHorologistApi
 @Composable

--- a/docs/compose-material.md
+++ b/docs/compose-material.md
@@ -1,0 +1,7 @@
+# Compose Material
+
+A library providing opinionated implementation of the components of
+the [Wear Material Compose library](https://developer.android.com/jetpack/androidx/releases/wear-compose)
+, based on the specifications
+of [Wear Material Design Kit](https://developer.android.com/design/ui/wear/guides/foundations/download)
+.

--- a/media/sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
+++ b/media/sample/src/main/java/com/google/android/horologist/mediasample/ui/entity/UampEntityScreen.kt
@@ -140,7 +140,7 @@ fun UampEntityScreen(
     }
 
     AlertDialog(
-        body = stringResource(R.string.entity_dialog_cancel_downloads),
+        message = stringResource(R.string.entity_dialog_cancel_downloads),
         onCancelButtonClick = {
             showCancelDownloadsDialog = false
         },
@@ -155,7 +155,7 @@ fun UampEntityScreen(
     )
 
     AlertDialog(
-        body = stringResource(R.string.entity_dialog_remove_downloads, playlistName),
+        message = stringResource(R.string.entity_dialog_remove_downloads, playlistName),
         onCancelButtonClick = {
             showRemoveDownloadsDialog = false
         },
@@ -170,7 +170,7 @@ fun UampEntityScreen(
     )
 
     AlertDialog(
-        body = stringResource(R.string.entity_dialog_remove_downloads, mediaTitleToDelete),
+        message = stringResource(R.string.entity_dialog_remove_downloads, mediaTitleToDelete),
         onCancelButtonClick = {
             showRemoveSingleMediaDownloadDialog = false
         },


### PR DESCRIPTION
#### WHAT

Improve documentation of `compose-material`.


#### WHY

Try to make clearer the differences between the components provided by this library and Wear Compose Material.


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
