### PR TITLE
Update Time and Date Pickers to wait until the whole screen is ready …

### DIFF
--- a/composables/src/main/java/com/google/android/horologist/composables/DatePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/DatePicker.kt
@@ -40,9 +40,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.focused
@@ -178,9 +178,8 @@ public fun DatePicker(
             }
         }
 
-        BoxWithConstraints(modifier = modifier
-            .fillMaxSize()
-            .graphicsLayer(alpha = fullyDrawn.value)
+        BoxWithConstraints(
+            modifier = modifier.fillMaxSize().alpha(fullyDrawn.value)
         ) {
             val boxConstraints = this
             Column(

--- a/composables/src/main/java/com/google/android/horologist/composables/DatePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/DatePicker.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.horologist.composables
 
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -41,6 +42,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.focused
@@ -81,6 +83,8 @@ public fun DatePicker(
     fromDate: LocalDate? = null,
     toDate: LocalDate? = null
 ) {
+    val fullyDrawn = remember { Animatable(0f) }
+
     if (fromDate != null && toDate != null) {
         verifyDates(date, fromDate, toDate)
     }
@@ -174,7 +178,10 @@ public fun DatePicker(
             }
         }
 
-        BoxWithConstraints(modifier = modifier.fillMaxSize()) {
+        BoxWithConstraints(modifier = modifier
+            .fillMaxSize()
+            .graphicsLayer(alpha = fullyDrawn.value)
+        ) {
             val boxConstraints = this
             Column(
                 verticalArrangement = Arrangement.Center,
@@ -330,6 +337,10 @@ public fun DatePicker(
                 Spacer(Modifier.height(12.dp))
             }
         }
+    }
+
+    LaunchedEffect(Unit) {
+        fullyDrawn.animateTo(1f)
     }
 }
 

--- a/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.view.accessibility.AccessibilityManager
 import androidx.annotation.PluralsRes
 import androidx.annotation.VisibleForTesting
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -37,6 +38,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -49,6 +51,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLifecycleOwner
@@ -105,6 +108,8 @@ public fun TimePicker(
     time: LocalTime = LocalTime.now(),
     showSeconds: Boolean = true
 ) {
+    val fullyDrawn = remember { Animatable(0f) }
+
     // Omit scaling according to Settings > Display > Font size for this screen
     val typography = MaterialTheme.typography.copy(
         display3 = MaterialTheme.typography.display3.copy(
@@ -178,7 +183,7 @@ public fun TimePicker(
                 }
             }
 
-        Box(modifier = modifier.fillMaxSize()) {
+        Box(modifier = modifier.fillMaxSize().graphicsLayer(alpha = fullyDrawn.value)) {
             Column(
                 verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally
@@ -292,6 +297,10 @@ public fun TimePicker(
             }
         }
     }
+
+    LaunchedEffect(Unit) {
+        fullyDrawn.animateTo(1f)
+    }
 }
 
 /**
@@ -312,6 +321,8 @@ public fun TimePickerWith12HourClock(
     modifier: Modifier = Modifier,
     time: LocalTime = LocalTime.now()
 ) {
+    val fullyDrawn = remember { Animatable(0f) }
+
     // Omit scaling according to Settings > Display > Font size for this screen,
     val typography = MaterialTheme.typography.copy(
         display1 = MaterialTheme.typography.display1.copy(
@@ -382,7 +393,7 @@ public fun TimePickerWith12HourClock(
             }
         }
         Box(
-            modifier = modifier.fillMaxSize()
+            modifier = modifier.fillMaxSize().graphicsLayer(alpha = fullyDrawn.value)
         ) {
             Column(
                 modifier = modifier.fillMaxSize(),
@@ -505,6 +516,10 @@ public fun TimePickerWith12HourClock(
                 Spacer(Modifier.height(8.dp))
             }
         }
+    }
+
+    LaunchedEffect(Unit) {
+        fullyDrawn.animateTo(1f)
     }
 }
 

--- a/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
@@ -52,7 +52,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLifecycleOwner

--- a/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
@@ -49,6 +49,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.graphicsLayer
@@ -183,7 +184,7 @@ public fun TimePicker(
                 }
             }
 
-        Box(modifier = modifier.fillMaxSize().graphicsLayer(alpha = fullyDrawn.value)) {
+        Box(modifier = modifier.fillMaxSize().alpha(fullyDrawn.value)) {
             Column(
                 verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally
@@ -393,7 +394,7 @@ public fun TimePickerWith12HourClock(
             }
         }
         Box(
-            modifier = modifier.fillMaxSize().graphicsLayer(alpha = fullyDrawn.value)
+            modifier = modifier.fillMaxSize().alpha(fullyDrawn.value)
         ) {
             Column(
                 modifier = modifier.fillMaxSize(),


### PR DESCRIPTION
…before drawing

Bug: 283250297

#### WHAT. 
Updated Time and Date pickers to delay displaying the screen until it is all ready.

#### WHY
Time and Date Pickers had delays between rendering simple UI elements (text/Button) and then showing the pickers

#### HOW
Add alpha in a graphics layer to hide the content until ready to draw.

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
