### PR TITLE
Add demo for Install App Prompt to datalayer phone sample app

### DIFF
--- a/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/PhoneUiDataLayerHelper.kt
+++ b/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/PhoneUiDataLayerHelper.kt
@@ -35,7 +35,7 @@ private const val NO_RESULT_REQUESTED_REQUEST_CODE = -1
 public class PhoneUiDataLayerHelper {
 
     /**
-     * Alternative to [showInstallAppPrompt] for activities that are not [ComponentActivity].
+     * Display an install app prompt to the user.
      *
      * Use [requestCode] as an option to check in [Activity.onActivityResult] if the prompt was
      * dismissed ([Activity.RESULT_CANCELED]).
@@ -84,13 +84,13 @@ public class PhoneUiDataLayerHelper {
      * It can also be used directly in an [ComponentActivity] with
      * [ComponentActivity.registerForActivityResult]:
      * ```
-     * val launcher = registerForActivityResult(
-     *     ActivityResultContracts.StartActivityForResult(),
-     *     ActivityResultCallback { result ->
-     *         if (result.resultCode == RESULT_OK) {
-     *             // user pushed install!
-     *         }
-     * )
+     *  val launcher = registerForActivityResult(
+     *      ActivityResultContracts.StartActivityForResult()
+     *  ) { result ->
+     *      if (result.resultCode == RESULT_OK) {
+     *          // user pushed install!
+     *      }
+     *  }
      *
      * launcher.launch(getInstallPromptIntent(/*params*/))
      * ```

--- a/datalayer/phone/build.gradle.kts
+++ b/datalayer/phone/build.gradle.kts
@@ -87,8 +87,8 @@ metalava {
 
 dependencies {
     api(projects.annotations)
+    api(projects.datalayer.core)
 
-    implementation(projects.datalayer.core)
     implementation(libs.kotlin.stdlib)
     implementation(libs.kotlinx.coroutines.core)
 

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/Screen.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/Screen.kt
@@ -21,6 +21,7 @@ sealed class Screen(
 ) {
     data object MenuScreen : Screen("menuScreen")
     data object AppHelperNodesScreen : Screen("appHelperNodesScreen")
-    data object InAppPromptsScreen : Screen("inAppPromptsScreen")
+    data object InstallAppPromptDemoScreen : Screen("installAppPromptDemoScreen")
+    data object InstallAppPromptDemo2Screen : Screen("installAppPromptDemo2Screen")
     data object CounterScreen : Screen("counterScreen")
 }

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/InstallAppPromptDemo2Screen.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/InstallAppPromptDemo2Screen.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.datalayer.sample.screens.inappprompts
+
+import android.app.Activity.RESULT_OK
+import android.content.Intent
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.google.android.horologist.datalayer.sample.R
+
+@Composable
+fun InstallAppPromptDemo2Screen(
+    modifier: Modifier = Modifier,
+    viewModel: InstallAppPromptDemo2ViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    val context = LocalContext.current
+
+    InstallAppPromptDemo2Screen(
+        state = state,
+        onRunDemoClick = viewModel::onRunDemoClick,
+        getInstallPromptIntent = { watchName ->
+            viewModel.phoneUiDataLayerHelper.getInstallPromptIntent(
+                context = context,
+                appName = context.getString(R.string.install_app_prompt_sample_app_name),
+                appPackageName = context.getString(R.string.install_app_prompt_sample_app_package_name),
+                watchName = watchName,
+                message = context.getString(R.string.install_app_prompt_sample_message),
+                image = R.drawable.sample_app_wearos_screenshot,
+            )
+        },
+        onInstallPromptLaunched = viewModel::onInstallPromptLaunched,
+        onInstallPromptInstallClick = viewModel::onInstallPromptInstallClick,
+        onInstallPromptCancel = viewModel::onInstallPromptCancel,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun InstallAppPromptDemo2Screen(
+    state: InstallAppPromptDemo2ScreenState,
+    onRunDemoClick: () -> Unit,
+    getInstallPromptIntent: (watchName: String) -> Intent,
+    onInstallPromptLaunched: () -> Unit,
+    onInstallPromptInstallClick: () -> Unit,
+    onInstallPromptCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val launcher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        if (result.resultCode == RESULT_OK) {
+            onInstallPromptInstallClick()
+        } else {
+            onInstallPromptCancel()
+        }
+    }
+
+    Column(
+        modifier = modifier.padding(all = 10.dp),
+    ) {
+        Text(text = stringResource(id = R.string.install_app_prompt_api_call_demo2_message))
+
+        Button(
+            onClick = onRunDemoClick,
+            modifier = Modifier
+                .padding(top = 10.dp)
+                .align(Alignment.CenterHorizontally),
+        ) {
+            Text(text = stringResource(id = R.string.install_app_prompt_run_demo2_button_label))
+        }
+
+        when (state) {
+            InstallAppPromptDemo2ScreenState.Idle -> {
+                /* do nothing */
+            }
+
+            is InstallAppPromptDemo2ScreenState.WatchFound -> {
+                SideEffect { launcher.launch(getInstallPromptIntent(state.watchName)) }
+
+                onInstallPromptLaunched()
+            }
+
+            InstallAppPromptDemo2ScreenState.WatchNotFound -> {
+                Text(
+                    stringResource(
+                        id = R.string.install_app_prompt_demo2_result_label,
+                        stringResource(id = R.string.install_app_prompt_demo2_no_watches_found_label),
+                    ),
+                )
+            }
+
+            InstallAppPromptDemo2ScreenState.InstallPromptInstallClicked -> {
+                Text(
+                    stringResource(
+                        id = R.string.install_app_prompt_demo2_result_label,
+                        stringResource(id = R.string.install_app_prompt_demo2_prompt_install_result_label),
+                    ),
+                )
+            }
+
+            InstallAppPromptDemo2ScreenState.InstallPromptInstallCancelled -> {
+                Text(
+                    stringResource(
+                        id = R.string.install_app_prompt_demo2_result_label,
+                        stringResource(id = R.string.install_app_prompt_demo2_prompt_cancel_result_label),
+                    ),
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun InstallAppPromptDemo2ScreenPreview() {
+    InstallAppPromptDemo2Screen(
+        state = InstallAppPromptDemo2ScreenState.Idle,
+        onRunDemoClick = { },
+        getInstallPromptIntent = { Intent() },
+        onInstallPromptLaunched = { },
+        onInstallPromptInstallClick = { },
+        onInstallPromptCancel = { },
+    )
+}

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/InstallAppPromptDemo2ViewModel.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/InstallAppPromptDemo2ViewModel.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.datalayer.sample.screens.inappprompts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.android.horologist.data.apphelper.appInstalled
+import com.google.android.horologist.datalayer.phone.PhoneDataLayerAppHelper
+import com.google.android.horologist.datalayer.phone.ui.PhoneUiDataLayerHelper
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class InstallAppPromptDemo2ViewModel
+    @Inject
+    constructor(
+        private val phoneDataLayerAppHelper: PhoneDataLayerAppHelper,
+        val phoneUiDataLayerHelper: PhoneUiDataLayerHelper,
+    ) : ViewModel() {
+
+        private val _uiState =
+            MutableStateFlow<InstallAppPromptDemo2ScreenState>(InstallAppPromptDemo2ScreenState.Idle)
+        public val uiState: StateFlow<InstallAppPromptDemo2ScreenState> = _uiState
+
+        fun onRunDemoClick() {
+            viewModelScope.launch {
+                val node = phoneDataLayerAppHelper.connectedNodes().firstOrNull { !it.appInstalled }
+
+                _uiState.value = if (node != null) {
+                    InstallAppPromptDemo2ScreenState.WatchFound(watchName = node.displayName)
+                } else {
+                    InstallAppPromptDemo2ScreenState.WatchNotFound
+                }
+            }
+        }
+
+        fun onInstallPromptLaunched() {
+            _uiState.value = InstallAppPromptDemo2ScreenState.Idle
+        }
+
+        fun onInstallPromptInstallClick() {
+            _uiState.value = InstallAppPromptDemo2ScreenState.InstallPromptInstallClicked
+        }
+
+        fun onInstallPromptCancel() {
+            _uiState.value = InstallAppPromptDemo2ScreenState.InstallPromptInstallCancelled
+        }
+    }
+
+sealed class InstallAppPromptDemo2ScreenState {
+    data object Idle : InstallAppPromptDemo2ScreenState()
+    data class WatchFound(val watchName: String) : InstallAppPromptDemo2ScreenState()
+    data object WatchNotFound : InstallAppPromptDemo2ScreenState()
+    data object InstallPromptInstallClicked : InstallAppPromptDemo2ScreenState()
+    data object InstallPromptInstallCancelled : InstallAppPromptDemo2ScreenState()
+}

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/InstallAppPromptDemoScreen.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/InstallAppPromptDemoScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.unit.dp
 import com.google.android.horologist.datalayer.sample.R
 
 @Composable
-fun InAppPromptsScreen(
+fun InstallAppPromptDemoScreen(
     onShowInstallAppPrompt: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -51,8 +51,8 @@ fun InAppPromptsScreen(
 
 @Preview(showBackground = true)
 @Composable
-fun InAppPromptsScreenPreview() {
-    InAppPromptsScreen(
+fun InstallAppPromptDemoScreenPreview() {
+    InstallAppPromptDemoScreen(
         onShowInstallAppPrompt = { },
     )
 }

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/main/MainScreen.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/main/MainScreen.kt
@@ -30,7 +30,8 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.google.android.horologist.datalayer.sample.screens.Screen
 import com.google.android.horologist.datalayer.sample.screens.counter.CounterScreen
-import com.google.android.horologist.datalayer.sample.screens.inappprompts.InAppPromptsScreen
+import com.google.android.horologist.datalayer.sample.screens.inappprompts.InstallAppPromptDemo2Screen
+import com.google.android.horologist.datalayer.sample.screens.inappprompts.InstallAppPromptDemoScreen
 import com.google.android.horologist.datalayer.sample.screens.menu.MenuScreen
 import com.google.android.horologist.datalayer.sample.screens.nodes.NodesScreen
 
@@ -61,8 +62,11 @@ fun MainScreen(
                 composable(route = Screen.AppHelperNodesScreen.route) {
                     NodesScreen()
                 }
-                composable(route = Screen.InAppPromptsScreen.route) {
-                    InAppPromptsScreen(onShowInstallAppPrompt = onShowInstallAppPrompt)
+                composable(route = Screen.InstallAppPromptDemoScreen.route) {
+                    InstallAppPromptDemoScreen(onShowInstallAppPrompt = onShowInstallAppPrompt)
+                }
+                composable(route = Screen.InstallAppPromptDemo2Screen.route) {
+                    InstallAppPromptDemo2Screen()
                 }
                 composable(route = Screen.CounterScreen.route) {
                     CounterScreen()

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/menu/MenuScreen.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/menu/MenuScreen.kt
@@ -49,8 +49,12 @@ fun MenuScreen(
             modifier = Modifier.padding(top = 10.dp),
         )
 
-        Button(onClick = { navController.navigate(Screen.InAppPromptsScreen.route) }) {
-            Text(text = stringResource(id = R.string.menu_screen_install_app_item))
+        Button(onClick = { navController.navigate(Screen.InstallAppPromptDemoScreen.route) }) {
+            Text(text = stringResource(id = R.string.menu_screen_install_app_demo1_item))
+        }
+
+        Button(onClick = { navController.navigate(Screen.InstallAppPromptDemo2Screen.route) }) {
+            Text(text = stringResource(id = R.string.menu_screen_install_app_demo2_item))
         }
 
         Text(

--- a/datalayer/sample/phone/src/main/res/values/strings.xml
+++ b/datalayer/sample/phone/src/main/res/values/strings.xml
@@ -23,7 +23,8 @@
     <string name="menu_screen_apphelper_header">App Helper</string>
     <string name="menu_screen_nodes_item">Nodes</string>
     <string name="menu_screen_inapp_prompts_header">In-App prompts</string>
-    <string name="menu_screen_install_app_item">Install app</string>
+    <string name="menu_screen_install_app_demo1_item">Install app - demo 1</string>
+    <string name="menu_screen_install_app_demo2_item">Install app - demo 2</string>
     <string name="menu_screen_datalayer_header">Data Layer</string>
     <string name="menu_screen_counter_item">Counter sample</string>
 
@@ -55,9 +56,17 @@
     <string name="node_status_start_own_app_button_label">Start remote own app</string>
     <string name="node_status_start_remote_activity_button_label">Start remote activity</string>
 
-    <!-- In-app prompt - Install App screen -->
+    <!-- In-app prompt - Install App Demo 1 screen -->
     <string name="install_app_prompt_api_call_demo_message">This demo calls the API to display the install app prompt. The developer has to gather all the information to display on the prompt, such as app name and watch name.</string>
     <string name="install_app_prompt_run_demo_button_label">Run demo</string>
+
+    <!-- In-app prompt - Install App Demo 2 screen -->
+    <string name="install_app_prompt_api_call_demo2_message">This demo calls the API to display the install app prompt. The API will only display the prompt if there is a watch connected and the watch does not have the app installed already.</string>
+    <string name="install_app_prompt_run_demo2_button_label">Run demo</string>
+    <string name="install_app_prompt_demo2_result_label">Result: %1$s</string>
+    <string name="install_app_prompt_demo2_no_watches_found_label">No watches were found.</string>
+    <string name="install_app_prompt_demo2_prompt_install_result_label">User tapped install on the prompt.</string>
+    <string name="install_app_prompt_demo2_prompt_cancel_result_label">User dismissed the prompt.</string>
 
     <!-- Counter screen -->
     <string name="app_helper_counter_label">Counter: %1$s</string>


### PR DESCRIPTION
#### WHAT

Add second demo for Install App Prompt to datalayer phone sample app.

#### WHY

Showcase a more realistic scenario where the prompt is only displayed if there is a watch device paired that doesn't not have the app installed.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
