### PR TITLE
Update datalayer helpers guide

### DIFF
--- a/docs/datalayer-helpers-guide.md
+++ b/docs/datalayer-helpers-guide.md
@@ -120,10 +120,10 @@ phone.
     user the option to navigate to the companion app to install it:
 
     ```kotlin
-    if (node.installedTiles.isEmpty() && askUserAttempts < MAX_ATTEMPTS) {
+    if (node.surfacesInfo.tilesList.isEmpty() && askUserAttempts < MAX_ATTEMPTS) {
         // Show guidance to the user and then launch companion
         // to allow the to install the Tile.
-        val result = appHelper.startCompanion(nodeStatus.id)
+        val result = appHelper.startCompanion(node.id)
     }
     ```
 


### PR DESCRIPTION
#### WHAT

Update datalayer helpers guide.

#### WHY

In order to use the property available in `AppHelperNodeStatus`.

#### HOW

Call `AppHelperNodeStatus.surfacesInfo.tilesList` instead of `installedTiles` property that was removed in 
[#1085](https://github.com/google/horologist/pull/1085/files#diff-159d00e793a3be99febff98ea77bad8d371fbb09d5e4116abd43384c17ce466fL28).

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [N/A] Run tests
- [N/A] Update metalava's signature text files
