### PR TITLE
Adds support for setup complete state to DataLayer app helper

### DIFF
--- a/auth/sample/phone/src/main/java/com/google/android/horologist/auth/sample/AppHelperNodeStatusCard.kt
+++ b/auth/sample/phone/src/main/java/com/google/android/horologist/auth/sample/AppHelperNodeStatusCard.kt
@@ -34,11 +34,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.google.android.horologist.auth.sample.ui.theme.HorologistTheme
+import com.google.android.horologist.data.UsageStatus
 import com.google.android.horologist.data.apphelper.AppHelperNodeStatus
 import com.google.android.horologist.data.apphelper.AppHelperNodeType
 import com.google.android.horologist.data.complicationInfo
 import com.google.android.horologist.data.surfacesInfo
 import com.google.android.horologist.data.tileInfo
+import com.google.android.horologist.data.usageInfo
 import com.google.protobuf.Timestamp
 
 @Composable
@@ -95,15 +97,13 @@ fun AppHelperNodeStatusCard(
                         )
                     )
                 }
-                if (nodeStatus.surfacesInfo.activityLaunched.activityLaunchedOnce) {
-                    Text(
-                        style = MaterialTheme.typography.labelMedium,
-                        text = stringResource(
-                            R.string.app_has_been_opened,
-                            nodeStatus.surfacesInfo.activityLaunched.activityLaunchedOnce
-                        )
+                Text(
+                    style = MaterialTheme.typography.labelMedium,
+                    text = stringResource(
+                        R.string.app_helper_usage_status,
+                        nodeStatus.surfacesInfo.usageInfo.usageStatus.name
                     )
-                }
+                )
                 Row(
                     modifier = Modifier
                         .padding(8.dp)
@@ -157,6 +157,10 @@ fun NodeCardPreview() {
                     timestamp = System.currentTimeMillis().toProtoTimestamp()
                 }
             )
+            usageInfo = usageInfo {
+                usageStatus = UsageStatus.USAGE_STATUS_LAUNCHED_ONCE
+                timestamp = System.currentTimeMillis().toProtoTimestamp()
+            }
         }
     )
     HorologistTheme {

--- a/auth/sample/phone/src/main/res/values/strings.xml
+++ b/auth/sample/phone/src/main/res/values/strings.xml
@@ -26,7 +26,7 @@
     <string name="app_helper_is_app_installed_label">App installed: %1$s</string>
     <string name="app_helper_complications_label">Complications: %1$s</string>
     <string name="app_helper_tiles_label">Tiles: %1$s</string>
-    <string name="app_has_been_opened">Opened once: %1$s</string>
+    <string name="app_helper_usage_status">Usage: %1$s</string>
     <string name="app_helper_install_button_label">Install</string>
     <string name="app_helper_companion_button_label">Companion</string>
     <string name="app_helper_launch_button_label">Launch</string>

--- a/datalayer/core/src/main/proto/app_helper_pb.proto
+++ b/datalayer/core/src/main/proto/app_helper_pb.proto
@@ -54,6 +54,11 @@ message TileInfo {
   .google.protobuf.Timestamp timestamp = 3;
 }
 
+message ActivityLaunched {
+  bool activityLaunchedOnce = 1;
+  .google.protobuf.Timestamp timestamp = 2;
+}
+
 enum UsageStatus {
   USAGE_STATUS_UNSPECIFIED = 0;
   USAGE_STATUS_LAUNCHED_ONCE = 1;
@@ -69,6 +74,7 @@ message SurfacesInfo {
   reserved 1;
   repeated ComplicationInfo complications = 2;
   repeated TileInfo tiles = 3;
-  reserved 5;
-  UsageInfo usageInfo = 6;
+  // Temporarily keep [ActivityLaunched] - remove at a later date
+  ActivityLaunched activityLaunched = 4;
+  UsageInfo usageInfo = 5;
 }

--- a/datalayer/core/src/main/proto/app_helper_pb.proto
+++ b/datalayer/core/src/main/proto/app_helper_pb.proto
@@ -54,8 +54,14 @@ message TileInfo {
   .google.protobuf.Timestamp timestamp = 3;
 }
 
-message ActivityLaunched {
-  bool activityLaunchedOnce = 1;
+enum UsageStatus {
+  USAGE_STATUS_UNSPECIFIED = 0;
+  USAGE_STATUS_LAUNCHED_ONCE = 1;
+  USAGE_STATUS_SETUP_COMPLETE = 2;
+}
+
+message UsageInfo {
+  UsageStatus usageStatus = 1;
   .google.protobuf.Timestamp timestamp = 2;
 }
 
@@ -63,5 +69,6 @@ message SurfacesInfo {
   reserved 1;
   repeated ComplicationInfo complications = 2;
   repeated TileInfo tiles = 3;
-  ActivityLaunched activityLaunched = 4;
+  reserved 5;
+  UsageInfo usageInfo = 6;
 }

--- a/datalayer/watch/api/current.api
+++ b/datalayer/watch/api/current.api
@@ -7,6 +7,8 @@ package com.google.android.horologist.datalayer.watch {
     method public suspend Object? markActivityLaunchedOnce(kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? markComplicationAsActivated(String complicationName, int complicationInstanceId, androidx.wear.watchface.complications.data.ComplicationType complicationType, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? markComplicationAsDeactivated(String complicationName, int complicationInstanceId, androidx.wear.watchface.complications.data.ComplicationType complicationType, kotlin.coroutines.Continuation<? super kotlin.Unit>);
+    method public suspend Object? markSetupComplete(kotlin.coroutines.Continuation<? super kotlin.Unit>);
+    method public suspend Object? markSetupNoLongerComplete(kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? markTileAsInstalled(String tileName, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? markTileAsRemoved(String tileName, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method @CheckResult public suspend Object? startCompanion(String node, kotlin.coroutines.Continuation<? super com.google.android.horologist.data.AppHelperResultCode>);

--- a/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
+++ b/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
@@ -28,6 +28,7 @@ import com.google.android.horologist.data.ComplicationInfo
 import com.google.android.horologist.data.TileInfo
 import com.google.android.horologist.data.UsageStatus
 import com.google.android.horologist.data.WearDataLayerRegistry
+import com.google.android.horologist.data.activityLaunched
 import com.google.android.horologist.data.apphelper.DataLayerAppHelper
 import com.google.android.horologist.data.apphelper.SurfaceInfoSerializer
 import com.google.android.horologist.data.companionConfig
@@ -117,10 +118,20 @@ public class WearDataLayerAppHelper(
     public suspend fun markActivityLaunchedOnce() {
         surfaceInfoDataStore.updateData { info ->
             info.copy {
+                val launchTimestamp = System.currentTimeMillis().toProtoTimestamp()
                 if (usageInfo.usageStatus == UsageStatus.USAGE_STATUS_UNSPECIFIED) {
                     usageInfo = usageInfo {
                         usageStatus = UsageStatus.USAGE_STATUS_LAUNCHED_ONCE
-                        timestamp = System.currentTimeMillis().toProtoTimestamp()
+                        timestamp = launchTimestamp
+                    }
+                }
+
+                // Temporarily support previous location for this information in [ActivityLaunched]
+                // Remove in the longer term
+                if (!activityLaunched.activityLaunchedOnce) {
+                    activityLaunched = activityLaunched {
+                        activityLaunchedOnce = true
+                        timestamp = launchTimestamp
                     }
                 }
             }


### PR DESCRIPTION
#### WHAT

Adds the ability to store / read app setup complete via Data Layer app helper

#### WHY

For some apps, it is useful for the phone to know whether the user has completed all the necessary setup steps on the watch, such as logging in. In the case where the user hasn't logged in, the phone may show different options, or prompt the user to log in for example.

#### HOW

Moves the `ActivityLaunched` state into an enum to cover the following states:

- Unspecified
- Launched (at least) once
- Setup complete

With the behaviour:
- Marking setup as complete trumps launched once (so setting launched once after setup complete has no affect - the implication for now is that the app would need to be launched at least once to complete setup)
- Unmarking setup as complete returns to the launched once state - if setup had previously been completed, but has no effect if the state is currently unspecified

TODO: Add use of the `markSetupComplete` and `markSetupNoLongerComplete` hooks to the sign-in flows in the auth sample.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
