### PR TITLE
Describe API stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ The currently maintained branches of Horologist are.
 | Version | Branch | Description |
 | ------- | ------ | ----------- |
 | 0.4.x | release-0.4.x | Wear Compose 1.2.x (stable) and Media3, and generally stable APIs. |
-| 0.5.x | main | Wear Compose 1.3 alpha, Media3 and generally latest alphas of Androidx. |
+| 0.5.x | main | Wear Compose 1.3.x, Compose 1.5.x, Media3 and some betas of Androidx. |
+| 0.6.x | _future_ | Wear Compose 1.4.x, Compose 1.6.x and generally latest alphas of Androidx. |
+
+Maintenance branches will not delete existing APIs and they should remain stable. However
+the main branch will actively update to incorporate new API guidance, removing or changing
+APIs.
 
 ---
 


### PR DESCRIPTION
#### WHAT

Describe API stability.

#### WHY

Advise people wanting stability to stick to 0.4.x. And also recognise the 0.5.x is close to stable.

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
