### PR TITLE
Improve SectionedList 

### DIFF
--- a/composables/api/current.api
+++ b/composables/api/current.api
@@ -35,36 +35,48 @@ package com.google.android.horologist.composables {
   }
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public final class Section<T> {
-    ctor public Section(com.google.android.horologist.composables.Section.State<? extends T> state, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? headerContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? loadingContent, optional int loadingContentCount, optional kotlin.jvm.functions.Function2<? super com.google.android.horologist.composables.SectionContentScope,? super T,kotlin.Unit>? loadedContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? failedContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? emptyContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? footerContent, optional boolean displayFooterOnlyOnLoadedState);
+    ctor public Section(com.google.android.horologist.composables.Section.State<? extends T> state, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? headerContent, optional com.google.android.horologist.composables.Section.VisibleStates headerVisibleStates, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? loadingContent, optional int loadingContentCount, optional kotlin.jvm.functions.Function2<? super com.google.android.horologist.composables.SectionContentScope,? super T,kotlin.Unit>? loadedContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? failedContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? emptyContent, optional kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? footerContent, optional com.google.android.horologist.composables.Section.VisibleStates footerVisibleStates);
     method public com.google.android.horologist.composables.Section.State<T> component1();
+    method public com.google.android.horologist.composables.Section.VisibleStates component10();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? component2();
-    method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? component3();
-    method public int component4();
-    method public kotlin.jvm.functions.Function2<com.google.android.horologist.composables.SectionContentScope,T,kotlin.Unit>? component5();
-    method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? component6();
+    method public com.google.android.horologist.composables.Section.VisibleStates component3();
+    method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? component4();
+    method public int component5();
+    method public kotlin.jvm.functions.Function2<com.google.android.horologist.composables.SectionContentScope,T,kotlin.Unit>? component6();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? component7();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? component8();
-    method public boolean component9();
-    method public com.google.android.horologist.composables.Section<T> copy(com.google.android.horologist.composables.Section.State<? extends T> state, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? headerContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? loadingContent, int loadingContentCount, kotlin.jvm.functions.Function2<? super com.google.android.horologist.composables.SectionContentScope,? super T,kotlin.Unit>? loadedContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? failedContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? emptyContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? footerContent, boolean displayFooterOnlyOnLoadedState);
-    method public boolean getDisplayFooterOnlyOnLoadedState();
+    method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? component9();
+    method public com.google.android.horologist.composables.Section<T> copy(com.google.android.horologist.composables.Section.State<? extends T> state, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? headerContent, com.google.android.horologist.composables.Section.VisibleStates headerVisibleStates, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? loadingContent, int loadingContentCount, kotlin.jvm.functions.Function2<? super com.google.android.horologist.composables.SectionContentScope,? super T,kotlin.Unit>? loadedContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? failedContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? emptyContent, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? footerContent, com.google.android.horologist.composables.Section.VisibleStates footerVisibleStates);
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? getEmptyContent();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? getFailedContent();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? getFooterContent();
+    method public com.google.android.horologist.composables.Section.VisibleStates getFooterVisibleStates();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? getHeaderContent();
+    method public com.google.android.horologist.composables.Section.VisibleStates getHeaderVisibleStates();
     method public kotlin.jvm.functions.Function2<com.google.android.horologist.composables.SectionContentScope,T,kotlin.Unit>? getLoadedContent();
     method public kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? getLoadingContent();
     method public int getLoadingContentCount();
     method public com.google.android.horologist.composables.Section.State<T> getState();
-    property public final boolean displayFooterOnlyOnLoadedState;
     property public final kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? emptyContent;
     property public final kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? failedContent;
     property public final kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? footerContent;
+    property public final com.google.android.horologist.composables.Section.VisibleStates footerVisibleStates;
     property public final kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? headerContent;
+    property public final com.google.android.horologist.composables.Section.VisibleStates headerVisibleStates;
     property public final kotlin.jvm.functions.Function2<com.google.android.horologist.composables.SectionContentScope,T,kotlin.Unit>? loadedContent;
     property public final kotlin.jvm.functions.Function1<com.google.android.horologist.composables.SectionContentScope,kotlin.Unit>? loadingContent;
     property public final int loadingContentCount;
     property public final com.google.android.horologist.composables.Section.State<T> state;
-    field public static final int DEFAULT_LOADING_CONTENT_COUNT = 1; // 0x1
+    field public static final com.google.android.horologist.composables.Section.Companion Companion;
+  }
+
+  @com.google.android.horologist.annotations.ExperimentalHorologistApi public static final class Section.Companion {
+    method public com.google.android.horologist.composables.Section.VisibleStates getALL_STATES();
+    method public com.google.android.horologist.composables.Section.VisibleStates getLOADED_STATE_ONLY();
+    method public com.google.android.horologist.composables.Section.VisibleStates getNO_STATES();
+    property public final com.google.android.horologist.composables.Section.VisibleStates ALL_STATES;
+    property public final com.google.android.horologist.composables.Section.VisibleStates LOADED_STATE_ONLY;
+    property public final com.google.android.horologist.composables.Section.VisibleStates NO_STATES;
   }
 
   public abstract static sealed class Section.State<T> {
@@ -90,6 +102,23 @@ package com.google.android.horologist.composables {
     field public static final com.google.android.horologist.composables.Section.State.Loading INSTANCE;
   }
 
+  @com.google.android.horologist.annotations.ExperimentalHorologistApi public static final class Section.VisibleStates {
+    ctor public Section.VisibleStates(boolean loading, boolean loaded, boolean failed, boolean empty);
+    method public boolean component1();
+    method public boolean component2();
+    method public boolean component3();
+    method public boolean component4();
+    method public com.google.android.horologist.composables.Section.VisibleStates copy(boolean loading, boolean loaded, boolean failed, boolean empty);
+    method public boolean getEmpty();
+    method public boolean getFailed();
+    method public boolean getLoaded();
+    method public boolean getLoading();
+    property public final boolean empty;
+    property public final boolean failed;
+    property public final boolean loaded;
+    property public final boolean loading;
+  }
+
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public final class SectionContentScope {
     field public static final com.google.android.horologist.composables.SectionContentScope INSTANCE;
   }
@@ -98,8 +127,8 @@ package com.google.android.horologist.composables {
     ctor public SectionScope();
     method public void empty(kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit> content);
     method public void failed(kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit> content);
-    method public void footer(kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit> content);
-    method public void header(kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit> content);
+    method public void footer(optional com.google.android.horologist.composables.Section.VisibleStates visibleStates, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit> content);
+    method public void header(optional com.google.android.horologist.composables.Section.VisibleStates visibleStates, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit> content);
     method public void loaded(kotlin.jvm.functions.Function2<? super com.google.android.horologist.composables.SectionContentScope,? super T,kotlin.Unit> content);
     method public void loading(optional int count, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionContentScope,kotlin.Unit> content);
   }
@@ -111,7 +140,7 @@ package com.google.android.horologist.composables {
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public final class SectionedListScope {
     ctor public SectionedListScope();
-    method public <T> void section(com.google.android.horologist.composables.Section.State<? extends T> state, optional boolean displayFooterOnlyOnLoadedState, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionScope<T>,kotlin.Unit> content);
+    method public <T> void section(com.google.android.horologist.composables.Section.State<? extends T> state, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionScope<T>,kotlin.Unit> content);
     method public <T> void section(java.util.List<? extends T> list, kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionScope<T>,kotlin.Unit> content);
     method public void section(kotlin.jvm.functions.Function1<? super com.google.android.horologist.composables.SectionScope<kotlin.Unit>,kotlin.Unit> content);
   }

--- a/composables/build.gradle.kts
+++ b/composables/build.gradle.kts
@@ -46,7 +46,9 @@ android {
         jvmTarget = "11"
         freeCompilerArgs = freeCompilerArgs + listOf(
             "-opt-in=kotlin.RequiresOptIn",
-            "-opt-in=com.google.android.horologist.annotations.ExperimentalHorologistApi"
+            "-opt-in=com.google.android.horologist.annotations.ExperimentalHorologistApi",
+            // Enable context receivers https://github.com/Kotlin/KEEP/blob/master/proposals/context-receivers.md
+            "-Xcontext-receivers"
         )
     }
 
@@ -108,10 +110,12 @@ dependencies {
     debugImplementation(libs.compose.ui.tooling)
     debugImplementation(libs.compose.ui.test.manifest)
     debugImplementation(projects.composeTools)
+    debugImplementation(projects.composeMaterial)
 
     testImplementation(libs.junit)
     testImplementation(libs.truth)
     testImplementation(projects.composeTools)
+    testImplementation(projects.composeMaterial)
     testImplementation(projects.roboscreenshots)
     testImplementation(libs.robolectric)
 }

--- a/composables/src/debug/java/com/google/android/horologist/composables/SectionedListPreview.kt
+++ b/composables/src/debug/java/com/google/android/horologist/composables/SectionedListPreview.kt
@@ -16,7 +16,6 @@
 
 package com.google.android.horologist.composables
 
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -29,12 +28,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
+import com.google.android.horologist.compose.material.Chip
 
 @WearPreviewDevices
 @Composable
@@ -113,17 +112,8 @@ private fun DownloadsLoading() {
 @Composable
 private fun DownloadsLoaded(text: String) {
     Chip(
-        label = {
-            Text(
-                text = text,
-                modifier = Modifier.fillMaxWidth(),
-                textAlign = TextAlign.Start,
-                overflow = TextOverflow.Ellipsis,
-                maxLines = 2
-            )
-        },
+        label = text,
         onClick = { },
-        modifier = Modifier.fillMaxWidth(),
         icon = {
             Icon(
                 imageVector = Icons.Default.FeaturedPlayList,
@@ -134,6 +124,7 @@ private fun DownloadsLoaded(text: String) {
                 tint = Color.Green
             )
         },
+        largeIcon = true,
         colors = ChipDefaults.secondaryChipColors()
     )
 }
@@ -161,17 +152,8 @@ private fun DownloadsEmpty() {
 @Composable
 private fun DownloadsFooter() {
     Chip(
-        label = {
-            Text(
-                text = "More downloads..",
-                modifier = Modifier.fillMaxWidth(),
-                textAlign = TextAlign.Center,
-                overflow = TextOverflow.Ellipsis,
-                maxLines = 2
-            )
-        },
+        label = "More downloads..",
         onClick = { },
-        modifier = Modifier.fillMaxWidth(),
         colors = ChipDefaults.secondaryChipColors()
     )
 }
@@ -213,17 +195,8 @@ private fun FavouritesLoading() {
 @Composable
 private fun FavouritesLoaded(text: String) {
     Chip(
-        label = {
-            Text(
-                text = text,
-                modifier = Modifier.fillMaxWidth(),
-                textAlign = TextAlign.Start,
-                overflow = TextOverflow.Ellipsis,
-                maxLines = 2
-            )
-        },
+        label = text,
         onClick = { },
-        modifier = Modifier.fillMaxWidth(),
         icon = {
             Icon(
                 imageVector = Icons.Default.FeaturedPlayList,
@@ -234,6 +207,7 @@ private fun FavouritesLoaded(text: String) {
                 tint = Color.Green
             )
         },
+        largeIcon = true,
         colors = ChipDefaults.secondaryChipColors()
     )
 }
@@ -261,17 +235,8 @@ private fun FavouritesEmpty() {
 @Composable
 fun FavouritesFooter() {
     Chip(
-        label = {
-            Text(
-                text = "More favourites..",
-                modifier = Modifier.fillMaxWidth(),
-                textAlign = TextAlign.Center,
-                overflow = TextOverflow.Ellipsis,
-                maxLines = 2
-            )
-        },
+        label = "More favourites..",
         onClick = { },
-        modifier = Modifier.fillMaxWidth(),
         colors = ChipDefaults.secondaryChipColors()
     )
 }

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/SectionedListHeaderFooterTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/SectionedListHeaderFooterTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.composables
+
+import com.google.android.horologist.composables.Section.Companion.ALL_STATES
+import com.google.android.horologist.composables.Section.Companion.NO_STATES
+import com.google.android.horologist.composables.SectionedListTest.Companion.DownloadsEmpty
+import com.google.android.horologist.composables.SectionedListTest.Companion.DownloadsFailed
+import com.google.android.horologist.composables.SectionedListTest.Companion.DownloadsFooter
+import com.google.android.horologist.composables.SectionedListTest.Companion.DownloadsHeader
+import com.google.android.horologist.composables.SectionedListTest.Companion.DownloadsLoaded
+import com.google.android.horologist.composables.SectionedListTest.Companion.DownloadsLoading
+import com.google.android.horologist.composables.SectionedListTest.Companion.SectionedListPreview
+import com.google.android.horologist.composables.SectionedListTest.Companion.downloads
+import com.google.android.horologist.screenshots.ScreenshotBaseTest
+import com.google.android.horologist.screenshots.ScreenshotTestRule.Companion.screenshotTestRuleParams
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.ParameterizedRobolectricTestRunner
+
+@RunWith(ParameterizedRobolectricTestRunner::class)
+class SectionedListHeaderFooterTest(
+    private val headerVisibleStatesParam: Section.VisibleStates,
+    private val footerVisibleStatesParam: Section.VisibleStates,
+    private val sectionStateParam: Section.State<String>
+) : ScreenshotBaseTest(
+    screenshotTestRuleParams {
+        screenTimeText = {}
+    }
+) {
+
+    @Test
+    fun test() {
+        screenshotTestRule.setContent(takeScreenshot = true) {
+            val columnState = positionedState()
+
+            SectionedListPreview(columnState) {
+                SectionedList(columnState = columnState) {
+                    section(state = sectionStateParam) {
+                        header(visibleStates = headerVisibleStatesParam) { DownloadsHeader() }
+
+                        loading { DownloadsLoading() }
+
+                        loaded { DownloadsLoaded(it) }
+
+                        failed { DownloadsFailed() }
+
+                        empty { DownloadsEmpty() }
+
+                        footer(visibleStates = footerVisibleStatesParam) { DownloadsFooter() }
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        @ParameterizedRobolectricTestRunner.Parameters
+        @Suppress("unused") // it's used by the test as params
+        fun params() = listOf(
+            arrayOf(
+                ALL_STATES,
+                NO_STATES,
+                Section.State.Loading
+            ),
+            arrayOf(
+                ALL_STATES,
+                NO_STATES,
+                Section.State.Loaded(downloads)
+            ),
+            arrayOf(
+                ALL_STATES,
+                NO_STATES,
+                Section.State.Failed
+            ),
+            arrayOf(
+                ALL_STATES,
+                NO_STATES,
+                Section.State.Empty
+            ),
+            arrayOf(
+                NO_STATES,
+                ALL_STATES,
+                Section.State.Loading
+            ),
+            arrayOf(
+                NO_STATES,
+                ALL_STATES,
+                Section.State.Loaded(downloads)
+            ),
+            arrayOf(
+                NO_STATES,
+                ALL_STATES,
+                Section.State.Failed
+            ),
+            arrayOf(
+                NO_STATES,
+                ALL_STATES,
+                Section.State.Empty
+            )
+        )
+    }
+}

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/SectionedListTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/SectionedListTest.kt
@@ -21,7 +21,6 @@ package com.google.android.horologist.composables
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -34,7 +33,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
@@ -44,6 +42,7 @@ import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.TimeText
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.layout.scrollAway
+import com.google.android.horologist.compose.material.Chip
 import com.google.android.horologist.screenshots.FixedTimeSource
 import com.google.android.horologist.screenshots.ScreenshotBaseTest
 import com.google.android.horologist.screenshots.ScreenshotTestRule.Companion.screenshotTestRuleParams
@@ -176,223 +175,195 @@ class SectionedListTest : ScreenshotBaseTest(
         }
     }
 
-    @Composable
-    private fun SectionedListPreview(
-        columnState: ScalingLazyColumnState,
-        content: @Composable () -> Unit
-    ) {
-        Scaffold(
-            modifier = Modifier.fillMaxSize(),
-            positionIndicator = {
-                PositionIndicator(columnState.state)
-            },
-            timeText = {
-                TimeText(modifier = Modifier.scrollAway(columnState), timeSource = FixedTimeSource)
-            }
+    internal companion object {
+
+        @Composable
+        fun SectionedListPreview(
+            columnState: ScalingLazyColumnState,
+            content: @Composable () -> Unit
         ) {
-            Box(modifier = Modifier.background(Color.Black)) {
-                content()
+            Scaffold(
+                modifier = Modifier.fillMaxSize(),
+                positionIndicator = {
+                    PositionIndicator(columnState.state)
+                },
+                timeText = {
+                    TimeText(
+                        modifier = Modifier.scrollAway(columnState),
+                        timeSource = FixedTimeSource
+                    )
+                }
+            ) {
+                Box(modifier = Modifier.background(Color.Black)) {
+                    content()
+                }
             }
         }
-    }
 
-    private val downloads = listOf("Nu Metal Essentials", "00s Rock")
+        val downloads = listOf("Nu Metal Essentials", "00s Rock")
 
-    private fun SectionedListScope.downloadsSection(state: Section.State<String>) {
-        section(state = state) {
-            header { DownloadsHeader() }
+        private fun SectionedListScope.downloadsSection(state: Section.State<String>) {
+            section(state = state) {
+                header { DownloadsHeader() }
 
-            loading { DownloadsLoading() }
+                loading { DownloadsLoading() }
 
-            loaded { DownloadsLoaded(it) }
+                loaded { DownloadsLoaded(it) }
 
-            failed { DownloadsFailed() }
+                failed { DownloadsFailed() }
 
-            empty { DownloadsEmpty() }
+                empty { DownloadsEmpty() }
 
-            footer { DownloadsFooter() }
+                footer { DownloadsFooter() }
+            }
         }
-    }
 
-    @Composable
-    private fun DownloadsHeader() {
-        Text(
-            text = "Downloads",
-            modifier = Modifier.padding(bottom = 12.dp),
-            overflow = TextOverflow.Ellipsis,
-            maxLines = 3,
-            style = MaterialTheme.typography.title3
-        )
-    }
-
-    @Composable
-    private fun DownloadsLoading() {
-        PlaceholderChip(colors = ChipDefaults.secondaryChipColors())
-    }
-
-    @Composable
-    private fun DownloadsLoaded(text: String) {
-        Chip(
-            label = {
-                Text(
-                    text = text,
-                    modifier = Modifier.fillMaxWidth(),
-                    textAlign = TextAlign.Start,
-                    overflow = TextOverflow.Ellipsis,
-                    maxLines = 2
-                )
-            },
-            onClick = { },
-            modifier = Modifier.fillMaxWidth(),
-            icon = {
-                Icon(
-                    imageVector = Icons.Default.FeaturedPlayList,
-                    contentDescription = null,
-                    modifier = Modifier
-                        .size(ChipDefaults.LargeIconSize)
-                        .clip(CircleShape),
-                    tint = Color.Green
-                )
-            },
-            colors = ChipDefaults.secondaryChipColors()
-        )
-    }
-
-    @Composable
-    private fun DownloadsFailed() {
-        Text(
-            text = "Failed to load downloads. Please try again later.",
-            modifier = Modifier.padding(top = 8.dp, bottom = 8.dp),
-            textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.body2
-        )
-    }
-
-    @Composable
-    private fun DownloadsEmpty() {
-        Text(
-            text = "Download music to start listening.",
-            modifier = Modifier.padding(top = 8.dp, bottom = 8.dp),
-            textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.body2
-        )
-    }
-
-    @Composable
-    private fun DownloadsFooter() {
-        Chip(
-            label = {
-                Text(
-                    text = "More downloads..",
-                    modifier = Modifier.fillMaxWidth(),
-                    textAlign = TextAlign.Center,
-                    overflow = TextOverflow.Ellipsis,
-                    maxLines = 2
-                )
-            },
-            onClick = { },
-            modifier = Modifier.fillMaxWidth(),
-            colors = ChipDefaults.secondaryChipColors()
-        )
-    }
-
-    private val favourites = listOf("Dance Anthems", "Indie Jukebox")
-
-    private fun SectionedListScope.favouritesSection(state: Section.State<String>) {
-        section(state = state) {
-            header { FavouritesHeader() }
-
-            loading { FavouritesLoading() }
-
-            loaded { FavouritesLoaded(it) }
-
-            failed { FavouritesFailed() }
-
-            empty { FavouritesEmpty() }
-
-            footer { FavouritesFooter() }
+        @Composable
+        fun DownloadsHeader() {
+            Text(
+                text = "Downloads",
+                modifier = Modifier.padding(bottom = 12.dp),
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 3,
+                style = MaterialTheme.typography.title3
+            )
         }
-    }
 
-    @Composable
-    private fun FavouritesHeader() {
-        Text(
-            text = "Favourites",
-            modifier = Modifier.padding(top = 12.dp, bottom = 12.dp),
-            overflow = TextOverflow.Ellipsis,
-            maxLines = 3,
-            style = MaterialTheme.typography.title3
-        )
-    }
+        @Composable
+        fun DownloadsLoading() {
+            PlaceholderChip(colors = ChipDefaults.secondaryChipColors())
+        }
 
-    @Composable
-    private fun FavouritesLoading() {
-        PlaceholderChip(colors = ChipDefaults.secondaryChipColors())
-    }
+        @Composable
+        fun DownloadsLoaded(text: String) {
+            Chip(
+                label = text,
+                onClick = { },
+                icon = {
+                    Icon(
+                        imageVector = Icons.Default.FeaturedPlayList,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .size(ChipDefaults.LargeIconSize)
+                            .clip(CircleShape),
+                        tint = Color.Green
+                    )
+                },
+                largeIcon = true,
+                colors = ChipDefaults.secondaryChipColors()
+            )
+        }
 
-    @Composable
-    private fun FavouritesLoaded(text: String) {
-        Chip(
-            label = {
-                Text(
-                    text = text,
-                    modifier = Modifier.fillMaxWidth(),
-                    textAlign = TextAlign.Start,
-                    overflow = TextOverflow.Ellipsis,
-                    maxLines = 2
-                )
-            },
-            onClick = { },
-            modifier = Modifier.fillMaxWidth(),
-            icon = {
-                Icon(
-                    imageVector = Icons.Default.FeaturedPlayList,
-                    contentDescription = null,
-                    modifier = Modifier
-                        .size(ChipDefaults.LargeIconSize)
-                        .clip(CircleShape),
-                    tint = Color.Green
-                )
-            },
-            colors = ChipDefaults.secondaryChipColors()
-        )
-    }
+        @Composable
+        fun DownloadsFailed() {
+            Text(
+                text = "Failed to load downloads. Please try again later.",
+                modifier = Modifier.padding(top = 8.dp, bottom = 8.dp),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.body2
+            )
+        }
 
-    @Composable
-    private fun FavouritesFailed() {
-        Text(
-            text = "Failed to load favourites. Please try again later.",
-            modifier = Modifier.padding(top = 8.dp, bottom = 8.dp),
-            textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.body2
-        )
-    }
+        @Composable
+        fun DownloadsEmpty() {
+            Text(
+                text = "Download music to start listening.",
+                modifier = Modifier.padding(top = 8.dp, bottom = 8.dp),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.body2
+            )
+        }
 
-    @Composable
-    private fun FavouritesEmpty() {
-        Text(
-            text = "Mark songs or albums as favourites to see them here.",
-            modifier = Modifier.padding(top = 8.dp, bottom = 8.dp),
-            textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.body2
-        )
-    }
+        @Composable
+        fun DownloadsFooter() {
+            Chip(
+                label = "More downloads..",
+                onClick = { },
+                colors = ChipDefaults.secondaryChipColors()
+            )
+        }
 
-    @Composable
-    fun FavouritesFooter() {
-        Chip(
-            label = {
-                Text(
-                    text = "More favourites..",
-                    modifier = Modifier.fillMaxWidth(),
-                    textAlign = TextAlign.Center,
-                    overflow = TextOverflow.Ellipsis,
-                    maxLines = 2
-                )
-            },
-            onClick = { },
-            modifier = Modifier.fillMaxWidth(),
-            colors = ChipDefaults.secondaryChipColors()
-        )
+        val favourites = listOf("Dance Anthems", "Indie Jukebox")
+
+        private fun SectionedListScope.favouritesSection(state: Section.State<String>) {
+            section(state = state) {
+                header { FavouritesHeader() }
+
+                loading { FavouritesLoading() }
+
+                loaded { FavouritesLoaded(it) }
+
+                failed { FavouritesFailed() }
+
+                empty { FavouritesEmpty() }
+
+                footer { FavouritesFooter() }
+            }
+        }
+
+        @Composable
+        private fun FavouritesHeader() {
+            Text(
+                text = "Favourites",
+                modifier = Modifier.padding(top = 12.dp, bottom = 12.dp),
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 3,
+                style = MaterialTheme.typography.title3
+            )
+        }
+
+        @Composable
+        private fun FavouritesLoading() {
+            PlaceholderChip(colors = ChipDefaults.secondaryChipColors())
+        }
+
+        @Composable
+        private fun FavouritesLoaded(text: String) {
+            Chip(
+                label = text,
+                onClick = { },
+                icon = {
+                    Icon(
+                        imageVector = Icons.Default.FeaturedPlayList,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .size(ChipDefaults.LargeIconSize)
+                            .clip(CircleShape),
+                        tint = Color.Green
+                    )
+                },
+                largeIcon = true,
+                colors = ChipDefaults.secondaryChipColors()
+            )
+        }
+
+        @Composable
+        private fun FavouritesFailed() {
+            Text(
+                text = "Failed to load favourites. Please try again later.",
+                modifier = Modifier.padding(top = 8.dp, bottom = 8.dp),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.body2
+            )
+        }
+
+        @Composable
+        private fun FavouritesEmpty() {
+            Text(
+                text = "Mark songs or albums as favourites to see them here.",
+                modifier = Modifier.padding(top = 8.dp, bottom = 8.dp),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.body2
+            )
+        }
+
+        @Composable
+        fun FavouritesFooter() {
+            Chip(
+                label = "More favourites..",
+                onClick = { },
+                colors = ChipDefaults.secondaryChipColors()
+            )
+        }
     }
 }

--- a/composables/src/test/snapshots/images/com.google.android.horologist.composables_SectionedListHeaderFooterTest_test[0].png
+++ b/composables/src/test/snapshots/images/com.google.android.horologist.composables_SectionedListHeaderFooterTest_test[0].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:611cebe84d11d726ffc6d35f60080e765707e676487b902a9fc0a214f12888f2
+size 17730

--- a/composables/src/test/snapshots/images/com.google.android.horologist.composables_SectionedListHeaderFooterTest_test[1].png
+++ b/composables/src/test/snapshots/images/com.google.android.horologist.composables_SectionedListHeaderFooterTest_test[1].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:baca62e98458b857a4cf92feafa10b9e8068b24a61afa48a1cec8ff9b5abf44c
+size 26355

--- a/composables/src/test/snapshots/images/com.google.android.horologist.composables_SectionedListHeaderFooterTest_test[2].png
+++ b/composables/src/test/snapshots/images/com.google.android.horologist.composables_SectionedListHeaderFooterTest_test[2].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76fa35582e8ea5f0dd8a47d4ff1a608b4c788bad396f2d4005179d6cbccc8fa9
+size 21501

--- a/composables/src/test/snapshots/images/com.google.android.horologist.composables_SectionedListHeaderFooterTest_test[3].png
+++ b/composables/src/test/snapshots/images/com.google.android.horologist.composables_SectionedListHeaderFooterTest_test[3].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07342b65d34f4085eda0b9e13105eb5ff04efdaaa9593817d3ae49b5c3819931
+size 20624

--- a/composables/src/test/snapshots/images/com.google.android.horologist.composables_SectionedListHeaderFooterTest_test[4].png
+++ b/composables/src/test/snapshots/images/com.google.android.horologist.composables_SectionedListHeaderFooterTest_test[4].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9226b5ab11f5797f9cbc26404b9aae6228946abb51ff8bf8a68b9cadd9e4ad1f
+size 19951

--- a/composables/src/test/snapshots/images/com.google.android.horologist.composables_SectionedListHeaderFooterTest_test[5].png
+++ b/composables/src/test/snapshots/images/com.google.android.horologist.composables_SectionedListHeaderFooterTest_test[5].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5193f212d0109bce7f69e345486ab019d4dda91b03488b786e0866fd01945435
+size 28033

--- a/composables/src/test/snapshots/images/com.google.android.horologist.composables_SectionedListHeaderFooterTest_test[6].png
+++ b/composables/src/test/snapshots/images/com.google.android.horologist.composables_SectionedListHeaderFooterTest_test[6].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5b3fecc4fb159be1969e651e3531039ded410c2d18bbd63ab6dae78731cd7b7
+size 23917

--- a/composables/src/test/snapshots/images/com.google.android.horologist.composables_SectionedListHeaderFooterTest_test[7].png
+++ b/composables/src/test/snapshots/images/com.google.android.horologist.composables_SectionedListHeaderFooterTest_test[7].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87f336bb401c368a37e98b5e9b898cd7401bfe3f793fa5e12e05d15e5b64d14e
+size 23036

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreen.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreen.kt
@@ -29,6 +29,8 @@ import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.composables.Section
+import com.google.android.horologist.composables.Section.Companion.ALL_STATES
+import com.google.android.horologist.composables.Section.Companion.LOADED_STATE_ONLY
 import com.google.android.horologist.composables.SectionContentScope
 import com.google.android.horologist.composables.SectionedList
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
@@ -116,7 +118,11 @@ public class BrowseScreenScope {
                     )
                 },
                 footerContent = scope.footerContent,
-                displayFooterOnlyOnLoadedState = displayFooterOnlyOnLoadedState
+                footerVisibleStates = if (displayFooterOnlyOnLoadedState) {
+                    LOADED_STATE_ONLY
+                } else {
+                    ALL_STATES
+                }
             )
         )
     }


### PR DESCRIPTION
#### WHAT

Improve `SectionedList` to allow to specify states to display header or footer.

#### WHY

In order to provide more flexibility. 

Current implementation assumes that if present, header should be displayed in all states. Similarly if footer is present, it should either be displayed in all states or only in loaded state. 

#### HOW

Add `visibleStates` param to `header` and `footer` dsl.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
