### PR TITLE
[MediaUI] Don't encode null into route when navigating to a media item

### DIFF
--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/navigation/NavigationScreens.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/navigation/NavigationScreens.kt
@@ -73,7 +73,13 @@ public open class NavigationScreens(
         public fun destination(
             id: String,
             collectionId: String? = null
-        ): String = "mediaItem?id=$id" + (if (collectionId != null) "&collectionId=$collectionId" else null)
+        ): String {
+            var route = "mediaItem?id=$id"
+            if (collectionId != null) {
+                route += "&collectionId=$collectionId"
+            }
+            return route
+        }
 
         override fun deepLinks(deepLinkPrefix: String): List<NavDeepLink> = listOf(
             navDeepLink {


### PR DESCRIPTION
#### WHAT
When selecting a media item with a null collection, the route becomes
`mediaItem?id=<id>null`

I don't think this is the intended behavior. Instead we should skip the collection argument entirely in that case. Otherwise when parsing the argument you have to deal with the null at the end.

The sample app doesn't seem to call this function. I tried to add a simple unit test here but it doesn't look like there's any test coverage in the file so I think it'd be a lot of setup. Let me know if you want to me try though. 

Thanks

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
