### PR TITLE
Fix SampleTilePreview

### DIFF
--- a/compose-tools/api/current.api
+++ b/compose-tools/api/current.api
@@ -130,7 +130,7 @@ package com.google.android.horologist.compose.tools {
   }
 
   public final class TileRendererPreviewDataKt {
-    method @androidx.compose.runtime.Composable public static <T, R> androidx.wear.tiles.tooling.preview.TilePreviewData tileRendererPreviewData(com.google.android.horologist.tiles.render.TileLayoutRenderer<T,R> renderer, T tileState, R resourceState);
+    method public static <T, R> androidx.wear.tiles.tooling.preview.TilePreviewData tileRendererPreviewData(com.google.android.horologist.tiles.render.TileLayoutRenderer<T,R> renderer, T tileState, R resourceState);
   }
 
   public final class TypographyKt {

--- a/compose-tools/src/main/java/com/google/android/horologist/compose/tools/TileRendererPreviewData.kt
+++ b/compose-tools/src/main/java/com/google/android/horologist/compose/tools/TileRendererPreviewData.kt
@@ -16,11 +16,9 @@
 
 package com.google.android.horologist.compose.tools
 
-import androidx.compose.runtime.Composable
 import androidx.wear.tiles.tooling.preview.TilePreviewData
 import com.google.android.horologist.tiles.render.TileLayoutRenderer
 
-@Composable
 public fun <T, R> tileRendererPreviewData(
     renderer: TileLayoutRenderer<T, R>,
     tileState: T,

--- a/media/sample/src/main/java/com/google/android/horologist/mediasample/data/service/tile/MediaCollectionsTileService.kt
+++ b/media/sample/src/main/java/com/google/android/horologist/mediasample/data/service/tile/MediaCollectionsTileService.kt
@@ -18,7 +18,6 @@ package com.google.android.horologist.mediasample.data.service.tile
 
 import android.content.Context
 import android.graphics.BitmapFactory
-import androidx.compose.runtime.Composable
 import androidx.wear.protolayout.ActionBuilders
 import androidx.wear.protolayout.ActionBuilders.AndroidActivity
 import androidx.wear.protolayout.ResourceBuilders.Resources
@@ -149,7 +148,6 @@ class MediaCollectionsTileService : SuspendingTileService() {
 
 @Preview(device = WearDevices.LARGE_ROUND)
 @Preview(device = WearDevices.SMALL_ROUND)
-@Composable
 fun SampleTilePreview(context: Context): TilePreviewData = tileRendererPreviewData(
     renderer = MediaCollectionsTileRenderer(
         context = context,


### PR DESCRIPTION
The tile preview was not rendering due to the @Composable annotation.

#### WHAT
Fix the tile preview sample code.

#### WHY
It was not rendering properly and was raising an error: `<internal -- stub if needed>: <bitmap> requires a valid 'src' attribute`

#### HOW
By removing the `@Composable` annotation which is not required (and incompatible apparently) with a tile's `@Preview` annotation.


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
