### PR TITLE
Fix double talkback on VolumeScreen

### DIFF
--- a/media/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeScreen.kt
+++ b/media/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeScreen.kt
@@ -45,6 +45,7 @@ import com.google.android.horologist.audio.ui.components.DeviceChip
 import com.google.android.horologist.audio.ui.components.toAudioOutputUi
 import com.google.android.horologist.compose.material.Icon
 import com.google.android.horologist.compose.material.IconRtlMode
+import com.google.android.horologist.compose.material.util.DECORATIVE_ELEMENT_CONTENT_DESCRIPTION
 import com.google.android.horologist.compose.rotaryinput.RotaryDefaults.isLowResInput
 import com.google.android.horologist.images.base.paintable.ImageVectorPaintable.Companion.asPaintable
 
@@ -117,7 +118,7 @@ public fun VolumeScreen(
                 icon = {
                     Icon(
                         paintable = audioOutputUi.imageVector.asPaintable(),
-                        contentDescription = null,
+                        contentDescription = DECORATIVE_ELEMENT_CONTENT_DESCRIPTION,
                         tint = MaterialTheme.colors.onSurfaceVariant,
                     )
                 },

--- a/media/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeScreen.kt
+++ b/media/audio-ui/src/main/java/com/google/android/horologist/audio/ui/VolumeScreen.kt
@@ -117,7 +117,7 @@ public fun VolumeScreen(
                 icon = {
                     Icon(
                         paintable = audioOutputUi.imageVector.asPaintable(),
-                        contentDescription = audioOutputUi.displayName,
+                        contentDescription = null,
                         tint = MaterialTheme.colors.onSurfaceVariant,
                     )
                 },

--- a/media/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/DeviceChip.kt
+++ b/media/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/DeviceChip.kt
@@ -45,7 +45,7 @@ public fun DeviceChip(
     Chip(
         modifier = modifier
             .width(intrinsicSize = IntrinsicSize.Max)
-            .semantics {
+            .semantics(mergeDescendants = true) {
                 stateDescription = volumeDescription
                 onClick(onClickLabel) {
                     onAudioOutputClick()

--- a/media/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenA11yTest.kt
+++ b/media/audio-ui/src/test/kotlin/com/google/android/horologist/audio/ui/VolumeScreenA11yTest.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
 import androidx.test.filters.MediumTest
 import com.google.android.horologist.audio.AudioOutput
 import com.google.android.horologist.audio.VolumeState
@@ -59,7 +60,7 @@ class VolumeScreenA11yTest {
             .assertIsDisplayed()
             .assertHasClickAction()
 
-        composeTestRule.onNodeWithContentDescription("Pixelbuds")
+        composeTestRule.onNodeWithText("Pixelbuds")
             .assertIsDisplayed()
             .assertHasClickAction()
             .assertHasStateDescription("Connected, Volume 5")

--- a/media/audio-ui/src/test/snapshots/images/com.google.android.horologist.audio.ui_VolumeScreenA11yScreenshotTest_volumeScreenAtMinimums.png
+++ b/media/audio-ui/src/test/snapshots/images/com.google.android.horologist.audio.ui_VolumeScreenA11yScreenshotTest_volumeScreenAtMinimums.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5fb70beaa51e209c997301faeb89a2011946c41149a4afe20b43c44f2a702064
-size 27048
+oid sha256:79d5aaff7b690e4d7d060514ae299ae3ee2f75e10d7fc23002bf0ec28093eb19
+size 53202

--- a/media/audio-ui/src/test/snapshots/images/com.google.android.horologist.audio.ui_VolumeScreenA11yScreenshotTest_volumeScreenNotConnected.png
+++ b/media/audio-ui/src/test/snapshots/images/com.google.android.horologist.audio.ui_VolumeScreenA11yScreenshotTest_volumeScreenNotConnected.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c5041f9ac530ee5ab889c2eef51844e5cf3d9217a01b0765bd4cd3310b49f87
-size 27384
+oid sha256:30e277e313b13a725fad13cf2cdcab17f8d56ac630017a748b674e48c9b8012a
+size 53349

--- a/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/a11y/A11ySnapshotTransformer.kt
+++ b/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/a11y/A11ySnapshotTransformer.kt
@@ -128,7 +128,8 @@ internal class A11ySnapshotTransformer : SnapshotTransformer {
             }
             if (it.contentDescription != null) {
                 drawItem("Content Description \"${it.contentDescription.joinToString(", ")}\"")
-            } else if (it.text != null) {
+            }
+            if (it.text != null) {
                 drawItem("Text \"${it.text.joinToString(", ")}\"")
             }
             if (it.stateDescription != null) {


### PR DESCRIPTION
#### WHAT

Fix double talkback on VolumeScreen.

#### WHY

Even when merged, two nodes in the A11y tree, one with text, one with contentDescription will both be seen by talkback on Wear 4 devices.

#fixes https://github.com/google/horologist/issues/1920

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
