### PR TITLE
Adds iconSlot to MarqueeText

### DIFF
--- a/composables/api/current.api
+++ b/composables/api/current.api
@@ -6,7 +6,7 @@ package com.google.android.horologist.composables {
   }
 
   public final class MarqueeTextKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void MarqueeText(String text, optional androidx.compose.ui.Modifier modifier, optional long color, optional androidx.compose.ui.text.TextStyle style, optional int textAlign, optional float followGap, optional float edgeGradientWidth, optional float marqueeDpPerSecond, optional long pauseTime);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void MarqueeText(String text, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit>? iconSlot, optional long color, optional androidx.compose.ui.text.TextStyle style, optional int textAlign, optional float followGap, optional float edgeGradientWidth, optional float marqueeDpPerSecond, optional long pauseTime);
   }
 
   public final class PlaceholderChipKt {

--- a/composables/src/debug/java/com/google/android/horologist/composables/MarqueeTextPreview.kt
+++ b/composables/src/debug/java/com/google/android/horologist/composables/MarqueeTextPreview.kt
@@ -16,12 +16,17 @@
 
 package com.google.android.horologist.composables
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FireTruck
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.LayoutDirection
@@ -83,6 +88,27 @@ fun MarqueeTextShortTextRtlPreview() {
 fun MarqueeTextConstantScrollingPreview() {
     MarqueeText(
         text = "A very long text strings",
+        modifier = Modifier
+            .background(Color.DarkGray)
+            .width(100.dp),
+        textAlign = TextAlign.Center,
+        pauseTime = 0.seconds,
+    )
+}
+
+@WearPreview
+@Composable
+fun MarqueeTextConstantWithIconScrollingPreview() {
+    MarqueeText(
+        text = "A very long text strings",
+        iconSlot = {
+            Image(
+                imageVector = Icons.Default.FireTruck,
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(Color.White),
+                contentScale = ContentScale.FillHeight,
+            )
+        },
         modifier = Modifier
             .background(Color.DarkGray)
             .width(100.dp),

--- a/composables/src/main/java/com/google/android/horologist/composables/MarqueeText.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/MarqueeText.kt
@@ -21,13 +21,21 @@ package com.google.android.horologist.composables
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.MarqueeSpacing
 import androidx.compose.foundation.basicMarquee
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
@@ -36,6 +44,7 @@ import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layout
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -76,6 +85,7 @@ import kotlin.time.Duration.Companion.seconds
 public fun MarqueeText(
     text: String,
     modifier: Modifier = Modifier,
+    iconSlot: (@Composable () -> Unit)? = null,
     color: Color = Color.Unspecified,
     style: TextStyle = LocalTextStyle.current,
     textAlign: TextAlign = TextAlign.Left,
@@ -86,24 +96,48 @@ public fun MarqueeText(
 ) {
     val controller = remember(text, style) { MarqueeController(edgeGradientWidth) }
     controller.edgeGradientWidth = edgeGradientWidth
+    val parentModifier = modifier
+        .then(controller.outsideMarqueeModifier)
+        .basicMarquee(
+            iterations = Int.MAX_VALUE,
+            delayMillis = pauseTime.inWholeMilliseconds.toInt(),
+            initialDelayMillis = pauseTime.inWholeMilliseconds.toInt(),
+            spacing = MarqueeSpacing(followGap),
+            velocity = marqueeDpPerSecond,
+        )
+        .then(controller.insideMarqueeModifier)
 
-    Text(
-        text = text,
-        modifier = modifier
-            .then(controller.outsideMarqueeModifier)
-            .basicMarquee(
-                iterations = Int.MAX_VALUE,
-                delayMillis = pauseTime.inWholeMilliseconds.toInt(),
-                initialDelayMillis = pauseTime.inWholeMilliseconds.toInt(),
-                spacing = MarqueeSpacing(followGap),
-                velocity = marqueeDpPerSecond,
+    if (iconSlot != null) {
+        Row(
+            modifier = parentModifier.height(IntrinsicSize.Min).semantics(mergeDescendants = true) {},
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Box(
+                modifier = Modifier.fillMaxHeight(),
+                propagateMinConstraints = true,
+                contentAlignment = Alignment.Center,
+            ) {
+                iconSlot()
+            }
+            Text(
+                text = text,
+                textAlign = textAlign,
+                color = color,
+                style = style,
+                maxLines = 1,
             )
-            .then(controller.insideMarqueeModifier),
-        textAlign = textAlign,
-        color = color,
-        style = style,
-        maxLines = 1,
-    )
+        }
+    } else {
+        Text(
+            text = text,
+            modifier = parentModifier,
+            textAlign = textAlign,
+            color = color,
+            style = style,
+            maxLines = 1,
+        )
+    }
 }
 
 private class MarqueeController(edgeGradientWidth: Dp) {


### PR DESCRIPTION
#### WHAT
Adds the ability for `MarqueeText` to have an optional icon.
![image](https://github.com/google/horologist/assets/250887/e4bf1ad6-a48e-479a-a3f2-9f43b31ddf7a)

#### WHY
The icon can be used in media apps to add additional context to the title.

#### HOW
By adding an `iconSlot` composable parameter.

#### Checklist :clipboard:
- [X] Add explicit visibility modifier and explicit return types for public declarations
- [X] Run spotless check
- [X] Run tests
- [X] Update metalava's signature text files
