### PR TITLE
Fix progress timestamp issue

### DIFF
--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/state/ProgressStateHolder.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/state/ProgressStateHolder.kt
@@ -60,12 +60,10 @@ internal class ProgressStateHolder(
     }
 
     suspend fun predictProgress(predictor: (Long) -> Float) = coroutineScope {
-        val timestamp = timestampProvider.getTimestamp()
-        val initialFrameTime = withFrameMillis { it }
+        val initialFrameTime = withFrameMillis { timestampProvider.getTimestamp() - it }
         do {
             withFrameMillis {
-                val frameTimeOffset = it - initialFrameTime
-                actual.value = predictor(timestamp + frameTimeOffset)
+                actual.value = predictor(initialFrameTime + it)
             }
         } while (isActive)
     }


### PR DESCRIPTION
#### WHAT
Fix and simplify the progress prediction timestamp calculation

#### WHY
In the previous version, when the screen went off, line 63 got the `timestamp`, then `withFrameMillis` suspended. On wakeup, the two timestamps `timestamp` and `initialFrameTime` were not consistent.

#### HOW
Merging the two variables to a single one fixes the problem.

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
