### PR TITLE
Change Default back to belowTimeText

### DIFF
--- a/auth/sample/wear/src/main/java/com/google/android/horologist/auth/sample/WearApp.kt
+++ b/auth/sample/wear/src/main/java/com/google/android/horologist/auth/sample/WearApp.kt
@@ -116,23 +116,27 @@ fun WearApp(
                 modifier = modifier,
             )
         }
-        scrollable(route = Screen.StreamlineSignInMenuScreen.route,
-            columnStateFactory = ScalingLazyColumnDefaults.responsive(),) {
+        scrollable(
+            route = Screen.StreamlineSignInMenuScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),
+        ) {
             StreamlineSignInMenuScreen(
                 navController = navController,
                 columnState = it.columnState,
                 modifier = modifier,
             )
         }
-        scrollable(route = Screen.StreamlineSignInSampleScreen.route,
-            columnStateFactory = ScalingLazyColumnDefaults.responsive(),) {
+        scrollable(
+            route = Screen.StreamlineSignInSampleScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),
+        ) {
             StreamlineSignInSampleScreen(
                 navController = navController,
                 columnState = it.columnState,
                 modifier = modifier,
             )
         }
-        composable(route = Screen.GoogleSignInScreen.route,) {
+        composable(route = Screen.GoogleSignInScreen.route) {
             GoogleSignInScreen(
                 onAuthCancelled = navController::popBackStack,
                 onAuthSucceed = navController::popBackStack,
@@ -143,12 +147,16 @@ fun WearApp(
         composable(route = Screen.GoogleSignOutScreen.route) {
             GoogleSignOutScreen(navController = navController)
         }
-        scrollable(route = Screen.TokenShareDefaultKeyScreen.route,
-            columnStateFactory = ScalingLazyColumnDefaults.responsive(),) {
+        scrollable(
+            route = Screen.TokenShareDefaultKeyScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),
+        ) {
             TokenShareDefaultKeyScreen(columnState = it.columnState, modifier = modifier)
         }
-        scrollable(route = Screen.TokenShareCustomKeyScreen.route,
-            columnStateFactory = ScalingLazyColumnDefaults.responsive(),) {
+        scrollable(
+            route = Screen.TokenShareCustomKeyScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),
+        ) {
             TokenShareCustomKeyScreen(columnState = it.columnState, modifier = modifier)
         }
         scrollable(route = Screen.DataLayerScreen.route) {

--- a/auth/sample/wear/src/main/java/com/google/android/horologist/auth/sample/WearApp.kt
+++ b/auth/sample/wear/src/main/java/com/google/android/horologist/auth/sample/WearApp.kt
@@ -45,6 +45,7 @@ import com.google.android.horologist.auth.sample.screens.tokenshare.defaultkey.T
 import com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreen
 import com.google.android.horologist.auth.ui.oauth.devicegrant.signin.DeviceGrantSignInScreen
 import com.google.android.horologist.auth.ui.oauth.pkce.signin.PKCESignInScreen
+import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.navscaffold.WearNavScaffold
 import com.google.android.horologist.compose.navscaffold.composable
 import com.google.android.horologist.compose.navscaffold.scrollable
@@ -57,6 +58,7 @@ fun WearApp(
     WearNavScaffold(startDestination = Screen.MainScreen.route, navController = navController) {
         scrollable(
             route = Screen.MainScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),
         ) {
             MainScreen(
                 navigateToRoute = navController::navigate,
@@ -66,6 +68,7 @@ fun WearApp(
         }
         scrollable(
             route = Screen.PKCESignInPromptScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),
         ) {
             PKCESignInPromptScreen(
                 navController = navController,
@@ -85,6 +88,7 @@ fun WearApp(
         }
         scrollable(
             route = Screen.DeviceGrantSignInPromptScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),
         ) {
             DeviceGrantSignInPromptScreen(
                 navController = navController,
@@ -104,6 +108,7 @@ fun WearApp(
         }
         scrollable(
             route = Screen.GoogleSignInPromptSampleScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),
         ) {
             GoogleSignInPromptSampleScreen(
                 navController = navController,
@@ -111,21 +116,23 @@ fun WearApp(
                 modifier = modifier,
             )
         }
-        scrollable(route = Screen.StreamlineSignInMenuScreen.route) {
+        scrollable(route = Screen.StreamlineSignInMenuScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),) {
             StreamlineSignInMenuScreen(
                 navController = navController,
                 columnState = it.columnState,
                 modifier = modifier,
             )
         }
-        scrollable(route = Screen.StreamlineSignInSampleScreen.route) {
+        scrollable(route = Screen.StreamlineSignInSampleScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),) {
             StreamlineSignInSampleScreen(
                 navController = navController,
                 columnState = it.columnState,
                 modifier = modifier,
             )
         }
-        composable(route = Screen.GoogleSignInScreen.route) {
+        composable(route = Screen.GoogleSignInScreen.route,) {
             GoogleSignInScreen(
                 onAuthCancelled = navController::popBackStack,
                 onAuthSucceed = navController::popBackStack,
@@ -136,10 +143,12 @@ fun WearApp(
         composable(route = Screen.GoogleSignOutScreen.route) {
             GoogleSignOutScreen(navController = navController)
         }
-        scrollable(route = Screen.TokenShareDefaultKeyScreen.route) {
+        scrollable(route = Screen.TokenShareDefaultKeyScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),) {
             TokenShareDefaultKeyScreen(columnState = it.columnState, modifier = modifier)
         }
-        scrollable(route = Screen.TokenShareCustomKeyScreen.route) {
+        scrollable(route = Screen.TokenShareCustomKeyScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),) {
             TokenShareCustomKeyScreen(columnState = it.columnState, modifier = modifier)
         }
         scrollable(route = Screen.DataLayerScreen.route) {

--- a/composables/src/main/java/com/google/android/horologist/composables/SectionedList.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/SectionedList.kt
@@ -36,7 +36,7 @@ import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 @Composable
 public fun SectionedList(
     modifier: Modifier = Modifier,
-    columnState: ScalingLazyColumnState = ScalingLazyColumnDefaults.responsive().create(),
+    columnState: ScalingLazyColumnState = ScalingLazyColumnDefaults.belowTimeText().create(),
     content: SectionedListScope.() -> Unit,
 ) {
     SectionedList(
@@ -54,7 +54,7 @@ public fun SectionedList(
 @Composable
 public fun SectionedList(
     modifier: Modifier = Modifier,
-    columnState: ScalingLazyColumnState = ScalingLazyColumnDefaults.responsive().create(),
+    columnState: ScalingLazyColumnState = ScalingLazyColumnDefaults.belowTimeText().create(),
     sections: List<Section<*>> = emptyList(),
 ) {
     ScalingLazyColumn(

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/layout/ScalingLazyColumnState.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/layout/ScalingLazyColumnState.kt
@@ -110,7 +110,7 @@ public class ScalingLazyColumnState(
 
 @Composable
 public fun rememberColumnState(
-    factory: ScalingLazyColumnState.Factory = ScalingLazyColumnDefaults.responsive(),
+    factory: ScalingLazyColumnState.Factory = ScalingLazyColumnDefaults.belowTimeText(),
 ): ScalingLazyColumnState {
     val columnState = factory.create()
 

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/WearNavScaffold.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/navscaffold/WearNavScaffold.kt
@@ -191,7 +191,7 @@ public fun NavGraphBuilder.scrollable(
     route: String,
     arguments: List<NamedNavArgument> = emptyList(),
     deepLinks: List<NavDeepLink> = emptyList(),
-    columnStateFactory: ScalingLazyColumnState.Factory = ScalingLazyColumnDefaults.responsive(),
+    columnStateFactory: ScalingLazyColumnState.Factory = ScalingLazyColumnDefaults.belowTimeText(),
     content: @Composable (ScrollableScaffoldContext) -> Unit,
 ) {
     this@scrollable.composable(route, arguments, deepLinks) {

--- a/compose-layout/src/test/java/com/google/android/horologist/compose/navscaffold/NavScaffoldTest.kt
+++ b/compose-layout/src/test/java/com/google/android/horologist/compose/navscaffold/NavScaffoldTest.kt
@@ -55,6 +55,7 @@ import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.TimeText
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.rotaryinput.rotaryWithScroll
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.Dispatchers
@@ -184,6 +185,7 @@ class NavScaffoldTest {
             ) {
                 scrollable(
                     route = "a",
+                    columnStateFactory = ScalingLazyColumnDefaults.responsive(),
                 ) {
                     ScalingLazyColumn(
                         columnState = it.columnState,

--- a/media/sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
+++ b/media/sample/src/main/java/com/google/android/horologist/mediasample/ui/app/UampWearApp.kt
@@ -30,6 +30,7 @@ import androidx.navigation.NavHostController
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavHostState
 import com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreen
+import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.navscaffold.composable
 import com.google.android.horologist.compose.navscaffold.scrollable
 import com.google.android.horologist.media.ui.navigation.MediaNavController.navigateToCollection
@@ -188,7 +189,7 @@ fun UampWearApp(
             additionalNavRoutes = {
                 scrollable(
                     route = AudioDebug.navRoute,
-
+                    columnStateFactory = ScalingLazyColumnDefaults.responsive(),
                     arguments = AudioDebug.arguments,
                     deepLinks = AudioDebug.deepLinks(appViewModel.deepLinkPrefix),
                 ) {
@@ -200,7 +201,7 @@ fun UampWearApp(
 
                 scrollable(
                     route = Samples.navRoute,
-
+                    columnStateFactory = ScalingLazyColumnDefaults.responsive(),
                     arguments = Samples.arguments,
                     deepLinks = Samples.deepLinks(appViewModel.deepLinkPrefix),
                 ) {
@@ -213,7 +214,7 @@ fun UampWearApp(
 
                 scrollable(
                     route = DeveloperOptions.navRoute,
-
+                    columnStateFactory = ScalingLazyColumnDefaults.responsive(),
                     arguments = DeveloperOptions.arguments,
                     deepLinks = DeveloperOptions.deepLinks(appViewModel.deepLinkPrefix),
                 ) {
@@ -226,6 +227,7 @@ fun UampWearApp(
 
                 scrollable(
                     route = GoogleSignInPromptScreen.navRoute,
+                    columnStateFactory = ScalingLazyColumnDefaults.responsive(),
                 ) {
                     GoogleSignInPromptScreen(
                         navController = navController,

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/navigation/MediaPlayerScaffold.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/navigation/MediaPlayerScaffold.kt
@@ -35,6 +35,7 @@ import androidx.wear.compose.navigation.SwipeDismissableNavHostState
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavHostState
 import com.google.android.horologist.audio.ui.VolumeScreen
 import com.google.android.horologist.audio.ui.VolumeViewModel
+import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel
 import com.google.android.horologist.compose.navscaffold.WearNavScaffold
@@ -126,7 +127,7 @@ public fun MediaPlayerScaffold(
 
         scrollable(
             route = NavigationScreens.Collections.navRoute,
-
+            columnStateFactory = ScalingLazyColumnDefaults.belowTimeText(),
             arguments = NavigationScreens.Collections.arguments,
             deepLinks = NavigationScreens.Collections.deepLinks(deepLinkPrefix),
         ) {
@@ -135,7 +136,7 @@ public fun MediaPlayerScaffold(
 
         scrollable(
             route = NavigationScreens.Settings.navRoute,
-
+            columnStateFactory = ScalingLazyColumnDefaults.belowTimeText(),
             arguments = NavigationScreens.Settings.arguments,
             deepLinks = NavigationScreens.Settings.deepLinks(deepLinkPrefix),
         ) {
@@ -154,7 +155,7 @@ public fun MediaPlayerScaffold(
 
         scrollable(
             route = NavigationScreens.MediaItem.navRoute,
-
+            columnStateFactory = ScalingLazyColumnDefaults.belowTimeText(),
             arguments = NavigationScreens.MediaItem.arguments,
             deepLinks = NavigationScreens.MediaItem.deepLinks(deepLinkPrefix),
         ) {
@@ -163,7 +164,7 @@ public fun MediaPlayerScaffold(
 
         scrollable(
             route = NavigationScreens.Collection.navRoute,
-
+            columnStateFactory = ScalingLazyColumnDefaults.belowTimeText(),
             arguments = NavigationScreens.Collection.arguments,
             deepLinks = NavigationScreens.Collection.deepLinks(deepLinkPrefix),
         ) { scaffoldContext ->

--- a/sample/src/main/java/com/google/android/horologist/navsample/NavWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/navsample/NavWearApp.kt
@@ -39,6 +39,7 @@ import androidx.wear.compose.material.VignettePosition
 import androidx.wear.compose.material.dialog.Alert
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavHostState
 import com.google.android.horologist.audio.ui.VolumeScreen
+import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel
 import com.google.android.horologist.compose.navscaffold.WearNavScaffold
 import com.google.android.horologist.compose.navscaffold.composable
@@ -84,6 +85,7 @@ fun NavWearApp(
     ) {
         scrollable(
             NavScreen.Menu.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),
         ) {
             NavMenuScreen(
                 navigateToRoute = { route -> navController.navigate(route) },
@@ -93,6 +95,7 @@ fun NavWearApp(
 
         scrollable(
             NavScreen.ScalingLazyColumn.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),
         ) {
             it.timeTextMode = NavScaffoldViewModel.TimeTextMode.ScrollAway
             it.viewModel.vignettePosition =

--- a/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
@@ -69,6 +69,7 @@ fun SampleWearApp() {
     ) {
         scrollable(
             route = Screen.Menu.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),
         ) {
             MenuScreen(
                 navigateToRoute = { route -> navController.navigate(route) },
@@ -78,6 +79,7 @@ fun SampleWearApp() {
         }
         scrollable(
             Screen.DataLayerNodes.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),
         ) {
             DataLayerNodesScreen(
                 viewModel = viewModel(factory = DataLayerNodesViewModel.Factory),
@@ -105,6 +107,7 @@ fun SampleWearApp() {
         }
         scrollable(
             Screen.ScrollAwaySLC.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),
         ) {
             ScrollAwayScreenScalingLazyColumn(
                 columnState = it.columnState,
@@ -164,6 +167,7 @@ fun SampleWearApp() {
         }
         scrollable(
             route = Screen.SectionedListMenuScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),
         ) {
             SectionedListMenuScreen(
                 navigateToRoute = { route -> navController.navigate(route) },
@@ -172,6 +176,7 @@ fun SampleWearApp() {
         }
         scrollable(
             Screen.SectionedListStatelessScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),
         ) {
             SectionedListStatelessScreen(
                 columnState = it.columnState,
@@ -179,6 +184,7 @@ fun SampleWearApp() {
         }
         scrollable(
             Screen.SectionedListStatefulScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),
         ) {
             SectionedListStatefulScreen(
                 columnState = it.columnState,
@@ -186,6 +192,7 @@ fun SampleWearApp() {
         }
         scrollable(
             Screen.SectionedListExpandableScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),
         ) {
             SectionedListExpandableScreen(
                 columnState = it.columnState,
@@ -193,6 +200,7 @@ fun SampleWearApp() {
         }
         scrollable(
             route = Screen.RotaryMenuScreen.route,
+            columnStateFactory = ScalingLazyColumnDefaults.responsive(),
         ) {
             RotaryMenuScreen(
                 navigateToRoute = { route -> navController.navigate(route) },


### PR DESCRIPTION
#### WHAT

Change default back from responsive to belowTimeText.  The horologist screens known to be safe are overriding to keep using responsive.

#### WHY

Early iteration on responsive, not ready as default.

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
