### PR TITLE
Fix onClick A11y

### DIFF
--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/Button.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/Button.kt
@@ -36,9 +36,10 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.onLongClick
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.unit.Dp
-import androidx.wear.compose.material.Button
 import androidx.wear.compose.material.ButtonColors
 import androidx.wear.compose.material.ButtonDefaults
 import androidx.wear.compose.material.ButtonDefaults.DefaultButtonSize
@@ -51,6 +52,7 @@ import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.images.base.paintable.DrawableResPaintable
 import com.google.android.horologist.images.base.paintable.ImageVectorPaintable
 import com.google.android.horologist.images.base.paintable.PaintableIcon
+import androidx.wear.compose.material.Button as MaterialButton
 
 /**
  * This component is an alternative to [Button], providing the following:
@@ -133,7 +135,7 @@ internal fun Button(
     enabled: Boolean = true,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
-    Button(
+    MaterialButton(
         onClick = onClick,
         modifier = modifier
             .size(buttonSize.tapTargetSize)
@@ -142,6 +144,16 @@ internal fun Button(
                 this.contentDescription = contentDescription
                 if (!enabled) {
                     disabled()
+                }
+                this.onClick(action = {
+                    onClick()
+                    true
+                })
+                if (onLongClick != null) {
+                    this.onLongClick(action = {
+                        onLongClick()
+                        true
+                    })
                 }
             },
         enabled = enabled,

--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/Card.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/Card.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.CardDefaults
 import androidx.wear.compose.material.MaterialTheme
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import androidx.wear.compose.material.Card as MaterialCard
 
 /**
  * This component is an alternative to [Card], adding support for long and double-clicks.
@@ -56,7 +57,7 @@ public fun Card(
     content: @Composable () -> Unit,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
-    androidx.wear.compose.material.Card(
+    MaterialCard(
         onClick = onClick,
         modifier = modifier,
         backgroundPainter = backgroundPainter,

--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/Chip.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/Chip.kt
@@ -50,6 +50,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.onLongClick
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.text
 import androidx.compose.ui.text.buildAnnotatedString
@@ -247,6 +249,16 @@ public fun Chip(
                 role = Role.Button
                 if (!enabled) {
                     disabled()
+                }
+                this.onClick(action = {
+                    onClick()
+                    true
+                })
+                if (onLongClick != null) {
+                    this.onLongClick(action = {
+                        onLongClick()
+                        true
+                    })
                 }
             },
         secondaryLabel = secondaryLabelParam,

--- a/compose-material/src/test/java/com/google/android/horologist/compose/material/ButtonA11yTest.kt
+++ b/compose-material/src/test/java/com/google/android/horologist/compose/material/ButtonA11yTest.kt
@@ -25,12 +25,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher.Companion.keyIsDefined
-import androidx.compose.ui.test.SemanticsMatcher.Companion.keyNotDefined
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.assertHasClickAction
 import com.google.android.horologist.screenshots.ScreenshotBaseTest
-import com.google.android.horologist.screenshots.ScreenshotTestRule
 import com.google.android.horologist.screenshots.ScreenshotTestRule.Companion.screenshotTestRuleParams
 import org.junit.Test
 
@@ -38,32 +36,11 @@ class ButtonA11yTest : ScreenshotBaseTest(
     screenshotTestRuleParams {
         enableA11y = true
         screenTimeText = {}
-        record = ScreenshotTestRule.RecordMode.Record
     },
 ) {
 
     @Test
     fun default() {
-        screenshotTestRule.setContent(takeScreenshot = true) {
-            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
-                Button(
-                    imageVector = Icons.Default.Check,
-                    contentDescription = "contentDescription",
-                    onClick = { },
-                )
-            }
-        }
-
-        screenshotTestRule.interact {
-            onNode(keyIsDefined(SemanticsProperties.Role))
-                .assertHasClickAction()
-                .assert(keyNotDefined(SemanticsActions.OnLongClick))
-                .assertContentDescriptionEquals("contentDescription")
-        }
-    }
-
-    @Test
-    fun withLongClick() {
         screenshotTestRule.setContent(takeScreenshot = true) {
             Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
                 Button(

--- a/compose-material/src/test/java/com/google/android/horologist/compose/material/ButtonA11yTest.kt
+++ b/compose-material/src/test/java/com/google/android/horologist/compose/material/ButtonA11yTest.kt
@@ -22,17 +22,23 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.test.onRoot
-import androidx.compose.ui.test.printToString
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher.Companion.keyIsDefined
+import androidx.compose.ui.test.SemanticsMatcher.Companion.keyNotDefined
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.assertHasClickAction
 import com.google.android.horologist.screenshots.ScreenshotBaseTest
+import com.google.android.horologist.screenshots.ScreenshotTestRule
 import com.google.android.horologist.screenshots.ScreenshotTestRule.Companion.screenshotTestRuleParams
-import org.junit.Assert
 import org.junit.Test
 
 class ButtonA11yTest : ScreenshotBaseTest(
     screenshotTestRuleParams {
         enableA11y = true
         screenTimeText = {}
+        record = ScreenshotTestRule.RecordMode.Record
     },
 ) {
 
@@ -49,12 +55,31 @@ class ButtonA11yTest : ScreenshotBaseTest(
         }
 
         screenshotTestRule.interact {
-            val logEntries = onRoot().printToString()
-                .split("\n")
-                .map { it.trim() }
+            onNode(keyIsDefined(SemanticsProperties.Role))
+                .assertHasClickAction()
+                .assert(keyNotDefined(SemanticsActions.OnLongClick))
+                .assertContentDescriptionEquals("contentDescription")
+        }
+    }
 
-            Assert.assertEquals(1, logEntries.filter { it.startsWith("Role") }.size)
-            Assert.assertEquals(1, logEntries.filter { it.startsWith("ContentDescription") }.size)
+    @Test
+    fun withLongClick() {
+        screenshotTestRule.setContent(takeScreenshot = true) {
+            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                Button(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = "contentDescription",
+                    onClick = { },
+                    onLongClick = {},
+                )
+            }
+        }
+
+        screenshotTestRule.interact {
+            onNode(keyIsDefined(SemanticsProperties.Role))
+                .assertHasClickAction()
+                .assert(keyIsDefined(SemanticsActions.OnLongClick))
+                .assertContentDescriptionEquals("contentDescription")
         }
     }
 
@@ -72,12 +97,9 @@ class ButtonA11yTest : ScreenshotBaseTest(
         }
 
         screenshotTestRule.interact {
-            val logEntries = onRoot().printToString()
-                .split("\n")
-                .map { it.trim() }
-
-            Assert.assertEquals(1, logEntries.filter { it.startsWith("Role") }.size)
-            Assert.assertEquals(1, logEntries.filter { it.startsWith("ContentDescription") }.size)
+            onNode(keyIsDefined(SemanticsProperties.Role))
+                .assertHasClickAction()
+                .assertContentDescriptionEquals("contentDescription")
         }
     }
 }

--- a/compose-material/src/test/java/com/google/android/horologist/compose/material/CardA11yTest.kt
+++ b/compose-material/src/test/java/com/google/android/horologist/compose/material/CardA11yTest.kt
@@ -64,7 +64,7 @@ class CardA11yTest : ScreenshotBaseTest(
             onNode(keyIsDefined(SemanticsProperties.Role))
                 .assertTextEquals("Click me!")
                 .assertHasClickAction()
-                // Not set by combinedClickable
+            // Not set by combinedClickable
 //                .assert(keyIsDefined(SemanticsActions.OnLongClick))
         }
     }

--- a/compose-material/src/test/java/com/google/android/horologist/compose/material/CardA11yTest.kt
+++ b/compose-material/src/test/java/com/google/android/horologist/compose/material/CardA11yTest.kt
@@ -64,6 +64,7 @@ class CardA11yTest : ScreenshotBaseTest(
             onNode(keyIsDefined(SemanticsProperties.Role))
                 .assertTextEquals("Click me!")
                 .assertHasClickAction()
+                // Not set by combinedClickable
 //                .assert(keyIsDefined(SemanticsActions.OnLongClick))
         }
     }

--- a/compose-material/src/test/java/com/google/android/horologist/compose/material/CardA11yTest.kt
+++ b/compose-material/src/test/java/com/google/android/horologist/compose/material/CardA11yTest.kt
@@ -23,8 +23,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.SemanticsProperties
-import androidx.compose.ui.test.SemanticsMatcher
-import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.SemanticsMatcher.Companion.keyIsDefined
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertTextEquals
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.screenshots.ScreenshotBaseTest
 import com.google.android.horologist.screenshots.ScreenshotTestRule.Companion.screenshotTestRuleParams
@@ -60,7 +61,10 @@ class CardA11yTest : ScreenshotBaseTest(
         }
 
         screenshotTestRule.interact {
-            onAllNodes(SemanticsMatcher.keyIsDefined(SemanticsProperties.Role)).assertCountEquals(1)
+            onNode(keyIsDefined(SemanticsProperties.Role))
+                .assertTextEquals("Click me!")
+                .assertHasClickAction()
+//                .assert(keyIsDefined(SemanticsActions.OnLongClick))
         }
     }
 

--- a/compose-material/src/test/java/com/google/android/horologist/compose/material/ChipA11yTest.kt
+++ b/compose-material/src/test/java/com/google/android/horologist/compose/material/ChipA11yTest.kt
@@ -22,9 +22,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher.Companion.keyIsDefined
-import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertTextEquals
 import com.google.android.horologist.images.base.paintable.ImageVectorPaintable.Companion.asPaintable
 import com.google.android.horologist.screenshots.ScreenshotBaseTest
 import com.google.android.horologist.screenshots.ScreenshotTestRule
@@ -44,6 +47,8 @@ class ChipA11yTest : ScreenshotBaseTest(
                 Chip(
                     label = "Primary label",
                     onClick = { },
+                    onLongClick = {},
+                    onDoubleClick = {},
                     secondaryLabel = "Secondary label",
                     icon = Icons.Default.Image.asPaintable(),
                 )
@@ -51,7 +56,10 @@ class ChipA11yTest : ScreenshotBaseTest(
         }
 
         screenshotTestRule.interact {
-            onAllNodes(keyIsDefined(SemanticsProperties.Role)).assertCountEquals(1)
+            onNode(keyIsDefined(SemanticsProperties.Role))
+                .assertHasClickAction()
+                .assert(keyIsDefined(SemanticsActions.OnLongClick))
+                .assertTextEquals("Primary label, Secondary label")
         }
     }
 

--- a/compose-material/src/test/java/com/google/android/horologist/compose/material/ChipA11yTest.kt
+++ b/compose-material/src/test/java/com/google/android/horologist/compose/material/ChipA11yTest.kt
@@ -59,6 +59,7 @@ class ChipA11yTest : ScreenshotBaseTest(
             onNode(keyIsDefined(SemanticsProperties.Role))
                 .assertHasClickAction()
                 .assert(keyIsDefined(SemanticsActions.OnLongClick))
+                // not possible to define action for OnDoubleClick
                 .assertTextEquals("Primary label, Secondary label")
         }
     }


### PR DESCRIPTION
#### WHAT

set semantics labels when we override

#### WHY

fixes https://github.com/google/horologist/issues/2039

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
