### PR TITLE
Optimise MarqueeText

### DIFF
--- a/composables/src/test/kotlin/com/google/android/horologist/composables/MarqueeTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/MarqueeTest.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -55,7 +54,7 @@ class MarqueeTest : ScreenshotBaseTest(
         }
 
         screenshotTestRule.interact {
-            onNodeWithText(text).assertIsDisplayed()
+            onNodeWithText(text).assertExists()
         }
     }
 


### PR DESCRIPTION
#### WHAT

Optimise MarqueeText.

#### WHY

drawWithCache allows caching the gradients.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
