### PR TITLE
Improve Chip to use painterResource to render drawable res icons

### DIFF
--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/Chip.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/Chip.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -77,27 +78,35 @@ public fun Chip(
                 }
 
                 Row {
-                    if (icon is ImageVector) {
-                        Icon(
-                            imageVector = icon,
-                            contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
-                            modifier = Modifier
-                                .size(iconSize)
-                                .clip(CircleShape)
-                        )
-                    } else {
-                        Image(
-                            painter = rememberAsyncImagePainter(
-                                model = icon,
-                                placeholder = placeholder
-                            ),
-                            contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
-                            modifier = Modifier
-                                .size(iconSize)
-                                .clip(CircleShape),
-                            contentScale = ContentScale.Crop,
-                            alpha = LocalContentAlpha.current
-                        )
+                    val iconModifier = Modifier
+                        .size(iconSize)
+                        .clip(CircleShape)
+                    when (icon) {
+                        is ImageVector ->
+                            Icon(
+                                imageVector = icon,
+                                contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
+                                modifier = iconModifier
+                            )
+
+                        is Int ->
+                            Icon(
+                                painter = painterResource(id = icon),
+                                contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
+                                modifier = iconModifier
+                            )
+
+                        else ->
+                            Image(
+                                painter = rememberAsyncImagePainter(
+                                    model = icon,
+                                    placeholder = placeholder
+                                ),
+                                contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
+                                modifier = iconModifier,
+                                contentScale = ContentScale.Crop,
+                                alpha = LocalContentAlpha.current
+                            )
                     }
                 }
             }

--- a/compose-material/src/test/java/com/google/android/horologist/compose/material/ChipTest.kt
+++ b/compose-material/src/test/java/com/google/android/horologist/compose/material/ChipTest.kt
@@ -178,6 +178,17 @@ class ChipTest : ScreenshotBaseTest() {
     }
 
     @Test
+    fun usingDrawableResAsIcon() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            Chip(
+                label = "Primary label",
+                onClick = { },
+                icon = android.R.drawable.ic_delete
+            )
+        }
+    }
+
+    @Test
     fun withLargeIconUsingSmallIcon() {
         screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
             Chip(

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ChipTest_usingDrawableResAsIcon.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ChipTest_usingDrawableResAsIcon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e796909bc6d7080e36c564f89b84d6caa0a1e7bb1a9d8dd9cf0a478095db54a
+size 7993


### PR DESCRIPTION
#### WHAT

Improve Chip to use `painterResource` to render drawable res icons instead of Coil.

#### WHY

`painterResource` applies correct tint based on the colours of the Chip.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
