### PR TITLE
Remove animation from the InstallAppBottomSheetActivity when finishing it

### DIFF
--- a/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/installapp/InstallAppBottomSheetActivity.kt
+++ b/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/installapp/InstallAppBottomSheetActivity.kt
@@ -18,6 +18,7 @@ package com.google.android.horologist.datalayer.phone.ui.prompt.installapp
 
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -77,7 +78,7 @@ internal class InstallAppBottomSheetActivity : ComponentActivity() {
                             try {
                                 installAppBottomSheetState.hide()
                             } finally {
-                                finish()
+                                finishWithoutAnimation()
                             }
                         }
                     },
@@ -85,11 +86,21 @@ internal class InstallAppBottomSheetActivity : ComponentActivity() {
                         this.launchPlay(appPackageName)
 
                         setResult(RESULT_OK)
-                        finish()
+                        finishWithoutAnimation()
                     },
                     sheetState = installAppBottomSheetState,
                 )
             }
+        }
+    }
+
+    private fun finishWithoutAnimation() {
+        finish()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            overrideActivityTransition(OVERRIDE_TRANSITION_CLOSE, 0, 0)
+        } else {
+            @Suppress("DEPRECATION")
+            overridePendingTransition(0, 0)
         }
     }
 


### PR DESCRIPTION
#### WHAT

Remove animation from the `InstallAppBottomSheetActivity` when finishing it.

#### WHY

Before

https://github.com/google/horologist/assets/878134/73c63747-34b4-4f04-9d1a-d97d76f11a83

After

https://github.com/google/horologist/assets/878134/d379ecb5-ec84-40f4-8d22-f5b548be5573

#### HOW


#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
