### PR TITLE
Update HorizontalPagerDefaults to use TweenSpec.

### DIFF
--- a/compose-layout/src/main/java/com/google/android/horologist/compose/pager/HorizontalPagerDefaults.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/pager/HorizontalPagerDefaults.kt
@@ -16,7 +16,7 @@
 
 package com.google.android.horologist.compose.pager
 
-import androidx.compose.animation.core.SpringSpec
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.gestures.snapping.SnapFlingBehavior
 import androidx.compose.foundation.pager.HorizontalPager
@@ -45,7 +45,7 @@ public object HorizontalPagerDefaults {
         return PagerDefaults.flingBehavior(
             state = pagerState,
             pagerSnapDistance = PagerSnapDistance.atMost(0),
-            snapAnimationSpec = SpringSpec(dampingRatio = 1f, stiffness = 200f),
+            snapAnimationSpec = tween(150, 0),
         )
     }
 }


### PR DESCRIPTION
The default Pager animation spec takes longer to settle and consumes taps, which makes the UI seem unresponsive.

Bug: 303807950

#### WHAT


#### WHY


#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
