### PR TITLE
Improve A11y for ToggleChip and SplitToggleChip

### DIFF
--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/SplitToggleChip.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/SplitToggleChip.kt
@@ -25,6 +25,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.wear.compose.material.MaterialTheme
@@ -33,6 +35,7 @@ import androidx.wear.compose.material.SplitToggleChipColors
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.ToggleChipDefaults
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.compose.material.util.DECORATIVE_ELEMENT_CONTENT_DESCRIPTION
 import com.google.android.horologist.compose.material.util.adjustChipHeightToFontScale
 
 /**
@@ -82,19 +85,23 @@ public fun SplitToggleChip(
         }
 
     val toggleControlParam: (@Composable BoxScope.() -> Unit) = {
+        val stateDescriptionSemantics = stringResource(
+            if (checked) {
+                R.string.horologist_split_toggle_chip_on_content_description
+            } else {
+                R.string.horologist_split_toggle_chip_off_content_description
+            }
+        )
         Icon(
             imageVector = when (toggleControl) {
                 ToggleChipToggleControl.Switch -> ToggleChipDefaults.switchIcon(checked)
                 ToggleChipToggleControl.Radio -> ToggleChipDefaults.radioIcon(checked)
                 ToggleChipToggleControl.Checkbox -> ToggleChipDefaults.checkboxIcon(checked)
             },
-            contentDescription = stringResource(
-                if (checked) {
-                    R.string.horologist_split_toggle_chip_on_content_description
-                } else {
-                    R.string.horologist_split_toggle_chip_off_content_description
-                }
-            ),
+            contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
+            modifier = Modifier.semantics {
+                stateDescription = stateDescriptionSemantics
+            },
             rtlMode = IconRtlMode.Mirrored
         )
     }

--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/ToggleChip.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/ToggleChip.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.wear.compose.material.ChipDefaults
@@ -96,13 +98,7 @@ public fun ToggleChip(
                 ToggleChipToggleControl.Radio -> ToggleChipDefaults.radioIcon(checked)
                 ToggleChipToggleControl.Checkbox -> ToggleChipDefaults.checkboxIcon(checked)
             },
-            contentDescription = stringResource(
-                if (checked) {
-                    R.string.horologist_toggle_chip_on_content_description
-                } else {
-                    R.string.horologist_toggle_chip_off_content_description
-                }
-            ),
+            contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
             rtlMode = IconRtlMode.Mirrored
         )
     }
@@ -123,6 +119,13 @@ public fun ToggleChip(
             }
         }
 
+    val stateDescriptionSemantics = stringResource(
+        if (checked) {
+            R.string.horologist_toggle_chip_on_content_description
+        } else {
+            R.string.horologist_toggle_chip_off_content_description
+        }
+    )
     ToggleChip(
         checked = checked,
         onCheckedChange = onCheckedChanged,
@@ -130,7 +133,10 @@ public fun ToggleChip(
         toggleControl = toggleControlParam,
         modifier = modifier
             .adjustChipHeightToFontScale(LocalConfiguration.current.fontScale)
-            .fillMaxWidth(),
+            .fillMaxWidth()
+            .semantics {
+                stateDescription = stateDescriptionSemantics
+            },
         appIcon = iconParam,
         secondaryLabel = secondaryLabelParam,
         colors = colors,

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_SplitToggleChipA11yTest_disabled.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_SplitToggleChipA11yTest_disabled.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ef6180be59d7af0a223f52b4687313b85ea42e07c2ba1952bf4fa3ead110dfc5
-size 21138
+oid sha256:3fbb6a880fa82e7599979cb90b228fe22487dae74cd97fe616a212d60a01c930
+size 21143

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_SplitToggleChipA11yTest_unchecked.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_SplitToggleChipA11yTest_unchecked.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c947abf6247e59ee7fdd0f987f7c75dfb6087829d8713f747f02f5a07d401c30
-size 22063
+oid sha256:c6b84cf696c446b21a7a3e11080a545eabd78c0c7fdc33c5d0fe90a1d84b9f43
+size 22084

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_SplitToggleChipA11yTest_uncheckedAndDisabled.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_SplitToggleChipA11yTest_uncheckedAndDisabled.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b745f572604d9d014140e426e10f7bcc9ba2e9f4d49acaabb65364847c6e3831
-size 20998
+oid sha256:f61f7e4e3b59773e7200e216251be835eee5a94c2b573811a7bdb3fb16841fef
+size 21019

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_SplitToggleChipA11yTest_withSecondaryLabel.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_SplitToggleChipA11yTest_withSecondaryLabel.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5e0fcf3748cc2d3efd156e598e7e1b670b60c7b10b3af81587ecb8e20481c921
-size 22093
+oid sha256:b4fca73a39ddfbd96f67a99121fa18ba3608b4120f2148667b6e7c8089b43aad
+size 22099

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ToggleChipA11yTest_disabled.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ToggleChipA11yTest_disabled.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f82b0afdd8fe6fdd93a50056de4c77654ff262d3c6c3c5d1c3677d21e045b2ed
-size 41526
+oid sha256:29d3753a0dfff0085705957bb6518fc62157c5e312a5f3bf47b17912eb18917f
+size 42215

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ToggleChipA11yTest_unchecked.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ToggleChipA11yTest_unchecked.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:502cc3d13854551ed2088391474173273264d5ed8148a30b27efe96074afd429
-size 21198
+oid sha256:8d1170da01e7b7ac2f267066a6a97f675dd8a856d6b72e5d74ae0ee837c7bcee
+size 21919

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ToggleChipA11yTest_uncheckedAndDisabled.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ToggleChipA11yTest_uncheckedAndDisabled.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:29ca18cfd82ffa9437f69415fff115736de7079c0e2664ebf9e025850d461f4f
-size 24747
+oid sha256:fcd3506d1a8b6d21d68519093f171e8dc96a4ed2df193ee4bd9629b28fab8745
+size 25492

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ToggleChipA11yTest_withSecondaryLabelAndIcon.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ToggleChipA11yTest_withSecondaryLabelAndIcon.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:05afa8de6c05577c6a7db9b8779edbfe04ff55fe18ca5d2fbf426afb563ff5b5
-size 46823
+oid sha256:9765e63140669b2c53694bd363bb7cadaeb601d22f11b34179f1ccc707cc0658
+size 47490


### PR DESCRIPTION
#### WHAT

Improve A11y for `ToggleChip` and `SplitToggleChip`.

#### HOW

[Describe element state](https://developer.android.com/jetpack/compose/accessibility#anchor) with `stateDescription`.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
