### PR TITLE
Fix crash with Rotary input and empty visible items

### DIFF
--- a/composables/src/main/java/com/google/android/horologist/composables/picker/PickerRotaryScrollAdapter.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/picker/PickerRotaryScrollAdapter.kt
@@ -42,7 +42,7 @@ internal class PickerRotaryScrollAdapter(
      */
     override fun averageItemSize(): Float =
         scrollableState.scalingLazyListState
-            .layoutInfo.visibleItemsInfo.first().unadjustedSize.toFloat()
+            .layoutInfo.visibleItemsInfo.firstOrNull()?.unadjustedSize?.toFloat() ?: 0f
 
     /**
      * Current (centred) item index
@@ -81,7 +81,7 @@ internal class AndroidxPickerRotaryScrollAdapter(
      */
     override fun averageItemSize(): Float =
         scrollableState.scalingLazyListState
-            .layoutInfo.visibleItemsInfo.first().unadjustedSize.toFloat()
+            .layoutInfo.visibleItemsInfo.firstOrNull()?.unadjustedSize?.toFloat() ?: 0f
 
     /**
      * Current (centred) item index


### PR DESCRIPTION

#### WHAT
Crash was fixed Bug: b/305901991

#### WHY
Way to reproduce it : continuously scroll rsb and open new screen which has picker in it. Before picker is initialised, if it receives a rotary event , it crashes.
Another way to test is to revert changes in PickerRotaryScrollAdapter and launch RotaryInteractionTest.scrollPicker_receiveRotaryEventsBeforeInitialisation test. 

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
