### PR TITLE
Add loading state to Install App Prompt demo 2

### DIFF
--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/InstallAppPromptDemo2Screen.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/InstallAppPromptDemo2Screen.kt
@@ -23,6 +23,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
@@ -103,6 +104,10 @@ fun InstallAppPromptDemo2Screen(
         when (state) {
             InstallAppPromptDemo2ScreenState.Idle -> {
                 /* do nothing */
+            }
+
+            InstallAppPromptDemo2ScreenState.Loading -> {
+                CircularProgressIndicator()
             }
 
             is InstallAppPromptDemo2ScreenState.WatchFound -> {

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/InstallAppPromptDemo2ViewModel.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/InstallAppPromptDemo2ViewModel.kt
@@ -40,6 +40,8 @@ class InstallAppPromptDemo2ViewModel
         public val uiState: StateFlow<InstallAppPromptDemo2ScreenState> = _uiState
 
         fun onRunDemoClick() {
+            _uiState.value = InstallAppPromptDemo2ScreenState.Loading
+
             viewModelScope.launch {
                 val node = phoneDataLayerAppHelper.connectedNodes().firstOrNull { !it.appInstalled }
 
@@ -66,6 +68,7 @@ class InstallAppPromptDemo2ViewModel
 
 sealed class InstallAppPromptDemo2ScreenState {
     data object Idle : InstallAppPromptDemo2ScreenState()
+    data object Loading : InstallAppPromptDemo2ScreenState()
     data class WatchFound(val watchName: String) : InstallAppPromptDemo2ScreenState()
     data object WatchNotFound : InstallAppPromptDemo2ScreenState()
     data object InstallPromptInstallClicked : InstallAppPromptDemo2ScreenState()


### PR DESCRIPTION
#### WHAT

Add loading state to Install App Prompt demo 2.

#### WHY

To indicate that the app is taking an action.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
