### PR TITLE
Provide volumeUiState as state in PlayerScreen

### DIFF
--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/player/PlayerScreen.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/player/PlayerScreen.kt
@@ -82,6 +82,7 @@ public fun PlayerScreen(
     focusRequester: FocusRequester = rememberActiveFocusRequester()
 ) {
     val playerUiState by playerViewModel.playerUiState.collectAsStateWithLifecycle()
+    val volumeUiState by volumeViewModel.volumeUiState.collectAsStateWithLifecycle()
 
     PlayerScreen(
         mediaDisplay = { mediaDisplay(playerUiState) },
@@ -91,7 +92,7 @@ public fun PlayerScreen(
         },
         modifier = modifier.rotaryVolumeControlsWithFocus(
             focusRequester = focusRequester,
-            volumeUiStateProvider = { volumeViewModel.volumeUiState.value },
+            volumeUiStateProvider = { volumeUiState },
             onRotaryVolumeInput = { newVolume -> volumeViewModel.setVolume(newVolume) },
             localView = LocalView.current,
             isLowRes = isLowResInput()

--- a/media/ui/src/test/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenTest.kt
+++ b/media/ui/src/test/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenTest.kt
@@ -33,6 +33,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.audio.VolumeState
 import com.google.android.horologist.audio.ui.VolumeViewModel
+import com.google.android.horologist.audio.ui.mapper.VolumeUiStateMapper
 import com.google.android.horologist.media.model.Command
 import com.google.android.horologist.media.model.Media
 import com.google.android.horologist.media.model.PlayerState
@@ -453,5 +454,28 @@ class PlayerScreenTest {
 
         // then
         composeTestRule.onNode(hasText("Custom")).assertExists()
+    }
+
+    @Test
+    fun whenInit_thenVolumeShouldEqualToVolumeRepositoryState() {
+        // given
+        val playerRepository =
+            FakePlayerRepository()
+        val playerViewModel = PlayerViewModel(playerRepository)
+
+        // when
+        composeTestRule.setContent {
+            PlayerScreen(
+                playerViewModel = playerViewModel,
+                volumeViewModel = volumeViewModel
+            )
+        }
+
+        // then
+        assertThat(volumeViewModel.volumeUiState.value).isEqualTo(
+            VolumeUiStateMapper.map(
+                volumeRepository.volumeState.value
+            )
+        )
     }
 }


### PR DESCRIPTION
#### WHAT

Collect and provide volumeUiState as state instead of value

Fixes https://github.com/google/horologist/issues/1556

#### WHY

- `{ volumeViewModel.volumeUiState.value }` always provides the value when PlayerScreen is initialized.  To get value dynamically, `collectAsStateWithLifecycle()` should be used.
- Media sample did not have this issue because it was collected once before PlayerScreen [here](https://github.com/google/horologist/blob/c8fd2efd0c89fb37b2cc5e74d5f29e75197d971c/media/sample/src/main/java/com/google/android/horologist/mediasample/ui/player/UampMediaPlayerScreen.kt#L48C56-L48C83), which hid the issue unintentionally. This fix is especially important for people using PlayerScreen directly.

#### HOW

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [ ] Update metalava's signature text files
