### PR TITLE
Implementation of RotaryScrollAdapter for AndroidX Picker

### DIFF
--- a/composables/api/current.api
+++ b/composables/api/current.api
@@ -173,6 +173,7 @@ package com.google.android.horologist.composables.picker {
   }
 
   public final class PickerRotaryScrollAdapterKt {
+    method @com.google.android.horologist.annotations.ExperimentalHorologistApi public static com.google.android.horologist.compose.rotaryinput.RotaryScrollAdapter toRotaryScrollAdapter(androidx.wear.compose.material.PickerState);
   }
 
 }

--- a/composables/src/main/java/com/google/android/horologist/composables/picker/Picker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/picker/Picker.kt
@@ -574,7 +574,7 @@ internal class PickerState constructor(
         scalingLazyListState.animateScrollToItem(getClosestTargetItemIndex(index), 0)
     }
 
-    public companion object {
+    internal companion object {
         /**
          * The default [Saver] implementation for [PickerState].
          */

--- a/composables/src/main/java/com/google/android/horologist/composables/picker/PickerGroup.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/picker/PickerGroup.kt
@@ -213,7 +213,7 @@ internal class PickerGroupState constructor(
      */
     var selectedIndex by mutableIntStateOf(initiallySelectedIndex)
 
-    public companion object {
+    internal companion object {
         val Saver = listSaver<PickerGroupState, Any?>(
             save = {
                 listOf(

--- a/composables/src/main/java/com/google/android/horologist/composables/picker/PickerRotaryScrollAdapter.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/picker/PickerRotaryScrollAdapter.kt
@@ -58,7 +58,8 @@ internal class PickerRotaryScrollAdapter(
 }
 
 /**
- * Temporary implementation of RotaryScrollAdapter for PickerState.
+ * Temporary implementation of RotaryScrollAdapter for PickerState 
+ * from AndroidX wear-compose library.
  */
 @ExperimentalHorologistApi
 public fun androidx.wear.compose.material.PickerState.toRotaryScrollAdapter(): RotaryScrollAdapter =

--- a/composables/src/main/java/com/google/android/horologist/composables/picker/PickerRotaryScrollAdapter.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/picker/PickerRotaryScrollAdapter.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.horologist.composables.picker
 
+import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.rotaryinput.RotaryScrollAdapter
 
 // TODO(b/294842202): Remove once rotary modifiers are in AndroidX
@@ -31,6 +32,44 @@ internal fun PickerState.toRotaryScrollAdapter(): PickerRotaryScrollAdapter =
  */
 internal class PickerRotaryScrollAdapter(
     override val scrollableState: PickerState,
+) : RotaryScrollAdapter {
+
+    /**
+     * Returns a height of a first item, as all items in picker have the same height.
+     */
+    override fun averageItemSize(): Float =
+        scrollableState.scalingLazyListState
+            .layoutInfo.visibleItemsInfo.first().unadjustedSize.toFloat()
+
+    /**
+     * Current (centred) item index
+     */
+    override fun currentItemIndex(): Int =
+        scrollableState.scalingLazyListState.centerItemIndex
+
+    /**
+     * An offset from the item centre
+     */
+    override fun currentItemOffset(): Float =
+        scrollableState.scalingLazyListState.centerItemScrollOffset.toFloat()
+
+    override fun totalItemsCount(): Int =
+        scrollableState.scalingLazyListState.layoutInfo.totalItemsCount
+}
+
+/**
+ * Temporary implementation of RotaryScrollAdapter for PickerState.
+ */
+@ExperimentalHorologistApi
+public fun androidx.wear.compose.material.PickerState.toRotaryScrollAdapter(): RotaryScrollAdapter =
+    AndroidxPickerRotaryScrollAdapter(this)
+
+/**
+ * An implementation of rotary scroll adapter for [Picker]
+ */
+@Suppress("INVISIBLE_MEMBER")
+internal class AndroidxPickerRotaryScrollAdapter(
+    override val scrollableState: androidx.wear.compose.material.PickerState,
 ) : RotaryScrollAdapter {
 
     /**


### PR DESCRIPTION
#### WHAT

Small Picker API for RotaryScrollAdapter

#### WHY

Picker and PickerState are public APIs, so the internal implementations used by DatePicker and TimePicker should remain so.

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
