### PR TITLE
Fix signature of TextMediaDisplay

### DIFF
--- a/media/ui/api/current.api
+++ b/media/ui/api/current.api
@@ -230,7 +230,7 @@ package com.google.android.horologist.media.ui.components.display {
   }
 
   public final class TextMediaDisplayKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void TextMediaDisplay(optional androidx.compose.ui.Modifier modifier, String title, String subtitle);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void TextMediaDisplay(String title, String subtitle, optional androidx.compose.ui.Modifier modifier);
   }
 
   public final class TrackMediaDisplayKt {

--- a/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenPreview.kt
+++ b/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenPreview.kt
@@ -90,8 +90,8 @@ fun PlayerScreenPreview() {
             PlayerScreen(
                 mediaDisplay = {
                     TextMediaDisplay(
-                        subtitle = "Journey",
-                        title = "Don't Stop Believin'"
+                        title = "Don't Stop Believin'",
+                        subtitle = "Journey"
                     )
                 },
                 controlButtons = {
@@ -245,8 +245,8 @@ fun PlayerScreenPreviewCustomBackground() {
             PlayerScreen(
                 mediaDisplay = {
                     TextMediaDisplay(
-                        subtitle = "Casaca",
-                        title = "Da Da Da"
+                        title = "Da Da Da",
+                        subtitle = "Casaca"
                     )
                 },
                 controlButtons = {
@@ -337,8 +337,8 @@ fun DefaultMediaPreview() {
             PlayerScreen(
                 mediaDisplay = {
                     TextMediaDisplay(
-                        subtitle = "Journey",
-                        title = "Don't Stop Believin'"
+                        title = "Don't Stop Believin'",
+                        subtitle = "Journey"
                     )
                 },
                 controlButtons = {

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/components/display/LoadingMediaDisplay.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/components/display/LoadingMediaDisplay.kt
@@ -35,6 +35,7 @@ import androidx.wear.compose.material.placeholder
 import androidx.wear.compose.material.placeholderShimmer
 import androidx.wear.compose.material.rememberPlaceholderState
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.media.ui.components.animated.MarqueeTextMediaDisplay
 
 /**
  * A loading state display. This style is matched to the Text of [TextMediaDisplay] as

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/components/display/TextMediaDisplay.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/components/display/TextMediaDisplay.kt
@@ -33,9 +33,9 @@ import com.google.android.horologist.annotations.ExperimentalHorologistApi
 @ExperimentalHorologistApi
 @Composable
 public fun TextMediaDisplay(
-    modifier: Modifier = Modifier,
     title: String,
-    subtitle: String
+    subtitle: String,
+    modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
         Text(

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/components/display/TrackMediaDisplay.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/components/display/TrackMediaDisplay.kt
@@ -31,8 +31,8 @@ public fun TrackMediaDisplay(
     modifier: Modifier = Modifier
 ) {
     TextMediaDisplay(
-        modifier = modifier,
         title = media.title,
-        subtitle = media.subtitle
+        subtitle = media.subtitle,
+        modifier = modifier
     )
 }


### PR DESCRIPTION
#### WHAT

Fix signature of `TextMediaDisplay`.

#### WHY

Comply to [compose api guidelines](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-api-guidelines.md):

> "modifier" and MUST appear as the first optional parameter in the element function's parameter list.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
