### PR TITLE
Improve previews and tests of SignedInConfirmationDialog

### DIFF
--- a/auth/composables/src/debug/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogPreview.kt
+++ b/auth/composables/src/debug/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogPreview.kt
@@ -22,7 +22,8 @@ import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 @WearPreviewDevices
 @Composable
 fun SignedInConfirmationDialogPreview() {
-    SignedInConfirmationDialogContent(
+    SignedInConfirmationDialog(
+        onDismissOrTimeout = {},
         name = "Maggie",
         email = "maggie@example.com"
     )
@@ -31,7 +32,8 @@ fun SignedInConfirmationDialogPreview() {
 @WearPreviewDevices
 @Composable
 fun SignedInConfirmationDialogPreviewNoName() {
-    SignedInConfirmationDialogContent(
+    SignedInConfirmationDialog(
+        onDismissOrTimeout = {},
         email = "maggie@example.com"
     )
 }
@@ -39,7 +41,8 @@ fun SignedInConfirmationDialogPreviewNoName() {
 @WearPreviewDevices
 @Composable
 fun SignedInConfirmationDialogPreviewNoEmail() {
-    SignedInConfirmationDialogContent(
+    SignedInConfirmationDialog(
+        onDismissOrTimeout = {},
         name = "Maggie"
     )
 }
@@ -47,13 +50,14 @@ fun SignedInConfirmationDialogPreviewNoEmail() {
 @WearPreviewDevices
 @Composable
 fun SignedInConfirmationDialogPreviewNoInformation() {
-    SignedInConfirmationDialogContent()
+    SignedInConfirmationDialog(onDismissOrTimeout = {})
 }
 
 @WearPreviewDevices
 @Composable
 fun SignedInConfirmationDialogPreviewTruncation() {
-    SignedInConfirmationDialogContent(
+    SignedInConfirmationDialog(
+        onDismissOrTimeout = {},
         name = "Wolfeschlegelsteinhausenbergerdorff",
         email = "wolfeschlegelsteinhausenbergerdorff@example.com"
     )

--- a/auth/composables/src/main/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialog.kt
+++ b/auth/composables/src/main/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialog.kt
@@ -104,7 +104,7 @@ public fun SignedInConfirmationDialog(
 }
 
 @Composable
-internal fun SignedInConfirmationDialogContent(
+private fun SignedInConfirmationDialogContent(
     modifier: Modifier = Modifier,
     name: String? = null,
     email: String? = null,

--- a/auth/composables/src/test/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogTest.kt
+++ b/auth/composables/src/test/java/com/google/android/horologist/auth/composables/dialogs/SignedInConfirmationDialogTest.kt
@@ -42,7 +42,8 @@ class SignedInConfirmationDialogTest : ScreenshotBaseTest(
                 modifier = Modifier.background(Color.Black),
                 contentAlignment = Alignment.Center
             ) {
-                SignedInConfirmationDialogContent(
+                SignedInConfirmationDialog(
+                    onDismissOrTimeout = {},
                     name = "Maggie",
                     email = "maggie@example.com",
                     avatar = android.R.drawable.sym_def_app_icon
@@ -57,7 +58,8 @@ class SignedInConfirmationDialogTest : ScreenshotBaseTest(
             takeScreenshot = true,
             fakeImageLoader = FakeImageLoader.Resources
         ) {
-            SignedInConfirmationDialogContent(
+            SignedInConfirmationDialog(
+                onDismissOrTimeout = {},
                 email = "maggie@example.com",
                 avatar = android.R.drawable.sym_def_app_icon
             )
@@ -70,7 +72,8 @@ class SignedInConfirmationDialogTest : ScreenshotBaseTest(
             takeScreenshot = true,
             fakeImageLoader = FakeImageLoader.Resources
         ) {
-            SignedInConfirmationDialogContent(
+            SignedInConfirmationDialog(
+                onDismissOrTimeout = {},
                 name = "",
                 email = "maggie@example.com",
                 avatar = android.R.drawable.sym_def_app_icon
@@ -81,7 +84,8 @@ class SignedInConfirmationDialogTest : ScreenshotBaseTest(
     @Test
     fun signedInConfirmationDialogNoNameNoAvatar() {
         screenshotTestRule.setContent(takeScreenshot = true) {
-            SignedInConfirmationDialogContent(
+            SignedInConfirmationDialog(
+                onDismissOrTimeout = {},
                 email = "maggie@example.com"
             )
         }
@@ -93,7 +97,8 @@ class SignedInConfirmationDialogTest : ScreenshotBaseTest(
             takeScreenshot = true,
             fakeImageLoader = FakeImageLoader.Resources
         ) {
-            SignedInConfirmationDialogContent(
+            SignedInConfirmationDialog(
+                onDismissOrTimeout = {},
                 name = "Maggie",
                 avatar = android.R.drawable.sym_def_app_icon
             )
@@ -103,7 +108,7 @@ class SignedInConfirmationDialogTest : ScreenshotBaseTest(
     @Test
     fun signedInConfirmationDialogNoInformation() {
         screenshotTestRule.setContent(takeScreenshot = true) {
-            SignedInConfirmationDialogContent()
+            SignedInConfirmationDialog(onDismissOrTimeout = {})
         }
     }
 
@@ -113,7 +118,8 @@ class SignedInConfirmationDialogTest : ScreenshotBaseTest(
             takeScreenshot = true,
             fakeImageLoader = FakeImageLoader.Resources
         ) {
-            SignedInConfirmationDialogContent(
+            SignedInConfirmationDialog(
+                onDismissOrTimeout = {},
                 name = "Wolfeschlegelsteinhausenbergerdorff",
                 email = "wolfeschlegelsteinhausenbergerdorff@example.com",
                 avatar = android.R.drawable.sym_def_app_icon

--- a/auth/composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialog.png
+++ b/auth/composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialog.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6b90748d0c52df718e115420fd136c6c5f2932c6b92bfb50c0f0905bd471499d
-size 21154
+oid sha256:dde19fa7bf215f8dcfe550b24984ab4f325138aa0e1ebd73dc391489e4c6849c
+size 20887

--- a/auth/composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogEmptyName.png
+++ b/auth/composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogEmptyName.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:84e9ff8b09fed7046d663cf5c5b2ad19eba16695fee1c0945fc8b0a1467a069e
-size 18882
+oid sha256:b19fa1e09ea6b68661f4e9c48e537bd2ea388fabae1b79df57e0403c9c40bbd3
+size 18831

--- a/auth/composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogNoEmail.png
+++ b/auth/composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogNoEmail.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ddad5962f8787470eca2295cdc3a0e996ab9b2b8f45a1014815cad60df6f502e
-size 15892
+oid sha256:30a52e949a7bbea64ec70731d7698d00752aef5102135e45b4680c4f3d1e3173
+size 15765

--- a/auth/composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogNoInformation.png
+++ b/auth/composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogNoInformation.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e4f80852a64d08467c82daf353a41c110a2b7ad1a581d9bbf88c4a54db04312d
-size 11651
+oid sha256:8d6f53ddfff70a2e08bdc4a2ef7ead2fe022b7c7e7b9b4f8451cdbda182522a6
+size 11633

--- a/auth/composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogNoName.png
+++ b/auth/composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogNoName.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:84e9ff8b09fed7046d663cf5c5b2ad19eba16695fee1c0945fc8b0a1467a069e
-size 18882
+oid sha256:b19fa1e09ea6b68661f4e9c48e537bd2ea388fabae1b79df57e0403c9c40bbd3
+size 18831

--- a/auth/composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogNoNameNoAvatar.png
+++ b/auth/composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogNoNameNoAvatar.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5947346cced912f6b8dfe49713091d768d5c6a04b1ca26c03c06d6ddd5219da7
-size 17036
+oid sha256:141f2356afbc35dd6842d5ad77eb41164f0a726b4a1e3b24fc2aad3f69814080
+size 17048

--- a/auth/composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogTruncation.png
+++ b/auth/composables/src/test/snapshots/images/com.google.android.horologist.auth.composables.dialogs_SignedInConfirmationDialogTest_signedInConfirmationDialogTruncation.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ee8a6ace1c0ceef7097809460e597ff7815c97cd7b7cb72595e8adf9c0cd18f6
-size 23745
+oid sha256:8c3f2f2713085582007b2640c3c7c7455fcf8388fe5f0f0e06d0d3951292acab
+size 23074


### PR DESCRIPTION
#### WHAT

Improve previews and tests of `SignedInConfirmationDialog`.

#### WHY

Previously, previews and tests were not working with Dialog component.

#### HOW

Change previews and tests to use `SignedInConfirmationDialog` directly.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
