### PR TITLE
Improve Button and Icon

### DIFF
--- a/base-ui/src/main/java/com/google/android/horologist/base/ui/components/StandardButton.kt
+++ b/base-ui/src/main/java/com/google/android/horologist/base/ui/components/StandardButton.kt
@@ -64,7 +64,7 @@ public fun StandardButton(
             StandardButtonSize.Default -> ButtonSize.Default
             StandardButtonSize.Large -> ButtonSize.Large
             StandardButtonSize.Small -> ButtonSize.Small
-            StandardButtonSize.ExtraSmall -> ButtonSize.ExtraSmall
+            StandardButtonSize.ExtraSmall -> ButtonSize.Small
         },
         enabled = enabled
     )

--- a/compose-material/api/current.api
+++ b/compose-material/api/current.api
@@ -6,7 +6,8 @@ package com.google.android.horologist.compose.material {
   }
 
   public final class ButtonKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void Button(androidx.compose.ui.graphics.vector.ImageVector imageVector, String contentDescription, kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors, optional com.google.android.horologist.compose.material.ButtonSize buttonSize, optional boolean enabled);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void Button(androidx.compose.ui.graphics.vector.ImageVector imageVector, String contentDescription, kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors, optional com.google.android.horologist.compose.material.ButtonSize buttonSize, optional com.google.android.horologist.compose.material.IconRtlMode iconRtlMode, optional boolean enabled);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void Button(@DrawableRes int id, String contentDescription, kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors, optional com.google.android.horologist.compose.material.ButtonSize buttonSize, optional com.google.android.horologist.compose.material.IconRtlMode iconRtlMode, optional boolean enabled);
   }
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public enum ButtonSize {
@@ -17,7 +18,6 @@ package com.google.android.horologist.compose.material {
     property public final float iconSize;
     property public final float tapTargetSize;
     enum_constant public static final com.google.android.horologist.compose.material.ButtonSize Default;
-    enum_constant public static final com.google.android.horologist.compose.material.ButtonSize ExtraSmall;
     enum_constant public static final com.google.android.horologist.compose.material.ButtonSize Large;
     enum_constant public static final com.google.android.horologist.compose.material.ButtonSize Small;
   }
@@ -39,6 +39,7 @@ package com.google.android.horologist.compose.material {
 
   public final class IconKt {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void Icon(androidx.compose.ui.graphics.vector.ImageVector imageVector, String? contentDescription, optional androidx.compose.ui.Modifier modifier, optional long tint, optional com.google.android.horologist.compose.material.IconRtlMode rtlMode);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void Icon(@DrawableRes int id, String? contentDescription, optional androidx.compose.ui.Modifier modifier, optional long tint, optional com.google.android.horologist.compose.material.IconRtlMode rtlMode);
   }
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public enum IconRtlMode {

--- a/compose-material/src/debug/java/com/google/android/horologist/compose/material/ButtonPreview.kt
+++ b/compose-material/src/debug/java/com/google/android/horologist/compose/material/ButtonPreview.kt
@@ -56,17 +56,6 @@ fun ButtonPreviewSmall() {
 
 @WearPreview
 @Composable
-fun ButtonPreviewExtraSmall() {
-    Button(
-        imageVector = Icons.Default.Check,
-        contentDescription = "contentDescription",
-        onClick = { },
-        buttonSize = ButtonSize.ExtraSmall
-    )
-}
-
-@WearPreview
-@Composable
 fun ButtonPreviewDisabled() {
     Button(
         imageVector = Icons.Default.Check,

--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/Button.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/Button.kt
@@ -16,17 +16,22 @@
 
 package com.google.android.horologist.compose.material
 
+import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Button
 import androidx.wear.compose.material.ButtonColors
 import androidx.wear.compose.material.ButtonDefaults
-import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.ButtonDefaults.DefaultButtonSize
+import androidx.wear.compose.material.ButtonDefaults.DefaultIconSize
+import androidx.wear.compose.material.ButtonDefaults.LargeButtonSize
+import androidx.wear.compose.material.ButtonDefaults.LargeIconSize
+import androidx.wear.compose.material.ButtonDefaults.SmallButtonSize
+import androidx.wear.compose.material.ButtonDefaults.SmallIconSize
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
 /**
@@ -43,6 +48,59 @@ public fun Button(
     modifier: Modifier = Modifier,
     colors: ButtonColors = ButtonDefaults.primaryButtonColors(),
     buttonSize: ButtonSize = ButtonSize.Default,
+    iconRtlMode: IconRtlMode = IconRtlMode.Default,
+    enabled: Boolean = true
+) {
+    Button(
+        icon = imageVector,
+        contentDescription = contentDescription,
+        onClick = onClick,
+        modifier = modifier,
+        colors = colors,
+        buttonSize = buttonSize,
+        iconRtlMode = iconRtlMode,
+        enabled = enabled
+    )
+}
+
+/**
+ * This component is an alternative to [Button], providing the following:
+ * - a convenient way of providing an icon and choosing its size from a range of sizes recommended
+ * by the Wear guidelines;
+ */
+@ExperimentalHorologistApi
+@Composable
+public fun Button(
+    @DrawableRes id: Int,
+    contentDescription: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    colors: ButtonColors = ButtonDefaults.primaryButtonColors(),
+    buttonSize: ButtonSize = ButtonSize.Default,
+    iconRtlMode: IconRtlMode = IconRtlMode.Default,
+    enabled: Boolean = true
+) {
+    Button(
+        icon = id,
+        contentDescription = contentDescription,
+        onClick = onClick,
+        modifier = modifier,
+        colors = colors,
+        buttonSize = buttonSize,
+        iconRtlMode = iconRtlMode,
+        enabled = enabled
+    )
+}
+
+@Composable
+internal fun Button(
+    icon: Any,
+    contentDescription: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    colors: ButtonColors = ButtonDefaults.primaryButtonColors(),
+    buttonSize: ButtonSize = ButtonSize.Default,
+    iconRtlMode: IconRtlMode = IconRtlMode.Default,
     enabled: Boolean = true
 ) {
     Button(
@@ -51,12 +109,15 @@ public fun Button(
         enabled = enabled,
         colors = colors
     ) {
+        val iconModifier = Modifier
+            .size(buttonSize.iconSize)
+            .align(Alignment.Center)
+
         Icon(
-            imageVector = imageVector,
+            icon = icon,
             contentDescription = contentDescription,
-            modifier = Modifier
-                .size(buttonSize.iconSize)
-                .align(Alignment.Center)
+            modifier = iconModifier,
+            rtlMode = iconRtlMode
         )
     }
 }
@@ -66,8 +127,7 @@ public enum class ButtonSize(
     public val iconSize: Dp,
     public val tapTargetSize: Dp
 ) {
-    Default(iconSize = 26.dp, tapTargetSize = 52.dp),
-    Large(iconSize = 30.dp, tapTargetSize = 60.dp),
-    Small(iconSize = 24.dp, tapTargetSize = 48.dp),
-    ExtraSmall(iconSize = 24.dp, tapTargetSize = 48.dp),
+    Default(iconSize = DefaultIconSize, tapTargetSize = DefaultButtonSize),
+    Large(iconSize = LargeIconSize, tapTargetSize = LargeButtonSize),
+    Small(iconSize = SmallIconSize, tapTargetSize = SmallButtonSize)
 }

--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/Icon.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/Icon.kt
@@ -16,12 +16,14 @@
 
 package com.google.android.horologist.compose.material
 
+import androidx.annotation.DrawableRes
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.LocalContentAlpha
@@ -44,15 +46,79 @@ public fun Icon(
     val shouldMirror =
         rtlMode == IconRtlMode.Mirrored && LocalLayoutDirection.current == LayoutDirection.Rtl
     Icon(
-        modifier = modifier
-            .scale(
-                scaleX = if (shouldMirror) -1f else 1f,
-                scaleY = 1f
-            ),
+        modifier = modifier.scale(
+            scaleX = if (shouldMirror) -1f else 1f,
+            scaleY = 1f
+        ),
         imageVector = imageVector,
         contentDescription = contentDescription,
         tint = tint
     )
+}
+
+/**
+ * This component is an alternative to [Icon], providing the following:
+ * - a convenient way of setting the icon to be mirrored in RTL mode;
+ */
+@ExperimentalHorologistApi
+@Composable
+public fun Icon(
+    @DrawableRes id: Int,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    tint: Color = LocalContentColor.current.copy(alpha = LocalContentAlpha.current),
+    rtlMode: IconRtlMode = IconRtlMode.Default
+) {
+    val shouldMirror =
+        rtlMode == IconRtlMode.Mirrored && LocalLayoutDirection.current == LayoutDirection.Rtl
+
+    Icon(
+        painter = painterResource(id = id),
+        contentDescription = contentDescription,
+        modifier = modifier.scale(
+            scaleX = if (shouldMirror) -1f else 1f,
+            scaleY = 1f
+        ),
+        tint = tint
+    )
+}
+
+@Composable
+internal fun Icon(
+    icon: Any,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    tint: Color = LocalContentColor.current.copy(alpha = LocalContentAlpha.current),
+    rtlMode: IconRtlMode = IconRtlMode.Default
+) {
+    val shouldMirror =
+        rtlMode == IconRtlMode.Mirrored && LocalLayoutDirection.current == LayoutDirection.Rtl
+
+    val iconModifier = modifier.scale(
+        scaleX = if (shouldMirror) -1f else 1f,
+        scaleY = 1f
+    )
+    when (icon) {
+        is ImageVector -> {
+            Icon(
+                imageVector = icon,
+                modifier = iconModifier,
+                contentDescription = contentDescription,
+                tint = tint
+            )
+        }
+
+        is Int -> {
+            Icon(
+                painter = painterResource(id = icon),
+                contentDescription = contentDescription,
+                modifier = iconModifier,
+                tint = tint
+            )
+        }
+
+        else -> throw IllegalArgumentException("Type not supported.")
+    }
 }
 
 @ExperimentalHorologistApi

--- a/compose-material/src/test/java/com/google/android/horologist/compose/material/ButtonA11yTest.kt
+++ b/compose-material/src/test/java/com/google/android/horologist/compose/material/ButtonA11yTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.compose.material
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.google.android.horologist.screenshots.ScreenshotBaseTest
+import com.google.android.horologist.screenshots.ScreenshotTestRule.Companion.screenshotTestRuleParams
+import org.junit.Test
+
+class ButtonA11yTest : ScreenshotBaseTest(
+    screenshotTestRuleParams {
+        enableA11y = true
+        screenTimeText = {}
+    }
+) {
+
+    @Test
+    fun default() {
+        screenshotTestRule.setContent(takeScreenshot = true) {
+            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                Button(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = "contentDescription",
+                    onClick = { }
+                )
+            }
+        }
+    }
+
+    @Test
+    fun disabled() {
+        screenshotTestRule.setContent(takeScreenshot = true) {
+            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                Button(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = "contentDescription",
+                    onClick = { },
+                    enabled = false
+                )
+            }
+        }
+    }
+}

--- a/compose-material/src/test/java/com/google/android/horologist/compose/material/ButtonTest.kt
+++ b/compose-material/src/test/java/com/google/android/horologist/compose/material/ButtonTest.kt
@@ -18,7 +18,10 @@ package com.google.android.horologist.compose.material
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.DirectionsBike
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.wear.compose.material.ButtonDefaults
+import com.google.accompanist.testharness.TestHarness
 import com.google.android.horologist.screenshots.ScreenshotBaseTest
 import org.junit.Test
 
@@ -72,18 +75,6 @@ internal class ButtonTest : ScreenshotBaseTest() {
     }
 
     @Test
-    fun extraSmall() {
-        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
-            Button(
-                imageVector = Icons.Default.Check,
-                contentDescription = "contentDescription",
-                onClick = { },
-                buttonSize = ButtonSize.ExtraSmall
-            )
-        }
-    }
-
-    @Test
     fun withSecondaryButtonColors() {
         screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
             Button(
@@ -104,6 +95,95 @@ internal class ButtonTest : ScreenshotBaseTest() {
                 onClick = { },
                 colors = ButtonDefaults.iconButtonColors()
             )
+        }
+    }
+
+    @Test
+    fun usingDrawableResAsIcon() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            Button(
+                id = android.R.drawable.ic_media_play,
+                contentDescription = "contentDescription",
+                onClick = { }
+            )
+        }
+    }
+
+    @Test
+    fun usingDrawableResAsIconRtl() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            TestHarness(layoutDirection = LayoutDirection.Rtl) {
+                Button(
+                    id = android.R.drawable.ic_media_play,
+                    contentDescription = "contentDescription",
+                    onClick = { }
+                )
+            }
+        }
+    }
+
+    @Test
+    fun usingDrawableResAsIconMirrored() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            Button(
+                id = android.R.drawable.ic_media_play,
+                contentDescription = "contentDescription",
+                onClick = { },
+                iconRtlMode = IconRtlMode.Mirrored
+            )
+        }
+    }
+
+    @Test
+    fun usingDrawableResAsIconMirroredRtl() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            TestHarness(layoutDirection = LayoutDirection.Rtl) {
+                Button(
+                    id = android.R.drawable.ic_media_play,
+                    contentDescription = "contentDescription",
+                    onClick = { },
+                    iconRtlMode = IconRtlMode.Mirrored
+                )
+            }
+        }
+    }
+
+    @Test
+    fun defaultRtl() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            TestHarness(layoutDirection = LayoutDirection.Rtl) {
+                Button(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = "contentDescription",
+                    onClick = { }
+                )
+            }
+        }
+    }
+
+    @Test
+    fun mirrored() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            Button(
+                imageVector = Icons.Default.DirectionsBike,
+                contentDescription = "contentDescription",
+                onClick = { },
+                iconRtlMode = IconRtlMode.Mirrored
+            )
+        }
+    }
+
+    @Test
+    fun mirroredRtl() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            TestHarness(layoutDirection = LayoutDirection.Rtl) {
+                Button(
+                    imageVector = Icons.Default.DirectionsBike,
+                    contentDescription = "contentDescription",
+                    onClick = { },
+                    iconRtlMode = IconRtlMode.Mirrored
+                )
+            }
         }
     }
 }

--- a/compose-material/src/test/java/com/google/android/horologist/compose/material/IconTest.kt
+++ b/compose-material/src/test/java/com/google/android/horologist/compose/material/IconTest.kt
@@ -70,4 +70,50 @@ class IconTest : ScreenshotBaseTest() {
             }
         }
     }
+
+    @Test
+    fun usingDrawableResAsIcon() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            Icon(
+                id = android.R.drawable.ic_media_play,
+                contentDescription = "contentDescription"
+            )
+        }
+    }
+
+    @Test
+    fun usingDrawableResAsIconRtl() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            TestHarness(layoutDirection = LayoutDirection.Rtl) {
+                Icon(
+                    id = android.R.drawable.ic_media_play,
+                    contentDescription = "contentDescription"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun usingDrawableResAsIconMirrored() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            Icon(
+                id = android.R.drawable.ic_media_play,
+                contentDescription = "contentDescription",
+                rtlMode = IconRtlMode.Mirrored
+            )
+        }
+    }
+
+    @Test
+    fun usingDrawableResAsIconMirroredRtl() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            TestHarness(layoutDirection = LayoutDirection.Rtl) {
+                Icon(
+                    id = android.R.drawable.ic_media_play,
+                    contentDescription = "contentDescription",
+                    rtlMode = IconRtlMode.Mirrored
+                )
+            }
+        }
+    }
 }

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonA11yTest_default.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonA11yTest_default.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf395042c32928cda64b8d6b677a4538229e5bea0f55d522f95503c0405d2eb6
+size 13521

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonA11yTest_disabled.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonA11yTest_disabled.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02b137798031241d5ae744e2a722c5dad23804481c4cab250982b678e888bdf6
+size 13328

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_defaultRtl.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_defaultRtl.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3cacfebb96aa9f061dda27c665120bc2bdc669ec6f491eff39dfdd2e1c5a8424
+size 3258

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_extraSmall.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_extraSmall.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bd659dd0a0c6a3079d859f1bddc2185377898b5bf4cacb628bac906fc19d5068
-size 3031

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_mirrored.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_mirrored.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2aaa2fda498368678f1782ff6fff43c88129c55b051d8dba4632991c7f9c3552
+size 4725

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_mirroredRtl.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_mirroredRtl.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae80990bc8dd1bfc1cbf0ae9959fcea7f922d4c9efefed7a1de46086d0121d70
+size 4594

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_usingDrawableResAsIcon.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_usingDrawableResAsIcon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:142e873fdad535e911a4a9b0ddc78ba919483c722ef3e02cb2577451c645771d
+size 4331

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_usingDrawableResAsIconMirrored.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_usingDrawableResAsIconMirrored.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:142e873fdad535e911a4a9b0ddc78ba919483c722ef3e02cb2577451c645771d
+size 4331

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_usingDrawableResAsIconMirroredRtl.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_usingDrawableResAsIconMirroredRtl.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f2de4bb41ad260f6fbbe88938cee4e6b65f79768d72172aa191a331fe25e50d
+size 4343

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_usingDrawableResAsIconRtl.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_usingDrawableResAsIconRtl.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:142e873fdad535e911a4a9b0ddc78ba919483c722ef3e02cb2577451c645771d
+size 4331

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_IconTest_usingDrawableResAsIcon.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_IconTest_usingDrawableResAsIcon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd2f4d8af5ebfc4a8e7261620537cf907419a72b691e55d026526eabd26b27d3
+size 2353

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_IconTest_usingDrawableResAsIconMirrored.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_IconTest_usingDrawableResAsIconMirrored.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd2f4d8af5ebfc4a8e7261620537cf907419a72b691e55d026526eabd26b27d3
+size 2353

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_IconTest_usingDrawableResAsIconMirroredRtl.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_IconTest_usingDrawableResAsIconMirroredRtl.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79ba0aae109ba26288b6682477514667bedd8175d77418f2ca80fd72a7277b2e
+size 2382

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_IconTest_usingDrawableResAsIconRtl.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_IconTest_usingDrawableResAsIconRtl.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd2f4d8af5ebfc4a8e7261620537cf907419a72b691e55d026526eabd26b27d3
+size 2353


### PR DESCRIPTION
#### WHAT

Improve `Button` and `Icon`.

#### HOW

- Add overloaded version for both to accept an int drawable res as param;
- Add `iconRtlMode` param to Button;
- Add A11y tests for Button;

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
