### PR TITLE
Add default icon size to custom action media button aligning to the media button

### DIFF
--- a/media/ui/api/current.api
+++ b/media/ui/api/current.api
@@ -45,7 +45,7 @@ package com.google.android.horologist.media.ui.components {
   }
 
   public final class CustomActionMediaButtonKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void CustomActionMediaButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, String contentDescription, String iconUri, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional androidx.wear.compose.material.ButtonColors colors, optional long tapTargetSize);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void CustomActionMediaButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, String contentDescription, String iconUri, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional androidx.wear.compose.material.ButtonColors colors, optional float iconSize, optional long tapTargetSize, optional androidx.compose.ui.Alignment.Horizontal iconAlign);
   }
 
   public final class EntityButtonKt {

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/components/CustomActionMediaButton.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/components/CustomActionMediaButton.kt
@@ -16,10 +16,13 @@
 
 package com.google.android.horologist.media.ui.components
 
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Button
@@ -40,7 +43,9 @@ public fun CustomActionMediaButton(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     colors: ButtonColors = ButtonDefaults.iconButtonColors(),
+    iconSize: Dp = 30.dp,
     tapTargetSize: DpSize = DpSize(48.dp, 60.dp),
+    iconAlign: Alignment.Horizontal = Alignment.CenterHorizontally,
 ) {
     Button(
         onClick = onClick,
@@ -52,6 +57,22 @@ public fun CustomActionMediaButton(
             model = iconUri,
             contentDescription = contentDescription,
             colorFilter = ColorFilter.tint(colors.contentColor(enabled = enabled).value),
+            modifier = Modifier
+                .size(iconSize)
+                .run {
+                    when (iconAlign) {
+                        Alignment.Start -> {
+                            offset(x = -7.5.dp)
+                        }
+                        Alignment.End -> {
+                            offset(x = 7.5.dp)
+                        }
+                        else -> {
+                            this
+                        }
+                    }
+                }
+                .align(Alignment.Center),
         )
     }
 }


### PR DESCRIPTION
#### WHAT
Add default icon size for custom action media button

#### WHY
Currently the custom action sizes do not match the previous / next media control buttons

#### HOW
Add default icon size and alignment matching the media button (`media/ui/src/main/java/com/google/android/horologist/media/ui/components/controls/MediaButton.kt`)


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
