### PR TITLE
Change datalayer sample app to use available API

### DIFF
--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/MainActivity.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/MainActivity.kt
@@ -49,7 +49,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.lifecycleScope
 import com.google.android.horologist.data.ProtoDataStoreHelper.protoDataStore
 import com.google.android.horologist.data.WearDataLayerRegistry
-import com.google.android.horologist.data.WearableApiAvailability
 import com.google.android.horologist.data.apphelper.AppHelperNodeStatus
 import com.google.android.horologist.data.apphelper.AppInstallationStatus
 import com.google.android.horologist.data.apphelper.AppInstallationStatusNodeType
@@ -96,7 +95,7 @@ class MainActivity : ComponentActivity() {
                     var apiAvailable by remember { mutableStateOf(false) }
                     LaunchedEffect(Unit) {
                         coroutineScope.launch {
-                            apiAvailable = WearableApiAvailability.isAvailable(registry.dataClient)
+                            apiAvailable = phoneDataLayerAppHelper.isAvailable()
                             nodeList =
                                 if (apiAvailable) phoneDataLayerAppHelper.connectedNodes() else listOf()
                         }


### PR DESCRIPTION
#### WHAT

Change datalayer sample app to use available API.

#### WHY

Showcase the available API + convenience.

#### HOW

Change sample to use API from `PhoneDataLayerAppHelper` instead of `WearableApiAvailability`.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
