### PR TITLE
Fix VersionFileTest

### DIFF
--- a/datalayer/core/src/androidTest/java/com/google/android/horologist/data/VersionFileTest.kt
+++ b/datalayer/core/src/androidTest/java/com/google/android/horologist/data/VersionFileTest.kt
@@ -26,7 +26,7 @@ import java.io.InputStreamReader
 class VersionFileTest {
     @Test
     fun testVersionFileIsPresent() {
-        val resource = TargetNodeId::class.java.getResource("/META-INF/com.google.android.horologist_datalayer.version")
+        val resource = TargetNodeId::class.java.getResource("/META-INF/com.google.android.horologist_datalayercore.version")
         assertThat(resource).isNotNull()
 
         val version = resource!!.openStream().use {


### PR DESCRIPTION
#### WHAT

Fix VersionFileTest

#### WHY

Broken since project's folder was changed.

```
com.google.android.horologist.data.VersionFileTest > testVersionFileIsPresent[test(AVD) - 11] FAILED 
	expected not to be: null
	at com.google.android.horologist.data.VersionFileTest.testVersionFileIsPresent(VersionFileTest.kt:30)
```

#### HOW

Change expected version file name.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
