### PR TITLE
Add a seek projection track position model

### DIFF
--- a/media/core/api/current.api
+++ b/media/core/api/current.api
@@ -121,7 +121,7 @@ package com.google.android.horologist.media.model {
   }
 
   public final class PlaybackState {
-    ctor public PlaybackState(com.google.android.horologist.media.model.PlayerState playerState, boolean isLive, kotlin.time.Duration? currentPosition, kotlin.time.Duration? seekProjection, kotlin.time.Duration? duration, float playbackSpeed);
+    ctor public PlaybackState(com.google.android.horologist.media.model.PlayerState playerState, boolean isLive, kotlin.time.Duration? currentPosition, optional kotlin.time.Duration? seekProjection, kotlin.time.Duration? duration, float playbackSpeed);
     method public com.google.android.horologist.media.model.PlayerState component1();
     method public boolean component2();
     method public kotlin.time.Duration? component3-FghU774();

--- a/media/core/api/current.api
+++ b/media/core/api/current.api
@@ -121,18 +121,20 @@ package com.google.android.horologist.media.model {
   }
 
   public final class PlaybackState {
-    ctor public PlaybackState(com.google.android.horologist.media.model.PlayerState playerState, boolean isLive, kotlin.time.Duration? currentPosition, kotlin.time.Duration? duration, float playbackSpeed);
+    ctor public PlaybackState(com.google.android.horologist.media.model.PlayerState playerState, boolean isLive, kotlin.time.Duration? currentPosition, kotlin.time.Duration? seekProjection, kotlin.time.Duration? duration, float playbackSpeed);
     method public com.google.android.horologist.media.model.PlayerState component1();
     method public boolean component2();
     method public kotlin.time.Duration? component3-FghU774();
     method public kotlin.time.Duration? component4-FghU774();
-    method public float component5();
-    method public com.google.android.horologist.media.model.PlaybackState copy-5TNNnBA(com.google.android.horologist.media.model.PlayerState playerState, boolean isLive, kotlin.time.Duration? currentPosition, kotlin.time.Duration? duration, float playbackSpeed);
+    method public kotlin.time.Duration? component5-FghU774();
+    method public float component6();
+    method public com.google.android.horologist.media.model.PlaybackState copy-dOnIrbo(com.google.android.horologist.media.model.PlayerState playerState, boolean isLive, kotlin.time.Duration? currentPosition, kotlin.time.Duration? seekProjection, kotlin.time.Duration? duration, float playbackSpeed);
     method public boolean equals(Object? other);
     method public kotlin.time.Duration? getCurrentPosition();
     method public kotlin.time.Duration? getDuration();
     method public float getPlaybackSpeed();
     method public com.google.android.horologist.media.model.PlayerState getPlayerState();
+    method public kotlin.time.Duration? getSeekProjection();
     method public int hashCode();
     method public boolean isLive();
     method public boolean isPlaying();
@@ -143,6 +145,7 @@ package com.google.android.horologist.media.model {
     property public final boolean isPlaying;
     property public final float playbackSpeed;
     property public final com.google.android.horologist.media.model.PlayerState playerState;
+    property public final kotlin.time.Duration? seekProjection;
     field public static final com.google.android.horologist.media.model.PlaybackState.Companion Companion;
   }
 
@@ -178,6 +181,7 @@ package com.google.android.horologist.media.model {
     enum_constant public static final com.google.android.horologist.media.model.PlaybackStateEvent.Cause ParametersChanged;
     enum_constant public static final com.google.android.horologist.media.model.PlaybackStateEvent.Cause PlayerStateChanged;
     enum_constant public static final com.google.android.horologist.media.model.PlaybackStateEvent.Cause PositionDiscontinuity;
+    enum_constant public static final com.google.android.horologist.media.model.PlaybackStateEvent.Cause SeekProjecting;
   }
 
   public static final class PlaybackStateEvent.Companion {

--- a/media/core/src/main/java/com/google/android/horologist/media/model/PlaybackState.kt
+++ b/media/core/src/main/java/com/google/android/horologist/media/model/PlaybackState.kt
@@ -28,7 +28,7 @@ public data class PlaybackState(
     public val playerState: PlayerState,
     public val isLive: Boolean,
     public val currentPosition: Duration?,
-    public val seekProjection: Duration?,
+    public val seekProjection: Duration? = null,
     public val duration: Duration?,
     public val playbackSpeed: Float,
 ) {

--- a/media/core/src/main/java/com/google/android/horologist/media/model/PlaybackState.kt
+++ b/media/core/src/main/java/com/google/android/horologist/media/model/PlaybackState.kt
@@ -28,6 +28,7 @@ public data class PlaybackState(
     public val playerState: PlayerState,
     public val isLive: Boolean,
     public val currentPosition: Duration?,
+    public val seekProjection: Duration?,
     public val duration: Duration?,
     public val playbackSpeed: Float,
 ) {
@@ -38,6 +39,7 @@ public data class PlaybackState(
             playerState = PlayerState.Idle,
             isLive = false,
             currentPosition = null,
+            seekProjection = null,
             duration = null,
             playbackSpeed = 1f,
         )

--- a/media/core/src/main/java/com/google/android/horologist/media/model/PlaybackStateEvent.kt
+++ b/media/core/src/main/java/com/google/android/horologist/media/model/PlaybackStateEvent.kt
@@ -30,6 +30,7 @@ public data class PlaybackStateEvent(
         PlayerStateChanged,
         ParametersChanged,
         PositionDiscontinuity,
+        SeekProjecting,
         Other,
     }
 

--- a/media/data/api/current.api
+++ b/media/data/api/current.api
@@ -265,7 +265,7 @@ package com.google.android.horologist.media.data.mapper {
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public final class PlaybackStateMapper {
     ctor public PlaybackStateMapper(optional com.google.android.horologist.media.model.TimestampProvider timestampProvider);
-    method public com.google.android.horologist.media.model.PlaybackStateEvent createEvent(androidx.media3.common.Player? player, com.google.android.horologist.media.model.PlaybackStateEvent.Cause cause);
+    method public com.google.android.horologist.media.model.PlaybackStateEvent createEvent(androidx.media3.common.Player? player, com.google.android.horologist.media.model.PlaybackStateEvent.Cause cause, optional kotlin.time.Duration? seekProjection);
   }
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public final class PlayerStateMapper {

--- a/media/data/src/main/java/com/google/android/horologist/media/data/mapper/PlaybackStateMapper.kt
+++ b/media/data/src/main/java/com/google/android/horologist/media/data/mapper/PlaybackStateMapper.kt
@@ -24,6 +24,7 @@ import com.google.android.horologist.media.model.PlaybackState
 import com.google.android.horologist.media.model.PlaybackStateEvent
 import com.google.android.horologist.media.model.PlayerState
 import com.google.android.horologist.media.model.TimestampProvider
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
@@ -31,15 +32,15 @@ import kotlin.time.Duration.Companion.milliseconds
  */
 @ExperimentalHorologistApi
 public class PlaybackStateMapper(private val timestampProvider: TimestampProvider = TimestampProvider { SystemClock.elapsedRealtime() }) {
-    public fun createEvent(player: Player?, cause: PlaybackStateEvent.Cause): PlaybackStateEvent =
+    public fun createEvent(player: Player?, cause: PlaybackStateEvent.Cause, seekProjection: Duration? = null): PlaybackStateEvent =
         PlaybackStateEvent(
-            playbackState = map(player),
+            playbackState = map(player, seekProjection),
             cause = cause,
             timestamp = timestampProvider.getTimestamp().milliseconds,
         )
 
     // should only be mapped as an event
-    internal fun map(player: Player?): PlaybackState {
+    internal fun map(player: Player?, seekProjection: Duration? = null): PlaybackState {
         if (player == null) {
             return PlaybackState.IDLE
         }
@@ -56,6 +57,7 @@ public class PlaybackStateMapper(private val timestampProvider: TimestampProvide
             PlaybackState(
                 playerState = playerState,
                 currentPosition = null,
+                seekProjection = null,
                 duration = null,
                 playbackSpeed = playbackSpeed,
                 isLive = isLive,
@@ -64,6 +66,7 @@ public class PlaybackStateMapper(private val timestampProvider: TimestampProvide
             PlaybackState(
                 playerState = playerState,
                 currentPosition = player.currentPosition.milliseconds,
+                seekProjection = seekProjection,
                 duration = (player.duration.coerceAtLeast(player.currentPosition)).milliseconds,
                 playbackSpeed = playbackSpeed,
                 isLive = isLive,

--- a/media/ui/api/current.api
+++ b/media/ui/api/current.api
@@ -825,8 +825,6 @@ package com.google.android.horologist.media.ui.state.model {
   }
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public abstract sealed class TrackPositionUiModel {
-    method public final long getCurrentPlaybackDuration();
-    method public final long getCurrentPlaybackPosition();
     method public abstract boolean getShouldAnimate();
     method public abstract boolean getShowProgress();
     method public abstract boolean isLoading();

--- a/media/ui/api/current.api
+++ b/media/ui/api/current.api
@@ -674,7 +674,7 @@ package com.google.android.horologist.media.ui.state.mapper {
   }
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public final class TrackPositionUiModelMapper {
-    method public com.google.android.horologist.media.ui.state.model.TrackPositionUiModel map(com.google.android.horologist.media.model.PlaybackStateEvent event);
+    method public com.google.android.horologist.media.ui.state.model.TrackPositionUiModel map(com.google.android.horologist.media.model.PlaybackStateEvent event, optional Long? seekProjection);
     field public static final com.google.android.horologist.media.ui.state.mapper.TrackPositionUiModelMapper INSTANCE;
   }
 
@@ -896,6 +896,27 @@ package com.google.android.horologist.media.ui.state.model {
     method public boolean isLoading();
     property public boolean isLoading;
     property public final com.google.android.horologist.media.model.PositionPredictor predictor;
+    property public boolean shouldAnimate;
+    property public boolean showProgress;
+  }
+
+  public static final class TrackPositionUiModel.SeekProjection extends com.google.android.horologist.media.ui.state.model.TrackPositionUiModel {
+    ctor public TrackPositionUiModel.SeekProjection(float percent, long duration, long position, optional boolean shouldAnimate);
+    method public float component1();
+    method public long component2-UwyO8pc();
+    method public long component3-UwyO8pc();
+    method public boolean component4();
+    method public com.google.android.horologist.media.ui.state.model.TrackPositionUiModel.SeekProjection copy-vLdBGDU(float percent, long duration, long position, boolean shouldAnimate);
+    method public long getDuration();
+    method public float getPercent();
+    method public long getPosition();
+    method public boolean getShouldAnimate();
+    method public boolean getShowProgress();
+    method public boolean isLoading();
+    property public final long duration;
+    property public boolean isLoading;
+    property public final float percent;
+    property public final long position;
     property public boolean shouldAnimate;
     property public boolean showProgress;
   }

--- a/media/ui/api/current.api
+++ b/media/ui/api/current.api
@@ -674,7 +674,7 @@ package com.google.android.horologist.media.ui.state.mapper {
   }
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public final class TrackPositionUiModelMapper {
-    method public com.google.android.horologist.media.ui.state.model.TrackPositionUiModel map(com.google.android.horologist.media.model.PlaybackStateEvent event, optional Long? seekProjection);
+    method public com.google.android.horologist.media.ui.state.model.TrackPositionUiModel map(com.google.android.horologist.media.model.PlaybackStateEvent event);
     field public static final com.google.android.horologist.media.ui.state.mapper.TrackPositionUiModelMapper INSTANCE;
   }
 

--- a/media/ui/api/current.api
+++ b/media/ui/api/current.api
@@ -825,6 +825,8 @@ package com.google.android.horologist.media.ui.state.model {
   }
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public abstract sealed class TrackPositionUiModel {
+    method public final long getCurrentPlaybackDuration();
+    method public final long getCurrentPlaybackPosition();
     method public abstract boolean getShouldAnimate();
     method public abstract boolean getShowProgress();
     method public abstract boolean isLoading();

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/state/ProgressStateHolder.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/state/ProgressStateHolder.kt
@@ -90,6 +90,7 @@ internal class ProgressStateHolder(
 
         private fun TrackPositionUiModel.getCurrentPercent(timestamp: Long) = when (this) {
             is TrackPositionUiModel.Actual -> percent
+            is TrackPositionUiModel.SeekProjection -> percent
             is TrackPositionUiModel.Predictive -> predictor.predictPercent(timestamp)
             else -> 0f
         }

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
@@ -20,6 +20,7 @@ import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.PlaybackStateEvent
 import com.google.android.horologist.media.model.PlayerState
 import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
+import kotlin.time.Duration
 
 /**
  * Functions to map a [TrackPositionUiModel] based on data from other layers.
@@ -38,7 +39,7 @@ public object TrackPositionUiModelMapper {
             return TrackPositionUiModel.Hidden
         }
         event.playbackState.seekProjection?.let { seek ->
-            if (seek.inWholeMilliseconds >= 0) {
+            if (seek > Duration.ZERO) {
                 val percent = seek.inWholeMilliseconds.toFloat() / durationMs.toFloat()
                 return TrackPositionUiModel.SeekProjection(percent, duration, seek)
             }

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
@@ -38,11 +38,9 @@ public object TrackPositionUiModelMapper {
         if (currentPositionMs == null || durationMs == null || durationMs <= 0) {
             return TrackPositionUiModel.Hidden
         }
-        event.playbackState.seekProjection?.let { seek ->
-            if (seek > Duration.ZERO) {
-                val percent = seek.inWholeMilliseconds.toFloat() / durationMs.toFloat()
-                return TrackPositionUiModel.SeekProjection(percent, duration, seek)
-            }
+        event.playbackState.seekProjection?.takeIf { it > Duration.ZERO }?.let { seek ->
+            val percent = seek.inWholeMilliseconds.toFloat() / durationMs.toFloat()
+            return TrackPositionUiModel.SeekProjection(percent, duration, seek)
         }
         val predictor = event.createPositionPredictor()
         if (event.playbackState.isPlaying && predictor != null) {

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
@@ -20,14 +20,13 @@ import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.PlaybackStateEvent
 import com.google.android.horologist.media.model.PlayerState
 import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
-import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Functions to map a [TrackPositionUiModel] based on data from other layers.
  */
 @ExperimentalHorologistApi
 public object TrackPositionUiModelMapper {
-    public fun map(event: PlaybackStateEvent, seekProjection: Long? = null): TrackPositionUiModel {
+    public fun map(event: PlaybackStateEvent): TrackPositionUiModel {
         val currentPosition = event.playbackState.currentPosition
         val duration = event.playbackState.duration
         val durationMs = duration?.inWholeMilliseconds
@@ -38,14 +37,10 @@ public object TrackPositionUiModelMapper {
         if (currentPositionMs == null || durationMs == null || durationMs <= 0) {
             return TrackPositionUiModel.Hidden
         }
-        seekProjection?.let { projection ->
-            if (projection >= 0) {
-                val percent = projection.toFloat() / durationMs.toFloat()
-                return TrackPositionUiModel.SeekProjection(
-                    percent = percent,
-                    duration = duration,
-                    position = projection.milliseconds,
-                )
+        event.playbackState.seekProjection?.let { seek ->
+            if (seek.inWholeMilliseconds >= 0) {
+                val percent = seek.inWholeMilliseconds.toFloat() / durationMs.toFloat()
+                return TrackPositionUiModel.SeekProjection(percent, duration, seek)
             }
         }
         val predictor = event.createPositionPredictor()

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
@@ -21,8 +21,6 @@ import com.google.android.horologist.media.model.PlaybackStateEvent
 import com.google.android.horologist.media.model.PlayerState
 import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
 
 /**
  * Functions to map a [TrackPositionUiModel] based on data from other layers.
@@ -46,7 +44,7 @@ public object TrackPositionUiModelMapper {
                 return TrackPositionUiModel.SeekProjection(
                     percent = percent,
                     duration = duration,
-                    position = projection.milliseconds
+                    position = projection.milliseconds,
                 )
             }
         }

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
@@ -16,7 +16,6 @@
 
 package com.google.android.horologist.media.ui.state.model
 
-import android.os.SystemClock
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.PositionPredictor
 import kotlin.time.Duration
@@ -26,21 +25,6 @@ public sealed class TrackPositionUiModel {
     public abstract val showProgress: Boolean
     public abstract val shouldAnimate: Boolean
     public abstract val isLoading: Boolean
-
-    public fun getCurrentPlaybackDuration(): Duration =
-        when (this) {
-            is Actual -> duration
-            is SeekProjection -> duration
-            is Predictive -> predictor.predictDuration(SystemClock.elapsedRealtime())
-            else -> Duration.INFINITE
-        }
-
-    public fun getCurrentPlaybackPosition(): Duration =
-        when (this) {
-            is Actual -> position
-            is Predictive -> predictor.predictPosition(SystemClock.elapsedRealtime())
-            else -> Duration.ZERO
-        }
 
     public data class Predictive(
         public val predictor: PositionPredictor,

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
@@ -34,6 +34,16 @@ public sealed class TrackPositionUiModel {
         override val showProgress: Boolean get() = true
     }
 
+    public data class SeekProjection(
+        public val percent: Float,
+        public val duration: Duration,
+        public val position: Duration,
+        public override val shouldAnimate: Boolean = false,
+    ) : TrackPositionUiModel() {
+        override val showProgress: Boolean = true
+        override val isLoading: Boolean = false
+    }
+
     public data class Actual(
         public val percent: Float,
         public val duration: Duration,

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/state/model/TrackPositionUiModel.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.horologist.media.ui.state.model
 
+import android.os.SystemClock
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.PositionPredictor
 import kotlin.time.Duration
@@ -25,6 +26,21 @@ public sealed class TrackPositionUiModel {
     public abstract val showProgress: Boolean
     public abstract val shouldAnimate: Boolean
     public abstract val isLoading: Boolean
+
+    public fun getCurrentPlaybackDuration(): Duration =
+        when (this) {
+            is Actual -> duration
+            is SeekProjection -> duration
+            is Predictive -> predictor.predictDuration(SystemClock.elapsedRealtime())
+            else -> Duration.INFINITE
+        }
+
+    public fun getCurrentPlaybackPosition(): Duration =
+        when (this) {
+            is Actual -> position
+            is Predictive -> predictor.predictPosition(SystemClock.elapsedRealtime())
+            else -> Duration.ZERO
+        }
 
     public data class Predictive(
         public val predictor: PositionPredictor,


### PR DESCRIPTION
#### WHAT
Add a new type of `TrackPositionUiModel` for displaying seeking projection. 

#### WHY
This gives clients an opportunity to show seek projection in addition to the Actual, Loading, Predictive ui models. For example, this could enable `PlayerRepositoryImpl` to accumulate seeking duration and displaying it without making multiple repeated calls to `seekBack` or `seekForward` on long press and only flush the position on finger up.  

#### HOW
When the seek projection is passed in (as duration), use the `TrackPositionUiModel`

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
