### PR TITLE
AmbientAware isAlwaysOnScreen flag

### DIFF
--- a/compose-layout/api/current.api
+++ b/compose-layout/api/current.api
@@ -2,7 +2,7 @@
 package com.google.android.horologist.compose.ambient {
 
   public final class AmbientAwareKt {
-    method @androidx.compose.runtime.Composable public static void AmbientAware(kotlin.jvm.functions.Function1<? super com.google.android.horologist.compose.ambient.AmbientStateUpdate,kotlin.Unit> block);
+    method @androidx.compose.runtime.Composable public static void AmbientAware(optional boolean isAlwaysOnScreen, kotlin.jvm.functions.Function1<? super com.google.android.horologist.compose.ambient.AmbientStateUpdate,kotlin.Unit> block);
   }
 
   public final class AmbientAwareTimeKt {

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
@@ -17,6 +17,8 @@
 package com.google.android.horologist.compose.ambient
 
 import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -40,7 +42,21 @@ import androidx.wear.ambient.AmbientLifecycleObserver
  */
 @Composable
 fun AmbientAware(block: @Composable (AmbientStateUpdate) -> Unit) {
-    val activity = LocalContext.current as Activity
+    val activity = LocalContext.current.findActivityOrNull()
+    // Using AmbientAware correctly relies on there being an Activity context. If there isn't, then
+    // gracefully allow the composition of [block], but no ambient-mode functionality is enabled.
+    if (activity == null) {
+        AmbientAwareNoActivity(block)
+    } else {
+        AmbientAwareWithActivity(activity, block)
+    }
+}
+
+@Composable
+private fun AmbientAwareWithActivity(
+    activity: Activity,
+    block: @Composable (AmbientStateUpdate) -> Unit,
+) {
     val lifecycle = LocalLifecycleOwner.current.lifecycle
     var ambientUpdate by remember { mutableStateOf<AmbientStateUpdate?>(null) }
 
@@ -55,7 +71,8 @@ fun AmbientAware(block: @Composable (AmbientStateUpdate) -> Unit) {
             }
 
             override fun onUpdateAmbient() {
-                val lastAmbientDetails = (ambientUpdate?.ambientState as? AmbientState.Ambient)?.ambientDetails
+                val lastAmbientDetails =
+                    (ambientUpdate?.ambientState as? AmbientState.Ambient)?.ambientDetails
                 ambientUpdate = AmbientStateUpdate(AmbientState.Ambient(lastAmbientDetails))
             }
         }
@@ -81,4 +98,19 @@ fun AmbientAware(block: @Composable (AmbientStateUpdate) -> Unit) {
     ambientUpdate?.let {
         block(it)
     }
+}
+
+@Composable
+private fun AmbientAwareNoActivity(block: @Composable (AmbientStateUpdate) -> Unit) {
+    val staticAmbientState by remember { mutableStateOf(AmbientStateUpdate(AmbientState.Interactive)) }
+    block(staticAmbientState)
+}
+
+private fun Context.findActivityOrNull(): Activity? {
+    var context = this
+    while (context is ContextWrapper) {
+        if (context is Activity) return context
+        context = context.baseContext
+    }
+    return null
 }

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
@@ -49,14 +49,13 @@ import androidx.wear.ambient.AmbientLifecycleObserver
 @Composable
 fun AmbientAware(
     isAlwaysOnScreen: Boolean = true,
-    block: @Composable (AmbientStateUpdate) -> Unit
+    block: @Composable (AmbientStateUpdate) -> Unit,
 ) {
     val activity = LocalContext.current.findActivityOrNull()
     // Using AmbientAware correctly relies on there being an Activity context. If there isn't, then
     // gracefully allow the composition of [block], but no ambient-mode functionality is enabled.
     if (activity != null && isAlwaysOnScreen) {
         AmbientAwareEnabled(activity, block)
-
     } else {
         AmbientAwareDisabled(block)
     }

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
@@ -39,21 +39,31 @@ import androidx.wear.ambient.AmbientLifecycleObserver
  *     https://developer.android.com/training/wearables/views/always-on).
  *
  * It should therefore be used high up in the tree of composables.
+ *
+ * @param isAlwaysOnScreen If supplied, this indicates whether always-on should be enabled. This can
+ * be used to ensure that some screens display an ambient-mode version, whereas others do not, for
+ * example, a workout screen vs a end-of-workout summary screen.
+ * @param block Lambda that will be used for building the UI, which is passed the current ambient
+ * state.
  */
 @Composable
-fun AmbientAware(block: @Composable (AmbientStateUpdate) -> Unit) {
+fun AmbientAware(
+    isAlwaysOnScreen: Boolean = true,
+    block: @Composable (AmbientStateUpdate) -> Unit
+) {
     val activity = LocalContext.current.findActivityOrNull()
     // Using AmbientAware correctly relies on there being an Activity context. If there isn't, then
     // gracefully allow the composition of [block], but no ambient-mode functionality is enabled.
-    if (activity == null) {
-        AmbientAwareNoActivity(block)
+    if (activity != null && isAlwaysOnScreen) {
+        AmbientAwareEnabled(activity, block)
+
     } else {
-        AmbientAwareWithActivity(activity, block)
+        AmbientAwareDisabled(block)
     }
 }
 
 @Composable
-private fun AmbientAwareWithActivity(
+private fun AmbientAwareEnabled(
     activity: Activity,
     block: @Composable (AmbientStateUpdate) -> Unit,
 ) {
@@ -101,7 +111,7 @@ private fun AmbientAwareWithActivity(
 }
 
 @Composable
-private fun AmbientAwareNoActivity(block: @Composable (AmbientStateUpdate) -> Unit) {
+private fun AmbientAwareDisabled(block: @Composable (AmbientStateUpdate) -> Unit) {
     val staticAmbientState by remember { mutableStateOf(AmbientStateUpdate(AmbientState.Interactive)) }
     block(staticAmbientState)
 }


### PR DESCRIPTION
#### WHAT

Adds support for selectively enabling or disabling always-on

#### WHY

Some screens will require always-on, but some will not, for example, a workout screen (yes) vs a workout summary screen (no). 

#### HOW

`AmbientAware` now takes an optional parameter to specify whether the screen should enable always-on or not. This can be hoisted above the use of `AmbientAware` e.g.

```
AmbientAware(isAlwaysOnScreen == currentScreen.useAlwaysOn) { ambientStateUpdate ->

// ...

}
```


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
