### PR TITLE
Update datalayer docs with capability setup step

### DIFF
--- a/datalayer/phone/src/res/values/wear.xml
+++ b/datalayer/phone/src/res/values/wear.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string-array name="android_wear_capabilities">
-        <!-- Used to indicate that the app is installed on this device -->
-        <item>data_layer_app_helper_device_phone</item>
-        <!-- Used to indicate the device is a phone -->
-        <item>horologist_phone</item>
-    </string-array>
-</resources>

--- a/datalayer/sample/wear/src/main/res/values/wear.xml
+++ b/datalayer/sample/wear/src/main/res/values/wear.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   ~ Copyright 2023 The Android Open Source Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,15 +14,11 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-
-<resources xmlns:tools="http://schemas.android.com/tools">
-    <string-array
-        name="android_wear_capabilities"
-        translatable="false"
-        tools:ignore="UnusedResources">
+<resources>
+    <string-array name="android_wear_capabilities">
         <!-- Used to indicate that the app is installed on this device -->
-        <item>data_layer_app_helper_device_phone</item>
-        <!-- Used to indicate the device is a phone -->
-        <item>horologist_phone</item>
+        <item>data_layer_app_helper_device_watch</item>
+        <!-- Used to indicate the device is a watch -->
+        <item>horologist_watch</item>
     </string-array>
 </resources>

--- a/datalayer/watch/src/main/res/values/wear.xml
+++ b/datalayer/watch/src/main/res/values/wear.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string-array name="android_wear_capabilities">
-        <!-- Used to indicate that the app is installed on this device -->
-        <item>data_layer_app_helper_device_watch</item>
-        <!-- Used to indicate the device is a watch -->
-        <item>horologist_watch</item>
-    </string-array>
-</resources>

--- a/docs/auth-tokenshare-guide.md
+++ b/docs/auth-tokenshare-guide.md
@@ -43,12 +43,16 @@ your phone and watch apps must:
     content:
 
     ```xml
-    <resources>
+    <resources xmlns:tools="http://schemas.android.com/tools"
+        tools:keep="@array/android_wear_capabilities">
         <string-array name="android_wear_capabilities">
             <item>horologist_phone</item>
         </string-array>
     </resources>
     ```
+    
+    For more details, see
+    [Specify capability names for detecting your apps](https://developer.android.com/training/wearables/apps/standalone-apps#capability-names).
 
 1.  Create a `WearDataLayerRegistry`
 

--- a/docs/datalayer-helpers-guide.md
+++ b/docs/datalayer-helpers-guide.md
@@ -25,6 +25,35 @@ phone.
 
     For your watch and phone projects respectively.
 
+1.  Add the capability
+
+    Add a `wear.xml` file in the `res/values` folder with the following content:
+
+    ```xml
+    <resources xmlns:tools="http://schemas.android.com/tools"
+        tools:keep="@array/android_wear_capabilities">
+        <string-array name="android_wear_capabilities">
+            <item>data_layer_app_helper_device_watch</item>
+        </string-array>
+    </resources>
+    ```
+
+    and
+
+    ```xml
+    <resources xmlns:tools="http://schemas.android.com/tools"
+        tools:keep="@array/android_wear_capabilities">
+        <string-array name="android_wear_capabilities">
+            <item>data_layer_app_helper_device_phone</item>
+        </string-array>
+    </resources>
+    ```
+
+    On your watch and phone projects respectively.
+
+    For more details, see
+    [Specify capability names for detecting your apps](https://developer.android.com/training/wearables/apps/standalone-apps#capability-names).
+
 1.  Initialize the client, including passing a `WearDataLayerRegistry`.
 
     ```kotlin


### PR DESCRIPTION
#### WHAT

Update datalayer docs with capability setup step. 
Add capability to sample apps.

#### WHY

Capabilities defined in `wear.xml` of libraries are not copied over to apps using the libraries.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
