### PR TITLE
Use bigger Chips already for medium font scale.

### DIFF
--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/util/AdjustChipHeightToFontScale.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/util/AdjustChipHeightToFontScale.kt
@@ -25,7 +25,7 @@ import com.google.android.horologist.annotations.ExperimentalHorologistApi
 /** Adjusts height of the chip as per the font scale. */
 @ExperimentalHorologistApi
 public fun Modifier.adjustChipHeightToFontScale(fontScale: Float, padding: Dp = 0.dp): Modifier =
-    if (fontScale > 1.06) {
+    if (fontScale > 1) {
         this.then(Modifier.height(60.dp + padding))
     } else {
         this

--- a/compose-material/src/test/java/com/google/android/horologist/compose/material/ChipTest.kt
+++ b/compose-material/src/test/java/com/google/android/horologist/compose/material/ChipTest.kt
@@ -141,6 +141,18 @@ class ChipTest : ScreenshotBaseTest() {
     }
 
     @Test
+    fun withLongTextAndMediumFontScale() {
+        screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
+            TestHarness(fontScale = 1.06f) {
+                Chip(
+                    label = "Primary label very very very very very very very very very very very very very very very very very long text",
+                    onClick = { }
+                )
+            }
+        }
+    }
+
+    @Test
     fun withSecondaryLabelAndIconAndLongText() {
         screenshotTestRule.setContent(isComponent = true, takeScreenshot = true) {
             Chip(

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ChipTest_withLongTextAndMediumFontScale.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ChipTest_withLongTextAndMediumFontScale.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc6edaf741604b8d256671f7fba5f2a0aa506ce83a83f37b049e72431a98d926
+size 9780


### PR DESCRIPTION
For some fonts, it's fine to only increase the size of the Chip for "large" (or bigger).

However, some fonts (including Google Sans) already require this chip size increase for "medium" (1.06) font scale.
