### PR TITLE
Make DataLayerAppHelper.startRemoteActivity more strict

### DIFF
--- a/datalayer/core/src/main/java/com/google/android/horologist/data/apphelper/DataLayerAppHelper.kt
+++ b/datalayer/core/src/main/java/com/google/android/horologist/data/apphelper/DataLayerAppHelper.kt
@@ -152,7 +152,10 @@ abstract class DataLayerAppHelper(
     abstract suspend fun startCompanion(node: String): AppHelperResultCode
 
     /**
-     * Launch an activity on the specified node.
+     * Launch an activity, which belongs to the same app (same package name), on the specified node.
+     *
+     * [Class name][ActivityConfig.getClassFullName] should be a fully qualified class name, such
+     * as, "com.example.project.SampleActivity".
      */
     @CheckResult
     public suspend fun startRemoteActivity(

--- a/datalayer/core/src/main/java/com/google/android/horologist/data/apphelper/DataLayerAppHelperService.kt
+++ b/datalayer/core/src/main/java/com/google/android/horologist/data/apphelper/DataLayerAppHelperService.kt
@@ -64,13 +64,14 @@ public abstract class DataLayerAppHelperService : WearableListenerService() {
     }
 
     /**
-     * Attempts to launch an activity on the device.
+     * Attempts to launch an activity, which belongs to the same app (same package name), on this
+     * device.
      */
     private fun launchActivity(activityConfig: ActivityConfig): AppHelperResultCode {
         try {
             val intent = Intent().apply {
-                setPackage(activityConfig.packageName)
-                setClassName(activityConfig.packageName, activityConfig.classFullName)
+                setPackage(packageName)
+                setClassName(packageName, activityConfig.classFullName)
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK
             }
             wakeDeviceAndStartActivity(intent)

--- a/datalayer/core/src/main/proto/app_helper_pb.proto
+++ b/datalayer/core/src/main/proto/app_helper_pb.proto
@@ -36,7 +36,7 @@ message CompanionConfig {
 }
 
 message ActivityConfig {
-  string packageName = 1;
+  reserved 1;
   string classFullName = 2;
 }
 

--- a/datalayer/sample/phone/src/main/AndroidManifest.xml
+++ b/datalayer/sample/phone/src/main/AndroidManifest.xml
@@ -42,6 +42,13 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".screens.startremote.StartRemoteSampleActivity"
+            android:exported="true"
+            android:taskAffinity=".main"
+            android:theme="@style/Theme.Horologist">
+        </activity>
+
         <service android:name=".grpc.WearCounterDataService" android:exported="true"
             tools:ignore="ExportedService">
             <intent-filter>

--- a/datalayer/sample/phone/src/main/AndroidManifest.xml
+++ b/datalayer/sample/phone/src/main/AndroidManifest.xml
@@ -44,7 +44,7 @@
 
         <activity
             android:name=".screens.startremote.StartRemoteSampleActivity"
-            android:exported="true"
+            android:exported="false"
             android:taskAffinity=".main"
             android:theme="@style/Theme.Horologist">
         </activity>

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/startremote/StartRemoteSampleActivity.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/startremote/StartRemoteSampleActivity.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.datalayer.sample.screens.startremote
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import com.google.android.horologist.datalayer.sample.R
+import com.google.android.horologist.datalayer.sample.ui.theme.HorologistTheme
+
+class StartRemoteSampleActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            HorologistTheme {
+                // A surface container using the 'background' color from the theme
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background,
+                ) {
+                    Box(modifier = Modifier.fillMaxSize()) {
+                        Text(
+                            text = stringResource(id = R.string.app_helper_start_remote_activity_message),
+                            modifier = Modifier.align(Alignment.Center),
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/datalayer/sample/phone/src/main/res/values/strings.xml
+++ b/datalayer/sample/phone/src/main/res/values/strings.xml
@@ -34,4 +34,6 @@
     <string name="app_helper_launch_button_label">Launch</string>
 
     <string name="app_helper_button_list_nodes">List connected nodes</string>
+
+    <string name="app_helper_start_remote_activity_message">This is a sample activity to demonstrate it being launched remotely from the watch.</string>
 </resources>

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsViewModel.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsViewModel.kt
@@ -28,8 +28,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-private const val REMOTE_ACTIVITY_SAMPLE_PACKAGE_NAME = "com.google.android.gm"
-private const val REMOTE_ACTIVITY_SAMPLE_CLASS_FULL_NAME = "com.google.android.gm.ConversationListActivityGmail"
+private const val REMOTE_ACTIVITY_SAMPLE_CLASS_FULL_NAME =
+    "com.google.android.horologist.datalayer.sample.screens.startremote.StartRemoteSampleActivity"
 
 @HiltViewModel
 class NodeDetailsViewModel
@@ -77,7 +77,6 @@ class NodeDetailsViewModel
         fun onStartRemoteActivityClick() {
             runActionAndHandleAppHelperResult {
                 val config = activityConfig {
-                    packageName = REMOTE_ACTIVITY_SAMPLE_PACKAGE_NAME
                     classFullName = REMOTE_ACTIVITY_SAMPLE_CLASS_FULL_NAME
                 }
                 wearDataLayerAppHelper.startRemoteActivity(nodeId, config)

--- a/docs/datalayer-helpers-guide.md
+++ b/docs/datalayer-helpers-guide.md
@@ -143,7 +143,6 @@ phone.
 
     ```kotlin
     val config = activityConfig { 
-        packageName = "com.example.myapp"
         classFullName = "com.example.myapp.MyActivity"
     }
     appHelper.startRemoteActivity(node.id, config)
@@ -208,7 +207,7 @@ phone.
 
     ```kotlin
     val connectedNodes = appHelper.connectedNodes()
-    // after picking a node, check if value is USAGE_STATUS_LAUNCHED_ONCE:
+    // after picking a node, check if value is USAGE_STATUS_LAUNCHED_ONCE
     node.surfacesInfo.usageInfo.usageStatus
     ```
 


### PR DESCRIPTION
#### WHAT

Change `DataLayerAppHelper.startRemoteActivity` to only launch activities of the same package.

#### WHY

It was not the initial intention of this function to be able to launch activities from other apps.

#### HOW

- Remove `packageName` attribute from `ActivityConfig`.
- Set the package name of the running app on the `Intent` used to launch the activity.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
