### PR TITLE
Rotary improvements

### DIFF
--- a/composables/src/test/kotlin/com/google/android/horologist/composables/RotaryInteractionTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/RotaryInteractionTest.kt
@@ -16,11 +16,13 @@
 
 package com.google.android.horologist.composables
 
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusTarget
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -98,7 +100,7 @@ class RotaryInteractionTest {
         rule.onNodeWithTag(TEST_TAG).performRotaryScrollInput {
             // Scroll by 2 items forward
             rotateToScrollVertically(50.0f)
-            advanceEventTime(50)
+            advanceEventTime(250)
             rotateToScrollVertically(50.0f)
         }
 
@@ -154,7 +156,7 @@ class RotaryInteractionTest {
         rule.onNodeWithTag(TEST_TAG).performRotaryScrollInput {
             // Scroll by 2 items backward
             rotateToScrollVertically(-50.0f)
-            advanceEventTime(50)
+            advanceEventTime(250)
             rotateToScrollVertically(-50.0f)
         }
 
@@ -167,7 +169,10 @@ class RotaryInteractionTest {
     private fun pickerOption():
         (@Composable PickerScope.(optionIndex: Int, pickerSelected: Boolean) -> Unit) =
         { value: Int, pickerSelected: Boolean ->
-            Text("$value, $pickerSelected")
+            Text(
+                modifier = Modifier.height(with(LocalDensity.current) { 30.toDp() }),
+                text = "$value, $pickerSelected"
+            )
         }
 
     @Composable

--- a/compose-layout/api/current.api
+++ b/compose-layout/api/current.api
@@ -309,7 +309,8 @@ package com.google.android.horologist.compose.rotaryinput {
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public final class DefaultSnapBehavior implements com.google.android.horologist.compose.rotaryinput.RotarySnapBehavior {
     ctor public DefaultSnapBehavior(com.google.android.horologist.compose.rotaryinput.RotaryScrollAdapter rotaryScrollAdapter, com.google.android.horologist.compose.rotaryinput.SnapParameters snapParameters);
     method @com.google.android.horologist.annotations.ExperimentalHorologistApi public void prepareSnapForItems(int moveForElements, boolean sequentialSnap);
-    method @com.google.android.horologist.annotations.ExperimentalHorologistApi public suspend Object? startSnappingSession(boolean toClosestItem, kotlin.coroutines.Continuation<? super kotlin.Unit>);
+    method public suspend Object? snapToClosestItem(kotlin.coroutines.Continuation<? super kotlin.Unit>);
+    method public suspend Object? snapToTargetItem(kotlin.coroutines.Continuation<? super kotlin.Unit>);
   }
 
   public final class GenericMotionRotaryInputAccumulator {
@@ -326,7 +327,7 @@ package com.google.android.horologist.compose.rotaryinput {
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public final class RotaryDefaults {
     method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public boolean isLowResInput();
     method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public com.google.android.horologist.compose.rotaryinput.RotaryScrollHandler rememberFlingHandler(androidx.compose.foundation.gestures.ScrollableState scrollableState, optional androidx.compose.foundation.gestures.FlingBehavior? flingBehavior, optional boolean isLowRes);
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public com.google.android.horologist.compose.rotaryinput.RotaryScrollHandler rememberSnapHandler(com.google.android.horologist.compose.rotaryinput.RotaryScrollAdapter rotaryScrollAdapter, optional com.google.android.horologist.compose.rotaryinput.SnapParameters snapParameters);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public com.google.android.horologist.compose.rotaryinput.RotaryScrollHandler rememberSnapHandler(com.google.android.horologist.compose.rotaryinput.RotaryScrollAdapter rotaryScrollAdapter, optional com.google.android.horologist.compose.rotaryinput.SnapParameters snapParameters, optional boolean isLowRes);
     method @com.google.android.horologist.annotations.ExperimentalHorologistApi public com.google.android.horologist.compose.rotaryinput.SnapParameters snapParametersDefault();
     field public static final com.google.android.horologist.compose.rotaryinput.RotaryDefaults INSTANCE;
   }
@@ -370,7 +371,7 @@ package com.google.android.horologist.compose.rotaryinput {
 
   public final class RotaryKt {
     method @com.google.android.horologist.annotations.ExperimentalHorologistApi public static kotlinx.coroutines.flow.Flow<com.google.android.horologist.compose.rotaryinput.TimestampedDelta> batchRequestsWithinTimeframe(kotlinx.coroutines.flow.Flow<com.google.android.horologist.compose.rotaryinput.TimestampedDelta>, long timeframe);
-    method @com.google.android.horologist.annotations.ExperimentalHorologistApi public static androidx.compose.ui.Modifier rotaryHandler(androidx.compose.ui.Modifier, com.google.android.horologist.compose.rotaryinput.RotaryScrollHandler rotaryScrollHandler, optional long batchTimeframe, boolean reverseDirection, com.google.android.horologist.compose.rotaryinput.RotaryHapticHandler rotaryHaptics);
+    method @com.google.android.horologist.annotations.ExperimentalHorologistApi public static androidx.compose.ui.Modifier rotaryHandler(androidx.compose.ui.Modifier, com.google.android.horologist.compose.rotaryinput.RotaryScrollHandler rotaryScrollHandler, boolean reverseDirection, com.google.android.horologist.compose.rotaryinput.RotaryHapticHandler rotaryHaptics);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static androidx.compose.ui.Modifier rotaryWithFling(androidx.compose.ui.Modifier, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.compose.foundation.gestures.ScrollableState scrollableState, optional androidx.compose.foundation.gestures.FlingBehavior flingBehavior, optional com.google.android.horologist.compose.rotaryinput.RotaryHapticHandler rotaryHaptics, optional boolean reverseDirection);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static androidx.compose.ui.Modifier rotaryWithScroll(androidx.compose.ui.Modifier, androidx.compose.ui.focus.FocusRequester focusRequester, androidx.compose.foundation.gestures.ScrollableState scrollableState, optional com.google.android.horologist.compose.rotaryinput.RotaryHapticHandler rotaryHaptics, optional boolean reverseDirection);
     method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static androidx.compose.ui.Modifier rotaryWithSnap(androidx.compose.ui.Modifier, androidx.compose.ui.focus.FocusRequester focusRequester, com.google.android.horologist.compose.rotaryinput.RotaryScrollAdapter rotaryScrollAdapter, optional com.google.android.horologist.compose.rotaryinput.SnapParameters snapParameters, optional com.google.android.horologist.compose.rotaryinput.RotaryHapticHandler rotaryHaptics, optional boolean reverseDirection);
@@ -395,7 +396,8 @@ package com.google.android.horologist.compose.rotaryinput {
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public interface RotarySnapBehavior {
     method public void prepareSnapForItems(int moveForElements, boolean sequentialSnap);
-    method @com.google.android.horologist.annotations.ExperimentalHorologistApi public suspend Object? startSnappingSession(boolean toClosestItem, kotlin.coroutines.Continuation<? super kotlin.Unit>);
+    method public suspend Object? snapToClosestItem(kotlin.coroutines.Continuation<? super kotlin.Unit>);
+    method public suspend Object? snapToTargetItem(kotlin.coroutines.Continuation<? super kotlin.Unit>);
   }
 
   public final class RotaryVelocityTracker {

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
@@ -219,7 +219,7 @@ public fun rememberDisabledHaptic(): RotaryHapticHandler = remember {
 @Composable
 public fun rememberRotaryHapticHandler(
     scrollableState: ScrollableState,
-    throttleThresholdMs: Long = 40,
+    throttleThresholdMs: Long = 30,
     hapticsThresholdPx: Long = 50,
     hapticsChannel: Channel<RotaryHapticsType> = rememberHapticChannel(),
     rotaryHaptics: RotaryHapticFeedback = rememberDefaultRotaryHapticFeedback()

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Rotary.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Rotary.kt
@@ -746,7 +746,7 @@ public class DefaultSnapBehavior(
 @OptIn(ExperimentalComposeUiApi::class)
 public fun Modifier.rotaryHandler(
     rotaryScrollHandler: RotaryScrollHandler,
-    batchTimeframe: Long = 0L,
+    /* batchTimeframe: Long = 0L,*/
     reverseDirection: Boolean,
     rotaryHaptics: RotaryHapticHandler
 ): Modifier = composed {
@@ -1034,7 +1034,8 @@ internal class HighResSnapHandler(
 
         snapAccumulator += event.delta
         if (!snapJob.isActive) {
-            val resistanceCoeff = 1 - scrollEasing.transform(rotaryScrollDistance.absoluteValue / snapThreshold)
+            val resistanceCoeff =
+                1 - scrollEasing.transform(rotaryScrollDistance.absoluteValue / snapThreshold)
             rotaryScrollDistance += event.delta * resistanceCoeff
         }
 


### PR DESCRIPTION
Fixed an issue with fast snapping

#### WHAT
Snapping was only limited to 1 snap per event, which is wrong as some events might have very large values.  Made it cumulative so that scroll values are not lost and used later.  Also limited snap distance to 2 items per event as more items were causing lags and sudden jumps

A scroll easing was also added for making scroll look smoother. 

Separate LowResSnapHandler was added as well to accomodate Low-res devices
#### WHY


#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
