### PR TITLE
Improve connectedAndInstalledNodes to only query/listen to a single capability

### DIFF
--- a/datalayer/core/api/current.api
+++ b/datalayer/core/api/current.api
@@ -139,8 +139,9 @@ package com.google.android.horologist.data.apphelper {
   public abstract class DataLayerAppHelper {
     ctor public DataLayerAppHelper(android.content.Context context, com.google.android.horologist.data.WearDataLayerRegistry registry);
     method protected final void checkIsForegroundOrThrow();
+    method protected final kotlinx.coroutines.flow.Flow<java.util.Set<com.google.android.gms.wearable.Node>> connectedAndInstalledNodes(String capability);
     method public final suspend Object? connectedNodes(kotlin.coroutines.Continuation<? super java.util.List<? extends com.google.android.horologist.data.apphelper.AppHelperNodeStatus>>);
-    method public final kotlinx.coroutines.flow.Flow<java.util.Set<com.google.android.gms.wearable.Node>> getConnectedAndInstalledNodes();
+    method public abstract kotlinx.coroutines.flow.Flow<java.util.Set<com.google.android.gms.wearable.Node>> getConnectedAndInstalledNodes();
     method protected final android.content.Context getContext();
     method protected final String getPlayStoreUri();
     method protected final com.google.android.horologist.data.WearDataLayerRegistry getRegistry();
@@ -151,7 +152,7 @@ package com.google.android.horologist.data.apphelper {
     method @CheckResult public abstract suspend Object? startCompanion(String nodeId, kotlin.coroutines.Continuation<? super error.NonExistentClass>);
     method @CheckResult public final suspend Object? startRemoteActivity(String nodeId, error.NonExistentClass config, kotlin.coroutines.Continuation<? super error.NonExistentClass>);
     method @CheckResult public final suspend Object? startRemoteOwnApp(String nodeId, kotlin.coroutines.Continuation<? super error.NonExistentClass>);
-    property public final kotlinx.coroutines.flow.Flow<java.util.Set<com.google.android.gms.wearable.Node>> connectedAndInstalledNodes;
+    property public abstract kotlinx.coroutines.flow.Flow<java.util.Set<com.google.android.gms.wearable.Node>> connectedAndInstalledNodes;
     property protected final android.content.Context context;
     property protected final String playStoreUri;
     property protected final com.google.android.horologist.data.WearDataLayerRegistry registry;

--- a/datalayer/core/src/main/java/com/google/android/horologist/data/apphelper/DataLayerAppHelper.kt
+++ b/datalayer/core/src/main/java/com/google/android/horologist/data/apphelper/DataLayerAppHelper.kt
@@ -19,7 +19,6 @@ package com.google.android.horologist.data.apphelper
 import android.app.ActivityManager
 import android.app.ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
 import android.content.Context
-import android.net.Uri
 import android.os.Process
 import androidx.annotation.CheckResult
 import androidx.wear.remote.interactions.RemoteActivityHelper
@@ -132,13 +131,7 @@ abstract class DataLayerAppHelper(
                     val unused = trySend(capability.nodes.filter { it.isNearby }.toSet())
                 }
 
-            val installedDeviceCapabilityUri = "wear://*/$capability"
-
-            registry.capabilityClient.addListener(
-                listener,
-                Uri.parse(installedDeviceCapabilityUri),
-                CapabilityClient.FILTER_LITERAL,
-            )
+            registry.capabilityClient.addListener(listener, capability)
             awaitClose {
                 registry.capabilityClient.removeListener(listener)
             }

--- a/datalayer/phone/api/current.api
+++ b/datalayer/phone/api/current.api
@@ -3,8 +3,10 @@ package com.google.android.horologist.datalayer.phone {
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public final class PhoneDataLayerAppHelper extends com.google.android.horologist.data.apphelper.DataLayerAppHelper {
     ctor public PhoneDataLayerAppHelper(android.content.Context context, com.google.android.horologist.data.WearDataLayerRegistry registry);
+    method public kotlinx.coroutines.flow.Flow<java.util.Set<com.google.android.gms.wearable.Node>> getConnectedAndInstalledNodes();
     method public suspend Object? installOnNode(String nodeId, kotlin.coroutines.Continuation<? super com.google.android.horologist.data.AppHelperResultCode>);
     method @CheckResult public suspend Object? startCompanion(String nodeId, kotlin.coroutines.Continuation<? super com.google.android.horologist.data.AppHelperResultCode>);
+    property public kotlinx.coroutines.flow.Flow<java.util.Set<com.google.android.gms.wearable.Node>> connectedAndInstalledNodes;
   }
 
   public final class PhoneDataLayerListenerService extends com.google.android.horologist.data.apphelper.DataLayerAppHelperService {

--- a/datalayer/phone/src/main/java/com/google/android/horologist/datalayer/phone/PhoneDataLayerAppHelper.kt
+++ b/datalayer/phone/src/main/java/com/google/android/horologist/datalayer/phone/PhoneDataLayerAppHelper.kt
@@ -23,11 +23,15 @@ import android.net.Uri
 import androidx.annotation.CheckResult
 import androidx.concurrent.futures.await
 import androidx.wear.remote.interactions.RemoteActivityHelper
+import com.google.android.gms.wearable.Node
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.data.AppHelperResultCode
 import com.google.android.horologist.data.WearDataLayerRegistry
 import com.google.android.horologist.data.apphelper.DataLayerAppHelper
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.tasks.await
+
+private const val SAMSUNG_COMPANION_PKG = "com.samsung.android.app.watchmanager"
 
 /**
  * Subclass of [DataLayerAppHelper] for use on phones.
@@ -37,7 +41,9 @@ public class PhoneDataLayerAppHelper(
     context: Context,
     registry: WearDataLayerRegistry,
 ) : DataLayerAppHelper(context, registry) {
-    private val SAMSUNG_COMPANION_PKG = "com.samsung.android.app.watchmanager"
+
+    override val connectedAndInstalledNodes: Flow<Set<Node>>
+        get() = connectedAndInstalledNodes(WATCH_CAPABILITY)
 
     override suspend fun installOnNode(nodeId: String): AppHelperResultCode {
         checkIsForegroundOrThrow()

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodeslistener/NodesListenerScreen.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodeslistener/NodesListenerScreen.kt
@@ -85,10 +85,11 @@ fun NodesListenerScreen(
             }
 
             is NodesListenerScreenState.Loaded -> {
+                item {
+                    Text(stringResource(id = R.string.nodes_listener_screen_message))
+                }
+
                 if (state.nodeList.isNotEmpty()) {
-                    item {
-                        Text(stringResource(id = R.string.nodes_listener_screen_message))
-                    }
                     items(state.nodeList.toList()) { node ->
                         Chip(
                             label = node.displayName,

--- a/datalayer/watch/api/current.api
+++ b/datalayer/watch/api/current.api
@@ -3,6 +3,7 @@ package com.google.android.horologist.datalayer.watch {
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public final class WearDataLayerAppHelper extends com.google.android.horologist.data.apphelper.DataLayerAppHelper {
     ctor public WearDataLayerAppHelper(android.content.Context context, com.google.android.horologist.data.WearDataLayerRegistry registry, kotlinx.coroutines.CoroutineScope scope, optional String? appStoreUri);
+    method public kotlinx.coroutines.flow.Flow<java.util.Set<com.google.android.gms.wearable.Node>> getConnectedAndInstalledNodes();
     method public kotlinx.coroutines.flow.Flow<com.google.android.horologist.data.SurfacesInfo> getSurfacesInfo();
     method public suspend Object? installOnNode(String nodeId, kotlin.coroutines.Continuation<? super com.google.android.horologist.data.AppHelperResultCode>);
     method public suspend Object? markActivityLaunchedOnce(kotlin.coroutines.Continuation<? super kotlin.Unit>);
@@ -13,6 +14,7 @@ package com.google.android.horologist.datalayer.watch {
     method public suspend Object? markTileAsInstalled(String tileName, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? markTileAsRemoved(String tileName, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method @CheckResult public suspend Object? startCompanion(String nodeId, kotlin.coroutines.Continuation<? super com.google.android.horologist.data.AppHelperResultCode>);
+    property public kotlinx.coroutines.flow.Flow<java.util.Set<com.google.android.gms.wearable.Node>> connectedAndInstalledNodes;
     property public final kotlinx.coroutines.flow.Flow<com.google.android.horologist.data.SurfacesInfo> surfacesInfo;
   }
 

--- a/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
+++ b/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
@@ -25,6 +25,7 @@ import androidx.wear.phone.interactions.PhoneTypeHelper
 import androidx.wear.remote.interactions.RemoteActivityHelper
 import androidx.wear.watchface.complications.data.ComplicationType
 import androidx.wear.watchface.complications.datasource.ComplicationDataSourceService
+import com.google.android.gms.wearable.Node
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.data.AppHelperResultCode
 import com.google.android.horologist.data.ComplicationInfo
@@ -61,270 +62,272 @@ public class WearDataLayerAppHelper(
     registry: WearDataLayerRegistry,
     scope: CoroutineScope,
     private val appStoreUri: String? = null,
-) :
-    DataLayerAppHelper(context, registry) {
+) : DataLayerAppHelper(context, registry) {
 
-        private val surfacesInfoDataStore by lazy {
-            registry.protoDataStore(
-                path = SURFACE_INFO_PATH,
-                coroutineScope = scope,
-                serializer = SurfacesInfoSerializer,
-            )
-        }
+    private val surfacesInfoDataStore by lazy {
+        registry.protoDataStore(
+            path = SURFACE_INFO_PATH,
+            coroutineScope = scope,
+            serializer = SurfacesInfoSerializer,
+        )
+    }
 
-        /**
-         * Return the [SurfacesInfo] of this node.
-         */
-        public val surfacesInfo: Flow<SurfacesInfo> = surfacesInfoDataStore.data
+    /**
+     * Return the [SurfacesInfo] of this node.
+     */
+    public val surfacesInfo: Flow<SurfacesInfo> = surfacesInfoDataStore.data
 
-        override suspend fun installOnNode(nodeId: String): AppHelperResultCode {
-            checkIsForegroundOrThrow()
+    override val connectedAndInstalledNodes: Flow<Set<Node>>
+        get() = connectedAndInstalledNodes(PHONE_CAPABILITY)
 
-            val intent = when (PhoneTypeHelper.getPhoneDeviceType(context)) {
-                PhoneTypeHelper.DEVICE_TYPE_ANDROID -> {
-                    Intent(Intent.ACTION_VIEW)
-                        .addCategory(Intent.CATEGORY_BROWSABLE)
-                        .setData(Uri.parse(playStoreUri))
-                }
+    override suspend fun installOnNode(nodeId: String): AppHelperResultCode {
+        checkIsForegroundOrThrow()
 
-                PhoneTypeHelper.DEVICE_TYPE_IOS -> {
-                    requireNotNull(appStoreUri) {
-                        "The uri for the app store should be provided when using this function with " +
-                            "an iOS device."
-                    }
-
-                    Intent(Intent.ACTION_VIEW)
-                        .addCategory(Intent.CATEGORY_BROWSABLE)
-                        .setData(Uri.parse(appStoreUri))
-                }
-
-                else -> {
-                    return AppHelperResultCode.APP_HELPER_RESULT_CANNOT_DETERMINE_DEVICE_TYPE
-                }
+        val intent = when (PhoneTypeHelper.getPhoneDeviceType(context)) {
+            PhoneTypeHelper.DEVICE_TYPE_ANDROID -> {
+                Intent(Intent.ACTION_VIEW)
+                    .addCategory(Intent.CATEGORY_BROWSABLE)
+                    .setData(Uri.parse(playStoreUri))
             }
 
-            val availabilityStatus = remoteActivityHelper.availabilityStatus.first()
-
-            // As per documentation, calls should be made when status is either STATUS_AVAILABLE
-            // or STATUS_UNKNOWN.
-            when (availabilityStatus) {
-                RemoteActivityHelper.STATUS_UNAVAILABLE -> {
-                    return AppHelperResultCode.APP_HELPER_RESULT_UNAVAILABLE
+            PhoneTypeHelper.DEVICE_TYPE_IOS -> {
+                requireNotNull(appStoreUri) {
+                    "The uri for the app store should be provided when using this function with " +
+                        "an iOS device."
                 }
 
-                RemoteActivityHelper.STATUS_TEMPORARILY_UNAVAILABLE -> {
-                    return AppHelperResultCode.APP_HELPER_RESULT_TEMPORARILY_UNAVAILABLE
-                }
+                Intent(Intent.ACTION_VIEW)
+                    .addCategory(Intent.CATEGORY_BROWSABLE)
+                    .setData(Uri.parse(appStoreUri))
             }
 
-            try {
-                remoteActivityHelper.startRemoteActivity(intent, nodeId).await()
-            } catch (e: RemoteActivityHelper.RemoteIntentException) {
-                return AppHelperResultCode.APP_HELPER_RESULT_ERROR_STARTING_ACTIVITY
-            }
-            return AppHelperResultCode.APP_HELPER_RESULT_SUCCESS
-        }
-
-        @CheckResult
-        override suspend fun startCompanion(nodeId: String): AppHelperResultCode {
-            checkIsForegroundOrThrow()
-            val localNode = registry.nodeClient.localNode.await()
-            val request = launchRequest {
-                companion = companionConfig {
-                    sourceNode = localNode.id
-                }
-            }
-            return sendRequestWithTimeout(nodeId, LAUNCH_APP, request.toByteArray())
-        }
-
-        /**
-         * Marks a tile as installed. Call this in [TileService#onTileAddEvent]. Supplying a name is
-         * mandatory to disambiguate from the installation or removal of other tiles your app may have.
-         *
-         * @param tileName The name of the tile.
-         */
-        public suspend fun markTileAsInstalled(tileName: String) {
-            surfacesInfoDataStore.updateData { info ->
-                val tile = tileInfo {
-                    timestamp = System.currentTimeMillis().toProtoTimestamp()
-                    name = tileName
-                }
-                info.copy {
-                    val exists = tiles.find { it.equalWithoutTimestamp(tile) } != null
-                    if (!exists) {
-                        tiles.add(tile)
-                    }
-                }
+            else -> {
+                return AppHelperResultCode.APP_HELPER_RESULT_CANNOT_DETERMINE_DEVICE_TYPE
             }
         }
 
-        /**
-         * Marks that the main activity has been launched at least once.
-         */
-        public suspend fun markActivityLaunchedOnce() {
-            surfacesInfoDataStore.updateData { info ->
-                info.copy {
-                    val launchTimestamp = System.currentTimeMillis().toProtoTimestamp()
-                    if (usageInfo.usageStatus == UsageStatus.USAGE_STATUS_UNSPECIFIED) {
-                        usageInfo = usageInfo {
-                            usageStatus = UsageStatus.USAGE_STATUS_LAUNCHED_ONCE
-                            timestamp = launchTimestamp
-                        }
-                    }
+        val availabilityStatus = remoteActivityHelper.availabilityStatus.first()
 
-                    // Temporarily support previous location for this information in [ActivityLaunched]
-                    // Remove in the longer term
-                    if (!activityLaunched.activityLaunchedOnce) {
-                        activityLaunched = activityLaunched {
-                            activityLaunchedOnce = true
-                            timestamp = launchTimestamp
-                        }
-                    }
-                }
+        // As per documentation, calls should be made when status is either STATUS_AVAILABLE
+        // or STATUS_UNKNOWN.
+        when (availabilityStatus) {
+            RemoteActivityHelper.STATUS_UNAVAILABLE -> {
+                return AppHelperResultCode.APP_HELPER_RESULT_UNAVAILABLE
+            }
+
+            RemoteActivityHelper.STATUS_TEMPORARILY_UNAVAILABLE -> {
+                return AppHelperResultCode.APP_HELPER_RESULT_TEMPORARILY_UNAVAILABLE
             }
         }
 
-        /**
-         * Marks that the necessary setup steps have been completed in the app such that it is ready for
-         * use. Typically this should be called when any pairing/login has been completed.
-         */
-        public suspend fun markSetupComplete() {
-            surfacesInfoDataStore.updateData { info ->
-                info.copy {
-                    if (usageInfo.usageStatus != UsageStatus.USAGE_STATUS_SETUP_COMPLETE) {
-                        usageInfo = usageInfo {
-                            usageStatus = UsageStatus.USAGE_STATUS_SETUP_COMPLETE
-                            timestamp = System.currentTimeMillis().toProtoTimestamp()
-                        }
-                    }
-                }
+        try {
+            remoteActivityHelper.startRemoteActivity(intent, nodeId).await()
+        } catch (e: RemoteActivityHelper.RemoteIntentException) {
+            return AppHelperResultCode.APP_HELPER_RESULT_ERROR_STARTING_ACTIVITY
+        }
+        return AppHelperResultCode.APP_HELPER_RESULT_SUCCESS
+    }
+
+    @CheckResult
+    override suspend fun startCompanion(nodeId: String): AppHelperResultCode {
+        checkIsForegroundOrThrow()
+        val localNode = registry.nodeClient.localNode.await()
+        val request = launchRequest {
+            companion = companionConfig {
+                sourceNode = localNode.id
             }
         }
+        return sendRequestWithTimeout(nodeId, LAUNCH_APP, request.toByteArray())
+    }
 
-        /**
-         * Marks that the app is no longer considered in a fully setup state. For example, the user has
-         * logged out. This will roll the state back to the app having been used once - if the setup
-         * had previously been completed, but will have no effect if this is not the case.
-         */
-        public suspend fun markSetupNoLongerComplete() {
-            surfacesInfoDataStore.updateData { info ->
-                info.copy {
-                    if (usageInfo.usageStatus == UsageStatus.USAGE_STATUS_SETUP_COMPLETE) {
-                        usageInfo = usageInfo {
-                            usageStatus = UsageStatus.USAGE_STATUS_LAUNCHED_ONCE
-                            timestamp = System.currentTimeMillis().toProtoTimestamp()
-                        }
-                    }
-                }
+    /**
+     * Marks a tile as installed. Call this in [TileService#onTileAddEvent]. Supplying a name is
+     * mandatory to disambiguate from the installation or removal of other tiles your app may have.
+     *
+     * @param tileName The name of the tile.
+     */
+    public suspend fun markTileAsInstalled(tileName: String) {
+        surfacesInfoDataStore.updateData { info ->
+            val tile = tileInfo {
+                timestamp = System.currentTimeMillis().toProtoTimestamp()
+                name = tileName
             }
-        }
-
-        /**
-         * Marks a tile as removed. Call this in [TileService#onTileRemoveEvent]. Supplying a name is
-         * mandatory to disambiguate from the installation or removal of other tiles your app may have.
-         *
-         * @param tileName The name of the tile.
-         */
-        public suspend fun markTileAsRemoved(tileName: String) {
-            surfacesInfoDataStore.updateData { info ->
-                val tile = tileInfo {
-                    timestamp = System.currentTimeMillis().toProtoTimestamp()
-                    name = tileName
+            info.copy {
+                val exists = tiles.find { it.equalWithoutTimestamp(tile) } != null
+                if (!exists) {
+                    tiles.add(tile)
                 }
-                info.copy {
-                    val filtered = tiles.filter { !tile.equalWithoutTimestamp(it) }
-                    if (filtered.size != tiles.size) {
-                        tiles.clear()
-                        tiles.addAll(filtered)
-                    }
-                }
-            }
-        }
-
-        /**
-         * Marks a complication as activated. Call this in
-         * [ComplicationDataSourceService.onComplicationActivated].
-         *
-         * @param complicationName The name of the complication, to disambiguate from others.
-         * @param complicationInstanceId Passed from [ComplicationDataSourceService.onComplicationActivated]
-         * @param complicationType Passed from [ComplicationDataSourceService.onComplicationActivated]
-         */
-        public suspend fun markComplicationAsActivated(
-            complicationName: String,
-            complicationInstanceId: Int,
-            complicationType: ComplicationType,
-        ) {
-            surfacesInfoDataStore.updateData { info ->
-                val complication = complicationInfo {
-                    timestamp = System.currentTimeMillis().toProtoTimestamp()
-                    name = complicationName
-                    instanceId = complicationInstanceId
-                    type = complicationType.name
-                }
-                info.copy {
-                    val exists = complications.find { it.equalWithoutTimestamp(complication) } != null
-                    if (!exists) {
-                        complications.add(complication)
-                    }
-                }
-            }
-        }
-
-        /**
-         * Marks a complication as deactivated. Call this in
-         * [ComplicationDataSourceService.onComplicationDeactivated].
-         *
-         * @param complicationName The name of the complication, to disambiguate from others.
-         * @param complicationInstanceId Passed from [ComplicationDataSourceService.onComplicationDeactivated]
-         * @param complicationType Passed from [ComplicationDataSourceService.onComplicationDeactivated]
-         */
-        public suspend fun markComplicationAsDeactivated(
-            complicationName: String,
-            complicationInstanceId: Int,
-            complicationType: ComplicationType,
-        ) {
-            surfacesInfoDataStore.updateData { info ->
-                val complication = complicationInfo {
-                    timestamp = System.currentTimeMillis().toProtoTimestamp()
-
-                    name = complicationName
-                    instanceId = complicationInstanceId
-                    type = complicationType.name
-                }
-                info.copy {
-                    val filtered = complications.filter { !complication.equalWithoutTimestamp(it) }
-                    if (filtered.size != complications.size) {
-                        complications.clear()
-                        complications.addAll(filtered)
-                    }
-                }
-            }
-        }
-
-        /**
-         * Compares equality of [TileInfo] excluding timestamp, as when the Tile was added is not
-         * relevant.
-         */
-        private fun TileInfo.equalWithoutTimestamp(other: TileInfo): Boolean =
-            this.copy { timestamp = Timestamp.getDefaultInstance() } == other.copy {
-                timestamp = Timestamp.getDefaultInstance()
-            }
-
-        /**
-         * Compares equality of [ComplicationInfo] excluding timestamp, as when the Complication was
-         * added is not relevant.
-         */
-        private fun ComplicationInfo.equalWithoutTimestamp(other: ComplicationInfo): Boolean =
-            this.copy { timestamp = Timestamp.getDefaultInstance() } == other.copy {
-                timestamp = Timestamp.getDefaultInstance()
-            }
-
-        internal companion object {
-            internal fun Long.toProtoTimestamp(): Timestamp {
-                return Timestamp.newBuilder()
-                    .setSeconds(this / 1000)
-                    .setNanos((this % 1000).toInt() * 1000000)
-                    .build()
             }
         }
     }
+
+    /**
+     * Marks that the main activity has been launched at least once.
+     */
+    public suspend fun markActivityLaunchedOnce() {
+        surfacesInfoDataStore.updateData { info ->
+            info.copy {
+                val launchTimestamp = System.currentTimeMillis().toProtoTimestamp()
+                if (usageInfo.usageStatus == UsageStatus.USAGE_STATUS_UNSPECIFIED) {
+                    usageInfo = usageInfo {
+                        usageStatus = UsageStatus.USAGE_STATUS_LAUNCHED_ONCE
+                        timestamp = launchTimestamp
+                    }
+                }
+
+                // Temporarily support previous location for this information in [ActivityLaunched]
+                // Remove in the longer term
+                if (!activityLaunched.activityLaunchedOnce) {
+                    activityLaunched = activityLaunched {
+                        activityLaunchedOnce = true
+                        timestamp = launchTimestamp
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Marks that the necessary setup steps have been completed in the app such that it is ready for
+     * use. Typically this should be called when any pairing/login has been completed.
+     */
+    public suspend fun markSetupComplete() {
+        surfacesInfoDataStore.updateData { info ->
+            info.copy {
+                if (usageInfo.usageStatus != UsageStatus.USAGE_STATUS_SETUP_COMPLETE) {
+                    usageInfo = usageInfo {
+                        usageStatus = UsageStatus.USAGE_STATUS_SETUP_COMPLETE
+                        timestamp = System.currentTimeMillis().toProtoTimestamp()
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Marks that the app is no longer considered in a fully setup state. For example, the user has
+     * logged out. This will roll the state back to the app having been used once - if the setup
+     * had previously been completed, but will have no effect if this is not the case.
+     */
+    public suspend fun markSetupNoLongerComplete() {
+        surfacesInfoDataStore.updateData { info ->
+            info.copy {
+                if (usageInfo.usageStatus == UsageStatus.USAGE_STATUS_SETUP_COMPLETE) {
+                    usageInfo = usageInfo {
+                        usageStatus = UsageStatus.USAGE_STATUS_LAUNCHED_ONCE
+                        timestamp = System.currentTimeMillis().toProtoTimestamp()
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Marks a tile as removed. Call this in [TileService#onTileRemoveEvent]. Supplying a name is
+     * mandatory to disambiguate from the installation or removal of other tiles your app may have.
+     *
+     * @param tileName The name of the tile.
+     */
+    public suspend fun markTileAsRemoved(tileName: String) {
+        surfacesInfoDataStore.updateData { info ->
+            val tile = tileInfo {
+                timestamp = System.currentTimeMillis().toProtoTimestamp()
+                name = tileName
+            }
+            info.copy {
+                val filtered = tiles.filter { !tile.equalWithoutTimestamp(it) }
+                if (filtered.size != tiles.size) {
+                    tiles.clear()
+                    tiles.addAll(filtered)
+                }
+            }
+        }
+    }
+
+    /**
+     * Marks a complication as activated. Call this in
+     * [ComplicationDataSourceService.onComplicationActivated].
+     *
+     * @param complicationName The name of the complication, to disambiguate from others.
+     * @param complicationInstanceId Passed from [ComplicationDataSourceService.onComplicationActivated]
+     * @param complicationType Passed from [ComplicationDataSourceService.onComplicationActivated]
+     */
+    public suspend fun markComplicationAsActivated(
+        complicationName: String,
+        complicationInstanceId: Int,
+        complicationType: ComplicationType,
+    ) {
+        surfacesInfoDataStore.updateData { info ->
+            val complication = complicationInfo {
+                timestamp = System.currentTimeMillis().toProtoTimestamp()
+                name = complicationName
+                instanceId = complicationInstanceId
+                type = complicationType.name
+            }
+            info.copy {
+                val exists = complications.find { it.equalWithoutTimestamp(complication) } != null
+                if (!exists) {
+                    complications.add(complication)
+                }
+            }
+        }
+    }
+
+    /**
+     * Marks a complication as deactivated. Call this in
+     * [ComplicationDataSourceService.onComplicationDeactivated].
+     *
+     * @param complicationName The name of the complication, to disambiguate from others.
+     * @param complicationInstanceId Passed from [ComplicationDataSourceService.onComplicationDeactivated]
+     * @param complicationType Passed from [ComplicationDataSourceService.onComplicationDeactivated]
+     */
+    public suspend fun markComplicationAsDeactivated(
+        complicationName: String,
+        complicationInstanceId: Int,
+        complicationType: ComplicationType,
+    ) {
+        surfacesInfoDataStore.updateData { info ->
+            val complication = complicationInfo {
+                timestamp = System.currentTimeMillis().toProtoTimestamp()
+
+                name = complicationName
+                instanceId = complicationInstanceId
+                type = complicationType.name
+            }
+            info.copy {
+                val filtered = complications.filter { !complication.equalWithoutTimestamp(it) }
+                if (filtered.size != complications.size) {
+                    complications.clear()
+                    complications.addAll(filtered)
+                }
+            }
+        }
+    }
+
+    /**
+     * Compares equality of [TileInfo] excluding timestamp, as when the Tile was added is not
+     * relevant.
+     */
+    private fun TileInfo.equalWithoutTimestamp(other: TileInfo): Boolean =
+        this.copy { timestamp = Timestamp.getDefaultInstance() } == other.copy {
+            timestamp = Timestamp.getDefaultInstance()
+        }
+
+    /**
+     * Compares equality of [ComplicationInfo] excluding timestamp, as when the Complication was
+     * added is not relevant.
+     */
+    private fun ComplicationInfo.equalWithoutTimestamp(other: ComplicationInfo): Boolean =
+        this.copy { timestamp = Timestamp.getDefaultInstance() } == other.copy {
+            timestamp = Timestamp.getDefaultInstance()
+        }
+
+    internal companion object {
+        internal fun Long.toProtoTimestamp(): Timestamp {
+            return Timestamp.newBuilder()
+                .setSeconds(this / 1000)
+                .setNanos((this % 1000).toInt() * 1000000)
+                .build()
+        }
+    }
+}


### PR DESCRIPTION
#### WHAT

Improve `connectedAndInstalledNodes` to only query/listen to a single capability.

#### WHY

- Remove assumption that a phone won't see another phone node - phone will now only listen to nodes with the capability meant for watches (`data_layer_app_helper_device_watch`);
- Remove assumption that a watch won't see another watch node nearby - watch will now only listen to nodes with the capability meant for phones (`data_layer_app_helper_device_phone`);
- Avoid issues in the future if another capability is added with prefix `data_layer_app_helper_device_`;

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
