### PR TITLE
Fix crash with instrumentation tests

### DIFF
--- a/datalayer/sample/wear/build.gradle.kts
+++ b/datalayer/sample/wear/build.gradle.kts
@@ -172,6 +172,8 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.truth)
     testImplementation(libs.robolectric)
+
+    androidTestImplementation(libs.androidx.test.runner)
 }
 
 tasks.maybeCreate("prepareKotlinIdeaImport")


### PR DESCRIPTION
#### WHAT

Fix crash with instrumentation tests for datalayer wear sample app.


#### WHY

It is crashing since https://github.com/google/horologist/pull/1885.

```
> Task :datalayer:sample:wear:connectedDebugAndroidTest
Starting 0 tests on test(AVD) - 11
Test run failed to complete. Instrumentation run failed due to Process crashed.
Logcat of last crash: 
Process: com.google.android.horologist.datalayer.sample.debug, PID: 5748
java.lang.RuntimeException: Unable to instantiate instrumentation ComponentInfo{com.google.android.horologist.datalayer.sample.debug.test/androidx.test.runner.AndroidJUnitRunner}: java.lang.ClassNotFoundException: Didn't find class "androidx.test.runner.AndroidJUnitRunner" on path: DexPathList[[zip file "/system/framework/android.test.runner.jar", zip file "/system/framework/android.test.mock.jar", zip file "/system/framework/android.test.base.jar", zip file "/data/app/~~blUH-Ldoy7wb2wOnLzyglw==/com.google.android.horologist.datalayer.sample.debug.test-IDTO8wPxif9FPcNAYSTJqg==/base.apk", zip file "/data/app/~~safyihv_yLuzrI_Sa-_1lA==/com.google.android.horologist.datalayer.sample.debug-O04ePjRfY5w-Px5-q9i-_w==/base.apk"],nativeLibraryDirectories=[/system/lib, /system_ext/lib]]
	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6651)
	at android.app.ActivityThread.access$1300(ActivityThread.java:237)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1913)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loop(Looper.java:223)
	at android.app.ActivityThread.main(ActivityThread.java:7660)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
Caused by: java.lang.ClassNotFoundException: Didn't find class "androidx.test.runner.AndroidJUnitRunner" on path: DexPathList[[zip file "/system/framework/android.test.runner.jar", zip file "/system/framework/android.test.mock.jar", zip file "/system/framework/android.test.base.jar", zip file "/data/app/~~blUH-Ldoy7wb2wOnLzyglw==/com.google.android.horologist.datalayer.sample.debug.test-IDTO8wPxif9FPcNAYSTJqg==/base.apk", zip file "/data/app/~~safyihv_yLuzrI_Sa-_1lA==/com.google.android.horologist.datalayer.sample.debug-O04ePjRfY5w-Px5-q9i-_w==/base.apk"],nativeLibraryDirectories=[/system/lib, /system_ext/lib]]
	at dalvik.system.BaseDexClassLoader.findClass(BaseDexClassLoader.java:207)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:379)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:312)
	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6647)
	... 8 more


> Task :datalayer:sample:wear:connectedDebugAndroidTest FAILED
```


#### HOW

Add `androidx.test:runner` dependency to androidTest.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
