### PR TITLE
Remove foreground check from sendRequestWithTimeout

### DIFF
--- a/datalayer/core/src/main/java/com/google/android/horologist/data/apphelper/DataLayerAppHelper.kt
+++ b/datalayer/core/src/main/java/com/google/android/horologist/data/apphelper/DataLayerAppHelper.kt
@@ -189,7 +189,6 @@ abstract class DataLayerAppHelper(
         data: ByteArray,
         timeoutMs: Long = MESSAGE_REQUEST_TIMEOUT_MS,
     ): AppHelperResultCode {
-        checkIsForegroundOrThrow()
         val response = try {
             withTimeout(timeoutMs) {
                 // Cancellation will not lead to the GMS Task itself being cancelled.


### PR DESCRIPTION
#### WHAT

Remove foreground check from `sendRequestWithTimeout`.

For future reference, it was added in https://github.com/google/horologist/pull/1728.

#### WHY

From @garanj:

> I don't think the one in sendRequestWithTimeout should exist: There's nothing in that which requires a foreground for it to be valid request, where as (for example) starting a remote activity should have the foreground check. sendRequestWithTimeout could be used for use cases that don't need a foreground check.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
