### PR TITLE
Define the min sdk policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ commonly required by developers but not yet available.
 
 The currently maintained branches of Horologist are.
 
-| Version | Branch | Min SDK | Description |
+| Version | Branch | Min SDK     | Description |
 | ------- | ------ | ----------- | ----------- |
 | 0.4.x | release-0.4.x | 25 | Wear Compose 1.2.x (stable) and Media3, and generally stable APIs. |
 | 0.5.x | main | 25 | Wear Compose 1.3.x, Compose 1.5.x, Media3 and some betas of Androidx. |

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ commonly required by developers but not yet available.
 
 The currently maintained branches of Horologist are.
 
-| Version | Branch | Min SDK      | Description |
-| ------- | ------ | -----------  | ----------- |
-| 0.4.x   | release-0.4.x | 25/26 | Wear Compose 1.2.x (stable) and Media3, and generally stable APIs. |
-| 0.5.x   | main   | 25           | Wear Compose 1.3.x, Compose 1.5.x, Media3 and some betas of Androidx. |
-| 0.6.x   | _future_ | 26         | Wear Compose 1.4.x, Compose 1.6.x and generally latest alphas of Androidx. |
+| Version | Branch        | Min SDK (Wear) | Description |
+| ------- | ------------- | -------------- | ----------- |
+| 0.4.x   | release-0.4.x | 25/26          | Wear Compose 1.2.x (stable) and Media3, and generally stable APIs. |
+| 0.5.x   | main          | 25             | Wear Compose 1.3.x, Compose 1.5.x, Media3 and some betas of Androidx. |
+| 0.6.x   | _future_      | 26             | Wear Compose 1.4.x, Compose 1.6.x and generally latest alphas of Androidx. |
 
 Maintenance branches will not delete existing APIs and they should remain stable. However
 the main branch will actively update to incorporate new API guidance, removing or changing

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ The currently maintained branches of Horologist are.
 
 | Version | Branch | Min SDK     | Description |
 | ------- | ------ | ----------- | ----------- |
-| 0.4.x | release-0.4.x | 25 | Wear Compose 1.2.x (stable) and Media3, and generally stable APIs. |
-| 0.5.x | main | 25 | Wear Compose 1.3.x, Compose 1.5.x, Media3 and some betas of Androidx. |
-| 0.6.x | _future_ | 26 | Wear Compose 1.4.x, Compose 1.6.x and generally latest alphas of Androidx. |
+| 0.4.x   | release-0.4.x | 25   | Wear Compose 1.2.x (stable) and Media3, and generally stable APIs. |
+| 0.5.x   | main   | 25          | Wear Compose 1.3.x, Compose 1.5.x, Media3 and some betas of Androidx. |
+| 0.6.x   | _future_ | 26        | Wear Compose 1.4.x, Compose 1.6.x and generally latest alphas of Androidx. |
 
 Maintenance branches will not delete existing APIs and they should remain stable. However
 the main branch will actively update to incorporate new API guidance, removing or changing

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ commonly required by developers but not yet available.
 
 The currently maintained branches of Horologist are.
 
-| Version | Branch | Description |
-| ------- | ------ | ----------- |
-| 0.4.x | release-0.4.x | Wear Compose 1.2.x (stable) and Media3, and generally stable APIs. |
-| 0.5.x | main | Wear Compose 1.3.x, Compose 1.5.x, Media3 and some betas of Androidx. |
-| 0.6.x | _future_ | Wear Compose 1.4.x, Compose 1.6.x and generally latest alphas of Androidx. |
+| Version | Branch | Min SDK | Description |
+| ------- | ------ | Description | ----------- |
+| 0.4.x | release-0.4.x | 25 | Wear Compose 1.2.x (stable) and Media3, and generally stable APIs. |
+| 0.5.x | main | 25 | Wear Compose 1.3.x, Compose 1.5.x, Media3 and some betas of Androidx. |
+| 0.6.x | _future_ | 26 | Wear Compose 1.4.x, Compose 1.6.x and generally latest alphas of Androidx. |
 
 Maintenance branches will not delete existing APIs and they should remain stable. However
 the main branch will actively update to incorporate new API guidance, removing or changing

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ commonly required by developers but not yet available.
 
 The currently maintained branches of Horologist are.
 
-| Version | Branch | Min SDK     | Description |
-| ------- | ------ | ----------- | ----------- |
-| 0.4.x   | release-0.4.x | 25   | Wear Compose 1.2.x (stable) and Media3, and generally stable APIs. |
-| 0.5.x   | main   | 25          | Wear Compose 1.3.x, Compose 1.5.x, Media3 and some betas of Androidx. |
-| 0.6.x   | _future_ | 26        | Wear Compose 1.4.x, Compose 1.6.x and generally latest alphas of Androidx. |
+| Version | Branch | Min SDK      | Description |
+| ------- | ------ | -----------  | ----------- |
+| 0.4.x   | release-0.4.x | 25/26 | Wear Compose 1.2.x (stable) and Media3, and generally stable APIs. |
+| 0.5.x   | main   | 25           | Wear Compose 1.3.x, Compose 1.5.x, Media3 and some betas of Androidx. |
+| 0.6.x   | _future_ | 26         | Wear Compose 1.4.x, Compose 1.6.x and generally latest alphas of Androidx. |
 
 Maintenance branches will not delete existing APIs and they should remain stable. However
 the main branch will actively update to incorporate new API guidance, removing or changing

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ commonly required by developers but not yet available.
 The currently maintained branches of Horologist are.
 
 | Version | Branch | Min SDK | Description |
-| ------- | ------ | Description | ----------- |
+| ------- | ------ | ----------- | ----------- |
 | 0.4.x | release-0.4.x | 25 | Wear Compose 1.2.x (stable) and Media3, and generally stable APIs. |
 | 0.5.x | main | 25 | Wear Compose 1.3.x, Compose 1.5.x, Media3 and some betas of Androidx. |
 | 0.6.x | _future_ | 26 | Wear Compose 1.4.x, Compose 1.6.x and generally latest alphas of Androidx. |


### PR DESCRIPTION
#### WHAT

Define the min sdk policy


| Version | Branch | Min SDK      | Description |
| ------- | ------ | -----------  | ----------- |
| 0.4.x   | release-0.4.x | 25/26 | Wear Compose 1.2.x (stable) and Media3, and generally stable APIs. |
| 0.5.x   | main   | 25           | Wear Compose 1.3.x, Compose 1.5.x, Media3 and some betas of Androidx. |
| 0.6.x   | _future_ | 26         | Wear Compose 1.4.x, Compose 1.6.x and generally latest alphas of Androidx. |

#### WHY

https://github.com/google/horologist/pull/1972

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
