### PR TITLE
Improve datalayer guide

### DIFF
--- a/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
+++ b/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
@@ -58,7 +58,7 @@ public class WearDataLayerAppHelper(
 
         private val surfacesInfoDataStore by lazy {
             registry.protoDataStore(
-                path = DataLayerAppHelper.SURFACE_INFO_PATH,
+                path = SURFACE_INFO_PATH,
                 coroutineScope = scope,
                 serializer = SurfacesInfoSerializer,
             )

--- a/docs/datalayer-helpers-guide.md
+++ b/docs/datalayer-helpers-guide.md
@@ -68,6 +68,14 @@ phone.
                     seconds: 1680016845
                 }
             }
+            usage_info {
+                timestamp {
+                    nanos: 669000000
+                    seconds: 1701708501
+                }
+                usage_status: USAGE_STATUS_LAUNCHED_ONCE
+                usage_status_value: 1
+            }
     )
     ```
 
@@ -161,11 +169,18 @@ phone.
 
 1. **Tracking the main activity has been launched at least once** (Wear-only)
 
-   To determine if your main activity has been launched once, use: 
+   To mark that your main activity on the watch app has been launched once, use: 
 
-   ```kotlin
+    ```kotlin
     wearAppHelper.markActivityLaunchedOnce()
-    ```    
+    ```
+
+    To check it on the phone side, use:
+    ```kotlin
+    val connectedNodes = appHelper.connectedNodes()
+    // after picking a node, check if value is USAGE_STATUS_LAUNCHED_ONCE:
+    node.surfacesInfo.usageInfo.usageStatus
+    ```
 
 1.  **Tracking the app has been set up** (Wear-only)
 
@@ -182,3 +197,10 @@ phone.
     wearAppHelper.markSetupNoLongerComplete()
     ```
 
+    To check it on the phone side, use:
+    ```kotlin
+    val connectedNodes = appHelper.connectedNodes()
+    // after picking a node, check if value is either USAGE_STATUS_LAUNCHED_ONCE
+    // or USAGE_STATUS_SETUP_COMPLETE
+    node.surfacesInfo.usageInfo.usageStatus
+    ```


### PR DESCRIPTION
#### WHAT

Improve datalayer guide:
- add `usage_info` information returned in `AppHelperNodeStatus`.
- improve sample code to show how to check the usage status.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [N/A] Run spotless check
- [N/A] Run tests
- [N/A] Update metalava's signature text files
