### PR TITLE
Allow custom sizes for Button

### DIFF
--- a/compose-material/api/current.api
+++ b/compose-material/api/current.api
@@ -10,16 +10,34 @@ package com.google.android.horologist.compose.material {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void Button(@DrawableRes int id, String contentDescription, kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.material.ButtonColors colors, optional com.google.android.horologist.compose.material.ButtonSize buttonSize, optional com.google.android.horologist.compose.material.IconRtlMode iconRtlMode, optional boolean enabled);
   }
 
-  @com.google.android.horologist.annotations.ExperimentalHorologistApi public enum ButtonSize {
+  @com.google.android.horologist.annotations.ExperimentalHorologistApi public abstract sealed class ButtonSize {
     method public final float getIconSize();
     method public final float getTapTargetSize();
-    method public static com.google.android.horologist.compose.material.ButtonSize valueOf(String name) throws java.lang.IllegalArgumentException;
-    method public static com.google.android.horologist.compose.material.ButtonSize[] values();
     property public final float iconSize;
     property public final float tapTargetSize;
-    enum_constant public static final com.google.android.horologist.compose.material.ButtonSize Default;
-    enum_constant public static final com.google.android.horologist.compose.material.ButtonSize Large;
-    enum_constant public static final com.google.android.horologist.compose.material.ButtonSize Small;
+  }
+
+  public static final class ButtonSize.Custom extends com.google.android.horologist.compose.material.ButtonSize {
+    ctor public ButtonSize.Custom(float customIconSize, float customTapTargetSize);
+    method public float component1-D9Ej5fM();
+    method public float component2-D9Ej5fM();
+    method public com.google.android.horologist.compose.material.ButtonSize.Custom copy-YgX7TsA(float customIconSize, float customTapTargetSize);
+    method public float getCustomIconSize();
+    method public float getCustomTapTargetSize();
+    property public final float customIconSize;
+    property public final float customTapTargetSize;
+  }
+
+  public static final class ButtonSize.Default extends com.google.android.horologist.compose.material.ButtonSize {
+    field public static final com.google.android.horologist.compose.material.ButtonSize.Default INSTANCE;
+  }
+
+  public static final class ButtonSize.Large extends com.google.android.horologist.compose.material.ButtonSize {
+    field public static final com.google.android.horologist.compose.material.ButtonSize.Large INSTANCE;
+  }
+
+  public static final class ButtonSize.Small extends com.google.android.horologist.compose.material.ButtonSize {
+    field public static final com.google.android.horologist.compose.material.ButtonSize.Small INSTANCE;
   }
 
   public final class ChipIconWithProgressKt {

--- a/compose-material/src/debug/java/com/google/android/horologist/compose/material/ButtonPreview.kt
+++ b/compose-material/src/debug/java/com/google/android/horologist/compose/material/ButtonPreview.kt
@@ -56,6 +56,20 @@ fun ButtonPreviewSmall() {
 
 @WearPreview
 @Composable
+fun ButtonPreviewCustomSize() {
+    Button(
+        imageVector = Icons.Default.Check,
+        contentDescription = "contentDescription",
+        onClick = { },
+        buttonSize = ButtonSize.Custom(
+            customIconSize = ButtonDefaults.SmallIconSize,
+            customTapTargetSize = ButtonDefaults.LargeButtonSize
+        )
+    )
+}
+
+@WearPreview
+@Composable
 fun ButtonPreviewDisabled() {
     Button(
         imageVector = Icons.Default.Check,

--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/Button.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/Button.kt
@@ -92,6 +92,7 @@ public fun Button(
     )
 }
 
+@OptIn(ExperimentalHorologistApi::class)
 @Composable
 internal fun Button(
     icon: Any,
@@ -123,11 +124,19 @@ internal fun Button(
 }
 
 @ExperimentalHorologistApi
-public enum class ButtonSize(
+public sealed class ButtonSize(
     public val iconSize: Dp,
     public val tapTargetSize: Dp
 ) {
-    Default(iconSize = DefaultIconSize, tapTargetSize = DefaultButtonSize),
-    Large(iconSize = LargeIconSize, tapTargetSize = LargeButtonSize),
-    Small(iconSize = SmallIconSize, tapTargetSize = SmallButtonSize)
+    public object Default :
+        ButtonSize(iconSize = DefaultIconSize, tapTargetSize = DefaultButtonSize)
+
+    public object Large : ButtonSize(iconSize = LargeIconSize, tapTargetSize = LargeButtonSize)
+    public object Small : ButtonSize(iconSize = SmallIconSize, tapTargetSize = SmallButtonSize)
+
+    /**
+     * Custom sizes should follow the [accessibility principles and guidance for touch targets](https://developer.android.com/training/wearables/accessibility#set-minimum).
+     */
+    public data class Custom(val customIconSize: Dp, val customTapTargetSize: Dp) :
+        ButtonSize(iconSize = customIconSize, tapTargetSize = customTapTargetSize)
 }

--- a/compose-material/src/test/java/com/google/android/horologist/compose/material/ButtonTest.kt
+++ b/compose-material/src/test/java/com/google/android/horologist/compose/material/ButtonTest.kt
@@ -75,6 +75,21 @@ internal class ButtonTest : ScreenshotBaseTest() {
     }
 
     @Test
+    fun customSize() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            Button(
+                imageVector = Icons.Default.Check,
+                contentDescription = "contentDescription",
+                onClick = { },
+                buttonSize = ButtonSize.Custom(
+                    customIconSize = ButtonDefaults.SmallIconSize,
+                    customTapTargetSize = ButtonDefaults.LargeButtonSize
+                )
+            )
+        }
+    }
+
+    @Test
     fun withSecondaryButtonColors() {
         screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
             Button(

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_customSize.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ButtonTest_customSize.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:037c83e033b46183eabfdf27d666e933698ce3d52aa62e463260c5b32c4047a3
+size 3669


### PR DESCRIPTION
#### WHAT

Allow custom sizes for `Button`.

#### WHY

Fixes https://github.com/google/horologist/issues/1481

#### HOW

Change `ButtonSize` from enum to sealed class and add `Custom` data class.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
