### PR TITLE
Run metalava and fix media audio api

### DIFF
--- a/media/audio/api/current.api
+++ b/media/audio/api/current.api
@@ -90,6 +90,11 @@ package com.google.android.horologist.audio {
     field public static final com.google.android.horologist.audio.BluetoothSettings INSTANCE;
   }
 
+  public final class OutputSwitcher {
+    method public boolean launchSystemMediaOutputSwitcherUi(android.content.Context);
+    field public static final com.google.android.horologist.audio.OutputSwitcher INSTANCE;
+  }
+
   public final class SystemAudioRepository implements com.google.android.horologist.audio.AudioOutputRepository com.google.android.horologist.audio.VolumeRepository {
     ctor public SystemAudioRepository(android.content.Context application, androidx.mediarouter.media.MediaRouter mediaRouter, optional androidx.mediarouter.media.MediaRouteSelector selector);
     method public void close();


### PR DESCRIPTION
#### WHAT
Run metalava and fix media audio api

#### WHY


#### HOW
`./gradlew spotlessApply spotlessCheck compileDebugSources compileReleaseSources metalavaGenerateSignature metalavaGenerateSignatureRelease lintDebug`

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
