### PR TITLE
Expands documentation for AmbientAware, adds support for AmbientDetails

### DIFF
--- a/compose-layout/api/current.api
+++ b/compose-layout/api/current.api
@@ -9,11 +9,19 @@ package com.google.android.horologist.compose.ambient {
     method @RequiresApi(android.os.Build.VERSION_CODES.O) @androidx.compose.runtime.Composable public static void AmbientAwareTime(com.google.android.horologist.compose.ambient.AmbientStateUpdate stateUpdate, optional long updatePeriodMillis, kotlin.jvm.functions.Function2<? super java.time.ZonedDateTime,? super java.lang.Boolean,kotlin.Unit> block);
   }
 
-  public enum AmbientState {
-    method public static com.google.android.horologist.compose.ambient.AmbientState valueOf(String name) throws java.lang.IllegalArgumentException;
-    method public static com.google.android.horologist.compose.ambient.AmbientState[] values();
-    enum_constant public static final com.google.android.horologist.compose.ambient.AmbientState AMBIENT;
-    enum_constant public static final com.google.android.horologist.compose.ambient.AmbientState INTERACTIVE;
+  public sealed interface AmbientState {
+  }
+
+  public static final class AmbientState.Ambient implements com.google.android.horologist.compose.ambient.AmbientState {
+    ctor public AmbientState.Ambient(optional androidx.wear.ambient.AmbientLifecycleObserver.AmbientDetails? ambientDetails);
+    method public androidx.wear.ambient.AmbientLifecycleObserver.AmbientDetails? component1();
+    method public com.google.android.horologist.compose.ambient.AmbientState.Ambient copy(androidx.wear.ambient.AmbientLifecycleObserver.AmbientDetails? ambientDetails);
+    method public androidx.wear.ambient.AmbientLifecycleObserver.AmbientDetails? getAmbientDetails();
+    property public final androidx.wear.ambient.AmbientLifecycleObserver.AmbientDetails? ambientDetails;
+  }
+
+  public static final class AmbientState.Interactive implements com.google.android.horologist.compose.ambient.AmbientState {
+    field public static final com.google.android.horologist.compose.ambient.AmbientState.Interactive INSTANCE;
   }
 
   public final class AmbientStateUpdate {

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
@@ -31,6 +31,12 @@ import androidx.wear.ambient.AmbientLifecycleObserver
  * Composable for general handling of changes and updates to ambient status. A new
  * [AmbientStateUpdate] is generated with any change of ambient state, as well as with any periodic
  * update generated whilst the screen is in ambient mode.
+ *
+ * This composable changes the behavior of the activity, enabling Always-On. See:
+ *
+ *     https://developer.android.com/training/wearables/views/always-on).
+ *
+ * It should therefore be used high up in the tree of composables.
  */
 @Composable
 fun AmbientAware(block: @Composable (AmbientStateUpdate) -> Unit) {
@@ -41,23 +47,23 @@ fun AmbientAware(block: @Composable (AmbientStateUpdate) -> Unit) {
     val observer = remember {
         val callback = object : AmbientLifecycleObserver.AmbientLifecycleCallback {
             override fun onEnterAmbient(ambientDetails: AmbientLifecycleObserver.AmbientDetails) {
-                ambientUpdate = AmbientStateUpdate(AmbientState.AMBIENT)
+                ambientUpdate = AmbientStateUpdate(AmbientState.Ambient(ambientDetails))
             }
 
             override fun onExitAmbient() {
-                ambientUpdate = AmbientStateUpdate(AmbientState.INTERACTIVE)
+                ambientUpdate = AmbientStateUpdate(AmbientState.Interactive)
             }
 
             override fun onUpdateAmbient() {
-                ambientUpdate = AmbientStateUpdate(AmbientState.AMBIENT)
+                ambientUpdate = AmbientStateUpdate(AmbientState.Ambient())
             }
         }
         AmbientLifecycleObserver(activity, callback).also {
             // Necessary to populate the initial value
             val initialAmbientState = if (it.isAmbient) {
-                AmbientState.AMBIENT
+                AmbientState.Ambient()
             } else {
-                AmbientState.INTERACTIVE
+                AmbientState.Interactive
             }
             ambientUpdate = AmbientStateUpdate(initialAmbientState)
         }

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
@@ -55,13 +55,7 @@ fun AmbientAware(block: @Composable (AmbientStateUpdate) -> Unit) {
             }
 
             override fun onUpdateAmbient() {
-                val lastAmbientDetails = ambientUpdate?.ambientState?.let {
-                    if (it is AmbientState.Ambient) {
-                        it.ambientDetails
-                    } else {
-                        null
-                    }
-                }
+                val lastAmbientDetails = (ambientUpdate?.ambientState as? AmbientState.Ambient).ambientDetails
                 ambientUpdate = AmbientStateUpdate(AmbientState.Ambient(lastAmbientDetails))
             }
         }

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
@@ -43,19 +43,10 @@ fun AmbientAware(block: @Composable (AmbientStateUpdate) -> Unit) {
     val activity = LocalContext.current as Activity
     val lifecycle = LocalLifecycleOwner.current.lifecycle
     var ambientUpdate by remember { mutableStateOf<AmbientStateUpdate?>(null) }
-    // On entering ambient mode, the [onEnterAmbient] callback method provides details of burn-in
-    // protection and low-bit support. These are stored here such that they can be provided as a
-    // convenience with each [AmbientStateUpdate] as [onUpdateAmbient] does not provide them.
-    var lastAmbientDetails by remember {
-        mutableStateOf<AmbientLifecycleObserver.AmbientDetails?>(
-            null,
-        )
-    }
 
     val observer = remember {
         val callback = object : AmbientLifecycleObserver.AmbientLifecycleCallback {
             override fun onEnterAmbient(ambientDetails: AmbientLifecycleObserver.AmbientDetails) {
-                lastAmbientDetails = ambientDetails
                 ambientUpdate = AmbientStateUpdate(AmbientState.Ambient(ambientDetails))
             }
 
@@ -64,13 +55,20 @@ fun AmbientAware(block: @Composable (AmbientStateUpdate) -> Unit) {
             }
 
             override fun onUpdateAmbient() {
+                val lastAmbientDetails = ambientUpdate?.ambientState?.let {
+                    if (it is AmbientState.Ambient) {
+                        it.ambientDetails
+                    } else {
+                        null
+                    }
+                }
                 ambientUpdate = AmbientStateUpdate(AmbientState.Ambient(lastAmbientDetails))
             }
         }
         AmbientLifecycleObserver(activity, callback).also {
             // Necessary to populate the initial value
             val initialAmbientState = if (it.isAmbient) {
-                AmbientState.Ambient(lastAmbientDetails)
+                AmbientState.Ambient(null)
             } else {
                 AmbientState.Interactive
             }

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
@@ -55,7 +55,7 @@ fun AmbientAware(block: @Composable (AmbientStateUpdate) -> Unit) {
             }
 
             override fun onUpdateAmbient() {
-                val lastAmbientDetails = (ambientUpdate?.ambientState as? AmbientState.Ambient).ambientDetails
+                val lastAmbientDetails = (ambientUpdate?.ambientState as? AmbientState.Ambient)?.ambientDetails
                 ambientUpdate = AmbientStateUpdate(AmbientState.Ambient(lastAmbientDetails))
             }
         }

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAwareTime.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAwareTime.kt
@@ -75,15 +75,15 @@ fun AmbientAwareTime(
     }
 
     LaunchedEffect(stateUpdate) {
-        if (stateUpdate.ambientState == AmbientState.AMBIENT) {
-            isAmbient = true
-            currentTime = ZonedDateTime.now()
-        } else {
+        if (stateUpdate.ambientState == AmbientState.Interactive) {
             while (isActive) {
                 isAmbient = false
                 currentTime = ZonedDateTime.now()
                 delay(updatePeriodMillis - System.currentTimeMillis() % updatePeriodMillis)
             }
+        } else {
+            isAmbient = true
+            currentTime = ZonedDateTime.now()
         }
     }
 }

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientStateUpdate.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientStateUpdate.kt
@@ -16,6 +16,8 @@
 
 package com.google.android.horologist.compose.ambient
 
+import androidx.wear.ambient.AmbientLifecycleObserver
+
 /**
  * Represent Ambient as updates, with the state and time of change. This is necessary to ensure that
  * when the system provides a (typically) 1min-frequency callback to onUpdateAmbient, the developer
@@ -26,7 +28,9 @@ data class AmbientStateUpdate(
     val changeTimeMillis: Long = System.currentTimeMillis(),
 )
 
-enum class AmbientState {
-    AMBIENT,
-    INTERACTIVE,
+sealed interface AmbientState {
+    data class Ambient(val ambientDetails: AmbientLifecycleObserver.AmbientDetails? = null) :
+        AmbientState
+
+    object Interactive : AmbientState
 }


### PR DESCRIPTION
#### WHAT

Provides further guidance on using `AmbientAware` and adds support for `AmbientDetails`

#### WHY

Using the `AmbientAware` composable changes the behavior of the `Activity`, so should ideally be used high up in the composable tree. This needs clarifying in the documentation.

`AmbientDetails` are provided by the system when entering ambient mode, and can be used by the app to make decisions about how to render the UI.

#### HOW

Updates kdoc and adds `AmbientDetails` as a property of the `Ambient` state.

#### Checklist :clipboard:
- [ x] Add explicit visibility modifier and explicit return types for public declarations
- [ x] Run spotless check
- [ x] Run tests
- [ x] Update metalava's signature text files
