### PR TITLE
Update wearcompose to v1.3.0-alpha02

### DIFF
--- a/composables/src/main/java/com/google/android/horologist/composables/PlaceholderChip.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/PlaceholderChip.kt
@@ -63,7 +63,7 @@ public fun PlaceholderChip(
 
     Chip(
         modifier = modifier
-            .height(52.dp) // ChipDefaults.Height
+            .height(ChipDefaults.Height)
             .fillMaxWidth()
             .clip(shape = MaterialTheme.shapes.small)
             .paint(

--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/Chip.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/Chip.kt
@@ -200,11 +200,11 @@ public fun Chip(
         }
 
     val contentPadding = if (largeIcon) {
-        val verticalPadding = 6.dp // same as ChipDefaults.ChipVerticalPadding
+        val verticalPadding = ChipDefaults.ChipVerticalPadding
         PaddingValues(
             start = 10.dp,
             top = verticalPadding,
-            end = 14.dp, // same as ChipDefaults.ChipHorizontalPadding
+            end = ChipDefaults.ChipHorizontalPadding,
             bottom = verticalPadding
         )
     } else {

--- a/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ChipTest_withLongText.png
+++ b/compose-material/src/test/snapshots/images/com.google.android.horologist.compose.material_ChipTest_withLongText.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8e922e5b2c98729c4d5ecd0b008778f6d54aff177c97b15342daab5ee92708d0
-size 9149
+oid sha256:4c42c7736f40b9c2df0b744ca5eeeb3688f8b376e1a63e0e6e08c3ea8ed4d94c
+size 9056

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,7 +59,7 @@ tracingPerfetto = "1.0"
 tracingPerfettoBinary = "1.0"
 truth = "1.1.5"
 versionCatalogUpdate = "0.8.1"
-wearcompose = "1.3.0-alpha01"
+wearcompose = "1.3.0-alpha02"
 
 [libraries]
 accompanist-testharness = { module = "com.google.accompanist:accompanist-testharness", version.ref = "accompanist" }

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChip.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/components/actions/ShowPlaylistChip.kt
@@ -17,16 +17,13 @@
 package com.google.android.horologist.media.ui.components.actions
 
 import androidx.compose.foundation.layout.BoxScope
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.text.style.TextOverflow
-import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
-import androidx.wear.compose.material.Text
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.compose.material.Chip
 import com.google.android.horologist.media.ui.components.MediaArtwork
 
 /**
@@ -53,15 +50,10 @@ public fun ShowPlaylistChip(
     }
 
     Chip(
-        modifier = modifier.fillMaxWidth(),
-        colors = ChipDefaults.secondaryChipColors(),
+        label = name.orEmpty(),
+        onClick = onClick,
+        modifier = modifier,
         icon = appIcon,
-        label = {
-            Text(
-                text = name.orEmpty(),
-                overflow = TextOverflow.Ellipsis
-            )
-        },
-        onClick = onClick
+        colors = ChipDefaults.secondaryChipColors()
     )
 }

--- a/sample/src/main/java/com/google/android/horologist/navsample/NavWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/navsample/NavWearApp.kt
@@ -30,13 +30,13 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
+import androidx.wear.compose.foundation.edgeSwipeToDismiss
+import androidx.wear.compose.foundation.rememberSwipeToDismissBoxState
 import androidx.wear.compose.material.Button
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.VignettePosition
 import androidx.wear.compose.material.dialog.Alert
-import androidx.wear.compose.material.edgeSwipeToDismiss
-import androidx.wear.compose.material.rememberSwipeToDismissBoxState
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavHostState
 import com.google.android.horologist.audio.ui.VolumeScreen
 import com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel

--- a/sample/src/main/java/com/google/android/horologist/pager/SamplePagerScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/pager/SamplePagerScreen.kt
@@ -27,9 +27,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.wear.compose.material.SwipeToDismissBoxState
+import androidx.wear.compose.foundation.SwipeToDismissBoxState
+import androidx.wear.compose.foundation.edgeSwipeToDismiss
 import androidx.wear.compose.material.Text
-import androidx.wear.compose.material.edgeSwipeToDismiss
 import com.google.android.horologist.compose.pager.PagerScreen
 
 @Composable

--- a/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
@@ -24,7 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
-import androidx.wear.compose.material.rememberSwipeToDismissBoxState
+import androidx.wear.compose.foundation.rememberSwipeToDismissBoxState
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavHostState
 import com.google.android.horologist.audio.ui.VolumeScreen


### PR DESCRIPTION
#### WHAT

Update wearcompose to `v1.3.0-alpha02`.

#### WHY

https://github.com/google/horologist/pull/1533

#### HOW

Update code according to https://developer.android.com/jetpack/androidx/releases/wear-compose#1.3.0-alpha02.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
