### PR TITLE
Don't write when data is unchanged

### DIFF
--- a/datalayer/src/main/java/com/google/android/horologist/data/store/impl/WearLocalDataStore.kt
+++ b/datalayer/src/main/java/com/google/android/horologist/data/store/impl/WearLocalDataStore.kt
@@ -93,15 +93,15 @@ public class WearLocalDataStore<T>(
         val oldT = readExistingValue(nodeId)
         val newT = transform(oldT)
 
-        if (newT != null) {
+        if (newT == null) {
+            dataClient.deleteDataItems(nodeId.fullPath)
+                .await()
+        } else if (newT != oldT) {
             val request = PutDataRequest.create(path).apply {
                 data = writeBytes(newT)
             }
 
             dataClient.putDataItem(request).await()
-        } else {
-            dataClient.deleteDataItems(nodeId.fullPath)
-                .await()
         }
 
         return newT


### PR DESCRIPTION
#### WHAT

Don't write when data is unchanged.

#### WHY

The pattern of DataLayer helper includes writing just in case, when data may not have changed. We should de-dupe these updates to minimise extra work.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
