### PR TITLE
Rename SurfacesInfoSerializer

### DIFF
--- a/datalayer/core/api/current.api
+++ b/datalayer/core/api/current.api
@@ -183,12 +183,12 @@ package com.google.android.horologist.data.apphelper {
   public static final class DataLayerAppHelperService.Companion {
   }
 
-  public final class SurfaceInfoSerializer implements androidx.datastore.core.Serializer<error.NonExistentClass> {
+  public final class SurfacesInfoSerializer implements androidx.datastore.core.Serializer<error.NonExistentClass> {
     method public error.NonExistentClass! getDefaultValue();
     method public suspend Object? readFrom(java.io.InputStream input, kotlin.coroutines.Continuation<? super error.NonExistentClass>);
     method public suspend Object? writeTo(error.NonExistentClass t, java.io.OutputStream output, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     property public error.NonExistentClass! defaultValue;
-    field public static final com.google.android.horologist.data.apphelper.SurfaceInfoSerializer INSTANCE;
+    field public static final com.google.android.horologist.data.apphelper.SurfacesInfoSerializer INSTANCE;
   }
 
 }

--- a/datalayer/core/src/main/java/com/google/android/horologist/data/apphelper/DataLayerAppHelper.kt
+++ b/datalayer/core/src/main/java/com/google/android/horologist/data/apphelper/DataLayerAppHelper.kt
@@ -98,7 +98,7 @@ abstract class DataLayerAppHelper(
 
     private suspend fun getSurfaceStatus(nodeId: String) = registry.protoFlow(
         targetNodeId = TargetNodeId.SpecificNodeId(nodeId),
-        serializer = SurfaceInfoSerializer,
+        serializer = SurfacesInfoSerializer,
         path = SURFACE_INFO_PATH,
     ).first()
 

--- a/datalayer/core/src/main/java/com/google/android/horologist/data/apphelper/SurfacesInfoSerializer.kt
+++ b/datalayer/core/src/main/java/com/google/android/horologist/data/apphelper/SurfacesInfoSerializer.kt
@@ -23,7 +23,7 @@ import com.google.protobuf.InvalidProtocolBufferException
 import java.io.InputStream
 import java.io.OutputStream
 
-public object SurfaceInfoSerializer : Serializer<SurfacesInfo> {
+public object SurfacesInfoSerializer : Serializer<SurfacesInfo> {
     override val defaultValue: SurfacesInfo = SurfacesInfo.getDefaultInstance()
 
     override suspend fun readFrom(input: InputStream): SurfacesInfo =

--- a/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
+++ b/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
@@ -30,7 +30,7 @@ import com.google.android.horologist.data.UsageStatus
 import com.google.android.horologist.data.WearDataLayerRegistry
 import com.google.android.horologist.data.activityLaunched
 import com.google.android.horologist.data.apphelper.DataLayerAppHelper
-import com.google.android.horologist.data.apphelper.SurfaceInfoSerializer
+import com.google.android.horologist.data.apphelper.SurfacesInfoSerializer
 import com.google.android.horologist.data.companionConfig
 import com.google.android.horologist.data.complicationInfo
 import com.google.android.horologist.data.copy
@@ -56,11 +56,11 @@ public class WearDataLayerAppHelper(
 ) :
     DataLayerAppHelper(context, registry) {
 
-        private val surfaceInfoDataStore by lazy {
+        private val surfacesInfoDataStore by lazy {
             registry.protoDataStore(
                 path = DataLayerAppHelper.SURFACE_INFO_PATH,
                 coroutineScope = scope,
-                serializer = SurfaceInfoSerializer,
+                serializer = SurfacesInfoSerializer,
             )
         }
 
@@ -100,7 +100,7 @@ public class WearDataLayerAppHelper(
          * @param tileName The name of the tile.
          */
         public suspend fun markTileAsInstalled(tileName: String) {
-            surfaceInfoDataStore.updateData { info ->
+            surfacesInfoDataStore.updateData { info ->
                 val tile = tileInfo {
                     timestamp = System.currentTimeMillis().toProtoTimestamp()
                     name = tileName
@@ -118,7 +118,7 @@ public class WearDataLayerAppHelper(
          * Marks that the main activity has been launched at least once.
          */
         public suspend fun markActivityLaunchedOnce() {
-            surfaceInfoDataStore.updateData { info ->
+            surfacesInfoDataStore.updateData { info ->
                 info.copy {
                     val launchTimestamp = System.currentTimeMillis().toProtoTimestamp()
                     if (usageInfo.usageStatus == UsageStatus.USAGE_STATUS_UNSPECIFIED) {
@@ -145,7 +145,7 @@ public class WearDataLayerAppHelper(
          * use. Typically this should be called when any pairing/login has been completed.
          */
         public suspend fun markSetupComplete() {
-            surfaceInfoDataStore.updateData { info ->
+            surfacesInfoDataStore.updateData { info ->
                 info.copy {
                     if (usageInfo.usageStatus != UsageStatus.USAGE_STATUS_SETUP_COMPLETE) {
                         usageInfo = usageInfo {
@@ -163,7 +163,7 @@ public class WearDataLayerAppHelper(
          * had previously been completed, but will have no effect if this is not the case.
          */
         public suspend fun markSetupNoLongerComplete() {
-            surfaceInfoDataStore.updateData { info ->
+            surfacesInfoDataStore.updateData { info ->
                 info.copy {
                     if (usageInfo.usageStatus == UsageStatus.USAGE_STATUS_SETUP_COMPLETE) {
                         usageInfo = usageInfo {
@@ -182,7 +182,7 @@ public class WearDataLayerAppHelper(
          * @param tileName The name of the tile.
          */
         public suspend fun markTileAsRemoved(tileName: String) {
-            surfaceInfoDataStore.updateData { info ->
+            surfacesInfoDataStore.updateData { info ->
                 val tile = tileInfo {
                     timestamp = System.currentTimeMillis().toProtoTimestamp()
                     name = tileName
@@ -210,7 +210,7 @@ public class WearDataLayerAppHelper(
             complicationInstanceId: Int,
             complicationType: ComplicationType,
         ) {
-            surfaceInfoDataStore.updateData { info ->
+            surfacesInfoDataStore.updateData { info ->
                 val complication = complicationInfo {
                     timestamp = System.currentTimeMillis().toProtoTimestamp()
                     name = complicationName
@@ -239,7 +239,7 @@ public class WearDataLayerAppHelper(
             complicationInstanceId: Int,
             complicationType: ComplicationType,
         ) {
-            surfaceInfoDataStore.updateData { info ->
+            surfacesInfoDataStore.updateData { info ->
                 val complication = complicationInfo {
                     timestamp = System.currentTimeMillis().toProtoTimestamp()
 


### PR DESCRIPTION
#### WHAT

Rename `SurfacesInfoSerializer`.

#### WHY

in order to match the name of `SurfacesInfo` object.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
