### PR TITLE
Add surfacesInfo property to WearDataLayerAppHelper

### DIFF
--- a/datalayer/watch/api/current.api
+++ b/datalayer/watch/api/current.api
@@ -3,6 +3,7 @@ package com.google.android.horologist.datalayer.watch {
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public final class WearDataLayerAppHelper extends com.google.android.horologist.data.apphelper.DataLayerAppHelper {
     ctor public WearDataLayerAppHelper(android.content.Context context, com.google.android.horologist.data.WearDataLayerRegistry registry, kotlinx.coroutines.CoroutineScope scope, optional String? appStoreUri);
+    method public kotlinx.coroutines.flow.Flow<com.google.android.horologist.data.SurfacesInfo> getSurfacesInfo();
     method public suspend Object? installOnNode(String node, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? markActivityLaunchedOnce(kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? markComplicationAsActivated(String complicationName, int complicationInstanceId, androidx.wear.watchface.complications.data.ComplicationType complicationType, kotlin.coroutines.Continuation<? super kotlin.Unit>);
@@ -12,6 +13,7 @@ package com.google.android.horologist.datalayer.watch {
     method public suspend Object? markTileAsInstalled(String tileName, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? markTileAsRemoved(String tileName, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method @CheckResult public suspend Object? startCompanion(String node, kotlin.coroutines.Continuation<? super com.google.android.horologist.data.AppHelperResultCode>);
+    property public final kotlinx.coroutines.flow.Flow<com.google.android.horologist.data.SurfacesInfo> surfacesInfo;
   }
 
   public final class WearDataLayerAppHelperKt {

--- a/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
+++ b/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
@@ -25,6 +25,7 @@ import androidx.wear.watchface.complications.data.ComplicationType
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.data.AppHelperResultCode
 import com.google.android.horologist.data.ComplicationInfo
+import com.google.android.horologist.data.SurfacesInfo
 import com.google.android.horologist.data.TileInfo
 import com.google.android.horologist.data.UsageStatus
 import com.google.android.horologist.data.WearDataLayerRegistry
@@ -39,6 +40,7 @@ import com.google.android.horologist.data.tileInfo
 import com.google.android.horologist.data.usageInfo
 import com.google.protobuf.Timestamp
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.guava.await
 import kotlinx.coroutines.tasks.await
 
@@ -63,6 +65,11 @@ public class WearDataLayerAppHelper(
                 serializer = SurfacesInfoSerializer,
             )
         }
+
+        /**
+         * Return the [SurfacesInfo] of this node.
+         */
+        public val surfacesInfo: Flow<SurfacesInfo> = surfacesInfoDataStore.data
 
         override suspend fun installOnNode(node: String) {
             checkIsForegroundOrThrow()


### PR DESCRIPTION
#### WHAT

Add `surfacesInfo` property to `WearDataLayerAppHelper`.

#### WHY

Convenience property to check the information about itself.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
