### PR TITLE
Add device specific haptics for Pixel Watch and GW4 Classic

### DIFF
--- a/compose-layout/api/current.api
+++ b/compose-layout/api/current.api
@@ -301,13 +301,6 @@ package com.google.android.horologist.compose.rotaryinput {
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public final class DefaultRotaryHapticFeedback implements com.google.android.horologist.compose.rotaryinput.RotaryHapticFeedback {
     ctor public DefaultRotaryHapticFeedback(android.view.View view);
     method @com.google.android.horologist.annotations.ExperimentalHorologistApi public void performHapticFeedback(int type);
-    field public static final com.google.android.horologist.compose.rotaryinput.DefaultRotaryHapticFeedback.Companion Companion;
-    field public static final int ROTARY_SCROLL_ITEM_FOCUS = 19; // 0x13
-    field public static final int ROTARY_SCROLL_LIMIT = 20; // 0x14
-    field public static final int ROTARY_SCROLL_TICK = 18; // 0x12
-  }
-
-  public static final class DefaultRotaryHapticFeedback.Companion {
   }
 
   public final class DefaultRotaryHapticHandler implements com.google.android.horologist.compose.rotaryinput.RotaryHapticHandler {

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
@@ -262,9 +262,9 @@ public fun rememberDefaultRotaryHapticFeedback(): RotaryHapticFeedback =
     LocalView.current.let { view -> remember { findDeviceSpecificHapticFeedback(view) } }
 
 internal fun findDeviceSpecificHapticFeedback(view: View): RotaryHapticFeedback =
-    if (Build.MODEL.startsWith("Google Pixel Watch")) {
+    if (isGooglePixelWatch()) {
         PixelWatchRotaryHapticFeedback(view)
-    } else if (Build.MODEL.matches("SM-R8[89]5.".toRegex())) {
+    } else if (isGalaxyWatchClassic()) {
         GalaxyWatchClassicHapticFeedback(view)
     } else {
         DefaultRotaryHapticFeedback(view)
@@ -308,23 +308,23 @@ private class PixelWatchRotaryHapticFeedback(private val view: View) : RotaryHap
     ) {
         when (type) {
             RotaryHapticsType.ScrollItemFocus -> {
-                view.performHapticFeedback(SCROLL_ITEM_FOCUS)
+                view.performHapticFeedback(WEAR_SCROLL_ITEM_FOCUS)
             }
 
             RotaryHapticsType.ScrollTick -> {
-                view.performHapticFeedback(SCROLL_TICK)
+                view.performHapticFeedback(WEAR_SCROLL_TICK)
             }
 
             RotaryHapticsType.ScrollLimit -> {
-                view.performHapticFeedback(SCROLL_LIMIT)
+                view.performHapticFeedback(WEAR_SCROLL_LIMIT)
             }
         }
     }
     private companion object {
-        // Hidden constants from HapticFeedbackConstants.java
-        public const val SCROLL_TICK: Int = 10002
-        public const val SCROLL_ITEM_FOCUS: Int = 10003
-        public const val SCROLL_LIMIT: Int = 10003
+        // Hidden constants from HapticFeedbackConstants.java specific for Pixel Watch
+        public const val WEAR_SCROLL_TICK: Int = 10002
+        public const val WEAR_SCROLL_ITEM_FOCUS: Int = 10003
+        public const val WEAR_SCROLL_LIMIT: Int = 10003
     }
 }
 
@@ -353,3 +353,9 @@ private class GalaxyWatchClassicHapticFeedback(private val view: View) : RotaryH
         }
     }
 }
+
+private fun isGalaxyWatchClassic(): Boolean =
+    Build.MODEL.matches("SM-R8[89]5.".toRegex())
+
+private fun isGooglePixelWatch(): Boolean =
+    Build.MODEL.startsWith("Google Pixel Watch")

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.horologist.compose.rotaryinput
 
+import android.os.Build
 import android.view.HapticFeedbackConstants
 import android.view.View
 import androidx.compose.foundation.gestures.ScrollableState
@@ -258,7 +259,16 @@ private fun rememberHapticChannel() =
 @ExperimentalHorologistApi
 @Composable
 public fun rememberDefaultRotaryHapticFeedback(): RotaryHapticFeedback =
-    LocalView.current.let { view -> remember { DefaultRotaryHapticFeedback(view) } }
+    LocalView.current.let { view -> remember { findDeviceSpecificHapticFeedback(view) } }
+
+internal fun findDeviceSpecificHapticFeedback(view: View): RotaryHapticFeedback =
+    if (Build.MODEL.startsWith("Google Pixel Watch")) {
+        PixelWatchRotaryHapticFeedback(view)
+    } else if (Build.MODEL.matches("SM-R8[89]5.".toRegex())) {
+        GalaxyWatchClassicHapticFeedback(view)
+    } else {
+        DefaultRotaryHapticFeedback(view)
+    }
 
 /**
  * Default Rotary implementation for [RotaryHapticFeedback]
@@ -284,11 +294,62 @@ public class DefaultRotaryHapticFeedback(private val view: View) : RotaryHapticF
             }
         }
     }
+}
 
-    public companion object {
+/**
+ * Implementation of [RotaryHapticFeedback] for Pixel Watch
+ */
+@ExperimentalHorologistApi
+private class PixelWatchRotaryHapticFeedback(private val view: View) : RotaryHapticFeedback {
+
+    @ExperimentalHorologistApi
+    override fun performHapticFeedback(
+        type: RotaryHapticsType
+    ) {
+        when (type) {
+            RotaryHapticsType.ScrollItemFocus -> {
+                view.performHapticFeedback(SCROLL_ITEM_FOCUS)
+            }
+
+            RotaryHapticsType.ScrollTick -> {
+                view.performHapticFeedback(SCROLL_TICK)
+            }
+
+            RotaryHapticsType.ScrollLimit -> {
+                view.performHapticFeedback(SCROLL_LIMIT)
+            }
+        }
+    }
+    private companion object {
         // Hidden constants from HapticFeedbackConstants.java
-        public const val ROTARY_SCROLL_TICK: Int = 18
-        public const val ROTARY_SCROLL_ITEM_FOCUS: Int = 19
-        public const val ROTARY_SCROLL_LIMIT: Int = 20
+        public const val SCROLL_TICK: Int = 10002
+        public const val SCROLL_ITEM_FOCUS: Int = 10003
+        public const val SCROLL_LIMIT: Int = 10003
+    }
+}
+
+/**
+ * Implementation of [RotaryHapticFeedback] for Galaxy Watch 4 Classic
+ */
+@ExperimentalHorologistApi
+private class GalaxyWatchClassicHapticFeedback(private val view: View) : RotaryHapticFeedback {
+
+    @ExperimentalHorologistApi
+    override fun performHapticFeedback(
+        type: RotaryHapticsType
+    ) {
+        when (type) {
+            RotaryHapticsType.ScrollItemFocus -> {
+                // No haptic for scroll snap ( we have physical bezel)
+            }
+
+            RotaryHapticsType.ScrollTick -> {
+                // No haptic for scroll tick ( we have physical bezel)
+            }
+
+            RotaryHapticsType.ScrollLimit -> {
+                view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+            }
+        }
     }
 }


### PR DESCRIPTION
#### WHAT
Add device specific haptics for Pixel Watch and GW4 Classic

#### WHY
Haptics on Pixel Watch in compose was different from View-haptics. It wasn't possible to switch it off in settings by disabling crown haptics. 
Scroll haptics on GW4 Classic were switched off because we have a physical bezel so there is no need for them.

#### HOW
Custom RotaryHapticFeedback implementations were added for Pixel watch and GW4 Classic

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
