### PR TITLE
Avoid OkHttp double caching

### DIFF
--- a/media/sample/src/main/java/com/google/android/horologist/mediasample/di/DownloadModule.kt
+++ b/media/sample/src/main/java/com/google/android/horologist/mediasample/di/DownloadModule.kt
@@ -50,6 +50,7 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import okhttp3.CacheControl
 import okhttp3.Call
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -74,7 +75,9 @@ object DownloadModule {
             delegate = callFactory,
             defaultRequestType = DownloadRequest
         )
-    ).setTransferListener(transferListener)
+    )
+        .setCacheControl(CacheControl.Builder().noCache().noStore().build())
+        .setTransferListener(transferListener)
 
     @DownloadFeature
     @Provides

--- a/media/sample/src/main/java/com/google/android/horologist/mediasample/di/PlaybackServiceModule.kt
+++ b/media/sample/src/main/java/com/google/android/horologist/mediasample/di/PlaybackServiceModule.kt
@@ -72,6 +72,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import okhttp3.CacheControl
 import okhttp3.Call
 import javax.inject.Provider
 
@@ -138,6 +139,7 @@ object PlaybackServiceModule {
                 defaultRequestType = StreamRequest
             )
         )
+            .setCacheControl(CacheControl.Builder().noCache().noStore().build())
             .setTransferListener(transferListener)
 
     @ServiceScoped


### PR DESCRIPTION
#### WHAT

Avoid OkHttp double caching

#### WHY

ExoPlayer has a cache

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
