### PR TITLE
Doc for in app prompts

### DIFF
--- a/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
+++ b/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
@@ -189,7 +189,8 @@ public class WearDataLayerAppHelper(
 
     /**
      * Marks that the necessary setup steps have been completed in the app such that it is ready for
-     * use. Typically this should be called when any pairing/login has been completed.
+     * use. Typically this should be called when any pairing/login has been completed. If used for
+     * prompting login, it should also be called during startup if login happened before
      */
     public suspend fun markSetupComplete() {
         surfacesInfoDataStore.updateData { info ->

--- a/docs/datalayer-phone-ui.md
+++ b/docs/datalayer-phone-ui.md
@@ -1,0 +1,31 @@
+# DataLayer phone UI
+
+The DataLayer phone UI library provides an implementation for phone prompts UI that can be used to
+bring more users to the Wear app.
+
+## Install app
+Use the `InstallAppPrompt` to build the UI of a prompt to ask the user to install the app on their watch.
+
+The `shouldDisplayPrompt` method allows to check if the prompt should be displayed, based on the following conditions:
+
+- there is a watch connected
+
+- the app is not installed
+
+The `shouldDisplayPrompt` method is relying on the capability defined in the wear.xml of the Wear app, if the Wear app is installed 
+but hasn't been updated with the capability definition, this method may still return a `AppHelperNodeStatus`
+indicating that the Wear app is not installed.
+
+## ReEngage prompt
+Use the `ReEngagePrompt` to build the UI of a prompt to ask the user to install the app on their watch.
+The `shouldDisplayPrompt` method allows to check if the prompt should be displayed, based on
+the criteria that the app is already installed.
+
+## SignIn prompt
+Use the `SignInPrompt` to build the UI of a prompt to ask the user to finish the sign in on the watch.
+The `shouldDisplayPrompt` method allows to check if the prompt should be displayed, if any of the 
+following conditions for the `UsageStatus` is true: 
+
+- `UsageStatus.UNRECOGNIZED`
+- `UsageStatus.USAGE_STATUS_UNSPECIFIED`
+- `UsageStatus.USAGE_STATUS_LAUNCHED_ONCE`

--- a/docs/datalayer-sample.md
+++ b/docs/datalayer-sample.md
@@ -1,0 +1,18 @@
+# DataLayer sample app
+
+The goal of this sample is to show how to use the DataLayer helpers both on phone and watch.
+
+## DataLayer phone sample app
+
+### In-app prompts
+This sample shows how to build in app prompts by using the 
+[Phone UI library](https://github.com/google/horologist/tree/main/datalayer/phone-ui) and the 
+[PhoneDataLayerAppHelper](https://github.com/google/horologist/blob/main/datalayer/phone/src/main/java/com/google/android/horologist/datalayer/phone/PhoneDataLayerAppHelper.kt).
+
+
+
+
+
+
+
+

--- a/docs/datalayer.md
+++ b/docs/datalayer.md
@@ -1,13 +1,10 @@
-# DataLayer library
+# Horologist DataLayer library.
 
-DataStore documentation https://developer.android.com/topic/libraries/architecture/datastore
-
-Direct DataLayer sample code https://github.com/android/wear-os-samples
-
-## DataLayer approach.
-
-The Horologist DataLayer libraries, provide common abstractions on top of the Wearable DataLayer.
-These are built upon a common assumption of Google Protobuf and gRPC, which allows sharing data
+The Horologist DataLayer library, provide common abstractions on top of the 
+[Wearable DataLayer](https://developer.android.com/training/wearables/data/data-layer).
+- [Google Protobuf](https://protobuf.dev/) is used to structure the data.  
+- [gRPC](https://grpc.io/docs/what-is-grpc/introduction/) is used to define how messages are [sent and received](https://developer.android.com/training/wearables/data/messages).
+- [DataStore](https://developer.android.com/topic/libraries/architecture/datastore) is used to [sync data across devices](https://developer.android.com/training/wearables/data/data-items).
 definitions throughout your Wear and Mobile apps.
 
 See this 
@@ -34,7 +31,8 @@ service CounterService {
 
 ## Registering Serializers.
 
-The WearDataLayerRegistry is an application singleton to register the Serializers.
+The [WearDataLayerRegistry](https://google.github.io/horologist/api/datalayer/core/com.google.android.horologist.data/-wear-data-layer-registry/index.html) 
+is an application singleton to register the Serializers.
 
 ```kotlin
 object CounterValueSerializer : Serializer<CounterValue> {
@@ -64,7 +62,8 @@ val registry = WearDataLayerRegistry.fromContext(
 ## Use Androidx DataStore
 
 This library provides a new implementation of Androidx DataStore, in addition to the local
-Proto and Preferences implementations.  The implementation uses the Wearable DataClient
+Proto and Preferences implementations.  The implementation uses the 
+[WearableDataClient](https://developers.google.com/android/reference/com/google/android/gms/wearable/DataClient)
 with a single owner and multiple readers.
 
 See [DataStore](https://developer.android.com/topic/libraries/architecture/datastore).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,8 @@ nav:
   - 'Data Layer':
       - 'Guide': datalayer.md
       - 'App Helpers': datalayer-helpers-guide.md
+      - 'Phone UI': datalayer-phone-ui.md
+      - 'Sample': datalayer-sample.md
   - 'Media':
       - 'Overview': media-toolkit.md
       - 'Simple app guide': simple-media-app-guide.md


### PR DESCRIPTION
#### WHAT
Adds docs for in app prompts. Code is still evolving so will need a second pass soon after new features are merged.


#### WHY
It's missing documentation for the in app prompts

#### HOW
Creates some new doc pages

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
