### PR TITLE
AGP with compileSdk 34

### DIFF
--- a/auth/composables/build.gradle.kts
+++ b/auth/composables/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/auth/data-phone/build.gradle.kts
+++ b/auth/data-phone/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 23

--- a/auth/data-watch-oauth/build.gradle.kts
+++ b/auth/data-watch-oauth/build.gradle.kts
@@ -26,7 +26,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/auth/data/build.gradle.kts
+++ b/auth/data/build.gradle.kts
@@ -26,7 +26,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/auth/sample/phone/build.gradle.kts
+++ b/auth/sample/phone/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.google.android.horologist.auth.sample"

--- a/auth/sample/shared/build.gradle.kts
+++ b/auth/sample/shared/build.gradle.kts
@@ -26,7 +26,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 21

--- a/auth/sample/wear/build.gradle.kts
+++ b/auth/sample/wear/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.google.android.horologist.auth.sample"

--- a/auth/ui/build.gradle.kts
+++ b/auth/ui/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/base-ui/build.gradle.kts
+++ b/base-ui/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/composables/build.gradle.kts
+++ b/composables/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/compose-layout/build.gradle.kts
+++ b/compose-layout/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 25

--- a/compose-material/build.gradle.kts
+++ b/compose-material/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/compose-tools/build.gradle.kts
+++ b/compose-tools/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 25

--- a/datalayer-phone/build.gradle.kts
+++ b/datalayer-phone/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 23

--- a/datalayer-watch/build.gradle.kts
+++ b/datalayer-watch/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/datalayer/build.gradle.kts
+++ b/datalayer/build.gradle.kts
@@ -27,7 +27,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 23

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,3 +55,7 @@ RELEASE_SIGNING_ENABLED=true
 # unnecessary performance hit in CI. Once all modules are reviewed, this line can be removed, and
 # the "apply" in each module should also be removed.
 dependency.analysis.autoapply=false
+
+# We recommend using a newer Android Gradle plugin to use compileSdk = 34
+# This Android Gradle plugin (8.0.2) was tested up to compileSdk = 33.
+android.suppressUnsupportedCompileSdk=34

--- a/health-composables/build.gradle.kts
+++ b/health-composables/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 30

--- a/logo/build.gradle.kts
+++ b/logo/build.gradle.kts
@@ -20,5 +20,5 @@ plugins {
 
 android {
     namespace = "com.google.android.horologist.logo"
-    compileSdk = 33
+    compileSdk = 34
 }

--- a/media/audio-ui/build.gradle.kts
+++ b/media/audio-ui/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/media/audio/build.gradle.kts
+++ b/media/audio/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 25

--- a/media/backend-media3/build.gradle.kts
+++ b/media/backend-media3/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/media/benchmark/build.gradle.kts
+++ b/media/benchmark/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 30

--- a/media/data/build.gradle.kts
+++ b/media/data/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/media/media3-audiooffload/build.gradle.kts
+++ b/media/media3-audiooffload/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/media/media3-logging/build.gradle.kts
+++ b/media/media3-logging/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/media/media3-outputswitcher/build.gradle.kts
+++ b/media/media3-outputswitcher/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/media/sample-benchmark/build.gradle.kts
+++ b/media/sample-benchmark/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 
 android {
     namespace = "com.google.android.horologist.mediasample.benchmark"
-    compileSdk = 33
+    compileSdk = 34
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/media/sample/build.gradle.kts
+++ b/media/sample/build.gradle.kts
@@ -35,7 +35,7 @@ if (localFile.exists()) {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.google.android.horologist.mediasample"

--- a/media/sync/build.gradle.kts
+++ b/media/sync/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/media/ui/build.gradle.kts
+++ b/media/ui/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/network-awareness/core/build.gradle.kts
+++ b/network-awareness/core/build.gradle.kts
@@ -26,7 +26,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/network-awareness/db/build.gradle.kts
+++ b/network-awareness/db/build.gradle.kts
@@ -26,7 +26,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/network-awareness/okhttp/build.gradle.kts
+++ b/network-awareness/okhttp/build.gradle.kts
@@ -26,7 +26,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/network-awareness/ui/build.gradle.kts
+++ b/network-awareness/ui/build.gradle.kts
@@ -26,7 +26,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/roboscreenshots/build.gradle.kts
+++ b/roboscreenshots/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 25

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.google.android.horologist.sample"

--- a/tiles/build.gradle.kts
+++ b/tiles/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         //        Tiles is API 26, but if we don't stop this here, then we can't run the sample app


### PR DESCRIPTION
#### WHAT

The latest androidx version bumps are using compileSdk 34.
But it requires disabling a check.

#### WHY

So we can track the newer releases.

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
