### PR TITLE
Adds support for AmbientAware when not used in the context of an Activity

### DIFF
--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
@@ -17,6 +17,8 @@
 package com.google.android.horologist.compose.ambient
 
 import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -40,7 +42,21 @@ import androidx.wear.ambient.AmbientLifecycleObserver
  */
 @Composable
 fun AmbientAware(block: @Composable (AmbientStateUpdate) -> Unit) {
-    val activity = LocalContext.current as Activity
+    val activity = LocalContext.current.findActivityOrNull()
+    // Using AmbientAware correctly relies on there being an Activity context. If there isn't, then
+    // gracefully allow the composition of [block], but no ambient-mode functionality is enabled.
+    if (activity == null) {
+        AmbientAwareNoActivity(block)
+    } else {
+        AmbientAwareWithActivity(activity, block)
+    }
+}
+
+@Composable
+private fun AmbientAwareWithActivity(
+    activity: Activity,
+    block: @Composable (AmbientStateUpdate) -> Unit,
+) {
     val lifecycle = LocalLifecycleOwner.current.lifecycle
     var ambientUpdate by remember { mutableStateOf<AmbientStateUpdate?>(null) }
 
@@ -55,7 +71,8 @@ fun AmbientAware(block: @Composable (AmbientStateUpdate) -> Unit) {
             }
 
             override fun onUpdateAmbient() {
-                val lastAmbientDetails = (ambientUpdate?.ambientState as? AmbientState.Ambient)?.ambientDetails
+                val lastAmbientDetails =
+                    (ambientUpdate?.ambientState as? AmbientState.Ambient)?.ambientDetails
                 ambientUpdate = AmbientStateUpdate(AmbientState.Ambient(lastAmbientDetails))
             }
         }
@@ -81,4 +98,19 @@ fun AmbientAware(block: @Composable (AmbientStateUpdate) -> Unit) {
     ambientUpdate?.let {
         block(it)
     }
+}
+
+@Composable
+private fun AmbientAwareNoActivity(block: @Composable (AmbientStateUpdate) -> Unit) {
+    val staticAmbientState by remember { mutableStateOf(AmbientStateUpdate(AmbientState.Interactive)) }
+    block(staticAmbientState)
+}
+
+private fun Context.findActivityOrNull(): Activity? {
+    var context = this
+    while (context is ContextWrapper) {
+        if (context is Activity) return context
+        context = context.baseContext
+    }
+    return null
 }


### PR DESCRIPTION
#### WHAT

Allows the `AmbientAware` composable to work in a default manner, when not used in the context of an Activity

#### WHY

`AmbientAware` should be used only in the context of an Activity, as it is necessary to set the ambient mode on the Activity and react to changes.

However, it may be desirable to have `AmbientAware` work to allow rendering of the UI, when an activity isn't present, such as in a test.

#### HOW

Checks for presence of an Activity, and if there isn't one, calls `block`, with a fixed ambient state of `Interactive`.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
