### PR TITLE
Adds AmbientAware and an example usage, AmbientAwareTime

### DIFF
--- a/compose-layout/api/current.api
+++ b/compose-layout/api/current.api
@@ -1,4 +1,34 @@
 // Signature format: 4.0
+package com.google.android.horologist.compose.ambient {
+
+  public final class AmbientAwareKt {
+    method @androidx.compose.runtime.Composable public static void AmbientAware(kotlin.jvm.functions.Function1<? super com.google.android.horologist.compose.ambient.AmbientStateUpdate,kotlin.Unit> block);
+  }
+
+  public final class AmbientAwareTimeKt {
+    method @RequiresApi(android.os.Build.VERSION_CODES.O) @androidx.compose.runtime.Composable public static void AmbientAwareTime(com.google.android.horologist.compose.ambient.AmbientStateUpdate stateUpdate, optional long updatePeriodMillis, kotlin.jvm.functions.Function2<? super java.time.ZonedDateTime,? super java.lang.Boolean,kotlin.Unit> block);
+  }
+
+  public enum AmbientState {
+    method public static com.google.android.horologist.compose.ambient.AmbientState valueOf(String name) throws java.lang.IllegalArgumentException;
+    method public static com.google.android.horologist.compose.ambient.AmbientState[] values();
+    enum_constant public static final com.google.android.horologist.compose.ambient.AmbientState AMBIENT;
+    enum_constant public static final com.google.android.horologist.compose.ambient.AmbientState INTERACTIVE;
+  }
+
+  public final class AmbientStateUpdate {
+    ctor public AmbientStateUpdate(com.google.android.horologist.compose.ambient.AmbientState ambientState, optional long changeTimeMillis);
+    method public com.google.android.horologist.compose.ambient.AmbientState component1();
+    method public long component2();
+    method public com.google.android.horologist.compose.ambient.AmbientStateUpdate copy(com.google.android.horologist.compose.ambient.AmbientState ambientState, long changeTimeMillis);
+    method public com.google.android.horologist.compose.ambient.AmbientState getAmbientState();
+    method public long getChangeTimeMillis();
+    property public final com.google.android.horologist.compose.ambient.AmbientState ambientState;
+    property public final long changeTimeMillis;
+  }
+
+}
+
 package com.google.android.horologist.compose.focus {
 
   public final class FocusNodeKt {

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.compose.ambient
+
+import android.app.Activity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.wear.ambient.AmbientLifecycleObserver
+
+/**
+ * Composable for general handling of changes and updates to ambient status. A new
+ * [AmbientStateUpdate] is generated with any change of ambient state, as well as with any periodic
+ * update generated whilst the screen is in ambient mode.
+ */
+@Composable
+fun AmbientAware(block: @Composable (AmbientStateUpdate) -> Unit) {
+    val activity = LocalContext.current as Activity
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
+    var ambientUpdate by remember { mutableStateOf<AmbientStateUpdate?>(null) }
+
+    val observer = remember {
+        val callback = object : AmbientLifecycleObserver.AmbientLifecycleCallback {
+            override fun onEnterAmbient(ambientDetails: AmbientLifecycleObserver.AmbientDetails) {
+                ambientUpdate = AmbientStateUpdate(AmbientState.AMBIENT)
+            }
+
+            override fun onExitAmbient() {
+                ambientUpdate = AmbientStateUpdate(AmbientState.INTERACTIVE)
+            }
+
+            override fun onUpdateAmbient() {
+                ambientUpdate = AmbientStateUpdate(AmbientState.AMBIENT)
+            }
+        }
+        AmbientLifecycleObserver(activity, callback).also {
+            // Necessary to populate the initial value
+            val initialAmbientState = if (it.isAmbient) {
+                AmbientState.AMBIENT
+            } else {
+                AmbientState.INTERACTIVE
+            }
+            ambientUpdate = AmbientStateUpdate(initialAmbientState)
+        }
+    }
+
+    DisposableEffect(Unit) {
+        lifecycle.addObserver(observer)
+
+        onDispose {
+            lifecycle.removeObserver(observer)
+        }
+    }
+
+    ambientUpdate?.let {
+        block(it)
+    }
+}

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAwareTime.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAwareTime.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.compose.ambient
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import java.time.ZonedDateTime
+
+/**
+ * An example of using [AmbientAware]: Provides the time, at the specified update frequency, whilst
+ * in interactive mode, or when ambient-generated updates occur (typically every 1 min).
+ *
+ * Example usage:
+ *
+ *  AmbientAware { stateUpdate ->
+ *     Box(
+ *         contentAlignment = Alignment.Center,
+ *         modifier = Modifier.fillMaxSize()
+ *     ) {
+ *          AmbientAwareTime(stateUpdate) { dateTime, isAmbient ->
+ *              // Basic example of AmbientAwareTime usage
+ *              val ambientFmt = remember { DateTimeFormatter.ofPattern("HH:mm") }
+ *              val interactiveFmt =
+ *                  remember { DateTimeFormatter.ofPattern("HH:mm:ss") }
+ *              val dateTimeStr = if (isAmbient) {
+ *                  ambientFmt.format(ZonedDateTime.now())
+ *              } else {
+ *                  interactiveFmt.format(ZonedDateTime.now())
+ *              }
+ *              Text(dateTimeStr)
+ *          }
+ *      }
+ *  }
+ *
+ * @param stateUpdate The state update from [AmbientAware]
+ * @param updatePeriodMillis The update period, whilst in interactive mode
+ * @param block The developer-supplied composable for rendering the date and time.
+ */
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun AmbientAwareTime(
+    stateUpdate: AmbientStateUpdate,
+    updatePeriodMillis: Long = 1000,
+    block: @Composable (dateTime: ZonedDateTime, isAmbient: Boolean) -> Unit,
+) {
+    check(updatePeriodMillis >= 1000)
+
+    var isAmbient by remember { mutableStateOf(false) }
+    var currentTime by remember { mutableStateOf<ZonedDateTime?>(null) }
+
+    currentTime?.let {
+        block(it, isAmbient)
+    }
+
+    LaunchedEffect(stateUpdate) {
+        if (stateUpdate.ambientState == AmbientState.AMBIENT) {
+            isAmbient = true
+            currentTime = ZonedDateTime.now()
+        } else {
+            while (isActive) {
+                isAmbient = false
+                currentTime = ZonedDateTime.now()
+                delay(updatePeriodMillis - System.currentTimeMillis() % updatePeriodMillis)
+            }
+        }
+    }
+}

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientStateUpdate.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientStateUpdate.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.compose.ambient
+
+/**
+ * Represent Ambient as updates, with the state and time of change. This is necessary to ensure that
+ * when the system provides a (typically) 1min-frequency callback to onUpdateAmbient, the developer
+ * may wish to update composables, but the state hasn't changed.
+ */
+data class AmbientStateUpdate(
+    val ambientState: AmbientState,
+    val changeTimeMillis: Long = System.currentTimeMillis(),
+)
+
+enum class AmbientState {
+    AMBIENT,
+    INTERACTIVE,
+}


### PR DESCRIPTION
#### WHAT

Provides the ability to show different UI in interactive vs ambient mode, and respond to ambient update events, when the app is configured to support Always-On

#### WHY

It can be useful to show some basic UI whilst in ambient mode

#### HOW

Implements a wrapper around AmbientLifecycleObserver

#### Checklist :clipboard:
- [ x] Add explicit visibility modifier and explicit return types for public declarations
- [ x] Run spotless check
- [ x] Run tests
- [ x] Update metalava's signature text files
