### PR TITLE
Fix time text on NodeDetailsScreen

### DIFF
--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/info/InfoScreenNavigation.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/info/InfoScreenNavigation.kt
@@ -24,9 +24,9 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
+import androidx.wear.compose.navigation.composable
 import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.layout.rememberColumnState
-import com.google.android.horologist.compose.navscaffold.composable
 import com.google.android.horologist.datalayer.sample.Screen
 import java.net.URLDecoder
 import java.net.URLEncoder

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsScreenNavigation.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsScreenNavigation.kt
@@ -21,7 +21,9 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
-import com.google.android.horologist.compose.navscaffold.scrollable
+import androidx.wear.compose.navigation.composable
+import com.google.android.horologist.compose.layout.ScreenScaffold
+import com.google.android.horologist.compose.layout.rememberColumnState
 import com.google.android.horologist.datalayer.sample.Screen
 import java.net.URLDecoder
 import java.net.URLEncoder
@@ -44,14 +46,18 @@ fun NavController.navigateToNodeDetailsScreen(message: String) {
 }
 
 fun NavGraphBuilder.nodeDetailsScreen() {
-    scrollable(
+    composable(
         route = Screen.AppHelperNodeDetailsScreen.route,
         arguments = listOf(
             navArgument(nodeIdArg) { type = NavType.StringType },
         ),
     ) {
-        NodeDetailsScreen(
-            columnState = it.columnState,
-        )
+        val columnState = rememberColumnState()
+
+        ScreenScaffold(scrollState = columnState) {
+            NodeDetailsScreen(
+                columnState = columnState,
+            )
+        }
     }
 }


### PR DESCRIPTION
#### WHAT

Fix time text on `NodeDetailsScreen`.

#### WHY

It was not hiding when scrolling through the list.

#### HOW

Use `ScreenScaffold`.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
