### PR TITLE
Improve NodeDetailsScreen to show success/failure dialogs

### DIFF
--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsScreen.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsScreen.kt
@@ -18,18 +18,36 @@ package com.google.android.horologist.datalayer.sample.screens.nodesactions
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Done
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.wear.compose.material.CircularProgressIndicator
 import androidx.wear.compose.material.Text
+import androidx.wear.compose.material.dialog.Dialog
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.layout.belowTimeTextPreview
 import com.google.android.horologist.compose.material.Chip
+import com.google.android.horologist.compose.material.Confirmation
+import com.google.android.horologist.compose.material.Icon
+import com.google.android.horologist.compose.material.util.DECORATIVE_ELEMENT_CONTENT_DESCRIPTION
 import com.google.android.horologist.datalayer.sample.R
+import com.google.android.horologist.images.base.paintable.ImageVectorPaintable
 
 @Composable
 fun NodeDetailsScreen(
@@ -37,11 +55,15 @@ fun NodeDetailsScreen(
     modifier: Modifier = Modifier,
     viewModel: NodeDetailsViewModel = hiltViewModel(),
 ) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
     NodeDetailsScreen(
         nodeId = viewModel.nodeId,
+        state = state,
         onStartCompanionClick = viewModel::onStartCompanionClick,
         onInstallOnNodeClick = viewModel::onInstallOnNodeClick,
         onStartRemoteOwnAppClick = viewModel::onStartRemoteOwnAppClick,
+        onDialogDismiss = viewModel::onDialogDismiss,
         columnState = columnState,
         modifier = modifier,
     )
@@ -50,12 +72,18 @@ fun NodeDetailsScreen(
 @Composable
 fun NodeDetailsScreen(
     nodeId: String,
+    state: NodeDetailsScreenState,
     onStartCompanionClick: () -> Unit,
     onInstallOnNodeClick: () -> Unit,
     onStartRemoteOwnAppClick: () -> Unit,
+    onDialogDismiss: () -> Unit,
     columnState: ScalingLazyColumnState,
     modifier: Modifier = Modifier,
 ) {
+    var showSuccessDialog by rememberSaveable { mutableStateOf(false) }
+    var showFailureDialog by rememberSaveable { mutableStateOf(false) }
+    var errorCode by rememberSaveable { mutableStateOf("") }
+
     ScalingLazyColumn(
         columnState = columnState,
         modifier = modifier.fillMaxSize(),
@@ -72,22 +100,101 @@ fun NodeDetailsScreen(
                 text = stringResource(id = R.string.node_details_id, nodeId),
             )
         }
-        item {
-            Chip(
-                label = stringResource(id = R.string.node_details_start_companion_chip_label),
-                onClick = onStartCompanionClick,
+        when (state) {
+            NodeDetailsScreenState.Idle -> {
+                item {
+                    Chip(
+                        label = stringResource(id = R.string.node_details_start_companion_chip_label),
+                        onClick = onStartCompanionClick,
+                    )
+                }
+                item {
+                    Chip(
+                        label = stringResource(id = R.string.node_details_install_on_node_chip_label),
+                        onClick = onInstallOnNodeClick,
+                    )
+                }
+                item {
+                    Chip(
+                        label = stringResource(id = R.string.node_details_start_remote_own_app_chip_label),
+                        onClick = onStartRemoteOwnAppClick,
+                    )
+                }
+            }
+
+            NodeDetailsScreenState.ActionRunning -> {
+                item {
+                    CircularProgressIndicator(modifier = Modifier.padding(top = 10.dp))
+                }
+            }
+
+            NodeDetailsScreenState.ActionSucceeded -> {
+                item {
+                    CircularProgressIndicator(modifier = Modifier.padding(top = 10.dp))
+                }
+
+                showSuccessDialog = true
+            }
+
+            is NodeDetailsScreenState.ActionFailed -> {
+                item {
+                    CircularProgressIndicator(modifier = Modifier.padding(top = 10.dp))
+                }
+
+                showFailureDialog = true
+                errorCode = state.errorCode
+            }
+        }
+    }
+
+    Dialog(
+        showDialog = showSuccessDialog,
+        onDismissRequest = {
+            showSuccessDialog = false
+            onDialogDismiss()
+        },
+    ) {
+        Confirmation(onTimeout = {
+            showSuccessDialog = false
+            onDialogDismiss()
+        }) {
+            Icon(
+                paintable = ImageVectorPaintable(imageVector = Icons.Default.Done),
+                contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
+                modifier = Modifier
+                    .size(48.dp)
+                    .align(Alignment.CenterHorizontally),
+                tint = Color.Green,
+            )
+            Text(
+                stringResource(id = R.string.node_details_success_dialog_message),
+                textAlign = TextAlign.Center,
             )
         }
-        item {
-            Chip(
-                label = stringResource(id = R.string.node_details_install_on_node_chip_label),
-                onClick = onInstallOnNodeClick,
+    }
+
+    Dialog(
+        showDialog = showFailureDialog,
+        onDismissRequest = {
+            showFailureDialog = false
+            onDialogDismiss()
+        },
+    ) {
+        Confirmation(onTimeout = {
+            showFailureDialog = false
+            onDialogDismiss()
+        }) {
+            Icon(
+                paintable = ImageVectorPaintable(imageVector = Icons.Default.Close),
+                contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
+                modifier = Modifier
+                    .size(48.dp)
+                    .align(Alignment.CenterHorizontally),
+                tint = Color.Red,
             )
-        }
-        item {
-            Chip(
-                label = stringResource(id = R.string.node_details_start_remote_own_app_chip_label),
-                onClick = onStartRemoteOwnAppClick,
+            Text(
+                stringResource(id = R.string.node_details_failure_dialog_message, errorCode),
+                textAlign = TextAlign.Center,
             )
         }
     }
@@ -98,9 +205,11 @@ fun NodeDetailsScreen(
 fun NodeDetailsScreenPreview() {
     NodeDetailsScreen(
         nodeId = "12345",
+        state = NodeDetailsScreenState.Idle,
         onStartCompanionClick = { },
         onInstallOnNodeClick = { },
         onStartRemoteOwnAppClick = { },
+        onDialogDismiss = { },
         columnState = belowTimeTextPreview(),
     )
 }

--- a/datalayer/sample/wear/src/main/res/values/strings.xml
+++ b/datalayer/sample/wear/src/main/res/values/strings.xml
@@ -66,4 +66,6 @@
     <string name="node_details_start_companion_chip_label">Start companion</string>
     <string name="node_details_install_on_node_chip_label">Install on node</string>
     <string name="node_details_start_remote_own_app_chip_label">Start remote own app</string>
+    <string name="node_details_success_dialog_message">Success!</string>
+    <string name="node_details_failure_dialog_message">Failed: \n%1$s</string>
 </resources>


### PR DESCRIPTION
#### WHAT

Improve NodeDetailsScreen to show success/failure dialogs.

https://github.com/google/horologist/assets/878134/44cd77cd-f3a7-462e-8a42-dffb6006974e


#### WHY

Better UX.
App was crashing in scenarios described in https://github.com/google/horologist/issues/1902.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
