### PR TITLE
Fix density handling in robolectric screenshot tests.

### DIFF
--- a/sample/src/test/kotlin/com/google/android/horologist/screensizes/ScreenSizeTest.kt
+++ b/sample/src/test/kotlin/com/google/android/horologist/screensizes/ScreenSizeTest.kt
@@ -102,7 +102,7 @@ abstract class ScreenSizeTest(
 
             resources.updateConfiguration(
                 config,
-                resources.displayMetrics
+                resources.displayMetrics,
             )
         }
     }

--- a/sample/src/test/kotlin/com/google/android/horologist/screensizes/ScreenSizeTest.kt
+++ b/sample/src/test/kotlin/com/google/android/horologist/screensizes/ScreenSizeTest.kt
@@ -16,6 +16,8 @@
 
 package com.google.android.horologist.screensizes
 
+import android.content.Context
+import android.content.res.Configuration
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.font.FontWeight
 import androidx.wear.compose.material.MaterialTheme
@@ -88,5 +90,17 @@ abstract class ScreenSizeTest(
             GooglePixelWatch.copy("Small Device, Big Fonts", fontScale = 1.24f, boldText = true),
             MobvoiTicWatchPro5.copy("Large Device, Small Fonts", fontScale = 0.94f),
         )
+
+        @Suppress("DEPRECATION")
+        fun Context.setDisplayScale(density: Float) = apply {
+            // Modified from https://sergiosastre.hashnode.dev/efficient-testing-with-robolectric-roborazzi-across-many-ui-states-devices-and-configurations?ref=twitter-share
+            val config = Configuration(resources.configuration)
+            config.densityDpi = (density * 160f).toInt()
+
+            resources.updateConfiguration(
+                config,
+                resources.displayMetrics
+            )
+        }
     }
 }

--- a/sample/src/test/kotlin/com/google/android/horologist/screensizes/ScreenSizeTest.kt
+++ b/sample/src/test/kotlin/com/google/android/horologist/screensizes/ScreenSizeTest.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.content.res.Configuration
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.font.FontWeight
+import androidx.test.core.app.ApplicationProvider
 import androidx.wear.compose.material.MaterialTheme
 import com.google.android.horologist.compose.tools.Device
 import com.google.android.horologist.compose.tools.GenericLargeRound
@@ -66,6 +67,8 @@ abstract class ScreenSizeTest(
 
         RuntimeEnvironment.setFontScale(device.fontScale)
         RuntimeEnvironment.setQualifiers("+w${device.screenSizeDp}dp-h${device.screenSizeDp}dp")
+
+        ApplicationProvider.getApplicationContext<Context>().setDisplayScale(device.density)
 
         screenshotTestRule.setContent(takeScreenshot = true) {
             MaterialTheme(

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_AuthSignInTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_AuthSignInTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4a81fca191f3d2bc3f2048125e490ec7706867a726eaa52821d8344eef894189
-size 13852

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_AuthSignInTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_AuthSignInTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:550837a36b584aa2dfa19dcda3786ce0d278023c31d3b14debf6855221117daa
+size 17962

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_DatePickerTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_DatePickerTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c24bb6e0ae107a0baa76a8a8517d28790c0d75ebacde86fc9df9d9c64b8330ed
-size 22093

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_DatePickerTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_DatePickerTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c35a55b63641324f57ba998503a701751a325d0e6e4070d92e3a63a60958f4c2
+size 27461

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_DevicesTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_DevicesTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9913f0c2cd05045518b0d86fe1f496b4db5fd4edb24a6132b9d45518e505ec9e
-size 50255

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_DevicesTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_DevicesTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8eb421b467ad3d4152218be40f5415a5fb5bf8d56809cb95a260d96f56443fb
+size 56549

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_DialogTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_DialogTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9248e33d7a8d3fea08723e199fca4913ac06303ec7d0c79de389d46b83179ccd
+size 33244

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_DialogTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_DialogTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0f2e8593db69318d7b8bea1048935622f20c7a2b925f441fc9a1243b475c77a2
-size 31633

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_MediaPlayerLibraryTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_MediaPlayerLibraryTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dc98cdcebf6e3ea3ef78baba2c44d82cd07b3fd362423e4fcb8784981a8f805c
-size 37712

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_MediaPlayerLibraryTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_MediaPlayerLibraryTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:162caab1c65da7c3492a67947de499edcbdc7779b652a7328c15287798126e1a
+size 37210

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_MediaPlayerTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_MediaPlayerTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:313c0e60834260d2b8a5b97678b722f25173df5efa6607707af2834a19b70dfc
-size 122330

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_MediaPlayerTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_MediaPlayerTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8e3e94a8b5a88262ad533fa98f6a7c8961be5fd30c97f57c95e6708306e7fb1
+size 127805

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_SampleTileTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_SampleTileTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9664e42d1ab77edb2513cabc1c3c216cf7f91300a25c2232293b4301585056af
-size 25635

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_SampleTileTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_SampleTileTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a398b3878f844a02d341e21ab565023b2c375637238a0727430a624c37e6b45
+size 30403

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_ScalingLazyColumnDefaultsTest_belowTimeText[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_ScalingLazyColumnDefaultsTest_belowTimeText[2]_samsunggalaxywatch6large.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:18c9a41a8cd37a4d9bec542e315fd2feef13921c5e5df6e004360ecc125cd406
-size 41677

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_ScalingLazyColumnDefaultsTest_belowTimeText[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_ScalingLazyColumnDefaultsTest_belowTimeText[2]_samsunggalaxywatch6large.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebb17d4d336a0be5b84253c7e412a54dc7313d5181cc64a646705cad02d9c3f4
+size 42290

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_ScalingLazyColumnDefaultsTest_responsive[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_ScalingLazyColumnDefaultsTest_responsive[2]_samsunggalaxywatch6large.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fdd2141ad8307158f7164fcf9e327ccf64ca2361a68d64df773df6fd861efc6b
-size 43534

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_ScalingLazyColumnDefaultsTest_responsive[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_ScalingLazyColumnDefaultsTest_responsive[2]_samsunggalaxywatch6large.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a1ded42ecacefe260394f1026a2582e565efc0c81b51e72efed70f83ec03087
+size 43603

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_ScalingLazyColumnDefaultsTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_ScalingLazyColumnDefaultsTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8caafa7c2b3f44547fe75104709729e265f5201dad1ee11b0addb57bf6d357d
+size 41711

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_ScalingLazyColumnDefaultsTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_ScalingLazyColumnDefaultsTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:77decfbeaa71ccea9429b8d17f0fe74508b39e4cea8a742bef9164bf78f050a0
-size 40977

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_SectionedListDefaultTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_SectionedListDefaultTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82384a3c940dccd81f56282253df53e2dbd922bc160b0d118423dac90e398409
+size 37153

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_SectionedListDefaultTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_SectionedListDefaultTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:45c6aabe819955093ec3f4d5672c698706ddc19f4d7a5be6c995e2ddbef38085
-size 36951

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_SectionedListTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_SectionedListTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac1b6e06d38c188358b23f3cd51f39904e920125812f9a71aa3168e59c87038b
+size 41187

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_SectionedListTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_SectionedListTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1486726592ba723113da71d422d7755e12879602caafdc01bfc2ea1a429c28db
-size 40216

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_TimePicker12Test_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_TimePicker12Test_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c1f064ebfe5f57f76f11bca94fa933be137e4e141b69e0811e571a833805b47c
-size 22148

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_TimePicker12Test_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_TimePicker12Test_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7462a0ab48c490369ed8feb8441afe5d95efe299a247d90d77c572eed2f52974
+size 27300

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_TimePickerTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_TimePickerTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2197688501b719adf82bacf68a59b6f637a934feb1c77a63c7e45c78bfe6fc91
+size 25339

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_TimePickerTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_TimePickerTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:abb614ed70c8b7abcc8d72d183f7df11fd508b780cef8b2dfbc73ea93a1c6491
-size 20260

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_VolumeScreenTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_VolumeScreenTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7e6266fd1f6fc5d15810de147d42a2320b7b1aed980db1d876dd07ef171a16e4
-size 17918

--- a/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_VolumeScreenTest_screenshot[2]_samsunggalaxywatch6large.png
+++ b/sample/src/test/snapshots/images/com.google.android.horologist.screensizes_VolumeScreenTest_screenshot[2]_samsunggalaxywatch6large.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4670cc3a8cf086f6ad0412a96abe3d5cffbcc6bb9f5b2c0908b729514503b92f
+size 21686


### PR DESCRIPTION
#### WHAT

Fix density handling in robolectric screenshot tests.

#### WHY

Current code doesn't correctly handle the Samsung device with a density > 2

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
