### PR TITLE
Adds icon to MediaUiModel and display components

### DIFF
--- a/media/ui/api/current.api
+++ b/media/ui/api/current.api
@@ -125,7 +125,7 @@ package com.google.android.horologist.media.ui.components.animated {
   }
 
   public final class MarqueeTextMediaDisplayKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void MarqueeTextMediaDisplay(optional androidx.compose.ui.Modifier modifier, optional String? title, optional String? artist, optional int enterTransitionDelay, optional int subtextTransitionDelay, optional @FloatRange(from=0.0, to=1.0) float transitionLength);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void MarqueeTextMediaDisplay(optional androidx.compose.ui.Modifier modifier, optional String? title, optional String? artist, optional com.google.android.horologist.images.base.paintable.Paintable? titleIcon, optional int enterTransitionDelay, optional int subtextTransitionDelay, optional @FloatRange(from=0.0, to=1.0) float transitionLength);
   }
 
 }
@@ -230,7 +230,7 @@ package com.google.android.horologist.media.ui.components.display {
   }
 
   public final class TextMediaDisplayKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void TextMediaDisplay(String title, String subtitle, optional androidx.compose.ui.Modifier modifier);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void TextMediaDisplay(String title, String subtitle, optional com.google.android.horologist.images.base.paintable.Paintable? titleIcon, optional androidx.compose.ui.Modifier modifier);
   }
 
   public final class TrackMediaDisplayKt {
@@ -769,25 +769,28 @@ package com.google.android.horologist.media.ui.state.model {
   }
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public final class MediaUiModel {
-    ctor public MediaUiModel(String id, String title, optional String subtitle, optional String? artworkUri, optional androidx.compose.ui.graphics.Color? artworkColor);
+    ctor public MediaUiModel(String id, String title, optional String subtitle, optional String? artworkUri, optional androidx.compose.ui.graphics.Color? artworkColor, optional com.google.android.horologist.images.base.paintable.Paintable? titleIcon);
     method public String component1();
     method public String component2();
     method public String component3();
     method public String? component4();
     method public androidx.compose.ui.graphics.Color? component5-QN2ZGVo();
-    method public com.google.android.horologist.media.ui.state.model.MediaUiModel copy-6nskv5g(String id, String title, String subtitle, String? artworkUri, androidx.compose.ui.graphics.Color? artworkColor);
+    method public com.google.android.horologist.images.base.paintable.Paintable? component6();
+    method public com.google.android.horologist.media.ui.state.model.MediaUiModel copy-gCxFOHY(String id, String title, String subtitle, String? artworkUri, androidx.compose.ui.graphics.Color? artworkColor, com.google.android.horologist.images.base.paintable.Paintable? titleIcon);
     method public androidx.compose.ui.graphics.Color? getArtworkColor();
     method public String? getArtworkUri();
     method public String getId();
     method public boolean getLoading();
     method public String getSubtitle();
     method public String getTitle();
+    method public com.google.android.horologist.images.base.paintable.Paintable? getTitleIcon();
     property public final androidx.compose.ui.graphics.Color? artworkColor;
     property public final String? artworkUri;
     property public final String id;
     property public final boolean loading;
     property public final String subtitle;
     property public final String title;
+    property public final com.google.android.horologist.images.base.paintable.Paintable? titleIcon;
   }
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public abstract sealed class PlaylistDownloadUiModel {

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/components/animated/AnimatedMediaInfoDisplay.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/components/animated/AnimatedMediaInfoDisplay.kt
@@ -40,6 +40,7 @@ public fun AnimatedMediaInfoDisplay(
             modifier = modifier,
             title = media.title,
             artist = media.subtitle,
+            titleIcon = media.titleIcon,
         )
     } else {
         NothingPlayingDisplay(modifier)

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/components/animated/MarqueeTextMediaDisplay.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/components/animated/MarqueeTextMediaDisplay.kt
@@ -25,12 +25,15 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -38,6 +41,7 @@ import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.composables.MarqueeText
+import com.google.android.horologist.images.base.paintable.Paintable
 import kotlin.math.roundToInt
 
 /**
@@ -49,6 +53,7 @@ public fun MarqueeTextMediaDisplay(
     modifier: Modifier = Modifier,
     title: String? = null,
     artist: String? = null,
+    titleIcon: Paintable? = null,
     enterTransitionDelay: Int = 60,
     subtextTransitionDelay: Int = 30,
     @FloatRange(from = 0.0, to = 1.0) transitionLength: Float = 0.125f,
@@ -71,7 +76,19 @@ public fun MarqueeTextMediaDisplay(
                 currentTitle ->
             MarqueeText(
                 text = currentTitle.orEmpty(),
-                modifier = Modifier.fillMaxWidth(0.7f).padding(top = 2.dp, bottom = .8.dp),
+                iconSlot = titleIcon?.let {
+                    {
+                        Image(
+                            painter = it.rememberPainter(),
+                            contentDescription = null,
+                            colorFilter = ColorFilter.tint(MaterialTheme.colors.onBackground),
+                            contentScale = ContentScale.FillHeight,
+                        )
+                    }
+                },
+                modifier = Modifier
+                    .fillMaxWidth(0.7f)
+                    .padding(top = 2.dp, bottom = .8.dp),
                 color = MaterialTheme.colors.onBackground,
                 style = MaterialTheme.typography.button,
                 textAlign = TextAlign.Center,
@@ -85,7 +102,9 @@ public fun MarqueeTextMediaDisplay(
         ) { currentArtist ->
             Text(
                 text = currentArtist.orEmpty(),
-                modifier = Modifier.fillMaxWidth(0.8f).padding(top = 2.dp, bottom = .6.dp),
+                modifier = Modifier
+                    .fillMaxWidth(0.8f)
+                    .padding(top = 2.dp, bottom = .6.dp),
                 color = MaterialTheme.colors.onBackground,
                 textAlign = TextAlign.Center,
                 overflow = TextOverflow.Ellipsis,

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/components/display/TextMediaDisplay.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/components/display/TextMediaDisplay.kt
@@ -16,18 +16,25 @@
 
 package com.google.android.horologist.media.ui.components.display
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.images.base.paintable.Paintable
 
 /**
  * A simple text only display showing artist and title in two separated rows.
@@ -37,20 +44,38 @@ import com.google.android.horologist.annotations.ExperimentalHorologistApi
 public fun TextMediaDisplay(
     title: String,
     subtitle: String,
+    titleIcon: Paintable? = null,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
-        Text(
-            text = title,
-            modifier = Modifier.fillMaxWidth(0.7f).padding(top = 2.dp, bottom = .8.dp),
-            color = MaterialTheme.colors.onBackground,
-            textAlign = TextAlign.Center,
-            maxLines = 1,
-            style = MaterialTheme.typography.button,
-        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth(0.7f)
+                .padding(top = 2.dp, bottom = .8.dp)
+                .semantics(mergeDescendants = true) {},
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            if (titleIcon != null) {
+                Image(
+                    painter = titleIcon.rememberPainter(),
+                    contentDescription = null,
+                    colorFilter = ColorFilter.tint(MaterialTheme.colors.onBackground),
+                    contentScale = ContentScale.FillHeight,
+                )
+            }
+            Text(
+                text = title,
+                color = MaterialTheme.colors.onBackground,
+                textAlign = TextAlign.Center,
+                maxLines = 1,
+                style = MaterialTheme.typography.button,
+            )
+        }
         Text(
             text = subtitle,
-            modifier = Modifier.fillMaxWidth(0.8f).padding(top = 2.dp, bottom = .6.dp),
+            modifier = Modifier
+                .fillMaxWidth(0.8f)
+                .padding(top = 2.dp, bottom = .6.dp),
             color = MaterialTheme.colors.onBackground,
             textAlign = TextAlign.Center,
             overflow = TextOverflow.Ellipsis,

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/components/display/TrackMediaDisplay.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/components/display/TrackMediaDisplay.kt
@@ -33,6 +33,7 @@ public fun TrackMediaDisplay(
     TextMediaDisplay(
         title = media.title,
         subtitle = media.subtitle,
+        titleIcon = media.titleIcon,
         modifier = modifier,
     )
 }

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/state/model/MediaUiModel.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/state/model/MediaUiModel.kt
@@ -18,6 +18,7 @@ package com.google.android.horologist.media.ui.state.model
 
 import androidx.compose.ui.graphics.Color
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.images.base.paintable.Paintable
 
 @ExperimentalHorologistApi
 public data class MediaUiModel(
@@ -26,6 +27,7 @@ public data class MediaUiModel(
     val subtitle: String = "",
     val artworkUri: String? = null,
     val artworkColor: Color? = null,
+    val titleIcon: Paintable? = null,
 ) {
     // Consider making this a field
     val loading: Boolean get() = title.isEmpty() && subtitle.isEmpty()


### PR DESCRIPTION
#### WHAT
#1863 follow-up, adds the icon to `MediaUiModel`.

#### WHY
Makes it possible for apps to add an icon next to the media title.

#### HOW
Adds `titleIcon` optional property to `MediaUiModel` and consumes it in `MarqueeTextMediaDisplay` and `TextMediaDisplay`.

#### Checklist :clipboard:
- [X] Add explicit visibility modifier and explicit return types for public declarations
- [X] Run spotless check
- [X] Run tests
- [X] Update metalava's signature text files
