### PR TITLE
Use Wear 3/4 haptics by default

### DIFF
--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
@@ -282,15 +282,39 @@ public class DefaultRotaryHapticFeedback(private val view: View) : RotaryHapticF
     ) {
         when (type) {
             RotaryHapticsType.ScrollItemFocus -> {
-                view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                view.performHapticFeedback(
+                    if (Build.VERSION.SDK_INT >= 33) {
+                        PixelWatchRotaryHapticFeedback.ROTARY_SCROLL_ITEM_FOCUS
+                    } else if (Build.VERSION.SDK_INT >= 30) {
+                        PixelWatchRotaryHapticFeedback.WEAR_SCROLL_ITEM_FOCUS
+                    } else {
+                        HapticFeedbackConstants.LONG_PRESS
+                    },
+                )
             }
 
             RotaryHapticsType.ScrollTick -> {
-                view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                view.performHapticFeedback(
+                    if (Build.VERSION.SDK_INT >= 33) {
+                        PixelWatchRotaryHapticFeedback.ROTARY_SCROLL_TICK
+                    } else if (Build.VERSION.SDK_INT >= 30) {
+                        PixelWatchRotaryHapticFeedback.WEAR_SCROLL_TICK
+                    } else {
+                        HapticFeedbackConstants.KEYBOARD_TAP
+                    },
+                )
             }
 
             RotaryHapticsType.ScrollLimit -> {
-                view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                view.performHapticFeedback(
+                    if (Build.VERSION.SDK_INT >= 33) {
+                        PixelWatchRotaryHapticFeedback.ROTARY_SCROLL_LIMIT
+                    } else if (Build.VERSION.SDK_INT >= 30) {
+                        PixelWatchRotaryHapticFeedback.WEAR_SCROLL_LIMIT
+                    } else {
+                        HapticFeedbackConstants.LONG_PRESS
+                    },
+                )
             }
         }
     }
@@ -331,7 +355,7 @@ private class PixelWatchRotaryHapticFeedback(private val view: View) : RotaryHap
         }
     }
 
-    private companion object {
+    internal companion object {
         // Hidden constants from HapticFeedbackConstants.java specific for Pixel Watch
         // API 33
         public const val ROTARY_SCROLL_TICK: Int = 18


### PR DESCRIPTION
#### WHAT

Use Wear 3/4 haptics by default. Assume OEMs haven't customised these. 

#### WHY

We should have nice haptics on all devices, not just PixelWatch and Galaxy Watch.
To fix https://github.com/google/horologist/issues/1750

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
