### PR TITLE
Renaming for app prompts and updated text in counter sample.

### DIFF
--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/counter/CounterScreen.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/counter/CounterScreen.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.horologist.datalayer.sample.screens.counter
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -81,8 +82,16 @@ fun CounterScreen(
                         .padding(16.dp),
                 ) {
                     Text(text = stringResource(R.string.app_helper_counter_increase_explanation))
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text(text = "Counter: " + state.counter)
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center,
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                    ) {
+                        Text(
+                            text = "Counter: " + state.counter,
+                            modifier = Modifier.padding(16.dp),
+                        )
                         Button(onClick = onPlusClick) {
                             Icon(imageVector = Icons.Default.Add, contentDescription = "Plus 1")
                         }

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/InstallPlaystoreAppPromptDemoScreen.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/InstallPlaystoreAppPromptDemoScreen.kt
@@ -29,14 +29,14 @@ import androidx.compose.ui.unit.dp
 import com.google.android.horologist.datalayer.sample.R
 
 @Composable
-fun InstallAppPromptDemoScreen(
+fun InstallPlaystoreAppPromptDemoScreen(
     onShowInstallAppPrompt: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier.padding(all = 10.dp),
     ) {
-        Text(text = stringResource(id = R.string.install_app_prompt_api_call_demo_message))
+        Text(text = stringResource(id = R.string.install_playstore_app_prompt_api_call_demo_message))
 
         Button(
             onClick = onShowInstallAppPrompt,
@@ -44,7 +44,7 @@ fun InstallAppPromptDemoScreen(
                 .padding(top = 10.dp)
                 .align(Alignment.CenterHorizontally),
         ) {
-            Text(text = stringResource(id = R.string.install_app_prompt_run_demo_button_label))
+            Text(text = stringResource(id = R.string.install_playstore_app_prompt_run_demo_button_label))
         }
     }
 }
@@ -52,7 +52,7 @@ fun InstallAppPromptDemoScreen(
 @Preview(showBackground = true)
 @Composable
 fun InstallAppPromptDemoScreenPreview() {
-    InstallAppPromptDemoScreen(
+    InstallPlaystoreAppPromptDemoScreen(
         onShowInstallAppPrompt = { },
     )
 }

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/InstallSampleAppPromptDemoScreen.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/InstallSampleAppPromptDemoScreen.kt
@@ -39,15 +39,15 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.android.horologist.datalayer.sample.R
 
 @Composable
-fun InstallAppPromptDemo2Screen(
+fun InstallSampleAppPromptDemoScreen(
     modifier: Modifier = Modifier,
-    viewModel: InstallAppPromptDemo2ViewModel = hiltViewModel(),
+    viewModel: InstallSampleAppPromptDemoViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
     val context = LocalContext.current
 
-    InstallAppPromptDemo2Screen(
+    InstallSampleAppPromptDemoScreen(
         state = state,
         onRunDemoClick = viewModel::onRunDemoClick,
         getInstallPromptIntent = { watchName ->
@@ -56,7 +56,7 @@ fun InstallAppPromptDemo2Screen(
                 appName = context.getString(R.string.app_name),
                 appPackageName = context.packageName,
                 watchName = watchName,
-                message = context.getString(R.string.install_app_prompt_demo2_prompt_message),
+                message = context.getString(R.string.install_sample_app_prompt_demo_prompt_message),
                 image = R.drawable.watch_app_screenshot,
             )
         },
@@ -68,8 +68,8 @@ fun InstallAppPromptDemo2Screen(
 }
 
 @Composable
-fun InstallAppPromptDemo2Screen(
-    state: InstallAppPromptDemo2ScreenState,
+fun InstallSampleAppPromptDemoScreen(
+    state: InstallSampleAppPromptDemoScreenState,
     onRunDemoClick: () -> Unit,
     getInstallPromptIntent: (watchName: String) -> Intent,
     onInstallPromptLaunched: () -> Unit,
@@ -90,7 +90,7 @@ fun InstallAppPromptDemo2Screen(
     Column(
         modifier = modifier.padding(all = 10.dp),
     ) {
-        Text(text = stringResource(id = R.string.install_app_prompt_api_call_demo2_message))
+        Text(text = stringResource(id = R.string.install_sample_app_prompt_api_call_demo_message))
 
         Button(
             onClick = onRunDemoClick,
@@ -98,48 +98,51 @@ fun InstallAppPromptDemo2Screen(
                 .padding(top = 10.dp)
                 .align(Alignment.CenterHorizontally),
         ) {
-            Text(text = stringResource(id = R.string.install_app_prompt_run_demo2_button_label))
+            Text(text = stringResource(id = R.string.install_sample_app_prompt_run_demo_button_label))
         }
 
         when (state) {
-            InstallAppPromptDemo2ScreenState.Idle -> {
+            InstallSampleAppPromptDemoScreenState.Idle -> {
                 /* do nothing */
             }
 
-            InstallAppPromptDemo2ScreenState.Loading -> {
+            InstallSampleAppPromptDemoScreenState.Loading -> {
                 CircularProgressIndicator()
             }
 
-            is InstallAppPromptDemo2ScreenState.WatchFound -> {
+            is InstallSampleAppPromptDemoScreenState.WatchFound -> {
                 SideEffect { launcher.launch(getInstallPromptIntent(state.watchName)) }
 
                 onInstallPromptLaunched()
             }
 
-            InstallAppPromptDemo2ScreenState.WatchNotFound -> {
+            InstallSampleAppPromptDemoScreenState.WatchNotFound -> {
                 Text(
                     stringResource(
-                        id = R.string.install_app_prompt_demo2_result_label,
-                        stringResource(id = R.string.install_app_prompt_demo2_no_watches_found_label),
+                        id = R.string.install_sample_app_prompt_demo_result_label,
+                        stringResource(id = R.string.install_sample_app_prompt_demo_no_watches_found_label),
                     ),
+                    modifier = Modifier.padding(16.dp),
                 )
             }
 
-            InstallAppPromptDemo2ScreenState.InstallPromptInstallClicked -> {
+            InstallSampleAppPromptDemoScreenState.InstallPromptInstallClicked -> {
                 Text(
                     stringResource(
-                        id = R.string.install_app_prompt_demo2_result_label,
-                        stringResource(id = R.string.install_app_prompt_demo2_prompt_install_result_label),
+                        id = R.string.install_sample_app_prompt_demo_result_label,
+                        stringResource(id = R.string.install_sample_app_prompt_demo_prompt_install_result_label),
                     ),
+                    modifier = Modifier.padding(16.dp),
                 )
             }
 
-            InstallAppPromptDemo2ScreenState.InstallPromptInstallCancelled -> {
+            InstallSampleAppPromptDemoScreenState.InstallPromptInstallCancelled -> {
                 Text(
                     stringResource(
-                        id = R.string.install_app_prompt_demo2_result_label,
-                        stringResource(id = R.string.install_app_prompt_demo2_prompt_cancel_result_label),
+                        id = R.string.install_sample_app_prompt_demo_result_label,
+                        stringResource(id = R.string.install_sample_app_prompt_demo_prompt_cancel_result_label),
                     ),
+                    modifier = Modifier.padding(16.dp),
                 )
             }
         }
@@ -149,8 +152,8 @@ fun InstallAppPromptDemo2Screen(
 @Preview(showBackground = true)
 @Composable
 fun InstallAppPromptDemo2ScreenPreview() {
-    InstallAppPromptDemo2Screen(
-        state = InstallAppPromptDemo2ScreenState.Idle,
+    InstallSampleAppPromptDemoScreen(
+        state = InstallSampleAppPromptDemoScreenState.Idle,
         onRunDemoClick = { },
         getInstallPromptIntent = { Intent() },
         onInstallPromptLaunched = { },

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/InstallSampleAppPromptDemoViewModel.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/InstallSampleAppPromptDemoViewModel.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class InstallAppPromptDemo2ViewModel
+class InstallSampleAppPromptDemoViewModel
     @Inject
     constructor(
         private val phoneDataLayerAppHelper: PhoneDataLayerAppHelper,
@@ -36,41 +36,41 @@ class InstallAppPromptDemo2ViewModel
     ) : ViewModel() {
 
         private val _uiState =
-            MutableStateFlow<InstallAppPromptDemo2ScreenState>(InstallAppPromptDemo2ScreenState.Idle)
-        public val uiState: StateFlow<InstallAppPromptDemo2ScreenState> = _uiState
+            MutableStateFlow<InstallSampleAppPromptDemoScreenState>(InstallSampleAppPromptDemoScreenState.Idle)
+        public val uiState: StateFlow<InstallSampleAppPromptDemoScreenState> = _uiState
 
         fun onRunDemoClick() {
-            _uiState.value = InstallAppPromptDemo2ScreenState.Loading
+            _uiState.value = InstallSampleAppPromptDemoScreenState.Loading
 
             viewModelScope.launch {
                 val node = phoneDataLayerAppHelper.connectedNodes().firstOrNull { !it.appInstalled }
 
                 _uiState.value = if (node != null) {
-                    InstallAppPromptDemo2ScreenState.WatchFound(watchName = node.displayName)
+                    InstallSampleAppPromptDemoScreenState.WatchFound(watchName = node.displayName)
                 } else {
-                    InstallAppPromptDemo2ScreenState.WatchNotFound
+                    InstallSampleAppPromptDemoScreenState.WatchNotFound
                 }
             }
         }
 
         fun onInstallPromptLaunched() {
-            _uiState.value = InstallAppPromptDemo2ScreenState.Idle
+            _uiState.value = InstallSampleAppPromptDemoScreenState.Idle
         }
 
         fun onInstallPromptInstallClick() {
-            _uiState.value = InstallAppPromptDemo2ScreenState.InstallPromptInstallClicked
+            _uiState.value = InstallSampleAppPromptDemoScreenState.InstallPromptInstallClicked
         }
 
         fun onInstallPromptCancel() {
-            _uiState.value = InstallAppPromptDemo2ScreenState.InstallPromptInstallCancelled
+            _uiState.value = InstallSampleAppPromptDemoScreenState.InstallPromptInstallCancelled
         }
     }
 
-sealed class InstallAppPromptDemo2ScreenState {
-    data object Idle : InstallAppPromptDemo2ScreenState()
-    data object Loading : InstallAppPromptDemo2ScreenState()
-    data class WatchFound(val watchName: String) : InstallAppPromptDemo2ScreenState()
-    data object WatchNotFound : InstallAppPromptDemo2ScreenState()
-    data object InstallPromptInstallClicked : InstallAppPromptDemo2ScreenState()
-    data object InstallPromptInstallCancelled : InstallAppPromptDemo2ScreenState()
+sealed class InstallSampleAppPromptDemoScreenState {
+    data object Idle : InstallSampleAppPromptDemoScreenState()
+    data object Loading : InstallSampleAppPromptDemoScreenState()
+    data class WatchFound(val watchName: String) : InstallSampleAppPromptDemoScreenState()
+    data object WatchNotFound : InstallSampleAppPromptDemoScreenState()
+    data object InstallPromptInstallClicked : InstallSampleAppPromptDemoScreenState()
+    data object InstallPromptInstallCancelled : InstallSampleAppPromptDemoScreenState()
 }

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/main/MainScreen.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/main/MainScreen.kt
@@ -30,8 +30,8 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.google.android.horologist.datalayer.sample.screens.Screen
 import com.google.android.horologist.datalayer.sample.screens.counter.CounterScreen
-import com.google.android.horologist.datalayer.sample.screens.inappprompts.InstallAppPromptDemo2Screen
-import com.google.android.horologist.datalayer.sample.screens.inappprompts.InstallAppPromptDemoScreen
+import com.google.android.horologist.datalayer.sample.screens.inappprompts.InstallPlaystoreAppPromptDemoScreen
+import com.google.android.horologist.datalayer.sample.screens.inappprompts.InstallSampleAppPromptDemoScreen
 import com.google.android.horologist.datalayer.sample.screens.menu.MenuScreen
 import com.google.android.horologist.datalayer.sample.screens.nodes.NodesScreen
 
@@ -63,10 +63,10 @@ fun MainScreen(
                     NodesScreen()
                 }
                 composable(route = Screen.InstallAppPromptDemoScreen.route) {
-                    InstallAppPromptDemoScreen(onShowInstallAppPrompt = onShowInstallAppPrompt)
+                    InstallPlaystoreAppPromptDemoScreen(onShowInstallAppPrompt = onShowInstallAppPrompt)
                 }
                 composable(route = Screen.InstallAppPromptDemo2Screen.route) {
-                    InstallAppPromptDemo2Screen()
+                    InstallSampleAppPromptDemoScreen()
                 }
                 composable(route = Screen.CounterScreen.route) {
                     CounterScreen()

--- a/datalayer/sample/phone/src/main/res/values/strings.xml
+++ b/datalayer/sample/phone/src/main/res/values/strings.xml
@@ -23,8 +23,8 @@
     <string name="menu_screen_apphelper_header">App Helper</string>
     <string name="menu_screen_nodes_item">Nodes</string>
     <string name="menu_screen_inapp_prompts_header">In-App prompts</string>
-    <string name="menu_screen_install_app_demo1_item">Install app - demo 1</string>
-    <string name="menu_screen_install_app_demo2_item">Install app - demo 2</string>
+    <string name="menu_screen_install_app_demo1_item">Install Playstore app demo</string>
+    <string name="menu_screen_install_app_demo2_item">Install sample app demo</string>
     <string name="menu_screen_datalayer_header">Data Layer</string>
     <string name="menu_screen_counter_item">Counter sample</string>
 
@@ -56,18 +56,18 @@
     <string name="node_status_start_own_app_button_label">Start remote own app</string>
     <string name="node_status_start_remote_activity_button_label">Start remote activity</string>
 
-    <!-- In-app prompt - Install App Demo 1 screen -->
-    <string name="install_app_prompt_api_call_demo_message">This demo calls the Horologist API to show the install app prompt and the invocation of the deeplink to the Google Play by using the Gmail app as an example. The developer has to gather all the information to display on the prompt, such as app name and watch name to use the prompt in their app.</string>
-    <string name="install_app_prompt_run_demo_button_label">Run demo</string>
+    <!-- In-app prompt - Install Playstore app Demo screen -->
+    <string name="install_playstore_app_prompt_api_call_demo_message">This demo calls the Horologist API to show the install app prompt and the invocation of the deeplink to the Google Play by using the Gmail app as an example. The developer has to gather all the information to display on the prompt, such as app name and watch name to use the prompt in their app.</string>
+    <string name="install_playstore_app_prompt_run_demo_button_label">Run demo</string>
 
-    <!-- In-app prompt - Install App Demo 2 screen -->
-    <string name="install_app_prompt_api_call_demo2_message">This demo calls the Horologist API to show the install app prompt for the watch demo app. The API will only display the prompt if there is a watch connected and the watch does not have the app installed already.\n\nGoogle Play won\'t find this app as it is not published.</string>
-    <string name="install_app_prompt_run_demo2_button_label">Run demo</string>
-    <string name="install_app_prompt_demo2_prompt_message">Test the interactions between the phone and the watch with the demo app.</string>
-    <string name="install_app_prompt_demo2_result_label">Result: %1$s</string>
-    <string name="install_app_prompt_demo2_no_watches_found_label">No watches without the app installed were found.</string>
-    <string name="install_app_prompt_demo2_prompt_install_result_label">User tapped install on the prompt.</string>
-    <string name="install_app_prompt_demo2_prompt_cancel_result_label">User dismissed the prompt.</string>
+    <!-- In-app prompt - Install Sample App Demo screen -->
+    <string name="install_sample_app_prompt_api_call_demo_message">This demo calls the Horologist API to show the install app prompt for the watch demo app. The API will only display the prompt if there is a watch connected and the watch does not have the app installed already.\n\nGoogle Play won\'t find this app as it is not published.</string>
+    <string name="install_sample_app_prompt_run_demo_button_label">Run demo</string>
+    <string name="install_sample_app_prompt_demo_prompt_message">Test the interactions between the phone and the watch with the demo app.</string>
+    <string name="install_sample_app_prompt_demo_result_label">Result: %1$s</string>
+    <string name="install_sample_app_prompt_demo_no_watches_found_label">No watches without the app installed were found.</string>
+    <string name="install_sample_app_prompt_demo_prompt_install_result_label">User tapped install on the prompt.</string>
+    <string name="install_sample_app_prompt_demo_prompt_cancel_result_label">User dismissed the prompt.</string>
 
     <!-- Counter screen -->
     <string name="app_helper_counter_label">Counter: %1$s</string>

--- a/datalayer/sample/wear/src/main/res/values/strings.xml
+++ b/datalayer/sample/wear/src/main/res/values/strings.xml
@@ -30,13 +30,13 @@
     <string name="main_menu_apphelpers_nodes_actions_item">Nodes actions</string>
 
     <!-- Counter screen -->
-    <string name="server_counter_message">Value of the counter from Phone</string>
+    <string name="server_counter_message">Open the datalayer sample on your phone to observe how the counter number is incremented</string>
 
     <!-- Data Layer screen -->
     <string name="data_layer_title">Data Layer</string>
     <string name="data_layer_missing_message">Missing</string>
     <string name="data_layer_error_message">Error: %1$s</string>
-    <string name="data_layer_value_message">Value: %1$s</string>
+    <string name="data_layer_value_message">Counter: %1$s</string>
 
     <!-- App Helper Tracking screen -->
     <string name="apphelper_tracking_title">AppHelper Tracking</string>


### PR DESCRIPTION
#### WHAT
Renamed demo1 and demo2 to describe what they do. Also renamed text for counter sample to match phone and watch. 

#### WHY
To make it easy for developer running the sample to understand the purpose of the samples.

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
