### PR TITLE
Regenerate proto on branch changes

### DIFF
--- a/auth/sample/shared/build.gradle.kts
+++ b/auth/sample/shared/build.gradle.kts
@@ -111,3 +111,6 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.robolectric)
 }
+
+tasks.maybeCreate("prepareKotlinIdeaImport")
+    .dependsOn("generateDebugProto")

--- a/datalayer/build.gradle.kts
+++ b/datalayer/build.gradle.kts
@@ -132,3 +132,6 @@ dependencies {
 }
 
 apply(plugin = "com.vanniktech.maven.publish")
+
+tasks.maybeCreate("prepareKotlinIdeaImport")
+    .dependsOn("generateDebugProto")

--- a/media/sample/build.gradle.kts
+++ b/media/sample/build.gradle.kts
@@ -294,3 +294,6 @@ if (device != null) {
         commandLine = "adb -s $device shell dumpsys media.audio_flinger".split(" ")
     }
 }
+
+tasks.maybeCreate("prepareKotlinIdeaImport")
+    .dependsOn("generateDebugProto")

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -193,3 +193,6 @@ dependencies {
         }
     }
 }
+
+tasks.maybeCreate("prepareKotlinIdeaImport")
+    .dependsOn("generateDebugProto")


### PR DESCRIPTION
#### WHAT

Regenerate proto on branch changes.

#### WHY

PRs that change proto definitions should work immediately when changing, less red lines.

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
