### PR TITLE
Improve kdocs and samples of datalayer functions

### DIFF
--- a/datalayer/core/api/current.api
+++ b/datalayer/core/api/current.api
@@ -145,12 +145,12 @@ package com.google.android.horologist.data.apphelper {
     method protected final String getPlayStoreUri();
     method protected final com.google.android.horologist.data.WearDataLayerRegistry getRegistry();
     method protected final androidx.wear.remote.interactions.RemoteActivityHelper getRemoteActivityHelper();
-    method public abstract suspend Object? installOnNode(String node, kotlin.coroutines.Continuation<? super kotlin.Unit>);
+    method public abstract suspend Object? installOnNode(String nodeId, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public final suspend Object? isAvailable(kotlin.coroutines.Continuation<? super java.lang.Boolean>);
-    method @CheckResult protected final suspend Object? sendRequestWithTimeout(String node, String path, byte[] data, optional long timeoutMs, optional kotlin.coroutines.Continuation<? super error.NonExistentClass>);
-    method @CheckResult public abstract suspend Object? startCompanion(String node, kotlin.coroutines.Continuation<? super error.NonExistentClass>);
-    method @CheckResult public final suspend Object? startRemoteActivity(String node, error.NonExistentClass config, kotlin.coroutines.Continuation<? super error.NonExistentClass>);
-    method @CheckResult public final suspend Object? startRemoteOwnApp(String node, kotlin.coroutines.Continuation<? super error.NonExistentClass>);
+    method @CheckResult protected final suspend Object? sendRequestWithTimeout(String nodeId, String path, byte[] data, optional long timeoutMs, optional kotlin.coroutines.Continuation<? super error.NonExistentClass>);
+    method @CheckResult public abstract suspend Object? startCompanion(String nodeId, kotlin.coroutines.Continuation<? super error.NonExistentClass>);
+    method @CheckResult public final suspend Object? startRemoteActivity(String nodeId, error.NonExistentClass config, kotlin.coroutines.Continuation<? super error.NonExistentClass>);
+    method @CheckResult public final suspend Object? startRemoteOwnApp(String nodeId, kotlin.coroutines.Continuation<? super error.NonExistentClass>);
     property public final kotlinx.coroutines.flow.Flow<java.util.Set<com.google.android.gms.wearable.Node>> connectedAndInstalledNodes;
     property protected final android.content.Context context;
     property protected final String playStoreUri;

--- a/datalayer/core/src/main/java/com/google/android/horologist/data/apphelper/DataLayerAppHelperService.kt
+++ b/datalayer/core/src/main/java/com/google/android/horologist/data/apphelper/DataLayerAppHelperService.kt
@@ -35,7 +35,7 @@ import kotlinx.coroutines.runBlocking
 public abstract class DataLayerAppHelperService : WearableListenerService() {
     public abstract val appHelper: DataLayerAppHelper
 
-    override fun onRequest(node: String, path: String, byteArray: ByteArray): Task<ByteArray> {
+    override fun onRequest(nodeId: String, path: String, byteArray: ByteArray): Task<ByteArray> {
         if (path != DataLayerAppHelper.LAUNCH_APP) {
             return Tasks.forResult(byteArrayForResultCode(AppHelperResultCode.APP_HELPER_RESULT_UNKNOWN_REQUEST))
         }

--- a/datalayer/grpc/src/main/java/com/google/android/horologist/datalayer/grpc/server/BaseGrpcDataService.kt
+++ b/datalayer/grpc/src/main/java/com/google/android/horologist/datalayer/grpc/server/BaseGrpcDataService.kt
@@ -44,7 +44,7 @@ public abstract class BaseGrpcDataService<T : BindableService> : WearDataService
         )
     }
 
-    override fun onRequest(node: String, path: String, data: ByteArray): Task<ByteArray>? {
+    override fun onRequest(nodeId: String, path: String, data: ByteArray): Task<ByteArray>? {
         return rpcServer.handleIncomingMessage(data).asTask()
     }
 

--- a/datalayer/phone/api/current.api
+++ b/datalayer/phone/api/current.api
@@ -3,8 +3,8 @@ package com.google.android.horologist.datalayer.phone {
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public final class PhoneDataLayerAppHelper extends com.google.android.horologist.data.apphelper.DataLayerAppHelper {
     ctor public PhoneDataLayerAppHelper(android.content.Context context, com.google.android.horologist.data.WearDataLayerRegistry registry);
-    method public suspend Object? installOnNode(String node, kotlin.coroutines.Continuation<? super kotlin.Unit>);
-    method @CheckResult public suspend Object? startCompanion(String node, kotlin.coroutines.Continuation<? super com.google.android.horologist.data.AppHelperResultCode>);
+    method public suspend Object? installOnNode(String nodeId, kotlin.coroutines.Continuation<? super kotlin.Unit>);
+    method @CheckResult public suspend Object? startCompanion(String nodeId, kotlin.coroutines.Continuation<? super com.google.android.horologist.data.AppHelperResultCode>);
   }
 
   public final class PhoneDataLayerListenerService extends com.google.android.horologist.data.apphelper.DataLayerAppHelperService {

--- a/datalayer/phone/src/main/java/com/google/android/horologist/datalayer/phone/PhoneDataLayerAppHelper.kt
+++ b/datalayer/phone/src/main/java/com/google/android/horologist/datalayer/phone/PhoneDataLayerAppHelper.kt
@@ -38,18 +38,18 @@ public class PhoneDataLayerAppHelper(
 ) : DataLayerAppHelper(context, registry) {
     private val SAMSUNG_COMPANION_PKG = "com.samsung.android.app.watchmanager"
 
-    override suspend fun installOnNode(node: String) {
+    override suspend fun installOnNode(nodeId: String) {
         checkIsForegroundOrThrow()
         val intent = Intent(Intent.ACTION_VIEW)
             .addCategory(Intent.CATEGORY_BROWSABLE)
             .setData(Uri.parse(playStoreUri))
-        remoteActivityHelper.startRemoteActivity(intent, node).await()
+        remoteActivityHelper.startRemoteActivity(intent, nodeId).await()
     }
 
     @CheckResult
-    override suspend fun startCompanion(node: String): AppHelperResultCode {
+    override suspend fun startCompanion(nodeId: String): AppHelperResultCode {
         checkIsForegroundOrThrow()
-        val companionPackage = registry.nodeClient.getCompanionPackageForNode(node).await()
+        val companionPackage = registry.nodeClient.getCompanionPackageForNode(nodeId).await()
 
         /**
          * Some devices report the wrong companion for actually launching the Companion app: For

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodes/AppHelperNodeStatusCard.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodes/AppHelperNodeStatusCard.kt
@@ -54,9 +54,10 @@ fun AppHelperNodeStatusCard(
     onStartCompanionClick: (String) -> Unit,
     onStartRemoteOwnAppClick: (String) -> Unit,
     onStartRemoteActivityClick: (nodeId: String) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .padding(16.dp)
             .fillMaxWidth(),
         contentAlignment = Alignment.Center,
@@ -121,8 +122,8 @@ fun AppHelperNodeStatusCard(
                     horizontalArrangement = Arrangement.SpaceBetween,
                 ) {
                     Button(
-                        modifier = Modifier.wrapContentHeight(),
                         onClick = { onStartCompanionClick(nodeStatus.id) },
+                        modifier = Modifier.wrapContentHeight(),
                     ) {
                         Text(
                             stringResource(id = R.string.node_status_start_companion_button_label),
@@ -130,8 +131,8 @@ fun AppHelperNodeStatusCard(
                         )
                     }
                     Button(
-                        modifier = Modifier.wrapContentHeight().padding(start = 10.dp),
                         onClick = { onInstallOnNodeClick(nodeStatus.id) },
+                        modifier = Modifier.wrapContentHeight().padding(start = 10.dp),
                     ) {
                         Text(
                             stringResource(id = R.string.node_status_install_on_node_button_label),
@@ -146,8 +147,9 @@ fun AppHelperNodeStatusCard(
                     horizontalArrangement = Arrangement.SpaceBetween,
                 ) {
                     Button(
-                        modifier = Modifier.wrapContentHeight(),
                         onClick = { onStartRemoteOwnAppClick(nodeStatus.id) },
+                        modifier = Modifier.wrapContentHeight(),
+                        enabled = nodeStatus.appInstalled,
                     ) {
                         Text(
                             stringResource(id = R.string.node_status_start_own_app_button_label),
@@ -155,10 +157,11 @@ fun AppHelperNodeStatusCard(
                         )
                     }
                     Button(
+                        onClick = { onStartRemoteActivityClick(nodeStatus.id) },
                         modifier = Modifier
                             .wrapContentHeight()
                             .padding(start = 10.dp),
-                        onClick = { onStartRemoteActivityClick(nodeStatus.id) },
+                        enabled = nodeStatus.appInstalled,
                     ) {
                         Text(
                             stringResource(id = R.string.node_status_start_remote_activity_button_label),

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodes/NodesViewModel.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodes/NodesViewModel.kt
@@ -70,7 +70,7 @@ class NodesActionViewModel
 
         fun onStartCompanionClick(nodeId: String) {
             runActionAndHandleAppHelperResult {
-                phoneDataLayerAppHelper.startCompanion(node = nodeId)
+                phoneDataLayerAppHelper.startCompanion(nodeId = nodeId)
             }
         }
 
@@ -78,7 +78,7 @@ class NodesActionViewModel
             _uiState.value = NodesScreenState.ActionRunning
             viewModelScope.launch {
                 try {
-                    phoneDataLayerAppHelper.installOnNode(node = nodeId)
+                    phoneDataLayerAppHelper.installOnNode(nodeId = nodeId)
 
                     _uiState.value = NodesScreenState.ActionSucceeded
                 } catch (e: Exception) {
@@ -92,7 +92,7 @@ class NodesActionViewModel
 
         fun onStartRemoteOwnAppClick(nodeId: String) {
             runActionAndHandleAppHelperResult {
-                phoneDataLayerAppHelper.startRemoteOwnApp(node = nodeId)
+                phoneDataLayerAppHelper.startRemoteOwnApp(nodeId = nodeId)
             }
         }
 

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsScreen.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsScreen.kt
@@ -59,6 +59,7 @@ fun NodeDetailsScreen(
 
     NodeDetailsScreen(
         nodeId = viewModel.nodeId,
+        appInstalled = viewModel.appInstalled,
         state = state,
         onStartCompanionClick = viewModel::onStartCompanionClick,
         onInstallOnNodeClick = viewModel::onInstallOnNodeClick,
@@ -73,6 +74,7 @@ fun NodeDetailsScreen(
 @Composable
 fun NodeDetailsScreen(
     nodeId: String,
+    appInstalled: Boolean,
     state: NodeDetailsScreenState,
     onStartCompanionClick: () -> Unit,
     onInstallOnNodeClick: () -> Unit,
@@ -108,6 +110,7 @@ fun NodeDetailsScreen(
                     Chip(
                         label = stringResource(id = R.string.node_details_start_companion_chip_label),
                         onClick = onStartCompanionClick,
+                        enabled = appInstalled,
                     )
                 }
                 item {
@@ -120,12 +123,14 @@ fun NodeDetailsScreen(
                     Chip(
                         label = stringResource(id = R.string.node_details_start_remote_own_app_chip_label),
                         onClick = onStartRemoteOwnAppClick,
+                        enabled = appInstalled,
                     )
                 }
                 item {
                     Chip(
                         label = stringResource(id = R.string.node_details_start_remote_activity_chip_label),
                         onClick = onStartRemoteActivityClick,
+                        enabled = appInstalled,
                     )
                 }
             }
@@ -213,6 +218,7 @@ fun NodeDetailsScreen(
 fun NodeDetailsScreenPreview() {
     NodeDetailsScreen(
         nodeId = "12345",
+        appInstalled = true,
         state = NodeDetailsScreenState.Idle,
         onStartCompanionClick = { },
         onInstallOnNodeClick = { },

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsScreenNavigation.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsScreenNavigation.kt
@@ -29,20 +29,26 @@ import java.net.URLDecoder
 import java.net.URLEncoder
 
 private const val nodeIdArg = "nodeId"
+private const val appInstalledArg = "appInstalled"
 private const val routePrefix = "appHelperNodeDetailsScreen"
 
 private val URL_CHARACTER_ENCODING = Charsets.UTF_8.name()
 
-const val nodeDetailsScreenRoute = "$routePrefix/{$nodeIdArg}"
+const val nodeDetailsScreenRoute = "$routePrefix/$nodeIdArg={$nodeIdArg}&$appInstalledArg={$appInstalledArg}"
 
-internal class NodeDetailsScreenArgs(val nodeId: String) {
-    constructor(savedStateHandle: SavedStateHandle) :
-        this(URLDecoder.decode(checkNotNull(savedStateHandle[nodeIdArg]), URL_CHARACTER_ENCODING))
+internal class NodeDetailsScreenArgs(
+    val nodeId: String,
+    val appInstalled: Boolean,
+) {
+    constructor(savedStateHandle: SavedStateHandle) : this(
+        URLDecoder.decode(checkNotNull(savedStateHandle[nodeIdArg]), URL_CHARACTER_ENCODING),
+        checkNotNull(savedStateHandle[appInstalledArg]),
+    )
 }
 
-fun NavController.navigateToNodeDetailsScreen(message: String) {
-    val encodedMessage = URLEncoder.encode(message, URL_CHARACTER_ENCODING)
-    this.navigate("$routePrefix/$encodedMessage")
+fun NavController.navigateToNodeDetailsScreen(nodeId: String, appInstalled: Boolean) {
+    val encodedNodeId = URLEncoder.encode(nodeId, URL_CHARACTER_ENCODING)
+    this.navigate("$routePrefix/$nodeIdArg=$encodedNodeId&$appInstalledArg=$appInstalled")
 }
 
 fun NavGraphBuilder.nodeDetailsScreen() {
@@ -50,6 +56,7 @@ fun NavGraphBuilder.nodeDetailsScreen() {
         route = Screen.AppHelperNodeDetailsScreen.route,
         arguments = listOf(
             navArgument(nodeIdArg) { type = NavType.StringType },
+            navArgument(appInstalledArg) { type = NavType.BoolType },
         ),
     ) {
         val columnState = rememberColumnState()

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsViewModel.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsViewModel.kt
@@ -43,12 +43,15 @@ class NodeDetailsViewModel
         val nodeId: String
             get() = nodeDetailsScreenArgs.nodeId
 
+        val appInstalled: Boolean
+            get() = nodeDetailsScreenArgs.appInstalled
+
         private val _uiState = MutableStateFlow<NodeDetailsScreenState>(NodeDetailsScreenState.Idle)
         public val uiState: StateFlow<NodeDetailsScreenState> = _uiState
 
         fun onStartCompanionClick() {
             runActionAndHandleAppHelperResult {
-                wearDataLayerAppHelper.startCompanion(node = nodeId)
+                wearDataLayerAppHelper.startCompanion(nodeId = nodeId)
             }
         }
 
@@ -56,7 +59,7 @@ class NodeDetailsViewModel
             _uiState.value = NodeDetailsScreenState.ActionRunning
             viewModelScope.launch {
                 try {
-                    wearDataLayerAppHelper.installOnNode(node = nodeId)
+                    wearDataLayerAppHelper.installOnNode(nodeId = nodeId)
 
                     _uiState.value = NodeDetailsScreenState.ActionSucceeded
                 } catch (e: Exception) {
@@ -70,7 +73,7 @@ class NodeDetailsViewModel
 
         fun onStartRemoteOwnAppClick() {
             runActionAndHandleAppHelperResult {
-                wearDataLayerAppHelper.startRemoteOwnApp(node = nodeId)
+                wearDataLayerAppHelper.startRemoteOwnApp(nodeId = nodeId)
             }
         }
 

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodesActionsScreen.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodesActionsScreen.kt
@@ -44,7 +44,7 @@ import com.google.android.horologist.images.base.paintable.ImageVectorPaintable
 
 @Composable
 fun NodesActionsScreen(
-    onNodeClick: (nodeId: String) -> Unit,
+    onNodeClick: (nodeId: String, appInstalled: Boolean) -> Unit,
     columnState: ScalingLazyColumnState,
     modifier: Modifier = Modifier,
     viewModel: NodesActionViewModel = hiltViewModel(),
@@ -67,7 +67,7 @@ fun NodesActionsScreen(
 @Composable
 fun NodesActionsScreen(
     state: NodesActionScreenState,
-    onNodeClick: (nodeId: String) -> Unit,
+    onNodeClick: (nodeId: String, appInstalled: Boolean) -> Unit,
     onRefreshClick: () -> Unit,
     columnState: ScalingLazyColumnState,
     modifier: Modifier = Modifier,
@@ -105,7 +105,7 @@ fun NodesActionsScreen(
 
                         Chip(
                             label = node.name,
-                            onClick = { onNodeClick(node.id) },
+                            onClick = { onNodeClick(node.id, node.appInstalled) },
                             secondaryLabel = if (node.appInstalled) {
                                 stringResource(id = R.string.nodes_actions_app_installed_label)
                             } else {
@@ -164,7 +164,7 @@ fun NodesActionsScreenPreviewLoaded() {
                 ),
             ),
         ),
-        onNodeClick = { },
+        onNodeClick = { _, _ -> },
         onRefreshClick = { },
         columnState = belowTimeTextPreview(),
     )
@@ -175,7 +175,7 @@ fun NodesActionsScreenPreviewLoaded() {
 fun NodesActionsScreenPreviewEmptyNodes() {
     NodesActionsScreen(
         state = NodesActionScreenState.Loaded(emptyList()),
-        onNodeClick = { },
+        onNodeClick = { _, _ -> },
         onRefreshClick = { },
         columnState = belowTimeTextPreview(),
     )
@@ -186,7 +186,7 @@ fun NodesActionsScreenPreviewEmptyNodes() {
 fun NodesActionsScreenPreviewApiNotAvailable() {
     NodesActionsScreen(
         state = NodesActionScreenState.ApiNotAvailable,
-        onNodeClick = { },
+        onNodeClick = { _, _ -> },
         onRefreshClick = { },
         columnState = belowTimeTextPreview(),
     )

--- a/datalayer/watch/api/current.api
+++ b/datalayer/watch/api/current.api
@@ -4,7 +4,7 @@ package com.google.android.horologist.datalayer.watch {
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public final class WearDataLayerAppHelper extends com.google.android.horologist.data.apphelper.DataLayerAppHelper {
     ctor public WearDataLayerAppHelper(android.content.Context context, com.google.android.horologist.data.WearDataLayerRegistry registry, kotlinx.coroutines.CoroutineScope scope, optional String? appStoreUri);
     method public kotlinx.coroutines.flow.Flow<com.google.android.horologist.data.SurfacesInfo> getSurfacesInfo();
-    method public suspend Object? installOnNode(String node, kotlin.coroutines.Continuation<? super kotlin.Unit>);
+    method public suspend Object? installOnNode(String nodeId, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? markActivityLaunchedOnce(kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? markComplicationAsActivated(String complicationName, int complicationInstanceId, androidx.wear.watchface.complications.data.ComplicationType complicationType, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? markComplicationAsDeactivated(String complicationName, int complicationInstanceId, androidx.wear.watchface.complications.data.ComplicationType complicationType, kotlin.coroutines.Continuation<? super kotlin.Unit>);
@@ -12,7 +12,7 @@ package com.google.android.horologist.datalayer.watch {
     method public suspend Object? markSetupNoLongerComplete(kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? markTileAsInstalled(String tileName, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? markTileAsRemoved(String tileName, kotlin.coroutines.Continuation<? super kotlin.Unit>);
-    method @CheckResult public suspend Object? startCompanion(String node, kotlin.coroutines.Continuation<? super com.google.android.horologist.data.AppHelperResultCode>);
+    method @CheckResult public suspend Object? startCompanion(String nodeId, kotlin.coroutines.Continuation<? super com.google.android.horologist.data.AppHelperResultCode>);
     property public final kotlinx.coroutines.flow.Flow<com.google.android.horologist.data.SurfacesInfo> surfacesInfo;
   }
 

--- a/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
+++ b/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
@@ -72,7 +72,7 @@ public class WearDataLayerAppHelper(
          */
         public val surfacesInfo: Flow<SurfacesInfo> = surfacesInfoDataStore.data
 
-        override suspend fun installOnNode(node: String) {
+        override suspend fun installOnNode(nodeId: String) {
             checkIsForegroundOrThrow()
             if (appStoreUri != null &&
                 PhoneTypeHelper.getPhoneDeviceType(context) == PhoneTypeHelper.DEVICE_TYPE_IOS
@@ -80,17 +80,17 @@ public class WearDataLayerAppHelper(
                 val intent = Intent(Intent.ACTION_VIEW)
                     .addCategory(Intent.CATEGORY_BROWSABLE)
                     .setData(Uri.parse(appStoreUri))
-                remoteActivityHelper.startRemoteActivity(intent, node).await()
+                remoteActivityHelper.startRemoteActivity(intent, nodeId).await()
             } else if (PhoneTypeHelper.getPhoneDeviceType(context) == PhoneTypeHelper.DEVICE_TYPE_ANDROID) {
                 val intent = Intent(Intent.ACTION_VIEW)
                     .addCategory(Intent.CATEGORY_BROWSABLE)
                     .setData(Uri.parse(playStoreUri))
-                remoteActivityHelper.startRemoteActivity(intent, node).await()
+                remoteActivityHelper.startRemoteActivity(intent, nodeId).await()
             }
         }
 
         @CheckResult
-        override suspend fun startCompanion(node: String): AppHelperResultCode {
+        override suspend fun startCompanion(nodeId: String): AppHelperResultCode {
             checkIsForegroundOrThrow()
             val localNode = registry.nodeClient.localNode.await()
             val request = launchRequest {
@@ -98,7 +98,7 @@ public class WearDataLayerAppHelper(
                     sourceNode = localNode.id
                 }
             }
-            return sendRequestWithTimeout(node, LAUNCH_APP, request.toByteArray())
+            return sendRequestWithTimeout(nodeId, LAUNCH_APP, request.toByteArray())
         }
 
         /**


### PR DESCRIPTION
#### WHAT

Improve kdocs and samples of datalayer functions that require app installed on the remote node.

Update samples to disable buttons of functions that require app installed on the remote node, when the app is not installed:

| <img src='https://github.com/google/horologist/assets/878134/33b41606-10a0-4180-99c8-26d411e93008' width='400'> | ![Screenshot_20240117_144654](https://github.com/google/horologist/assets/878134/48eb6f1e-24a9-440e-82e6-8c28bd5f9242) | 
|--------|--------|




Also rename parameter `node` to `nodeId` in order to match:

- [MessageClient.sendRequest](https://developers.google.com/android/reference/com/google/android/gms/wearable/MessageClient#sendRequest(java.lang.String,%20java.lang.String,%20byte[]))
- [WearableListenerService.onRequest](https://developers.google.com/android/reference/com/google/android/gms/wearable/WearableListenerService#onRequest(java.lang.String,%20java.lang.String,%20byte[]))

#### WHY

Fixes https://github.com/google/horologist/issues/1900

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
