### PR TITLE
Remove outlined sample from Chip component

### DIFF
--- a/compose-material/src/debug/java/com/google/android/horologist/compose/material/ChipPreview.kt
+++ b/compose-material/src/debug/java/com/google/android/horologist/compose/material/ChipPreview.kt
@@ -161,22 +161,6 @@ fun ChipPreviewWithGradientBackgroundChipColors() {
 }
 
 @Preview(
-    name = "With outlined chip colors",
-    backgroundColor = 0xff000000,
-    showBackground = true
-)
-@Composable
-fun ChipPreviewWithOutlinedChipColors() {
-    Chip(
-        label = "Primary label",
-        onClick = { },
-        secondaryLabel = "Secondary label",
-        icon = Icons.Default.Image,
-        colors = ChipDefaults.outlinedChipColors()
-    )
-}
-
-@Preview(
     name = "With image background chip colors",
     backgroundColor = 0xff000000,
     showBackground = true

--- a/compose-material/src/test/java/com/google/android/horologist/compose/material/ChipTest.kt
+++ b/compose-material/src/test/java/com/google/android/horologist/compose/material/ChipTest.kt
@@ -288,19 +288,6 @@ class ChipTest : ScreenshotBaseTest() {
     }
 
     @Test
-    fun withOutlinedChipColors() {
-        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
-            Chip(
-                label = "Primary label",
-                onClick = { },
-                secondaryLabel = "Secondary label",
-                icon = Icons.Default.Image,
-                colors = ChipDefaults.outlinedChipColors()
-            )
-        }
-    }
-
-    @Test
     fun withImageBackgroundChipColors() {
         screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
             Chip(


### PR DESCRIPTION
#### WHAT

Remove outlined preview and test from `Chip` component.

#### WHY

Not appropriate usage of the `ChipDefaults. It should be used with `OutlinedChip` component. 

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
