### PR TITLE
Update next button action when no picker is selected in DatePicker

### DIFF
--- a/composables/src/main/java/com/google/android/horologist/composables/DatePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/DatePicker.kt
@@ -308,6 +308,11 @@ public fun DatePicker(
                                 FocusableElementDatePicker.MONTH,
                                 FocusableElementDatePicker.YEAR
                             )
+                        } else {
+                            onPickerSelected(
+                                FocusableElementDatePicker.NONE,
+                                FocusableElementDatePicker.DAY
+                            )
                         }
                     },
                     modifier = Modifier


### PR DESCRIPTION
#### WHAT
Update next button action when no picker is selected in DatePicker.

#### WHY
Clicking on Next button produced no action.

#### HOW
Select the first picker i.e. Day when none of the pickers are selected if the next button is clicked.

