### PR TITLE
Update auth-googlesignin-guide.md

### DIFF
--- a/docs/auth-googlesignin-guide.md
+++ b/docs/auth-googlesignin-guide.md
@@ -18,7 +18,7 @@ from [this link](https://developers.google.com/identity/sign-in/android/start-in
     dependencies {
         implementation "com.google.android.horologist:horologist-auth-composables:<version>"
         implementation "com.google.android.horologist:horologist-auth-ui:<version>"
-        implementation "com.google.android.horologist:horologist-base-ui:<version>"
+        implementation "com.google.android.horologist:horologist-compose-material:<version>"
     }
     ```
 


### PR DESCRIPTION
#### WHAT

Update auth-googlesignin-guide.md

#### WHY

Base-ui module was removed since 0.5.x.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [N/A] Run tests
- [N/A] Update metalava's signature text files
