### PR TITLE
Updates AmbientAware to avoid recreating whole tree

### DIFF
--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
@@ -101,12 +101,6 @@ fun AmbientAware(
     }
 }
 
-@Composable
-private fun AmbientAwareDisabled(block: @Composable (AmbientStateUpdate) -> Unit) {
-    val staticAmbientState by remember { mutableStateOf(AmbientStateUpdate(AmbientState.Interactive)) }
-    block(staticAmbientState)
-}
-
 private fun Context.findActivityOrNull(): Activity? {
     var context = this
     while (context is ContextWrapper) {


### PR DESCRIPTION
#### WHAT

Updates `AmbientAware` to avoid recreating whole tree (see issue #2041) - thanks to @marcin-adamczewski

#### WHY

Current implementation recreates whole tree when `isAlwaysOnScreen ` boolean changes

#### HOW

Follow best practice for remembering always-on state

#### Checklist :clipboard:
- [X] Add explicit visibility modifier and explicit return types for public declarations
- [X] Run spotless check
- [X] Run tests
- [X] Update metalava's signature text files
