### PR TITLE
Improve API for re-engage prompt

### DIFF
--- a/datalayer/phone-ui/api/current.api
+++ b/datalayer/phone-ui/api/current.api
@@ -4,9 +4,7 @@ package com.google.android.horologist.datalayer.phone.ui {
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public final class PhoneUiDataLayerHelper {
     ctor public PhoneUiDataLayerHelper();
     method public android.content.Intent getInstallAppPromptIntent(android.content.Context context, String appPackageName, @DrawableRes int image, String topMessage, String bottomMessage);
-    method public android.content.Intent getReEngagePromptIntent(android.content.Context context, String nodeId, @DrawableRes int image, String topMessage, String bottomMessage, optional String? positiveButtonLabel, optional String? negativeButtonLabel);
     method public void showInstallAppPrompt(android.app.Activity activity, String appPackageName, @DrawableRes int image, String topMessage, String bottomMessage, optional int requestCode);
-    method public void showReEngagePrompt(android.app.Activity activity, String nodeId, @DrawableRes int image, String topMessage, String bottomMessage, optional int requestCode);
   }
 
 }
@@ -31,6 +29,11 @@ package com.google.android.horologist.datalayer.phone.ui.prompt.reengage {
 
   public final class ReEngageBottomSheetKt {
     method @androidx.compose.runtime.Composable public static void ReEngageBottomSheet(kotlin.jvm.functions.Function0<kotlin.Unit>? image, String topMessage, String bottomMessage, kotlin.jvm.functions.Function0<kotlin.Unit> onDismissRequest, kotlin.jvm.functions.Function0<kotlin.Unit> onConfirmation, optional androidx.compose.ui.Modifier modifier, optional String? positiveButtonLabel, optional String? negativeButtonLabel, optional androidx.compose.material3.SheetState sheetState);
+  }
+
+  public final class ReEngagePrompt {
+    ctor public ReEngagePrompt(kotlinx.coroutines.CoroutineScope coroutineScope);
+    method public android.content.Intent getIntent(android.content.Context context, String nodeId, @DrawableRes int image, String topMessage, String bottomMessage, optional String? positiveButtonLabel, optional String? negativeButtonLabel);
   }
 
 }

--- a/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/reengage/CoroutineScopeHolder.kt
+++ b/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/reengage/CoroutineScopeHolder.kt
@@ -14,23 +14,10 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.datalayer.phone.ui.di
+package com.google.android.horologist.datalayer.phone.ui.prompt.reengage
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 
-internal class CoroutineAppScope private constructor() {
-    companion object {
-
-        @Volatile
-        private var instance: CoroutineScope? = null
-
-        fun getInstance() =
-            instance ?: synchronized(this) {
-                instance ?: CoroutineScope(SupervisorJob() + Dispatchers.Default).also {
-                    instance = it
-                }
-            }
-    }
+internal object CoroutineScopeHolder {
+    lateinit var coroutineScope: CoroutineScope
 }

--- a/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/reengage/ReEngageBottomSheetActivity.kt
+++ b/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/reengage/ReEngageBottomSheetActivity.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.res.painterResource
 import com.google.android.horologist.data.WearDataLayerRegistry
 import com.google.android.horologist.datalayer.phone.PhoneDataLayerAppHelper
-import com.google.android.horologist.datalayer.phone.ui.di.CoroutineAppScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -57,7 +56,7 @@ internal class ReEngageBottomSheetActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        coroutineAppScope = CoroutineAppScope.getInstance()
+        coroutineAppScope = CoroutineScopeHolder.coroutineScope
 
         phoneDataLayerAppHelper = PhoneDataLayerAppHelper(
             this,

--- a/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/reengage/ReEngagePrompt.kt
+++ b/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/reengage/ReEngagePrompt.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Android Open Source Project
+ * Copyright 2024 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,55 +14,24 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.datalayer.phone.ui
+package com.google.android.horologist.datalayer.phone.ui.prompt.reengage
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.DrawableRes
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.datalayer.phone.ui.prompt.installapp.InstallAppBottomSheetActivity
+import kotlinx.coroutines.CoroutineScope
 
-private const val NO_RESULT_REQUESTED_REQUEST_CODE = -1
+public class ReEngagePrompt(coroutineScope: CoroutineScope) {
 
-/**
- * Data layer related UI helper features, for use on phones.
- */
-@ExperimentalHorologistApi
-public class PhoneUiDataLayerHelper {
-
-    /**
-     * Display an install app prompt to the user.
-     *
-     * Use [requestCode] as an option to check in [Activity.onActivityResult] if the prompt was
-     * dismissed ([Activity.RESULT_CANCELED]).
-     */
-    public fun showInstallAppPrompt(
-        activity: Activity,
-        appPackageName: String,
-        @DrawableRes image: Int,
-        topMessage: String,
-        bottomMessage: String,
-        requestCode: Int = NO_RESULT_REQUESTED_REQUEST_CODE,
-    ) {
-        val intent = getInstallAppPromptIntent(
-            context = activity,
-            appPackageName = appPackageName,
-            image = image,
-            topMessage = topMessage,
-            bottomMessage = bottomMessage,
-        )
-        activity.startActivityForResult(
-            intent,
-            requestCode,
-        )
+    init {
+        CoroutineScopeHolder.coroutineScope = coroutineScope
     }
 
     /**
-     * Returns the [Intent] to display an install app prompt to the user.
+     * Returns the [Intent] to display a re-engage prompt to the user.
      *
      * This can be used in Compose with [rememberLauncherForActivityResult] and
      * [ActivityResultLauncher.launch]:
@@ -72,11 +41,11 @@ public class PhoneUiDataLayerHelper {
      *     ActivityResultContracts.StartActivityForResult()
      * ) { result ->
      *     if (result.resultCode == RESULT_OK) {
-     *         // user pushed install!
+     *         // user pushed the positive button!
      *     }
      * }
      *
-     * launcher.launch(getInstallAppPromptIntent(/*params*/))
+     * launcher.launch(getReEngagePromptIntent(/*params*/))
      * ```
      *
      * It can also be used directly in an [ComponentActivity] with
@@ -86,24 +55,28 @@ public class PhoneUiDataLayerHelper {
      *      ActivityResultContracts.StartActivityForResult()
      *  ) { result ->
      *      if (result.resultCode == RESULT_OK) {
-     *          // user pushed install!
+     *          // user pushed the positive button!
      *      }
      *  }
      *
-     * launcher.launch(getInstallAppPromptIntent(/*params*/))
+     * launcher.launch(getReEngagePromptIntent(/*params*/))
      * ```
      */
-    public fun getInstallAppPromptIntent(
+    public fun getIntent(
         context: Context,
-        appPackageName: String,
+        nodeId: String,
         @DrawableRes image: Int,
         topMessage: String,
         bottomMessage: String,
-    ): Intent = InstallAppBottomSheetActivity.getIntent(
+        positiveButtonLabel: String? = null,
+        negativeButtonLabel: String? = null,
+    ): Intent = ReEngageBottomSheetActivity.getIntent(
         context = context,
-        appPackageName = appPackageName,
+        nodeId = nodeId,
         image = image,
         topMessage = topMessage,
         bottomMessage = bottomMessage,
+        positiveButtonLabel = positiveButtonLabel,
+        negativeButtonLabel = negativeButtonLabel,
     )
 }

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/di/PromptModule.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/di/PromptModule.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.horologist.datalayer.sample.di
 
+import com.google.android.horologist.datalayer.phone.ui.prompt.reengage.ReEngagePrompt
 import com.google.android.horologist.datalayer.phone.ui.prompt.signin.SignInPrompt
 import dagger.Module
 import dagger.Provides
@@ -29,6 +30,12 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object PromptModule {
+
+    @Singleton
+    @Provides
+    fun reEngagePrompt(): ReEngagePrompt = ReEngagePrompt(
+        coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+    )
 
     @Singleton
     @Provides

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/reengage/ReEngagePromptDemoScreen.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/reengage/ReEngagePromptDemoScreen.kt
@@ -57,7 +57,7 @@ fun ReEngagePromptDemoScreen(
         state = state,
         onRunDemoClick = viewModel::onRunDemoClick,
         getReEngagePromptIntent = { nodeId ->
-            viewModel.phoneUiDataLayerHelper.getReEngagePromptIntent(
+            viewModel.reEngagePrompt.getIntent(
                 context = context,
                 nodeId = nodeId,
                 image = R.drawable.watch_app_screenshot,

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/reengage/ReEngagePromptDemoViewModel.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/reengage/ReEngagePromptDemoViewModel.kt
@@ -21,7 +21,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.android.horologist.data.apphelper.appInstalled
 import com.google.android.horologist.datalayer.phone.PhoneDataLayerAppHelper
-import com.google.android.horologist.datalayer.phone.ui.PhoneUiDataLayerHelper
+import com.google.android.horologist.datalayer.phone.ui.prompt.reengage.ReEngagePrompt
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -33,7 +33,7 @@ class ReEngagePromptDemoViewModel
     @Inject
     constructor(
         private val phoneDataLayerAppHelper: PhoneDataLayerAppHelper,
-        val phoneUiDataLayerHelper: PhoneUiDataLayerHelper,
+        val reEngagePrompt: ReEngagePrompt,
     ) : ViewModel() {
 
         private var initializeCalled = false

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/signin/SignInPromptDemoScreen.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/signin/SignInPromptDemoScreen.kt
@@ -133,7 +133,7 @@ fun SignInPromptDemoScreen(
                 )
             }
 
-            SignInPromptDemoScreenState.PromptPositiveButtonClicked -> {
+            SignInPromptDemoScreenState.PromptSignInClicked -> {
                 Text(
                     stringResource(
                         id = R.string.signin_prompt_demo_result_label,

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/signin/SignInPromptDemoViewModel.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/signin/SignInPromptDemoViewModel.kt
@@ -63,7 +63,15 @@ class SignInPromptDemoViewModel
 
             viewModelScope.launch {
                 val node = phoneDataLayerAppHelper.connectedNodes().firstOrNull {
-                    it.surfacesInfo.usageInfo.usageStatus == UsageStatus.USAGE_STATUS_SETUP_COMPLETE
+                    when (it.surfacesInfo.usageInfo.usageStatus) {
+                        UsageStatus.UNRECOGNIZED,
+                        UsageStatus.USAGE_STATUS_UNSPECIFIED,
+                        UsageStatus.USAGE_STATUS_LAUNCHED_ONCE,
+                        null,
+                        -> true
+
+                        UsageStatus.USAGE_STATUS_SETUP_COMPLETE -> false
+                    }
                 }
 
                 _uiState.value = if (node != null) {
@@ -79,7 +87,7 @@ class SignInPromptDemoViewModel
         }
 
         fun onPromptSignInClick() {
-            _uiState.value = SignInPromptDemoScreenState.PromptPositiveButtonClicked
+            _uiState.value = SignInPromptDemoScreenState.PromptSignInClicked
         }
 
         fun onPromptDismiss() {
@@ -93,7 +101,7 @@ sealed class SignInPromptDemoScreenState {
     data object Loaded : SignInPromptDemoScreenState()
     data class WatchFound(val nodeId: String) : SignInPromptDemoScreenState()
     data object WatchNotFound : SignInPromptDemoScreenState()
-    data object PromptPositiveButtonClicked : SignInPromptDemoScreenState()
+    data object PromptSignInClicked : SignInPromptDemoScreenState()
     data object PromptDismissed : SignInPromptDemoScreenState()
     data object ApiNotAvailable : SignInPromptDemoScreenState()
 }

--- a/datalayer/sample/phone/src/main/res/values/strings.xml
+++ b/datalayer/sample/phone/src/main/res/values/strings.xml
@@ -79,7 +79,7 @@
     <string name="install_app_prompt_demo2_prompt_top_message">Test the interactions between the phone and the watch with the demo app.</string>
     <string name="install_app_prompt_demo2_prompt_bottom_message">Install the demo app on your Wear OS watch.</string>
     <string name="install_app_prompt_demo2_result_label">Result: %1$s</string>
-    <string name="install_app_prompt_demo2_no_watches_found_label">No watches without the app installed were found.</string>
+    <string name="install_app_prompt_demo2_no_watches_found_label">No watches meeting the required conditions were found.</string>
     <string name="install_app_prompt_demo2_prompt_install_result_label">User tapped install on the prompt.</string>
     <string name="install_app_prompt_demo2_prompt_cancel_result_label">User dismissed the prompt.</string>
 
@@ -89,7 +89,7 @@
     <string name="reengage_prompt_demo_prompt_top_message">Test the interactions between the phone and the watch with the demo app.</string>
     <string name="reengage_prompt_demo_prompt_bottom_message">Open the demo app on your Wear OS watch.</string>
     <string name="reengage_prompt_demo_result_label">Result: %1$s</string>
-    <string name="reengage_prompt_demo_no_watches_found_label">No watches with the app installed were found.</string>
+    <string name="reengage_prompt_demo_no_watches_found_label">No watches meeting the required conditions were found.</string>
     <string name="reengage_prompt_demo_prompt_positive_result_label">User tapped on the positive button on the prompt.</string>
     <string name="reengage_prompt_demo_prompt_dismiss_result_label">User dismissed the prompt.</string>
 
@@ -100,7 +100,7 @@
     <string name="signin_prompt_demo_prompt_bottom_message">Sign in to the demo app on your Wear OS watch.</string>
     <string name="signin_prompt_demo_result_label">Result: %1$s</string>
     <string name="signin_prompt_demo_no_watches_found_label">No watches meeting the required conditions were found.</string>
-    <string name="signin_prompt_demo_prompt_positive_result_label">User tapped on the positive button on the prompt.</string>
+    <string name="signin_prompt_demo_prompt_positive_result_label">User tapped sign-in on the prompt.</string>
     <string name="signin_prompt_demo_prompt_dismiss_result_label">User dismissed the prompt.</string>
 
     <!-- Counter screen -->


### PR DESCRIPTION
#### WHAT

Improve API for re-engage prompt.

Address comments from https://github.com/google/horologist/pull/2060

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
