### PR TITLE
Preview support for Date and Time Picker

### DIFF
--- a/composables/src/main/java/com/google/android/horologist/composables/DatePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/DatePicker.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.focused
 import androidx.compose.ui.semantics.semantics
@@ -83,7 +84,8 @@ public fun DatePicker(
     fromDate: LocalDate? = null,
     toDate: LocalDate? = null,
 ) {
-    val fullyDrawn = remember { Animatable(0f) }
+    val inspectionMode = LocalInspectionMode.current
+    val fullyDrawn = remember { Animatable(if (inspectionMode) 1f else 0f) }
 
     if (fromDate != null && toDate != null) {
         verifyDates(date, fromDate, toDate)
@@ -346,8 +348,10 @@ public fun DatePicker(
         }
     }
 
-    LaunchedEffect(Unit) {
-        fullyDrawn.animateTo(1f)
+    if (!inspectionMode) {
+        LaunchedEffect(Unit) {
+            fullyDrawn.animateTo(1f)
+        }
     }
 }
 

--- a/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -104,7 +105,8 @@ public fun TimePicker(
     time: LocalTime = LocalTime.now(),
     showSeconds: Boolean = true,
 ) {
-    val fullyDrawn = remember { Animatable(0f) }
+    val inspectionMode = LocalInspectionMode.current
+    val fullyDrawn = remember { Animatable(if (inspectionMode) 1f else 0f) }
 
     // Omit scaling according to Settings > Display > Font size for this screen
     val typography = MaterialTheme.typography.copy(
@@ -301,8 +303,10 @@ public fun TimePicker(
         }
     }
 
-    LaunchedEffect(Unit) {
-        fullyDrawn.animateTo(1f)
+    if (!inspectionMode) {
+        LaunchedEffect(Unit) {
+            fullyDrawn.animateTo(1f)
+        }
     }
 }
 
@@ -324,7 +328,8 @@ public fun TimePickerWith12HourClock(
     modifier: Modifier = Modifier,
     time: LocalTime = LocalTime.now(),
 ) {
-    val fullyDrawn = remember { Animatable(0f) }
+    val inspectionMode = LocalInspectionMode.current
+    val fullyDrawn = remember { Animatable(if (inspectionMode) 1f else 0f) }
 
     // Omit scaling according to Settings > Display > Font size for this screen,
     val typography = MaterialTheme.typography.copy(
@@ -527,8 +532,10 @@ public fun TimePickerWith12HourClock(
         }
     }
 
-    LaunchedEffect(Unit) {
-        fullyDrawn.animateTo(1f)
+    if (!inspectionMode) {
+        LaunchedEffect(Unit) {
+            fullyDrawn.animateTo(1f)
+        }
     }
 }
 


### PR DESCRIPTION
#### WHAT

<img width="391" alt="image" src="https://github.com/google/horologist/assets/231923/55013fc5-3690-4ff7-bd38-1ff0317f88e6">

#### WHY

Previews are useful.

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
