### PR TITLE
Add sample screen for connectedAndInstalledNodes function

### DIFF
--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodes/NodesScreen.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodes/NodesScreen.kt
@@ -230,7 +230,7 @@ fun NodesScreenPreview() {
 
 @Preview(showBackground = true)
 @Composable
-fun NodesActionsScreenPreviewEmptyNodes() {
+fun NodesScreenPreviewEmptyNodes() {
     NodesScreen(
         state = NodesScreenState.Loaded(emptyList()),
         onRefreshClick = { },

--- a/datalayer/sample/phone/src/main/res/values/strings.xml
+++ b/datalayer/sample/phone/src/main/res/values/strings.xml
@@ -58,10 +58,10 @@
     <string name="node_status_start_remote_activity_button_label">Start remote activity</string>
 
     <!-- App Helper Nodes Listener screen -->
-    <string name="nodes_listener_screen_header">Nodes</string>
+    <string name="nodes_listener_screen_header">Nodes Listener</string>
     <string name="nodes_listener_screen_message">This screen shows all the connected nodes that have the app installed. The list updates automatically.</string>
     <string name="nodes_listener_screen_no_nodes">No nodes were found.</string>
-    <string name="nodes_listener_screen_node_name_label">Node: %1$s</string>
+    <string name="nodes_listener_screen_node_name_label">Name: %1$s</string>
     <string name="nodes_listener_screen_node_id_label">ID: %1$s</string>
 
     <!-- In-app prompt - Install App Demo 1 screen -->

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/Screen.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/Screen.kt
@@ -29,6 +29,7 @@ sealed class Screen(
 
     data object AppHelperTrackingScreen : Screen("appHelperTrackingScreen")
     data object AppHelperNodesActionsScreen : Screen("appHelperNodesActionsScreen")
+    data object AppHelperNodesListenerScreen : Screen("appHelperNodesListenerScreen")
 
     data object AppHelperNodeDetailsScreen : Screen(nodeDetailsScreenRoute)
 

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/WearApp.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/WearApp.kt
@@ -37,6 +37,7 @@ import com.google.android.horologist.datalayer.sample.screens.nodes.DataLayerNod
 import com.google.android.horologist.datalayer.sample.screens.nodesactions.NodesActionsScreen
 import com.google.android.horologist.datalayer.sample.screens.nodesactions.navigateToNodeDetailsScreen
 import com.google.android.horologist.datalayer.sample.screens.nodesactions.nodeDetailsScreen
+import com.google.android.horologist.datalayer.sample.screens.nodeslistener.NodesListenerScreen
 import com.google.android.horologist.datalayer.sample.screens.tracking.TrackingScreen
 
 @Composable
@@ -94,6 +95,13 @@ fun WearApp(
                         onNodeClick = navController::navigateToNodeDetailsScreen,
                         columnState = columnState,
                     )
+                }
+            }
+            composable(route = Screen.AppHelperNodesListenerScreen.route) {
+                val columnState = rememberColumnState()
+
+                ScreenScaffold(scrollState = columnState) {
+                    NodesListenerScreen(columnState = columnState)
                 }
             }
             nodeDetailsScreen()

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/MainScreen.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/MainScreen.kt
@@ -52,6 +52,7 @@ private fun SectionedListScope.appHelpersSection(navigateToRoute: (String) -> Un
         listOf(
             Pair(R.string.main_menu_apphelpers_tracking_item, Screen.AppHelperTrackingScreen.route),
             Pair(R.string.main_menu_apphelpers_nodes_actions_item, Screen.AppHelperNodesActionsScreen.route),
+            Pair(R.string.main_menu_apphelpers_nodes_listener_item, Screen.AppHelperNodesListenerScreen.route),
         ),
     ) {
         header {

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodes/DataLayerNodesScreen.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodes/DataLayerNodesScreen.kt
@@ -47,8 +47,9 @@ fun DataLayerNodesScreen(
         }
         items(state.nodes) {
             Chip(
-                label = "${it.displayName}(${it.id}) ${if (it.isNearby) "NEAR" else ""}",
+                label = it.displayName,
                 onClick = { },
+                secondaryLabel = "${it.id} ${if (it.isNearby) "(NEAR)" else ""}",
             )
         }
         item {

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsScreen.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodeDetailsScreen.kt
@@ -45,6 +45,7 @@ import com.google.android.horologist.compose.layout.belowTimeTextPreview
 import com.google.android.horologist.compose.material.Chip
 import com.google.android.horologist.compose.material.Confirmation
 import com.google.android.horologist.compose.material.Icon
+import com.google.android.horologist.compose.material.Title
 import com.google.android.horologist.compose.material.util.DECORATIVE_ELEMENT_CONTENT_DESCRIPTION
 import com.google.android.horologist.datalayer.sample.R
 import com.google.android.horologist.images.base.paintable.ImageVectorPaintable
@@ -93,8 +94,8 @@ fun NodeDetailsScreen(
         modifier = modifier.fillMaxSize(),
     ) {
         item {
-            Text(
-                text = stringResource(id = R.string.node_details_header),
+            Title(
+                textId = R.string.node_details_header,
                 modifier = Modifier.padding(bottom = 10.dp),
             )
         }

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodeslistener/NodesListenerScreen.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodeslistener/NodesListenerScreen.kt
@@ -16,32 +16,30 @@
 
 package com.google.android.horologist.datalayer.sample.screens.nodeslistener
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Card
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.wear.compose.foundation.lazy.items
+import androidx.wear.compose.material.CircularProgressIndicator
+import androidx.wear.compose.material.Text
+import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import com.google.android.gms.wearable.Node
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.layout.belowTimeTextPreview
+import com.google.android.horologist.compose.material.Chip
 import com.google.android.horologist.datalayer.sample.R
 
 @Composable
 fun NodesListenerScreen(
+    columnState: ScalingLazyColumnState,
     modifier: Modifier = Modifier,
     viewModel: NodesListenerViewModel = hiltViewModel(),
 ) {
@@ -55,6 +53,7 @@ fun NodesListenerScreen(
 
     NodesListenerScreen(
         state = state,
+        columnState = columnState,
         modifier = modifier,
     )
 }
@@ -62,30 +61,19 @@ fun NodesListenerScreen(
 @Composable
 fun NodesListenerScreen(
     state: NodesListenerScreenState,
+    columnState: ScalingLazyColumnState,
     modifier: Modifier = Modifier,
 ) {
-    LazyColumn(
+    ScalingLazyColumn(
+        columnState = columnState,
         modifier = modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         item {
             Text(
                 text = stringResource(id = R.string.nodes_listener_screen_header),
-                modifier = Modifier.padding(10.dp),
-                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.padding(bottom = 10.dp),
             )
         }
-
-        if (state != NodesListenerScreenState.ApiNotAvailable) {
-            item {
-                Text(
-                    text = stringResource(id = R.string.nodes_listener_screen_message),
-                    modifier = Modifier.padding(10.dp),
-                    style = MaterialTheme.typography.bodyLarge,
-                )
-            }
-        }
-
         when (state) {
             NodesListenerScreenState.Idle,
             NodesListenerScreenState.Loading,
@@ -97,36 +85,15 @@ fun NodesListenerScreen(
 
             is NodesListenerScreenState.Loaded -> {
                 if (state.nodeList.isNotEmpty()) {
-                    items(items = state.nodeList.toList()) { node ->
-                        Box(
-                            modifier = modifier
-                                .padding(16.dp)
-                                .fillMaxWidth(),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            Card {
-                                Column(
-                                    modifier = Modifier
-                                        .padding(16.dp)
-                                        .fillMaxWidth(),
-
-                                ) {
-                                    Text(
-                                        stringResource(
-                                            R.string.nodes_listener_screen_node_name_label,
-                                            node.displayName,
-                                        ),
-                                    )
-                                    Text(
-                                        style = MaterialTheme.typography.labelMedium,
-                                        text = stringResource(
-                                            R.string.nodes_listener_screen_node_id_label,
-                                            node.id,
-                                        ),
-                                    )
-                                }
-                            }
-                        }
+                    item {
+                        Text(stringResource(id = R.string.nodes_listener_screen_message))
+                    }
+                    items(state.nodeList.toList()) { node ->
+                        Chip(
+                            label = node.displayName,
+                            onClick = { /* do nothing */ },
+                            secondaryLabel = node.id,
+                        )
                     }
                 } else {
                     item {
@@ -144,9 +111,9 @@ fun NodesListenerScreen(
     }
 }
 
-@Preview(showBackground = true)
+@WearPreviewDevices
 @Composable
-fun NodesListenerScreenPreview() {
+fun NodesListenerScreenPreviewLoaded() {
     NodesListenerScreen(
         state = NodesListenerScreenState.Loaded(
             nodeList = setOf(
@@ -162,23 +129,26 @@ fun NodesListenerScreenPreview() {
                 ),
             ),
         ),
+        columnState = belowTimeTextPreview(),
     )
 }
 
-@Preview(showBackground = true)
+@WearPreviewDevices
 @Composable
 fun NodesListenerScreenPreviewEmptyNodes() {
     NodesListenerScreen(
-        state = NodesListenerScreenState.Loaded(
-            nodeList = emptySet(),
-        ),
+        state = NodesListenerScreenState.Loaded(emptySet()),
+        columnState = belowTimeTextPreview(),
     )
 }
 
-@Preview(showBackground = true)
+@WearPreviewDevices
 @Composable
 fun NodesListenerScreenPreviewApiNotAvailable() {
-    NodesListenerScreen(state = NodesListenerScreenState.ApiNotAvailable)
+    NodesListenerScreen(
+        state = NodesListenerScreenState.ApiNotAvailable,
+        columnState = belowTimeTextPreview(),
+    )
 }
 
 private class NodePreviewImpl(

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodeslistener/NodesListenerScreen.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodeslistener/NodesListenerScreen.kt
@@ -35,6 +35,7 @@ import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.layout.belowTimeTextPreview
 import com.google.android.horologist.compose.material.Chip
+import com.google.android.horologist.compose.material.Title
 import com.google.android.horologist.datalayer.sample.R
 
 @Composable
@@ -69,8 +70,8 @@ fun NodesListenerScreen(
         modifier = modifier.fillMaxSize(),
     ) {
         item {
-            Text(
-                text = stringResource(id = R.string.nodes_listener_screen_header),
+            Title(
+                textId = R.string.nodes_listener_screen_header,
                 modifier = Modifier.padding(bottom = 10.dp),
             )
         }

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodeslistener/NodesListenerViewModel.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodeslistener/NodesListenerViewModel.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.datalayer.sample.screens.nodeslistener
+
+import androidx.annotation.MainThread
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.android.gms.wearable.Node
+import com.google.android.horologist.datalayer.watch.WearDataLayerAppHelper
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class NodesListenerViewModel
+    @Inject
+    constructor(
+        private val wearDataLayerAppHelper: WearDataLayerAppHelper,
+    ) : ViewModel() {
+
+        private var initializeCalled = false
+
+        private val _uiState =
+            MutableStateFlow<NodesListenerScreenState>(NodesListenerScreenState.Idle)
+        public val uiState: StateFlow<NodesListenerScreenState> = _uiState
+
+        @MainThread
+        fun initialize() {
+            if (initializeCalled) return
+            initializeCalled = true
+
+            _uiState.value = NodesListenerScreenState.Loading
+
+            viewModelScope.launch {
+                if (!wearDataLayerAppHelper.isAvailable()) {
+                    _uiState.value = NodesListenerScreenState.ApiNotAvailable
+                } else {
+                    loadNodes()
+                }
+            }
+        }
+
+        private suspend fun loadNodes() {
+            _uiState.value = NodesListenerScreenState.Loading
+
+            wearDataLayerAppHelper.connectedAndInstalledNodes.collect {
+                _uiState.value = NodesListenerScreenState.Loaded(nodeList = it)
+            }
+        }
+    }
+
+sealed class NodesListenerScreenState {
+    data object Idle : NodesListenerScreenState()
+
+    data object Loading : NodesListenerScreenState()
+
+    data class Loaded(val nodeList: Set<Node>) : NodesListenerScreenState()
+
+    data object ApiNotAvailable : NodesListenerScreenState()
+}

--- a/datalayer/sample/wear/src/main/res/values/strings.xml
+++ b/datalayer/sample/wear/src/main/res/values/strings.xml
@@ -73,7 +73,7 @@
 
     <!-- App Helper Nodes Listener screen -->
     <string name="nodes_listener_screen_header">Nodes Listener</string>
-    <string name="nodes_listener_screen_message">This screen shows all the connected nodes that have the app installed. The list updates automatically.</string>
+    <string name="nodes_listener_screen_message">This screen shows all the connected nodes that have the app installed.\nOn the watch, there should be only a single connected node: the paired phone.\nThe list updates automatically.</string>
     <string name="nodes_listener_screen_no_nodes">No nodes were found.</string>
 
     <!--  Start Remote Sample Activity screen -->

--- a/datalayer/sample/wear/src/main/res/values/strings.xml
+++ b/datalayer/sample/wear/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="main_menu_apphelpers_header">App Helpers</string>
     <string name="main_menu_apphelpers_tracking_item">Tracking</string>
     <string name="main_menu_apphelpers_nodes_actions_item">Nodes actions</string>
+    <string name="main_menu_apphelpers_nodes_listener_item">Nodes listener</string>
 
     <!-- Counter screen -->
     <string name="server_counter_message">Open the datalayer sample on your phone to observe how the counter number is incremented.</string>
@@ -69,6 +70,11 @@
     <string name="node_details_start_remote_activity_chip_label">Start remote activity</string>
     <string name="node_details_success_dialog_message">Success!</string>
     <string name="node_details_failure_dialog_message">Failed: \n%1$s</string>
+
+    <!-- App Helper Nodes Listener screen -->
+    <string name="nodes_listener_screen_header">Nodes Listener</string>
+    <string name="nodes_listener_screen_message">This screen shows all the connected nodes that have the app installed. The list updates automatically.</string>
+    <string name="nodes_listener_screen_no_nodes">No nodes were found.</string>
 
     <!--  Start Remote Sample Activity screen -->
     <string name="app_helper_start_remote_activity_message">This is a sample activity to demonstrate it being launched remotely from the phone.</string>


### PR DESCRIPTION
#### WHAT

Add sample screen in wear sample app for `connectedAndInstalledNodes` function.

![Screenshot_20240123_105045](https://github.com/google/horologist/assets/878134/7cbf2ede-9815-439e-b977-b28d322a7837)

#### WHY

To demo the functionality.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
