### PR TITLE
Use the Tile's state in the TilePreview

### DIFF
--- a/compose-tools/src/main/java/com/google/android/horologist/compose/tools/TilePreview.kt
+++ b/compose-tools/src/main/java/com/google/android/horologist/compose/tools/TilePreview.kt
@@ -42,6 +42,7 @@ import androidx.wear.protolayout.StateBuilders.State
 import androidx.wear.protolayout.TimelineBuilders
 import androidx.wear.tiles.RequestBuilders
 import androidx.wear.tiles.TileBuilders
+import androidx.wear.tiles.renderer.TileRenderer
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.tiles.render.TileLayoutRenderer
 import kotlinx.coroutines.Dispatchers
@@ -85,11 +86,15 @@ public fun TilePreview(
             }
         },
         update = {
-            val tileRenderer = androidx.wear.tiles.renderer.TileRenderer(
+            val tileRenderer = TileRenderer(
                 /* uiContext = */ it.context,
                 /* loadActionExecutor = */ Dispatchers.IO.asExecutor(),
                 /* loadActionListener = */ {}
             )
+
+            tile.state?.let { state ->
+                tileRenderer.setState(state.keyToValueMapping)
+            }
 
             // Returning a future
             tileRenderer.inflateAsync(


### PR DESCRIPTION
#### WHAT
Use the Tile's state in the TilePreview

#### WHY
There was a recent change to support state changes in the public API of the TileRenderer: [aosp/2607086](https://android-review.git.corp.google.com/c/platform/frameworks/support/+/2607086).

Tile previews should be as close to what would be run on the device as possible.

#### HOW
By using the updated TileRenderer API.

Checklist 📋
* [N/A] Add explicit visibility modifier and explicit return types for public declarations
* [x] Run spotless check
* [x] Run tests
* [N/A] Update metalava's signature text files

