### PR TITLE
[0.5.x] Adding device specific haptic constants for Samsung devices. (#2035)

### DIFF
--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/Haptics.kt
@@ -265,10 +265,8 @@ public fun rememberDefaultRotaryHapticFeedback(): RotaryHapticFeedback =
     LocalView.current.let { view -> remember { findDeviceSpecificHapticFeedback(view) } }
 
 internal fun findDeviceSpecificHapticFeedback(view: View): RotaryHapticFeedback =
-    if (isGalaxyWatchClassic()) {
-        GalaxyWatchClassicHapticFeedback(view)
-    } else if (isGalaxyWatch()) {
-        DefaultRotaryHapticFeedback(view)
+    if (isGalaxyWatchClassic() || isGalaxyWatch()) {
+        GalaxyWatchHapticFeedback(view)
     } else if (isWear3point5(view.context)) {
         Wear3point5RotaryHapticFeedback(view)
     } else if (isWear4AtLeast()) {
@@ -372,10 +370,10 @@ private class Wear4AtLeastRotaryHapticFeedback(private val view: View) : RotaryH
 }
 
 /**
- * Implementation of [RotaryHapticFeedback] for Galaxy Watch 4 and 6 Classic
+ * Implementation of [RotaryHapticFeedback] for Galaxy Watches
  */
 @ExperimentalHorologistApi
-private class GalaxyWatchClassicHapticFeedback(private val view: View) : RotaryHapticFeedback {
+private class GalaxyWatchHapticFeedback(private val view: View) : RotaryHapticFeedback {
 
     @ExperimentalHorologistApi
     override fun performHapticFeedback(
@@ -383,15 +381,15 @@ private class GalaxyWatchClassicHapticFeedback(private val view: View) : RotaryH
     ) {
         when (type) {
             RotaryHapticsType.ScrollItemFocus -> {
-                // No haptic for scroll snap ( we have physical bezel)
+                view.performHapticFeedback(102)
             }
 
             RotaryHapticsType.ScrollTick -> {
-                // No haptic for scroll tick ( we have physical bezel)
+                view.performHapticFeedback(102)
             }
 
             RotaryHapticsType.ScrollLimit -> {
-                view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                view.performHapticFeedback(50107)
             }
         }
     }

--- a/compose-layout/src/test/java/com/google/android/horologist/compose/rotaryinput/HapticsTest.kt
+++ b/compose-layout/src/test/java/com/google/android/horologist/compose/rotaryinput/HapticsTest.kt
@@ -116,7 +116,7 @@ class HapticsTest {
 
         val hapticFeedback = getHapticFeedback()
 
-        assertThat(hapticFeedback.javaClass.simpleName).isEqualTo("GalaxyWatchClassicHapticFeedback")
+        assertThat(hapticFeedback.javaClass.simpleName).isEqualTo("GalaxyWatchHapticFeedback")
     }
 
     @Test
@@ -128,7 +128,7 @@ class HapticsTest {
 
         val hapticFeedback = getHapticFeedback()
 
-        assertThat(hapticFeedback.javaClass.simpleName).isEqualTo("DefaultRotaryHapticFeedback")
+        assertThat(hapticFeedback.javaClass.simpleName).isEqualTo("GalaxyWatchHapticFeedback")
     }
 
     private fun getHapticFeedback(): RotaryHapticFeedback {


### PR DESCRIPTION
* Adding device specific constants for Samsung devices.

These constants should bring better consistency with views rotary experience

(cherry picked from commit 91b797b563557580968bcc67d8550d1518c8aea0)

#### WHAT


#### WHY


#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
