### PR TITLE
Graduate auth experimental APIs

### DIFF
--- a/auth/composables/src/main/java/com/google/android/horologist/auth/composables/chips/CreateAccountChip.kt
+++ b/auth/composables/src/main/java/com/google/android/horologist/auth/composables/chips/CreateAccountChip.kt
@@ -37,7 +37,6 @@ import com.google.android.horologist.compose.material.util.DECORATIVE_ELEMENT_CO
  *
  * <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/create_account_chip.png" height="120" width="120" >
  */
-@ExperimentalHorologistApi
 @Composable
 public fun CreateAccountChip(
     onClick: () -> Unit,

--- a/auth/composables/src/main/java/com/google/android/horologist/auth/composables/chips/GuestModeChip.kt
+++ b/auth/composables/src/main/java/com/google/android/horologist/auth/composables/chips/GuestModeChip.kt
@@ -34,7 +34,6 @@ import com.google.android.horologist.compose.material.Chip
  *
  * @sample com.google.android.horologist.auth.sample.screens.googlesignin.prompt.GoogleSignInPromptSampleScreen
  */
-@ExperimentalHorologistApi
 @Composable
 public fun GuestModeChip(
     onClick: () -> Unit,

--- a/auth/composables/src/main/java/com/google/android/horologist/auth/composables/chips/OtherOptionsChip.kt
+++ b/auth/composables/src/main/java/com/google/android/horologist/auth/composables/chips/OtherOptionsChip.kt
@@ -33,7 +33,6 @@ import com.google.android.horologist.compose.material.Chip
  *
  * <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/other_options_chip.png" height="120" width="120" >
  */
-@ExperimentalHorologistApi
 @Composable
 public fun OtherOptionsChip(
     onClick: () -> Unit,

--- a/auth/composables/src/main/java/com/google/android/horologist/auth/composables/chips/SignInChip.kt
+++ b/auth/composables/src/main/java/com/google/android/horologist/auth/composables/chips/SignInChip.kt
@@ -34,7 +34,6 @@ import com.google.android.horologist.compose.material.Chip
  *
  * @sample com.google.android.horologist.auth.sample.screens.googlesignin.prompt.GoogleSignInPromptSampleScreen
  */
-@ExperimentalHorologistApi
 @Composable
 public fun SignInChip(
     onClick: () -> Unit,

--- a/auth/composables/src/main/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialog.kt
+++ b/auth/composables/src/main/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialog.kt
@@ -59,7 +59,6 @@ private const val HORIZONTAL_PADDING_SCREEN_PERCENTAGE = 0.094
  *
  * <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/signed_in_confirmation_dialog.png" height="120" width="120"/>
  */
-@ExperimentalHorologistApi
 @Composable
 public fun SignedInConfirmationDialog(
     onDismissOrTimeout: () -> Unit,
@@ -89,7 +88,6 @@ public fun SignedInConfirmationDialog(
  *
  * <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/signed_in_confirmation_dialog.png" height="120" width="120"/>
  */
-@ExperimentalHorologistApi
 @Composable
 public fun SignedInConfirmationDialog(
     onDismissOrTimeout: () -> Unit,
@@ -107,7 +105,6 @@ public fun SignedInConfirmationDialog(
     )
 }
 
-@ExperimentalHorologistApi
 @Composable
 internal fun SignedInConfirmationDialogContent(
     modifier: Modifier = Modifier,

--- a/auth/composables/src/main/java/com/google/android/horologist/auth/composables/model/AccountUiModel.kt
+++ b/auth/composables/src/main/java/com/google/android/horologist/auth/composables/model/AccountUiModel.kt
@@ -21,7 +21,6 @@ import com.google.android.horologist.annotations.ExperimentalHorologistApi
 /**
  * A UI model to represent an account.
  */
-@ExperimentalHorologistApi
 public data class AccountUiModel(
     val email: String,
     val name: String? = null,

--- a/auth/composables/src/main/java/com/google/android/horologist/auth/composables/screens/AuthErrorScreen.kt
+++ b/auth/composables/src/main/java/com/google/android/horologist/auth/composables/screens/AuthErrorScreen.kt
@@ -34,7 +34,6 @@ import com.google.android.horologist.auth.composables.R
  * A catch all error screen to be displayed to users when an error occurred during authentication
  * and no additional context can be given.
  */
-@ExperimentalHorologistApi
 @Composable
 public fun AuthErrorScreen(
     modifier: Modifier = Modifier

--- a/auth/composables/src/main/java/com/google/android/horologist/auth/composables/screens/CheckYourPhoneScreen.kt
+++ b/auth/composables/src/main/java/com/google/android/horologist/auth/composables/screens/CheckYourPhoneScreen.kt
@@ -50,7 +50,6 @@ private val progressBarStrokeWidth = 4.dp
  *
  * <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/check_your_phone_screen.png"  height="120" width="120"/>
  */
-@ExperimentalHorologistApi
 @Composable
 public fun CheckYourPhoneScreen(
     modifier: Modifier = Modifier
@@ -96,7 +95,6 @@ public fun CheckYourPhoneScreen(
  *
  * <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/check_your_phone_screen_code.png"  height="120" width="120"/>
  */
-@ExperimentalHorologistApi
 @Composable
 public fun CheckYourPhoneScreen(
     modifier: Modifier = Modifier,

--- a/auth/composables/src/main/java/com/google/android/horologist/auth/composables/screens/SelectAccountScreen.kt
+++ b/auth/composables/src/main/java/com/google/android/horologist/auth/composables/screens/SelectAccountScreen.kt
@@ -41,7 +41,6 @@ private const val HORIZONTAL_PADDING_SCREEN_PERCENTAGE = 0.052
  *
  * <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/select_account_screen.png" height="120" width="120"/>
  */
-@ExperimentalHorologistApi
 @Composable
 public fun SelectAccountScreen(
     accounts: List<AccountUiModel>,

--- a/auth/composables/src/main/java/com/google/android/horologist/auth/composables/screens/SignInPlaceholderScreen.kt
+++ b/auth/composables/src/main/java/com/google/android/horologist/auth/composables/screens/SignInPlaceholderScreen.kt
@@ -49,7 +49,6 @@ private const val HORIZONTAL_PADDING_SCREEN_PERCENTAGE = 0.094
  *
  * <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables/sign_in_placeholder_screen.png" height="120" width="120"/>
  */
-@ExperimentalHorologistApi
 @Composable
 public fun SignInPlaceholderScreen(
     modifier: Modifier = Modifier,

--- a/auth/data-phone/src/main/java/com/google/android/horologist/auth/data/phone/tokenshare/TokenBundleRepository.kt
+++ b/auth/data-phone/src/main/java/com/google/android/horologist/auth/data/phone/tokenshare/TokenBundleRepository.kt
@@ -23,7 +23,6 @@ import com.google.android.horologist.annotations.ExperimentalHorologistApi
  *
  * @sample com.google.android.horologist.auth.sample.MainActivity
  */
-@ExperimentalHorologistApi
 public interface TokenBundleRepository<T> {
 
     public suspend fun update(tokenBundle: T)

--- a/auth/data-phone/src/main/java/com/google/android/horologist/auth/data/phone/tokenshare/impl/TokenBundleRepositoryImpl.kt
+++ b/auth/data-phone/src/main/java/com/google/android/horologist/auth/data/phone/tokenshare/impl/TokenBundleRepositoryImpl.kt
@@ -34,7 +34,6 @@ import kotlinx.coroutines.CoroutineScope
  *
  * @sample com.google.android.horologist.auth.sample.MainActivity
  */
-@ExperimentalHorologistApi
 public class TokenBundleRepositoryImpl<T>(
     private val registry: WearDataLayerRegistry,
     private val key: String = DEFAULT_TOKEN_BUNDLE_KEY,

--- a/auth/data-watch-oauth/src/main/java/com/google/android/horologist/auth/data/watch/oauth/common/impl/google/api/GoogleOAuthService.kt
+++ b/auth/data-watch-oauth/src/main/java/com/google/android/horologist/auth/data/watch/oauth/common/impl/google/api/GoogleOAuthService.kt
@@ -21,7 +21,6 @@ import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
 import retrofit2.http.POST
 
-@ExperimentalHorologistApi
 public interface GoogleOAuthService {
 
     // https://developers.google.com/identity/protocols/oauth2/native-app#exchange-authorization-code

--- a/auth/data-watch-oauth/src/main/java/com/google/android/horologist/auth/data/watch/oauth/common/impl/google/api/GoogleOAuthServiceFactory.kt
+++ b/auth/data-watch-oauth/src/main/java/com/google/android/horologist/auth/data/watch/oauth/common/impl/google/api/GoogleOAuthServiceFactory.kt
@@ -22,7 +22,6 @@ import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 
-@ExperimentalHorologistApi
 public class GoogleOAuthServiceFactory(
     private val okHttpClient: OkHttpClient,
     private val moshi: Moshi

--- a/auth/data-watch-oauth/src/main/java/com/google/android/horologist/auth/data/watch/oauth/devicegrant/impl/DeviceGrantConfigRepositoryDefaultImpl.kt
+++ b/auth/data-watch-oauth/src/main/java/com/google/android/horologist/auth/data/watch/oauth/devicegrant/impl/DeviceGrantConfigRepositoryDefaultImpl.kt
@@ -19,7 +19,6 @@ package com.google.android.horologist.auth.data.watch.oauth.devicegrant.impl
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.auth.data.oauth.devicegrant.DeviceGrantConfigRepository
 
-@ExperimentalHorologistApi
 public class DeviceGrantConfigRepositoryDefaultImpl(
     private val clientId: String,
     private val clientSecret: String

--- a/auth/data-watch-oauth/src/main/java/com/google/android/horologist/auth/data/watch/oauth/devicegrant/impl/DeviceGrantDefaultConfig.kt
+++ b/auth/data-watch-oauth/src/main/java/com/google/android/horologist/auth/data/watch/oauth/devicegrant/impl/DeviceGrantDefaultConfig.kt
@@ -18,7 +18,6 @@ package com.google.android.horologist.auth.data.watch.oauth.devicegrant.impl
 
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
-@ExperimentalHorologistApi
 public data class DeviceGrantDefaultConfig(
     val clientId: String,
     val clientSecret: String

--- a/auth/data-watch-oauth/src/main/java/com/google/android/horologist/auth/data/watch/oauth/devicegrant/impl/google/DeviceGrantTokenRepositoryGoogleImpl.kt
+++ b/auth/data-watch-oauth/src/main/java/com/google/android/horologist/auth/data/watch/oauth/devicegrant/impl/google/DeviceGrantTokenRepositoryGoogleImpl.kt
@@ -32,7 +32,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.guava.await
 
-@ExperimentalHorologistApi
 public class DeviceGrantTokenRepositoryGoogleImpl(
     private val application: Application,
     private val googleOAuthService: GoogleOAuthService

--- a/auth/data-watch-oauth/src/main/java/com/google/android/horologist/auth/data/watch/oauth/devicegrant/impl/google/DeviceGrantVerificationInfoRepositoryGoogleImpl.kt
+++ b/auth/data-watch-oauth/src/main/java/com/google/android/horologist/auth/data/watch/oauth/devicegrant/impl/google/DeviceGrantVerificationInfoRepositoryGoogleImpl.kt
@@ -26,7 +26,6 @@ import com.google.android.horologist.auth.data.watch.oauth.common.logging.TAG
 import com.google.android.horologist.auth.data.watch.oauth.devicegrant.impl.DeviceGrantDefaultConfig
 import kotlinx.coroutines.CancellationException
 
-@ExperimentalHorologistApi
 public class DeviceGrantVerificationInfoRepositoryGoogleImpl(
     private val googleOAuthService: GoogleOAuthService
 ) : DeviceGrantVerificationInfoRepository<DeviceGrantDefaultConfig, DeviceCodeResponse> {

--- a/auth/data-watch-oauth/src/main/java/com/google/android/horologist/auth/data/watch/oauth/pkce/impl/PKCEDefaultConfig.kt
+++ b/auth/data-watch-oauth/src/main/java/com/google/android/horologist/auth/data/watch/oauth/pkce/impl/PKCEDefaultConfig.kt
@@ -19,7 +19,6 @@ package com.google.android.horologist.auth.data.watch.oauth.pkce.impl
 import android.net.Uri
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
-@ExperimentalHorologistApi
 public data class PKCEDefaultConfig(
     val clientId: String,
     val clientSecret: String,

--- a/auth/data-watch-oauth/src/main/java/com/google/android/horologist/auth/data/watch/oauth/pkce/impl/PKCEOAuthCodeRepositoryImpl.kt
+++ b/auth/data-watch-oauth/src/main/java/com/google/android/horologist/auth/data/watch/oauth/pkce/impl/PKCEOAuthCodeRepositoryImpl.kt
@@ -32,7 +32,6 @@ import java.io.IOException
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 
-@ExperimentalHorologistApi
 public class PKCEOAuthCodeRepositoryImpl(
     private val application: Application
 ) : PKCEOAuthCodeRepository<PKCEDefaultConfig, PKCEOAuthCodeGooglePayload> {

--- a/auth/data-watch-oauth/src/main/java/com/google/android/horologist/auth/data/watch/oauth/pkce/impl/google/PKCEConfigRepositoryGoogleImpl.kt
+++ b/auth/data-watch-oauth/src/main/java/com/google/android/horologist/auth/data/watch/oauth/pkce/impl/google/PKCEConfigRepositoryGoogleImpl.kt
@@ -24,7 +24,6 @@ import com.google.android.horologist.auth.data.watch.oauth.common.impl.google.ap
 import com.google.android.horologist.auth.data.watch.oauth.common.impl.google.api.GoogleOAuthService.Companion.USER_INFO_PROFILE_SCOPE_VALUE
 import com.google.android.horologist.auth.data.watch.oauth.pkce.impl.PKCEDefaultConfig
 
-@ExperimentalHorologistApi
 public class PKCEConfigRepositoryGoogleImpl(
     private val clientId: String,
     private val clientSecret: String,

--- a/auth/data-watch-oauth/src/main/java/com/google/android/horologist/auth/data/watch/oauth/pkce/impl/google/PKCEOAuthCodeGooglePayload.kt
+++ b/auth/data-watch-oauth/src/main/java/com/google/android/horologist/auth/data/watch/oauth/pkce/impl/google/PKCEOAuthCodeGooglePayload.kt
@@ -18,7 +18,6 @@ package com.google.android.horologist.auth.data.watch.oauth.pkce.impl.google
 
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
-@ExperimentalHorologistApi
 public data class PKCEOAuthCodeGooglePayload(
     val code: String,
     val redirectUrl: String

--- a/auth/data-watch-oauth/src/main/java/com/google/android/horologist/auth/data/watch/oauth/pkce/impl/google/PKCETokenRepositoryGoogleImpl.kt
+++ b/auth/data-watch-oauth/src/main/java/com/google/android/horologist/auth/data/watch/oauth/pkce/impl/google/PKCETokenRepositoryGoogleImpl.kt
@@ -26,7 +26,6 @@ import com.google.android.horologist.auth.data.watch.oauth.common.logging.TAG
 import com.google.android.horologist.auth.data.watch.oauth.pkce.impl.PKCEDefaultConfig
 import kotlinx.coroutines.CancellationException
 
-@ExperimentalHorologistApi
 public class PKCETokenRepositoryGoogleImpl(
     private val googleOAuthService: GoogleOAuthService
 ) : PKCETokenRepository<PKCEDefaultConfig, PKCEOAuthCodeGooglePayload, TokenResponse> {

--- a/auth/data/src/main/java/com/google/android/horologist/auth/data/common/model/AuthUser.kt
+++ b/auth/data/src/main/java/com/google/android/horologist/auth/data/common/model/AuthUser.kt
@@ -18,7 +18,6 @@ package com.google.android.horologist.auth.data.common.model
 
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
-@ExperimentalHorologistApi
 public data class AuthUser(
     val displayName: String? = null,
     val email: String? = null,

--- a/auth/data/src/main/java/com/google/android/horologist/auth/data/common/repository/AuthUserRepository.kt
+++ b/auth/data/src/main/java/com/google/android/horologist/auth/data/common/repository/AuthUserRepository.kt
@@ -26,7 +26,6 @@ import com.google.android.horologist.auth.data.common.model.AuthUser
  * @sample com.google.android.horologist.auth.sample.screens.oauth.pkce.data.PKCEAuthUserRepositorySample
  * @sample com.google.android.horologist.auth.sample.screens.common.streamline.AuthUserRepositoryStreamlineImpl
  */
-@ExperimentalHorologistApi
 public interface AuthUserRepository {
 
     /**

--- a/auth/data/src/main/java/com/google/android/horologist/auth/data/googlesignin/AuthUserMapper.kt
+++ b/auth/data/src/main/java/com/google/android/horologist/auth/data/googlesignin/AuthUserMapper.kt
@@ -23,7 +23,6 @@ import com.google.android.horologist.auth.data.common.model.AuthUser
 /**
  * Functions to map models from other layers and / or packages into an [AuthUser].
  */
-@ExperimentalHorologistApi
 public object AuthUserMapper {
 
     /**

--- a/auth/data/src/main/java/com/google/android/horologist/auth/data/googlesignin/GoogleSignInAuthUserRepository.kt
+++ b/auth/data/src/main/java/com/google/android/horologist/auth/data/googlesignin/GoogleSignInAuthUserRepository.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.withContext
 /**
  * An implementation of [AuthUserRepository] for the Google Sign-In authentication method.
  */
-@ExperimentalHorologistApi
 public class GoogleSignInAuthUserRepository(
     private val applicationContext: Context
 ) : AuthUserRepository {

--- a/auth/data/src/main/java/com/google/android/horologist/auth/data/googlesignin/GoogleSignInEventListener.kt
+++ b/auth/data/src/main/java/com/google/android/horologist/auth/data/googlesignin/GoogleSignInEventListener.kt
@@ -24,7 +24,6 @@ import com.google.android.horologist.annotations.ExperimentalHorologistApi
  *
  * @sample com.google.android.horologist.auth.sample.screens.googlesignin.signin.GoogleSignInEventListenerSample
  */
-@ExperimentalHorologistApi
 public interface GoogleSignInEventListener {
 
     /**
@@ -38,7 +37,6 @@ public interface GoogleSignInEventListener {
 /**
  * A no-op implementation of [GoogleSignInEventListener].
  */
-@ExperimentalHorologistApi
 public object GoogleSignInEventListenerNoOpImpl : GoogleSignInEventListener {
 
     override suspend fun onSignedIn(account: GoogleSignInAccount): Unit = Unit

--- a/auth/data/src/main/java/com/google/android/horologist/auth/data/oauth/devicegrant/DeviceGrantConfigRepository.kt
+++ b/auth/data/src/main/java/com/google/android/horologist/auth/data/oauth/devicegrant/DeviceGrantConfigRepository.kt
@@ -18,7 +18,6 @@ package com.google.android.horologist.auth.data.oauth.devicegrant
 
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
-@ExperimentalHorologistApi
 public interface DeviceGrantConfigRepository<Config> {
 
     public suspend fun fetch(): Config

--- a/auth/data/src/main/java/com/google/android/horologist/auth/data/oauth/devicegrant/DeviceGrantTokenPayloadListener.kt
+++ b/auth/data/src/main/java/com/google/android/horologist/auth/data/oauth/devicegrant/DeviceGrantTokenPayloadListener.kt
@@ -18,13 +18,11 @@ package com.google.android.horologist.auth.data.oauth.devicegrant
 
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
-@ExperimentalHorologistApi
 public interface DeviceGrantTokenPayloadListener<TokenPayload> {
 
     public suspend fun onPayloadReceived(payload: TokenPayload): Unit
 }
 
-@ExperimentalHorologistApi
 public class DeviceGrantTokenPayloadListenerNoOpImpl<TokenPayload> :
     DeviceGrantTokenPayloadListener<TokenPayload> {
 

--- a/auth/data/src/main/java/com/google/android/horologist/auth/data/oauth/devicegrant/DeviceGrantTokenRepository.kt
+++ b/auth/data/src/main/java/com/google/android/horologist/auth/data/oauth/devicegrant/DeviceGrantTokenRepository.kt
@@ -18,7 +18,6 @@ package com.google.android.horologist.auth.data.oauth.devicegrant
 
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
-@ExperimentalHorologistApi
 public interface DeviceGrantTokenRepository<DeviceGrantConfig, VerificationInfoPayload, TokenPayload> {
 
     public suspend fun fetch(

--- a/auth/data/src/main/java/com/google/android/horologist/auth/data/oauth/devicegrant/DeviceGrantVerificationInfoRepository.kt
+++ b/auth/data/src/main/java/com/google/android/horologist/auth/data/oauth/devicegrant/DeviceGrantVerificationInfoRepository.kt
@@ -18,7 +18,6 @@ package com.google.android.horologist.auth.data.oauth.devicegrant
 
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
-@ExperimentalHorologistApi
 public interface DeviceGrantVerificationInfoRepository<DeviceGrantConfig, VerificationInfo> {
 
     public suspend fun fetch(config: DeviceGrantConfig): Result<VerificationInfo>

--- a/auth/data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/PKCEConfigRepository.kt
+++ b/auth/data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/PKCEConfigRepository.kt
@@ -18,7 +18,6 @@ package com.google.android.horologist.auth.data.oauth.pkce
 
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
-@ExperimentalHorologistApi
 public interface PKCEConfigRepository<Config> {
 
     public suspend fun fetch(): Config

--- a/auth/data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/PKCEOAuthCodeRepository.kt
+++ b/auth/data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/PKCEOAuthCodeRepository.kt
@@ -19,7 +19,6 @@ package com.google.android.horologist.auth.data.oauth.pkce
 import androidx.wear.phone.interactions.authentication.CodeVerifier
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
-@ExperimentalHorologistApi
 public interface PKCEOAuthCodeRepository<PKCEConfig, OAuthCodePayload> {
 
     public suspend fun fetch(

--- a/auth/data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/PKCETokenPayloadListener.kt
+++ b/auth/data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/PKCETokenPayloadListener.kt
@@ -18,13 +18,11 @@ package com.google.android.horologist.auth.data.oauth.pkce
 
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
-@ExperimentalHorologistApi
 public interface PKCETokenPayloadListener<TokenPayload> {
 
     public suspend fun onPayloadReceived(payload: TokenPayload): Unit
 }
 
-@ExperimentalHorologistApi
 public class PKCETokenPayloadListenerNoOpImpl<TokenPayload> :
     PKCETokenPayloadListener<TokenPayload> {
 

--- a/auth/data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/PKCETokenRepository.kt
+++ b/auth/data/src/main/java/com/google/android/horologist/auth/data/oauth/pkce/PKCETokenRepository.kt
@@ -18,7 +18,6 @@ package com.google.android.horologist.auth.data.oauth.pkce
 
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 
-@ExperimentalHorologistApi
 public interface PKCETokenRepository<PKCEConfig, OAuthCodePayload, TokenPayload> {
 
     public suspend fun fetch(

--- a/auth/data/src/main/java/com/google/android/horologist/auth/data/tokenshare/TokenBundleRepository.kt
+++ b/auth/data/src/main/java/com/google/android/horologist/auth/data/tokenshare/TokenBundleRepository.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.flow.Flow
  * @sample com.google.android.horologist.auth.sample.screens.tokenshare.customkey.TokenShareCustomKeyViewModel
  * @sample com.google.android.horologist.auth.sample.screens.tokenshare.defaultkey.TokenShareDefaultKeyViewModel
  */
-@ExperimentalHorologistApi
 public interface TokenBundleRepository<T> {
 
     public val flow: Flow<T>

--- a/auth/data/src/main/java/com/google/android/horologist/auth/data/tokenshare/impl/TokenBundleRepositoryImpl.kt
+++ b/auth/data/src/main/java/com/google/android/horologist/auth/data/tokenshare/impl/TokenBundleRepositoryImpl.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.flow.Flow
  * @sample com.google.android.horologist.auth.sample.screens.tokenshare.customkey.TokenShareCustomKeyViewModel
  * @sample com.google.android.horologist.auth.sample.screens.tokenshare.defaultkey.TokenShareDefaultKeyViewModel
  */
-@ExperimentalHorologistApi
 public class TokenBundleRepositoryImpl<T>(
     private val registry: WearDataLayerRegistry,
     private val serializer: Serializer<T>,

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptScreen.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptScreen.kt
@@ -56,7 +56,6 @@ import com.google.android.horologist.compose.material.Title
  * @sample com.google.android.horologist.auth.sample.screens.oauth.devicegrant.prompt.DeviceGrantSignInPromptScreen
  * @sample com.google.android.horologist.auth.sample.screens.oauth.pkce.prompt.PKCESignInPromptScreen
  */
-@ExperimentalHorologistApi
 @Composable
 public fun SignInPromptScreen(
     message: String,

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptViewModel.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptViewModel.kt
@@ -37,7 +37,6 @@ import kotlinx.coroutines.launch
  * @sample com.google.android.horologist.auth.sample.screens.oauth.devicegrant.prompt.DeviceGrantSignInPromptScreen
  * @sample com.google.android.horologist.auth.sample.screens.oauth.pkce.prompt.PKCESignInPromptScreen
  */
-@ExperimentalHorologistApi
 public open class SignInPromptViewModel(
     private val authUserRepository: AuthUserRepository
 ) : ViewModel() {
@@ -69,7 +68,6 @@ public open class SignInPromptViewModel(
 /**
  * The states for a sign-in prompt screen.
  */
-@ExperimentalHorologistApi
 public sealed class SignInPromptScreenState {
 
     public object Idle : SignInPromptScreenState()

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInDefaultScreen.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInDefaultScreen.kt
@@ -39,7 +39,6 @@ import com.google.android.horologist.compose.layout.ScalingLazyColumnState
  *
  * @sample com.google.android.horologist.auth.sample.screens.common.streamline.StreamlineSignInSampleScreen
  */
-@ExperimentalHorologistApi
 @Composable
 public fun StreamlineSignInDefaultScreen(
     onSignedInConfirmationDialogDismissOrTimeout: (account: AccountUiModel) -> Unit,

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInDefaultViewModel.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInDefaultViewModel.kt
@@ -35,7 +35,6 @@ import kotlinx.coroutines.launch
  *
  * @sample com.google.android.horologist.auth.sample.screens.common.streamline.StreamlineSignInSampleScreen
  */
-@ExperimentalHorologistApi
 public class StreamlineSignInDefaultViewModel(
     private val authUserRepository: AuthUserRepository
 ) : ViewModel() {
@@ -83,7 +82,6 @@ public class StreamlineSignInDefaultViewModel(
     }
 }
 
-@ExperimentalHorologistApi
 public sealed class StreamlineSignInDefaultScreenState {
 
     public object Idle : StreamlineSignInDefaultScreenState()

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInScreen.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInScreen.kt
@@ -50,7 +50,6 @@ import com.google.android.horologist.auth.composables.model.AccountUiModel
  *
  * - [onNoAccountsAvailable] should navigate the user to the sign in screen.
  */
-@ExperimentalHorologistApi
 @Composable
 public fun StreamlineSignInScreen(
     onSingleAccountAvailable: (account: AccountUiModel) -> Unit,

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInViewModel.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInViewModel.kt
@@ -33,7 +33,6 @@ import kotlinx.coroutines.launch
  * It checks if there is a user already signed in, and emits the appropriate
  * [states][StreamlineSignInScreenState] through the [uiState] property.
  */
-@ExperimentalHorologistApi
 public open class StreamlineSignInViewModel(
     private val authUserRepository: AuthUserRepository
 ) : ViewModel() {
@@ -79,7 +78,6 @@ public open class StreamlineSignInViewModel(
 /**
  * The states for a streamline sign-in screen.
  */
-@ExperimentalHorologistApi
 public sealed class StreamlineSignInScreenState {
 
     public object Idle : StreamlineSignInScreenState()

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/mapper/AccountUiModelMapper.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/mapper/AccountUiModelMapper.kt
@@ -23,7 +23,6 @@ import com.google.android.horologist.auth.composables.model.AccountUiModel
 /**
  * Functions to map models from Google Sign In into a [AccountUiModel].
  */
-@ExperimentalHorologistApi
 public object AccountUiModelMapper {
 
     /**

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/prompt/GoogleSignInPromptViewModelFactory.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/prompt/GoogleSignInPromptViewModelFactory.kt
@@ -30,7 +30,6 @@ import com.google.android.horologist.auth.ui.common.screens.prompt.SignInPromptV
  *
  * @sample com.google.android.horologist.auth.sample.screens.googlesignin.prompt.GoogleSignInPromptSampleScreen
  */
-@ExperimentalHorologistApi
 public val GoogleSignInPromptViewModelFactory: ViewModelProvider.Factory = viewModelFactory {
     initializer {
         val application = this[APPLICATION_KEY]!!

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInScreen.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInScreen.kt
@@ -48,7 +48,6 @@ import com.google.android.horologist.auth.ui.common.logging.TAG
  *
  * [onAuthCancelled] should be used to navigate away from this screen.
  */
-@ExperimentalHorologistApi
 @Composable
 public fun GoogleSignInScreen(
     onAuthCancelled: () -> Unit,
@@ -135,7 +134,6 @@ public fun GoogleSignInScreen(
  * Parameters [onAuthCancelled] and [onAuthSucceed] should be used to navigate away from this screen
  * when these events happen.
  */
-@ExperimentalHorologistApi
 @Composable
 public fun GoogleSignInScreen(
     onAuthCancelled: () -> Unit,

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInViewModel.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInViewModel.kt
@@ -32,7 +32,6 @@ import kotlinx.coroutines.launch
 /**
  * A view model for a Google Sign-In screen.
  */
-@ExperimentalHorologistApi
 public open class GoogleSignInViewModel(
     public val googleSignInClient: GoogleSignInClient,
     private val googleSignInEventListener: GoogleSignInEventListener = GoogleSignInEventListenerNoOpImpl
@@ -85,7 +84,6 @@ public open class GoogleSignInViewModel(
 /**
  * The states for a Google Sign-In screen.
  */
-@ExperimentalHorologistApi
 public sealed class GoogleSignInScreenState {
 
     public object Idle : GoogleSignInScreenState()

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/mapper/AccountUiModelMapper.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/mapper/AccountUiModelMapper.kt
@@ -23,7 +23,6 @@ import com.google.android.horologist.auth.data.common.model.AuthUser
 /**
  * Functions to map models from other layers and / or packages into a [AccountUiModel].
  */
-@ExperimentalHorologistApi
 public object AccountUiModelMapper {
 
     /**

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/oauth/devicegrant/signin/DeviceGrantSignInScreen.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/oauth/devicegrant/signin/DeviceGrantSignInScreen.kt
@@ -27,7 +27,6 @@ import com.google.android.horologist.auth.composables.screens.AuthErrorScreen
 import com.google.android.horologist.auth.composables.screens.CheckYourPhoneScreen
 import com.google.android.horologist.auth.composables.screens.SignInPlaceholderScreen
 
-@ExperimentalHorologistApi
 @Composable
 public fun <DeviceGrantConfig, VerificationInfoPayload, TokenPayload> DeviceGrantSignInScreen(
     failedContent: @Composable () -> Unit,
@@ -63,7 +62,6 @@ public fun <DeviceGrantConfig, VerificationInfoPayload, TokenPayload> DeviceGran
     }
 }
 
-@ExperimentalHorologistApi
 @Composable
 public fun <DeviceGrantConfig, VerificationInfoPayload, TokenPayload> DeviceGrantSignInScreen(
     onAuthSucceed: () -> Unit,

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/oauth/devicegrant/signin/DeviceGrantSignInViewModel.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/oauth/devicegrant/signin/DeviceGrantSignInViewModel.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
-@ExperimentalHorologistApi
 public open class DeviceGrantViewModel<DeviceGrantConfig, VerificationInfoPayload, TokenPayload>(
     private val deviceGrantConfigRepository: DeviceGrantConfigRepository<DeviceGrantConfig>,
     private val deviceGrantVerificationInfoRepository: DeviceGrantVerificationInfoRepository<DeviceGrantConfig, VerificationInfoPayload>,
@@ -76,7 +75,6 @@ public open class DeviceGrantViewModel<DeviceGrantConfig, VerificationInfoPayloa
     }
 }
 
-@ExperimentalHorologistApi
 public sealed class DeviceGrantScreenState {
     public object Idle : DeviceGrantScreenState()
     public object Loading : DeviceGrantScreenState()

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/oauth/pkce/signin/PKCESignInScreen.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/oauth/pkce/signin/PKCESignInScreen.kt
@@ -26,7 +26,6 @@ import com.google.android.horologist.auth.composables.dialogs.SignedInConfirmati
 import com.google.android.horologist.auth.composables.screens.AuthErrorScreen
 import com.google.android.horologist.auth.composables.screens.CheckYourPhoneScreen
 
-@ExperimentalHorologistApi
 @Composable
 public fun <PKCEConfig, OAuthCodePayload, TokenPayload> PKCESignInScreen(
     failedContent: @Composable () -> Unit,
@@ -58,7 +57,6 @@ public fun <PKCEConfig, OAuthCodePayload, TokenPayload> PKCESignInScreen(
     }
 }
 
-@ExperimentalHorologistApi
 @Composable
 public fun <PKCEConfig, OAuthCodePayload, TokenPayload> PKCESignInScreen(
     onAuthSucceed: () -> Unit,

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/oauth/pkce/signin/PKCESignInViewModel.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/oauth/pkce/signin/PKCESignInViewModel.kt
@@ -30,7 +30,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
-@ExperimentalHorologistApi
 public open class PKCESignInViewModel<PKCEConfig, OAuthCodePayload, TokenPayload>(
     private val pkceConfigRepository: PKCEConfigRepository<PKCEConfig>,
     private val pkceOAuthCodeRepository: PKCEOAuthCodeRepository<PKCEConfig, OAuthCodePayload>,
@@ -80,7 +79,6 @@ public open class PKCESignInViewModel<PKCEConfig, OAuthCodePayload, TokenPayload
     }
 }
 
-@ExperimentalHorologistApi
 public sealed class PKCEScreenState {
     public object Idle : PKCEScreenState()
     public object Loading : PKCEScreenState()


### PR DESCRIPTION
#### WHAT

Graduate auth experimental APIs.

#### WHY

Bump to a new major version, APIs seem relatively stable. Even with this we can change APIs, either deprecating, or just giving a headsup (we are not androidx).

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
