### PR TITLE
Add app helper nodes actions screen to datalayer wear sample

### DIFF
--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/Screen.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/Screen.kt
@@ -17,6 +17,7 @@
 package com.google.android.horologist.datalayer.sample
 
 import com.google.android.horologist.datalayer.sample.screens.info.infoScreenRoute
+import com.google.android.horologist.datalayer.sample.screens.nodesactions.nodeDetailsScreenRoute
 
 sealed class Screen(
     val route: String,
@@ -28,5 +29,8 @@ sealed class Screen(
 
     data object AppHelperTrackingScreen : Screen("appHelperTrackingScreen")
     data object AppHelperNodesActionsScreen : Screen("appHelperNodesActionsScreen")
+
+    data object AppHelperNodeDetailsScreen : Screen(nodeDetailsScreenRoute)
+
     data object InfoScreen : Screen(infoScreenRoute)
 }

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/WearApp.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/WearApp.kt
@@ -35,6 +35,8 @@ import com.google.android.horologist.datalayer.sample.screens.info.infoScreen
 import com.google.android.horologist.datalayer.sample.screens.info.navigateToInfoScreen
 import com.google.android.horologist.datalayer.sample.screens.nodes.DataLayerNodesScreen
 import com.google.android.horologist.datalayer.sample.screens.nodesactions.NodesActionsScreen
+import com.google.android.horologist.datalayer.sample.screens.nodesactions.navigateToNodeDetailsScreen
+import com.google.android.horologist.datalayer.sample.screens.nodesactions.nodeDetailsScreen
 import com.google.android.horologist.datalayer.sample.screens.tracking.TrackingScreen
 
 @Composable
@@ -88,9 +90,13 @@ fun WearApp(
                 val columnState = rememberColumnState()
 
                 ScreenScaffold(scrollState = columnState) {
-                    NodesActionsScreen(columnState = columnState)
+                    NodesActionsScreen(
+                        onNodeClick = navController::navigateToNodeDetailsScreen,
+                        columnState = columnState,
+                    )
                 }
             }
+            nodeDetailsScreen()
             infoScreen(
                 onDismissClick = navController::popBackStack,
             )

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/info/InfoScreen.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/info/InfoScreen.kt
@@ -64,7 +64,7 @@ fun InfoScreen(
         item {
             Button(
                 imageVector = Icons.Default.Done,
-                contentDescription = stringResource(id = R.string.info_done_button_content_description),
+                contentDescription = stringResource(id = R.string.close_button_content_description),
                 onClick = onDismissClick,
                 modifier = Modifier.padding(top = 10.dp),
             )

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsScreen.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsScreen.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.datalayer.sample.screens.nodesactions
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.wear.compose.material.Text
+import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.layout.belowTimeTextPreview
+import com.google.android.horologist.compose.material.Chip
+import com.google.android.horologist.datalayer.sample.R
+
+@Composable
+fun NodeDetailsScreen(
+    columnState: ScalingLazyColumnState,
+    modifier: Modifier = Modifier,
+    viewModel: NodeDetailsViewModel = hiltViewModel(),
+) {
+    NodeDetailsScreen(
+        nodeId = viewModel.nodeId,
+        onStartCompanionClick = viewModel::onStartCompanionClick,
+        onInstallOnNodeClick = viewModel::onInstallOnNodeClick,
+        onStartRemoteOwnAppClick = viewModel::onStartRemoteOwnAppClick,
+        columnState = columnState,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun NodeDetailsScreen(
+    nodeId: String,
+    onStartCompanionClick: () -> Unit,
+    onInstallOnNodeClick: () -> Unit,
+    onStartRemoteOwnAppClick: () -> Unit,
+    columnState: ScalingLazyColumnState,
+    modifier: Modifier = Modifier,
+) {
+    ScalingLazyColumn(
+        columnState = columnState,
+        modifier = modifier.fillMaxSize(),
+    ) {
+        item {
+            Text(
+                text = stringResource(id = R.string.node_details_header),
+                modifier = Modifier.padding(bottom = 10.dp),
+            )
+        }
+
+        item {
+            Text(
+                text = stringResource(id = R.string.node_details_id, nodeId),
+            )
+        }
+        item {
+            Chip(
+                label = stringResource(id = R.string.node_details_start_companion_chip_label),
+                onClick = onStartCompanionClick,
+            )
+        }
+        item {
+            Chip(
+                label = stringResource(id = R.string.node_details_install_on_node_chip_label),
+                onClick = onInstallOnNodeClick,
+            )
+        }
+        item {
+            Chip(
+                label = stringResource(id = R.string.node_details_start_remote_own_app_chip_label),
+                onClick = onStartRemoteOwnAppClick,
+            )
+        }
+    }
+}
+
+@WearPreviewDevices
+@Composable
+fun NodeDetailsScreenPreview() {
+    NodeDetailsScreen(
+        nodeId = "12345",
+        onStartCompanionClick = { },
+        onInstallOnNodeClick = { },
+        onStartRemoteOwnAppClick = { },
+        columnState = belowTimeTextPreview(),
+    )
+}

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsScreenNavigation.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsScreenNavigation.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.datalayer.sample.screens.nodesactions
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
+import androidx.navigation.navArgument
+import com.google.android.horologist.compose.navscaffold.scrollable
+import com.google.android.horologist.datalayer.sample.Screen
+import java.net.URLDecoder
+import java.net.URLEncoder
+
+private const val nodeIdArg = "nodeId"
+private const val routePrefix = "appHelperNodeDetailsScreen"
+
+private val URL_CHARACTER_ENCODING = Charsets.UTF_8.name()
+
+const val nodeDetailsScreenRoute = "$routePrefix/{$nodeIdArg}"
+
+internal class NodeDetailsScreenArgs(val nodeId: String) {
+    constructor(savedStateHandle: SavedStateHandle) :
+        this(URLDecoder.decode(checkNotNull(savedStateHandle[nodeIdArg]), URL_CHARACTER_ENCODING))
+}
+
+fun NavController.navigateToNodeDetailsScreen(message: String) {
+    val encodedMessage = URLEncoder.encode(message, URL_CHARACTER_ENCODING)
+    this.navigate("$routePrefix/$encodedMessage")
+}
+
+fun NavGraphBuilder.nodeDetailsScreen() {
+    scrollable(
+        route = Screen.AppHelperNodeDetailsScreen.route,
+        arguments = listOf(
+            navArgument(nodeIdArg) { type = NavType.StringType },
+        ),
+    ) {
+        NodeDetailsScreen(
+            columnState = it.columnState,
+        )
+    }
+}

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsViewModel.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsViewModel.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.datalayer.sample.screens.nodesactions
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.android.horologist.datalayer.watch.WearDataLayerAppHelper
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class NodeDetailsViewModel
+    @Inject
+    constructor(
+        savedStateHandle: SavedStateHandle,
+        private val wearDataLayerAppHelper: WearDataLayerAppHelper,
+    ) : ViewModel() {
+        private val nodeDetailsScreenArgs: NodeDetailsScreenArgs =
+            NodeDetailsScreenArgs(savedStateHandle)
+
+        val nodeId: String
+            get() = nodeDetailsScreenArgs.nodeId
+
+        fun onStartCompanionClick() {
+            viewModelScope.launch {
+                wearDataLayerAppHelper.startCompanion(node = nodeId)
+            }
+        }
+
+        fun onInstallOnNodeClick() {
+            viewModelScope.launch {
+                wearDataLayerAppHelper.installOnNode(node = nodeId)
+            }
+        }
+
+        fun onStartRemoteOwnAppClick() {
+            viewModelScope.launch {
+                wearDataLayerAppHelper.startRemoteOwnApp(node = nodeId)
+            }
+        }
+    }

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeUiModel.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeUiModel.kt
@@ -14,22 +14,17 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.datalayer.sample.screens.info
+package com.google.android.horologist.datalayer.sample.screens.nodesactions
 
-import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.ViewModel
-import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
+data class NodeUiModel(
+    val id: String,
+    val name: String,
+    val appInstalled: Boolean,
+    val type: NodeTypeUiModel,
+)
 
-@HiltViewModel
-class InfoScreenViewModel
-    @Inject
-    constructor(
-        savedStateHandle: SavedStateHandle,
-    ) : ViewModel() {
-
-        private val infoScreenArgs: InfoScreenArgs = InfoScreenArgs(savedStateHandle)
-
-        val message: String
-            get() = infoScreenArgs.message
-    }
+enum class NodeTypeUiModel {
+    WATCH,
+    PHONE,
+    UNKNOWN,
+}

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodesActionViewModel.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodesActionViewModel.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.datalayer.sample.screens.nodesactions
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.android.horologist.data.apphelper.AppInstallationStatus
+import com.google.android.horologist.data.apphelper.AppInstallationStatusNodeType
+import com.google.android.horologist.datalayer.watch.WearDataLayerAppHelper
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class NodesActionViewModel
+    @Inject
+    constructor(
+        private val wearDataLayerAppHelper: WearDataLayerAppHelper,
+    ) : ViewModel() {
+
+        private var initializeCalled = false
+
+        private val _uiState =
+            MutableStateFlow<NodesActionScreenState>(NodesActionScreenState.Idle)
+        public val uiState: StateFlow<NodesActionScreenState> = _uiState
+
+        fun initialize() {
+            if (initializeCalled) return
+            initializeCalled = true
+
+            _uiState.value = NodesActionScreenState.Loading
+
+            viewModelScope.launch {
+                if (!wearDataLayerAppHelper.isAvailable()) {
+                    _uiState.value = NodesActionScreenState.ApiNotAvailable
+                } else {
+                    loadNodes()
+                }
+            }
+        }
+
+        fun onRefreshClick() {
+            _uiState.value = NodesActionScreenState.Loading
+
+            viewModelScope.launch {
+                loadNodes()
+            }
+        }
+
+        private suspend fun loadNodes() {
+            _uiState.value = NodesActionScreenState.Loaded(
+                nodeList = wearDataLayerAppHelper.connectedNodes().map { node ->
+                    val type = when (node.appInstallationStatus) {
+                        is AppInstallationStatus.Installed -> {
+                            val status = node.appInstallationStatus as AppInstallationStatus.Installed
+                            when (status.nodeType) {
+                                AppInstallationStatusNodeType.WATCH -> NodeTypeUiModel.WATCH
+                                AppInstallationStatusNodeType.PHONE -> NodeTypeUiModel.PHONE
+                                AppInstallationStatusNodeType.UNKNOWN -> NodeTypeUiModel.UNKNOWN
+                            }
+                        }
+                        AppInstallationStatus.NotInstalled -> NodeTypeUiModel.UNKNOWN
+                    }
+
+                    NodeUiModel(
+                        id = node.id,
+                        name = node.displayName,
+                        appInstalled = node.appInstallationStatus is AppInstallationStatus.Installed,
+                        type = type,
+                    )
+                },
+            )
+        }
+    }
+
+sealed class NodesActionScreenState {
+    data object Idle : NodesActionScreenState()
+
+    data object Loading : NodesActionScreenState()
+
+    data class Loaded(val nodeList: List<NodeUiModel>) : NodesActionScreenState()
+
+    data object ApiNotAvailable : NodesActionScreenState()
+}

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodesActionsScreen.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodesActionsScreen.kt
@@ -16,23 +16,178 @@
 
 package com.google.android.horologist.datalayer.sample.screens.nodesactions
 
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DeviceUnknown
+import androidx.compose.material.icons.filled.PhoneAndroid
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Watch
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.wear.compose.foundation.lazy.items
+import androidx.wear.compose.material.CircularProgressIndicator
 import androidx.wear.compose.material.Text
+import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.layout.belowTimeTextPreview
+import com.google.android.horologist.compose.material.Chip
+import com.google.android.horologist.compose.material.CompactChip
+import com.google.android.horologist.datalayer.sample.R
+import com.google.android.horologist.images.base.paintable.ImageVectorPaintable
 
 @Composable
 fun NodesActionsScreen(
+    onNodeClick: (nodeId: String) -> Unit,
+    columnState: ScalingLazyColumnState,
+    modifier: Modifier = Modifier,
+    viewModel: NodesActionViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    if (state == NodesActionScreenState.Idle) {
+        viewModel.initialize()
+    }
+
+    NodesActionsScreen(
+        state = state,
+        onNodeClick = onNodeClick,
+        onRefreshClick = viewModel::onRefreshClick,
+        columnState = columnState,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun NodesActionsScreen(
+    state: NodesActionScreenState,
+    onNodeClick: (nodeId: String) -> Unit,
+    onRefreshClick: () -> Unit,
     columnState: ScalingLazyColumnState,
     modifier: Modifier = Modifier,
 ) {
     ScalingLazyColumn(
         columnState = columnState,
-        modifier = modifier,
+        modifier = modifier.fillMaxSize(),
     ) {
         item {
-            Text("To be implemented")
+            Text(
+                text = stringResource(id = R.string.nodes_actions_header),
+                modifier = Modifier.padding(bottom = 10.dp),
+            )
+        }
+        when (state) {
+            NodesActionScreenState.Idle,
+            NodesActionScreenState.Loading,
+            -> {
+                item {
+                    CircularProgressIndicator()
+                }
+            }
+
+            is NodesActionScreenState.Loaded -> {
+                if (state.nodeList.isNotEmpty()) {
+                    item {
+                        Text(stringResource(id = R.string.nodes_actions_message))
+                    }
+                    items(state.nodeList) { node ->
+                        val icon = when (node.type) {
+                            NodeTypeUiModel.WATCH -> Icons.Default.Watch
+                            NodeTypeUiModel.PHONE -> Icons.Default.PhoneAndroid
+                            NodeTypeUiModel.UNKNOWN -> Icons.Default.DeviceUnknown
+                        }
+
+                        Chip(
+                            label = node.name,
+                            onClick = { onNodeClick(node.id) },
+                            secondaryLabel = if (node.appInstalled) {
+                                stringResource(id = R.string.nodes_actions_app_installed_label)
+                            } else {
+                                stringResource(id = R.string.nodes_actions_app_not_installed_label)
+                            },
+                            icon = ImageVectorPaintable(imageVector = icon),
+                        )
+                    }
+                } else {
+                    item {
+                        Text(stringResource(id = R.string.nodes_actions_no_nodes))
+                    }
+                }
+
+                item {
+                    CompactChip(
+                        label = stringResource(id = R.string.nodes_actions_refresh_chip_label),
+                        onClick = onRefreshClick,
+                        icon = ImageVectorPaintable(imageVector = Icons.Default.Refresh),
+                    )
+                }
+            }
+
+            NodesActionScreenState.ApiNotAvailable -> {
+                item {
+                    Text(stringResource(id = R.string.wearable_message_api_unavailable))
+                }
+            }
         }
     }
+}
+
+@WearPreviewDevices
+@Composable
+fun NodesActionsScreenPreviewLoaded() {
+    NodesActionsScreen(
+        state = NodesActionScreenState.Loaded(
+            listOf(
+                NodeUiModel(
+                    id = "123",
+                    name = "Pixel Watch",
+                    appInstalled = true,
+                    type = NodeTypeUiModel.WATCH,
+                ),
+                NodeUiModel(
+                    id = "123",
+                    name = "Pixel 6 Pro",
+                    appInstalled = true,
+                    type = NodeTypeUiModel.PHONE,
+                ),
+                NodeUiModel(
+                    id = "123",
+                    name = "Unknown",
+                    appInstalled = false,
+                    type = NodeTypeUiModel.UNKNOWN,
+                ),
+            ),
+        ),
+        onNodeClick = { },
+        onRefreshClick = { },
+        columnState = belowTimeTextPreview(),
+    )
+}
+
+@WearPreviewDevices
+@Composable
+fun NodesActionsScreenPreviewEmptyNodes() {
+    NodesActionsScreen(
+        state = NodesActionScreenState.Loaded(emptyList()),
+        onNodeClick = { },
+        onRefreshClick = { },
+        columnState = belowTimeTextPreview(),
+    )
+}
+
+@WearPreviewDevices
+@Composable
+fun NodesActionsScreenPreviewApiNotAvailable() {
+    NodesActionsScreen(
+        state = NodesActionScreenState.ApiNotAvailable,
+        onNodeClick = { },
+        onRefreshClick = { },
+        columnState = belowTimeTextPreview(),
+    )
 }

--- a/datalayer/sample/wear/src/main/res/values/strings.xml
+++ b/datalayer/sample/wear/src/main/res/values/strings.xml
@@ -15,8 +15,12 @@
   -->
 
 <resources>
+    <!-- General -->
     <string name="app_name">Horologist Datalayer Sample</string>
+    <string name="close_button_content_description">Close</string>
+    <string name="wearable_message_api_unavailable">This device does not have capability to communicate to Wearable Data Layer API</string>
 
+    <!-- Main Menu screen -->
     <string name="main_menu_datalayer_header">Data Layer</string>
     <string name="main_menu_datalayer_counter_item">Counter</string>
     <string name="main_menu_datalayer_nodes_item">Data Layer Nodes</string>
@@ -25,14 +29,16 @@
     <string name="main_menu_apphelpers_tracking_item">Tracking</string>
     <string name="main_menu_apphelpers_nodes_actions_item">Nodes actions</string>
 
+    <!-- Counter screen -->
     <string name="server_counter_message">Value of the counter from Phone</string>
+
+    <!-- Data Layer screen -->
     <string name="data_layer_title">Data Layer</string>
     <string name="data_layer_missing_message">Missing</string>
     <string name="data_layer_error_message">Error: %1$s</string>
     <string name="data_layer_value_message">Value: %1$s</string>
 
-    <string name="info_done_button_content_description">Close</string>
-
+    <!-- App Helper Tracking screen -->
     <string name="apphelper_tracking_title">AppHelper Tracking</string>
     <string name="apphelper_tracking_message">Tap on an item to learn more about it.</string>
     <string name="apphelper_tracking_activity_launched_chip_label">Activity launched once</string>
@@ -45,4 +51,19 @@
     <string name="apphelper_tracking_complication_header">Complications</string>
     <string name="apphelper_tracking_complication_installation_chip_label">Installation status</string>
     <string name="apphelper_tracking_complication_installation_info">Indicates that complication with name %1$s is installed on this watch.</string>
+
+    <!-- App Helper Nodes Actions screen -->
+    <string name="nodes_actions_header">Nodes Actions</string>
+    <string name="nodes_actions_message">Tap on a node to display the list of actions:</string>
+    <string name="nodes_actions_no_nodes">No nodes were found.</string>
+    <string name="nodes_actions_app_installed_label">App installed</string>
+    <string name="nodes_actions_app_not_installed_label">App NOT installed</string>
+    <string name="nodes_actions_refresh_chip_label">Refresh</string>
+
+    <!-- App Helper Nodes Details screen -->
+    <string name="node_details_header">Node Details</string>
+    <string name="node_details_id">ID: %1$s</string>
+    <string name="node_details_start_companion_chip_label">Start companion</string>
+    <string name="node_details_install_on_node_chip_label">Install on node</string>
+    <string name="node_details_start_remote_own_app_chip_label">Start remote own app</string>
 </resources>


### PR DESCRIPTION
#### WHAT

Add app helper nodes actions screen to datalayer wear sample.

| ![Screenshot_20231220_104647](https://github.com/google/horologist/assets/878134/87bed874-f35b-423b-b0f3-22eca71f12a8) | ![Screenshot_20231220_104710](https://github.com/google/horologist/assets/878134/a4842a7f-213f-454c-9e0d-9218a9d54102) | 
|--------|--------|

#### WHY

Show case app helper features.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
