### PR TITLE
Add "start remote activity" action to NodeDetailsScreen

### DIFF
--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsScreen.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsScreen.kt
@@ -63,6 +63,7 @@ fun NodeDetailsScreen(
         onStartCompanionClick = viewModel::onStartCompanionClick,
         onInstallOnNodeClick = viewModel::onInstallOnNodeClick,
         onStartRemoteOwnAppClick = viewModel::onStartRemoteOwnAppClick,
+        onStartRemoteActivityClick = viewModel::onStartRemoteActivityClick,
         onDialogDismiss = viewModel::onDialogDismiss,
         columnState = columnState,
         modifier = modifier,
@@ -76,6 +77,7 @@ fun NodeDetailsScreen(
     onStartCompanionClick: () -> Unit,
     onInstallOnNodeClick: () -> Unit,
     onStartRemoteOwnAppClick: () -> Unit,
+    onStartRemoteActivityClick: () -> Unit,
     onDialogDismiss: () -> Unit,
     columnState: ScalingLazyColumnState,
     modifier: Modifier = Modifier,
@@ -118,6 +120,12 @@ fun NodeDetailsScreen(
                     Chip(
                         label = stringResource(id = R.string.node_details_start_remote_own_app_chip_label),
                         onClick = onStartRemoteOwnAppClick,
+                    )
+                }
+                item {
+                    Chip(
+                        label = stringResource(id = R.string.node_details_start_remote_activity_chip_label),
+                        onClick = onStartRemoteActivityClick,
                     )
                 }
             }
@@ -209,6 +217,7 @@ fun NodeDetailsScreenPreview() {
         onStartCompanionClick = { },
         onInstallOnNodeClick = { },
         onStartRemoteOwnAppClick = { },
+        onStartRemoteActivityClick = { },
         onDialogDismiss = { },
         columnState = belowTimeTextPreview(),
     )

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsViewModel.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsViewModel.kt
@@ -20,12 +20,16 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.android.horologist.data.AppHelperResultCode
+import com.google.android.horologist.data.activityConfig
 import com.google.android.horologist.datalayer.watch.WearDataLayerAppHelper
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+
+private const val REMOTE_ACTIVITY_SAMPLE_PACKAGE_NAME = "com.google.android.gm"
+private const val REMOTE_ACTIVITY_SAMPLE_CLASS_FULL_NAME = "com.google.android.gm.ConversationListActivityGmail"
 
 @HiltViewModel
 class NodeDetailsViewModel
@@ -67,6 +71,16 @@ class NodeDetailsViewModel
         fun onStartRemoteOwnAppClick() {
             runActionAndHandleAppHelperResult {
                 wearDataLayerAppHelper.startRemoteOwnApp(node = nodeId)
+            }
+        }
+
+        fun onStartRemoteActivityClick() {
+            runActionAndHandleAppHelperResult {
+                val config = activityConfig {
+                    packageName = REMOTE_ACTIVITY_SAMPLE_PACKAGE_NAME
+                    classFullName = REMOTE_ACTIVITY_SAMPLE_CLASS_FULL_NAME
+                }
+                wearDataLayerAppHelper.startRemoteActivity(nodeId, config)
             }
         }
 

--- a/datalayer/sample/wear/src/main/res/values/strings.xml
+++ b/datalayer/sample/wear/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="node_details_start_companion_chip_label">Start companion</string>
     <string name="node_details_install_on_node_chip_label">Install on node</string>
     <string name="node_details_start_remote_own_app_chip_label">Start remote own app</string>
+    <string name="node_details_start_remote_activity_chip_label">Start remote activity</string>
     <string name="node_details_success_dialog_message">Success!</string>
     <string name="node_details_failure_dialog_message">Failed: \n%1$s</string>
 </resources>


### PR DESCRIPTION
#### WHAT

Add "start remote activity" action to `NodeDetailsScreen`.

#### WHY

In order to showcase the functionality available in the API.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
