### PR TITLE
Change rateLimitCoolDown for rotary accumulator for TimePicker.

### DIFF
--- a/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
@@ -540,7 +540,7 @@ internal fun pickerGroupItemWithRSB(
 
     return PickerGroupItem(
         pickerState = pickerState,
-        modifier = modifier.onRotaryInputAccumulated { change ->
+        modifier = modifier.onRotaryInputAccumulated(rateLimitCoolDownMs = 5L) { change ->
 
             val diff = sign(change)
 


### PR DESCRIPTION
This number (5ms) proofed to be better than default ( 30ms)

#### WHAT


#### WHY


#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
