### PR TITLE
Revert "Switch benchmark runner"

### DIFF
--- a/media/sample-benchmark/build.gradle.kts
+++ b/media/sample-benchmark/build.gradle.kts
@@ -38,7 +38,7 @@ android {
         minSdk = 30
         targetSdk = 33
 
-        testInstrumentationRunner = "androidx.benchmark.junit4.AndroidBenchmarkRunner"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments["androidx.benchmark.fullTracing.enable"] = "true"
     }
 


### PR DESCRIPTION
Reverts google/horologist#1430

Advised on https://issuetracker.google.com/issues/288043752 that we probably don't want the locks/thermal throttling for macrobenchmarks.  It was an erroneous warning, now fixed in androidx main.