### PR TITLE
Fix implementation of installOnNode for phones

### DIFF
--- a/datalayer/phone/src/main/java/com/google/android/horologist/datalayer/phone/PhoneDataLayerAppHelper.kt
+++ b/datalayer/phone/src/main/java/com/google/android/horologist/datalayer/phone/PhoneDataLayerAppHelper.kt
@@ -27,7 +27,6 @@ import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.data.AppHelperResultCode
 import com.google.android.horologist.data.WearDataLayerRegistry
 import com.google.android.horologist.data.apphelper.DataLayerAppHelper
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.tasks.await
 
 /**
@@ -46,20 +45,6 @@ public class PhoneDataLayerAppHelper(
         val intent = Intent(Intent.ACTION_VIEW)
             .addCategory(Intent.CATEGORY_BROWSABLE)
             .setData(Uri.parse(playStoreUri))
-
-        val availabilityStatus = remoteActivityHelper.availabilityStatus.first()
-
-        // As per documentation, calls should be made when status is either STATUS_AVAILABLE
-        // or STATUS_UNKNOWN.
-        when (availabilityStatus) {
-            RemoteActivityHelper.STATUS_UNAVAILABLE -> {
-                return AppHelperResultCode.APP_HELPER_RESULT_UNAVAILABLE
-            }
-
-            RemoteActivityHelper.STATUS_TEMPORARILY_UNAVAILABLE -> {
-                return AppHelperResultCode.APP_HELPER_RESULT_TEMPORARILY_UNAVAILABLE
-            }
-        }
 
         try {
             remoteActivityHelper.startRemoteActivity(intent, nodeId).await()

--- a/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
+++ b/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
@@ -105,6 +105,8 @@ public class WearDataLayerAppHelper(
 
             val availabilityStatus = remoteActivityHelper.availabilityStatus.first()
 
+            // As per documentation, calls should be made when status is either STATUS_AVAILABLE
+            // or STATUS_UNKNOWN.
             when (availabilityStatus) {
                 RemoteActivityHelper.STATUS_UNAVAILABLE -> {
                     return AppHelperResultCode.APP_HELPER_RESULT_UNAVAILABLE


### PR DESCRIPTION
#### WHAT

Fix implementation of installOnNode for phones.

#### WHY

- From [RemoteActivityHelper#getAvailabilityStatus](https://developer.android.com/reference/androidx/wear/remote/interactions/RemoteActivityHelper#getAvailabilityStatus()): 
> On phone devices, it will always return STATUS_UNKNOWN

- Missed adding comment to the watch implementation, requested in https://github.com/google/horologist/pull/1992#discussion_r1457584821 

#### HOW


#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
