### PR TITLE
Remove AppInstallationStatusNodeType.UNKNOWN

### DIFF
--- a/datalayer/core/api/current.api
+++ b/datalayer/core/api/current.api
@@ -135,7 +135,6 @@ package com.google.android.horologist.data.apphelper {
     method public static com.google.android.horologist.data.apphelper.AppInstallationStatusNodeType valueOf(String value) throws java.lang.IllegalArgumentException, java.lang.NullPointerException;
     method public static com.google.android.horologist.data.apphelper.AppInstallationStatusNodeType[] values();
     enum_constant public static final com.google.android.horologist.data.apphelper.AppInstallationStatusNodeType PHONE;
-    enum_constant public static final com.google.android.horologist.data.apphelper.AppInstallationStatusNodeType UNKNOWN;
     enum_constant public static final com.google.android.horologist.data.apphelper.AppInstallationStatusNodeType WATCH;
   }
 

--- a/datalayer/core/src/main/java/com/google/android/horologist/data/apphelper/AppHelperNodeStatus.kt
+++ b/datalayer/core/src/main/java/com/google/android/horologist/data/apphelper/AppHelperNodeStatus.kt
@@ -41,12 +41,6 @@ public sealed class AppInstallationStatus {
 public enum class AppInstallationStatusNodeType {
     WATCH,
     PHONE,
-
-    /**
-     * This case should not happen, but it's here in order to keep the node listed even in a
-     * scenario where there were issues retrieving the capability of the node.
-     */
-    UNKNOWN,
 }
 
 public val AppHelperNodeStatus.appInstalled: Boolean

--- a/datalayer/core/src/main/java/com/google/android/horologist/data/apphelper/DataLayerAppHelper.kt
+++ b/datalayer/core/src/main/java/com/google/android/horologist/data/apphelper/DataLayerAppHelper.kt
@@ -77,8 +77,7 @@ abstract class DataLayerAppHelper(
             val appInstallationStatus = if (allInstalledNodes.contains(it.id)) {
                 val nodeType = when (it.id) {
                     in installedPhoneNodes -> AppInstallationStatusNodeType.PHONE
-                    in installedWatchNodes -> AppInstallationStatusNodeType.WATCH
-                    else -> AppInstallationStatusNodeType.UNKNOWN
+                    else -> AppInstallationStatusNodeType.WATCH
                 }
                 AppInstallationStatus.Installed(nodeType = nodeType)
             } else {

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodesActionViewModel.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodesActionViewModel.kt
@@ -74,7 +74,6 @@ class NodesActionViewModel
                             when (status.nodeType) {
                                 AppInstallationStatusNodeType.WATCH -> NodeTypeUiModel.WATCH
                                 AppInstallationStatusNodeType.PHONE -> NodeTypeUiModel.PHONE
-                                AppInstallationStatusNodeType.UNKNOWN -> NodeTypeUiModel.UNKNOWN
                             }
                         }
                         AppInstallationStatus.NotInstalled -> NodeTypeUiModel.UNKNOWN


### PR DESCRIPTION
#### WHAT

Remove `AppInstallationStatusNodeType.UNKNOWN`.

#### WHY

It should not need based on current code: items in `allInstalledNodes` are either in `installedPhoneNodes` or `installedWatchNodes`.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
