### PR TITLE
Improve Galaxy Watch Classic detection for haptics

### DIFF
--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
@@ -346,7 +346,7 @@ private class PixelWatchRotaryHapticFeedback(private val view: View) : RotaryHap
 }
 
 /**
- * Implementation of [RotaryHapticFeedback] for Galaxy Watch 4 Classic
+ * Implementation of [RotaryHapticFeedback] for Galaxy Watch 4 and 6 Classic
  */
 @ExperimentalHorologistApi
 private class GalaxyWatchClassicHapticFeedback(private val view: View) : RotaryHapticFeedback {
@@ -372,7 +372,7 @@ private class GalaxyWatchClassicHapticFeedback(private val view: View) : RotaryH
 }
 
 private fun isGalaxyWatchClassic(): Boolean =
-    Build.MODEL.matches("SM-R8[89]5.".toRegex())
+    Build.MODEL.matches("SM-R(?:8[89][05]|9[56][05])".toRegex())
 
 private fun isGooglePixelWatch(): Boolean =
     Build.MODEL.startsWith("Google Pixel Watch")


### PR DESCRIPTION
#### WHAT
Improvement to the regex used to detect the Samsung Galaxy Watch model with a bezel. 

#### WHY
Because the previous regex missed 4 Classic 42mm and the newer 6 Classic models.

#### HOW
Match all Classic model numbers specified in:
https://en.wikipedia.org/wiki/Samsung_Galaxy_Watch_4
https://en.wikipedia.org/wiki/Samsung_Galaxy_Watch_6

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
