### PR TITLE
Fix crash with instrumentation tests

### DIFF
--- a/ai/sample/phone/build.gradle.kts
+++ b/ai/sample/phone/build.gradle.kts
@@ -124,4 +124,6 @@ dependencies {
 
     debugImplementation(libs.compose.ui.tooling)
     debugImplementation(libs.compose.ui.test.manifest)
+
+    androidTestImplementation(libs.androidx.test.runner)
 }

--- a/ai/sample/wear-gemini/build.gradle.kts
+++ b/ai/sample/wear-gemini/build.gradle.kts
@@ -172,4 +172,6 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.truth)
     testImplementation(libs.robolectric)
+
+    androidTestImplementation(libs.androidx.test.runner)
 }

--- a/ai/sample/wear-prompt-app/build.gradle.kts
+++ b/ai/sample/wear-prompt-app/build.gradle.kts
@@ -134,4 +134,6 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.truth)
     testImplementation(libs.robolectric)
+
+    androidTestImplementation(libs.androidx.test.runner)
 }


### PR DESCRIPTION
#### WHAT

Fix crash with instrumentation tests for AI sample apps.


#### WHY

They are crashing with:

```
> Task :ai:sample:wear-prompt-app:connectedDebugAndroidTest
Starting 0 tests on test(AVD) - 11
Test run failed to complete. Instrumentation run failed due to Process crashed.
Logcat of last crash: 
Process: com.google.android.horologist.ai.sample.prompt, PID: 8142
java.lang.RuntimeException: Unable to instantiate instrumentation ComponentInfo{com.google.android.horologist.ai.sample.prompt.test/androidx.test.runner.AndroidJUnitRunner}: java.lang.ClassNotFoundException: Didn't find class "androidx.test.runner.AndroidJUnitRunner" on path: DexPathList[[zip file "/system/framework/android.test.runner.jar", zip file "/system/framework/android.test.mock.jar", zip file "/system/framework/android.test.base.jar", zip file "/data/app/~~aVYv1hlskHzcJoFTHI7RYw==/com.google.android.horologist.ai.sample.prompt.test-rh557MUo9fUlMupk31xLuA==/base.apk", zip file "/data/app/~~K5gQvUvckj6JNYqIMiUfng==/com.google.android.horologist.ai.sample.prompt-wNOqH6lQNq1OIjgOfdj7qQ==/base.apk"],nativeLibraryDirectories=[/system/lib, /system_ext/lib]]
	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6651)
	at android.app.ActivityThread.access$1300(ActivityThread.java:237)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1913)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loop(Looper.java:223)
	at android.app.ActivityThread.main(ActivityThread.java:7660)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
Caused by: java.lang.ClassNotFoundException: Didn't find class "androidx.test.runner.AndroidJUnitRunner" on path: DexPathList[[zip file "/system/framework/android.test.runner.jar", zip file "/system/framework/android.test.mock.jar", zip file "/system/framework/android.test.base.jar", zip file "/data/app/~~aVYv1hlskHzcJoFTHI7RYw==/com.google.android.horologist.ai.sample.prompt.test-rh557MUo9fUlMupk31xLuA==/base.apk", zip file "/data/app/~~K5gQvUvckj6JNYqIMiUfng==/com.google.android.horologist.ai.sample.prompt-wNOqH6lQNq1OIjgOfdj7qQ==/base.apk"],nativeLibraryDirectories=[/system/lib, /system_ext/lib]]
	at dalvik.system.BaseDexClassLoader.findClass(BaseDexClassLoader.java:207)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:379)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:312)
	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6647)
	... 8 more


> Task :ai:sample:wear-prompt-app:connectedDebugAndroidTest FAILED
```


#### HOW

Add `androidx.test:runner` dependency to androidTest.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
