### PR TITLE
Remove SuppressLint annotation

### DIFF
--- a/datalayer/core/src/main/java/com/google/android/horologist/data/WearDataLayerRegistry.kt
+++ b/datalayer/core/src/main/java/com/google/android/horologist/data/WearDataLayerRegistry.kt
@@ -16,7 +16,6 @@
 
 package com.google.android.horologist.data
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.net.Uri
 import androidx.datastore.core.DataStore
@@ -42,8 +41,6 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
 import kotlin.reflect.KClass
 
-// Workaround https://issuetracker.google.com/issues/239451111
-@SuppressLint("VisibleForTests")
 @ExperimentalHorologistApi
 /**
  * Implementation of Androidx Datastore for Proto and Preferences on top of the

--- a/datalayer/core/src/main/java/com/google/android/horologist/data/store/impl/DataItemFlow.kt
+++ b/datalayer/core/src/main/java/com/google/android/horologist/data/store/impl/DataItemFlow.kt
@@ -16,7 +16,6 @@
 
 package com.google.android.horologist.data.store.impl
 
-import android.annotation.SuppressLint
 import android.net.Uri
 import androidx.datastore.core.Serializer
 import com.google.android.gms.wearable.DataClient
@@ -30,8 +29,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.tasks.await
 import java.io.ByteArrayInputStream
 
-// Workaround https://issuetracker.google.com/issues/239451111
-@SuppressLint("VisibleForTests")
 public fun <T> DataClient.dataItemFlow(
     nodeId: String,
     path: String,

--- a/datalayer/core/src/main/java/com/google/android/horologist/data/store/impl/WearLocalDataStore.kt
+++ b/datalayer/core/src/main/java/com/google/android/horologist/data/store/impl/WearLocalDataStore.kt
@@ -18,7 +18,6 @@
 
 package com.google.android.horologist.data.store.impl
 
-import android.annotation.SuppressLint
 import android.net.Uri
 import android.util.Log
 import androidx.datastore.core.DataStore
@@ -44,8 +43,6 @@ import kotlinx.coroutines.tasks.await
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 
-// Workaround https://issuetracker.google.com/issues/239451111
-@SuppressLint("VisibleForTests")
 @ExperimentalHorologistApi
 public class WearLocalDataStore<T>(
     private val wearDataLayerRegistry: WearDataLayerRegistry,


### PR DESCRIPTION
#### WHAT

Remove SuppressLint annotation.

#### WHY

It doesn't seem to be needed anymore in version [18.1.0](https://developer.android.com/wear/releases#2023-august-31_wearable_sdk_1810).

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
