### PR TITLE
Move sample Tile preview to debug folder

### DIFF
--- a/media/sample/src/debug/java/com/google/android/horologist/mediasample/data/service/tile/SampleTilePreview.kt
+++ b/media/sample/src/debug/java/com/google/android/horologist/mediasample/data/service/tile/SampleTilePreview.kt
@@ -18,7 +18,7 @@ package com.google.android.horologist.mediasample.data.service.tile
 
 import android.content.Context
 import android.graphics.BitmapFactory
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.wear.tiles.tooling.preview.Preview
 import androidx.wear.protolayout.ActionBuilders
 import androidx.wear.tiles.tooling.preview.TilePreviewData
 import androidx.wear.tooling.preview.devices.WearDevices

--- a/media/sample/src/debug/java/com/google/android/horologist/mediasample/data/service/tile/SampleTilePreview.kt
+++ b/media/sample/src/debug/java/com/google/android/horologist/mediasample/data/service/tile/SampleTilePreview.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.mediasample.data.service.tile
+
+import android.content.Context
+import android.graphics.BitmapFactory
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.wear.protolayout.ActionBuilders
+import androidx.wear.tiles.tooling.preview.TilePreviewData
+import androidx.wear.tooling.preview.devices.WearDevices
+import com.google.android.horologist.compose.tools.tileRendererPreviewData
+import com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer
+import com.google.android.horologist.media.ui.tiles.toTileColors
+import com.google.android.horologist.mediasample.BuildConfig
+import com.google.android.horologist.mediasample.R
+import com.google.android.horologist.mediasample.ui.app.UampColors
+import com.google.android.horologist.tiles.images.drawableResToImageResource
+import com.google.android.horologist.tiles.images.toImageResource
+
+@Preview(device = WearDevices.LARGE_ROUND)
+@Preview(device = WearDevices.SMALL_ROUND)
+fun SampleTilePreview(context: Context): TilePreviewData = tileRendererPreviewData(
+    renderer = MediaCollectionsTileRenderer(
+        context = context,
+        materialTheme = UampColors.toTileColors(),
+        debugResourceMode = BuildConfig.DEBUG,
+    ),
+    tileState = MediaCollectionsTileRenderer.MediaCollectionsState(
+        chipName = R.string.sample_playlists,
+        chipAction = ActionBuilders.LaunchAction.Builder().build(),
+        collection1 = MediaCollectionsTileRenderer.MediaCollection(
+            name = "Kyoto Songs",
+            artworkId = "s1",
+            action = ActionBuilders.LaunchAction.Builder().build(),
+        ),
+        collection2 = MediaCollectionsTileRenderer.MediaCollection(
+            name = "Podcasts",
+            artworkId = "c2",
+            action = ActionBuilders.LaunchAction.Builder().build(),
+        ),
+    ),
+    resourceState = MediaCollectionsTileRenderer.ResourceState(
+        appIcon = com.google.android.horologist.logo.R.drawable.ic_stat_horologist,
+        images = mapOf(
+            "s1" to BitmapFactory.decodeResource(context.resources, R.drawable.kyoto)
+                ?.toImageResource(),
+            "c2" to drawableResToImageResource(R.drawable.ic_baseline_podcasts_24),
+        ),
+    ),
+)

--- a/media/sample/src/debug/java/com/google/android/horologist/mediasample/data/service/tile/SampleTilePreview.kt
+++ b/media/sample/src/debug/java/com/google/android/horologist/mediasample/data/service/tile/SampleTilePreview.kt
@@ -18,8 +18,8 @@ package com.google.android.horologist.mediasample.data.service.tile
 
 import android.content.Context
 import android.graphics.BitmapFactory
-import androidx.wear.tiles.tooling.preview.Preview
 import androidx.wear.protolayout.ActionBuilders
+import androidx.wear.tiles.tooling.preview.Preview
 import androidx.wear.tiles.tooling.preview.TilePreviewData
 import androidx.wear.tooling.preview.devices.WearDevices
 import com.google.android.horologist.compose.tools.tileRendererPreviewData

--- a/media/sample/src/main/java/com/google/android/horologist/mediasample/data/service/tile/MediaCollectionsTileService.kt
+++ b/media/sample/src/main/java/com/google/android/horologist/mediasample/data/service/tile/MediaCollectionsTileService.kt
@@ -16,19 +16,13 @@
 
 package com.google.android.horologist.mediasample.data.service.tile
 
-import android.content.Context
-import android.graphics.BitmapFactory
 import androidx.wear.protolayout.ActionBuilders
 import androidx.wear.protolayout.ActionBuilders.AndroidActivity
 import androidx.wear.protolayout.ResourceBuilders.Resources
 import androidx.wear.tiles.RequestBuilders.ResourcesRequest
 import androidx.wear.tiles.RequestBuilders.TileRequest
 import androidx.wear.tiles.TileBuilders.Tile
-import androidx.wear.tiles.tooling.preview.Preview
-import androidx.wear.tiles.tooling.preview.TilePreviewData
-import androidx.wear.tooling.preview.devices.WearDevices
 import coil.ImageLoader
-import com.google.android.horologist.compose.tools.tileRendererPreviewData
 import com.google.android.horologist.media.repository.PlaylistRepository
 import com.google.android.horologist.media.ui.tiles.MediaCollectionsTileRenderer
 import com.google.android.horologist.media.ui.tiles.toTileColors
@@ -37,9 +31,7 @@ import com.google.android.horologist.mediasample.R
 import com.google.android.horologist.mediasample.ui.app.MediaActivity
 import com.google.android.horologist.mediasample.ui.app.UampColors
 import com.google.android.horologist.tiles.SuspendingTileService
-import com.google.android.horologist.tiles.images.drawableResToImageResource
 import com.google.android.horologist.tiles.images.loadImageResource
-import com.google.android.horologist.tiles.images.toImageResource
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
@@ -145,35 +137,3 @@ class MediaCollectionsTileService : SuspendingTileService() {
         )
     }
 }
-
-@Preview(device = WearDevices.LARGE_ROUND)
-@Preview(device = WearDevices.SMALL_ROUND)
-fun SampleTilePreview(context: Context): TilePreviewData = tileRendererPreviewData(
-    renderer = MediaCollectionsTileRenderer(
-        context = context,
-        materialTheme = UampColors.toTileColors(),
-        debugResourceMode = BuildConfig.DEBUG,
-    ),
-    tileState = MediaCollectionsTileRenderer.MediaCollectionsState(
-        chipName = R.string.sample_playlists,
-        chipAction = ActionBuilders.LaunchAction.Builder().build(),
-        collection1 = MediaCollectionsTileRenderer.MediaCollection(
-            name = "Kyoto Songs",
-            artworkId = "s1",
-            action = ActionBuilders.LaunchAction.Builder().build(),
-        ),
-        collection2 = MediaCollectionsTileRenderer.MediaCollection(
-            name = "Podcasts",
-            artworkId = "c2",
-            action = ActionBuilders.LaunchAction.Builder().build(),
-        ),
-    ),
-    resourceState = MediaCollectionsTileRenderer.ResourceState(
-        appIcon = com.google.android.horologist.logo.R.drawable.ic_stat_horologist,
-        images = mapOf(
-            "s1" to BitmapFactory.decodeResource(context.resources, R.drawable.kyoto)
-                ?.toImageResource(),
-            "c2" to drawableResToImageResource(R.drawable.ic_baseline_podcasts_24),
-        ),
-    ),
-)


### PR DESCRIPTION
#### WHAT

Move sample Tile preview to debug folder.

#### WHY

Nightly builds are failing with:
```
e: file:///home/runner/work/horologist/horologist/media/sample/src/main/java/com/google/android/horologist/mediasample/data/service/tile/MediaCollectionsTileService.kt:27:28 Unresolved reference: tooling

> Task :media:sample:compileReleaseKotlin FAILED
```

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
