### PR TITLE
Fix TrackPositionUiModelMapper for SeekProjection at 0 position

### DIFF
--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapper.kt
@@ -38,7 +38,7 @@ public object TrackPositionUiModelMapper {
         if (currentPositionMs == null || durationMs == null || durationMs <= 0) {
             return TrackPositionUiModel.Hidden
         }
-        event.playbackState.seekProjection?.takeIf { it > Duration.ZERO }?.let { seek ->
+        event.playbackState.seekProjection?.takeIf { it >= Duration.ZERO }?.let { seek ->
             val percent = seek.inWholeMilliseconds.toFloat() / durationMs.toFloat()
             return TrackPositionUiModel.SeekProjection(percent, duration, seek)
         }

--- a/media/ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapperTest.kt
+++ b/media/ui/src/test/java/com/google/android/horologist/media/ui/state/mapper/TrackPositionUiModelMapperTest.kt
@@ -22,6 +22,7 @@ import com.google.android.horologist.media.model.PlayerState
 import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
@@ -38,6 +39,7 @@ class TrackPositionUiModelMapperTest {
                 playerState = PlayerState.Playing,
                 isLive = false,
                 currentPosition = current,
+                seekProjection = null,
                 duration = duration,
                 playbackSpeed = 1f,
             ),
@@ -65,6 +67,7 @@ class TrackPositionUiModelMapperTest {
                 playerState = PlayerState.Stopped,
                 isLive = false,
                 currentPosition = current,
+                seekProjection = null,
                 duration = duration,
                 playbackSpeed = 1f,
             ),
@@ -91,6 +94,7 @@ class TrackPositionUiModelMapperTest {
                 playerState = PlayerState.Loading,
                 isLive = false,
                 currentPosition = current,
+                seekProjection = null,
                 duration = duration,
                 playbackSpeed = 1f,
             ),
@@ -104,6 +108,59 @@ class TrackPositionUiModelMapperTest {
         assertThat(result).isInstanceOf(TrackPositionUiModel.Loading::class.java)
         result as TrackPositionUiModel.Loading
         assertThat(result.isLoading).isTrue()
+    }
+
+    @Test
+    fun givenSeekProjectionNotNullButZero_thenMapsCorrectly() {
+        // given
+        val current = 1.seconds
+        val duration = 2.seconds
+        val playbackStateEvent = PlaybackStateEvent(
+            PlaybackState(
+                playerState = PlayerState.Playing,
+                isLive = false,
+                currentPosition = current,
+                seekProjection = Duration.ZERO,
+                duration = duration,
+                playbackSpeed = 1f,
+            ),
+            cause = PlaybackStateEvent.Cause.PositionDiscontinuity,
+        )
+
+        // when
+        val result = TrackPositionUiModelMapper.map(playbackStateEvent)
+
+        // then
+        assertThat(result).isInstanceOf(TrackPositionUiModel.SeekProjection::class.java)
+        result as TrackPositionUiModel.SeekProjection
+        assertThat(result.percent).isEqualTo(0.0f)
+    }
+
+    @Test
+    fun givenSeekProjectionNotNullAndNotZero_thenMapsCorrectly() {
+        // given
+        val current = 0.seconds
+        val duration = 2.seconds
+        val seekDuration = 1.seconds
+        val playbackStateEvent = PlaybackStateEvent(
+            PlaybackState(
+                playerState = PlayerState.Playing,
+                isLive = false,
+                currentPosition = current,
+                seekProjection = seekDuration,
+                duration = duration,
+                playbackSpeed = 1f,
+            ),
+            cause = PlaybackStateEvent.Cause.PositionDiscontinuity,
+        )
+
+        // when
+        val result = TrackPositionUiModelMapper.map(playbackStateEvent)
+
+        // then
+        assertThat(result).isInstanceOf(TrackPositionUiModel.SeekProjection::class.java)
+        result as TrackPositionUiModel.SeekProjection
+        assertThat(result.percent).isEqualTo(0.5f)
     }
 
     @Test


### PR DESCRIPTION
#### WHAT
Fix TrackPositionUiModelMapper for SeekProjection to work for seek to position 0

#### WHY
Currently, when seeking at to the beginning and seek duration is set to 0, the mapper would map back to predictive model instead of seek projected model. 

#### HOW
add the `=` to accommodate seeking to position 0

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
