### PR TITLE
Fix StandardChip

### DIFF
--- a/base-ui/src/main/java/com/google/android/horologist/base/ui/components/StandardChip.kt
+++ b/base-ui/src/main/java/com/google/android/horologist/base/ui/components/StandardChip.kt
@@ -144,17 +144,6 @@ public fun StandardChip(
         },
         enabled = enabled
     )
-    StandardChip(
-        label = stringResource(id = labelId),
-        onClick = onClick,
-        modifier = modifier,
-        secondaryLabel = secondaryLabel,
-        icon = icon,
-        largeIcon = largeIcon,
-        placeholder = placeholder,
-        chipType = chipType,
-        enabled = enabled
-    )
 }
 
 @Deprecated(


### PR DESCRIPTION
#### WHAT

Fix `StandardChip` function that accepts string resource as label.

#### WHY

Left over code is making it display two chips on top of each other.

Thanks @fstanis for reporting it!

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
