### PR TITLE
Fix display of SignedInConfirmationDialog when name is empty

### DIFF
--- a/auth/composables/src/main/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialog.kt
+++ b/auth/composables/src/main/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialog.kt
@@ -120,7 +120,7 @@ internal fun SignedInConfirmationDialogContent(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        val hasName = name != null
+        val hasName = !name.isNullOrEmpty()
         val hasAvatar = avatar != null
 
         Box(

--- a/auth/composables/src/test/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogTest.kt
+++ b/auth/composables/src/test/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogTest.kt
@@ -65,6 +65,20 @@ class SignedInConfirmationDialogTest : ScreenshotBaseTest(
     }
 
     @Test
+    fun signedInConfirmationDialogEmptyName() {
+        screenshotTestRule.setContent(
+            takeScreenshot = true,
+            fakeImageLoader = FakeImageLoader.Resources
+        ) {
+            SignedInConfirmationDialogContent(
+                name = "",
+                email = "maggie@example.com",
+                avatar = android.R.drawable.sym_def_app_icon
+            )
+        }
+    }
+
+    @Test
     fun signedInConfirmationDialogNoNameNoAvatar() {
         screenshotTestRule.setContent(takeScreenshot = true) {
             SignedInConfirmationDialogContent(

--- a/auth/composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogEmptyName.png
+++ b/auth/composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogEmptyName.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84e9ff8b09fed7046d663cf5c5b2ad19eba16695fee1c0945fc8b0a1467a069e
+size 18882


### PR DESCRIPTION
#### WHAT

Fix display of `SignedInConfirmationDialog` when name is empty.

#### WHY

It should display "Hi!" instead of "Hi,"

#### HOW

Change check to also check if string is empty.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
