### PR TITLE
Add performAction function to ReEngagePrompt

### DIFF
--- a/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/reengage/ReEngageBottomSheetActivity.kt
+++ b/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/reengage/ReEngageBottomSheetActivity.kt
@@ -116,7 +116,10 @@ internal class ReEngageBottomSheetActivity : ComponentActivity() {
         // Can't use the Activity's lifecycleScope as it is going to finish the activity immediately
         // after this call
         coroutineAppScope.launch {
-            phoneDataLayerAppHelper.startRemoteOwnApp(nodeId = nodeId)
+            ReEngagePromptAction.run(
+                phoneDataLayerAppHelper = phoneDataLayerAppHelper,
+                nodeId = nodeId,
+            )
         }
 
         // It returns OK to indicate that the user tapped on the positive button.

--- a/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/reengage/ReEngagePrompt.kt
+++ b/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/reengage/ReEngagePrompt.kt
@@ -94,4 +94,14 @@ public class ReEngagePrompt(
         positiveButtonLabel = positiveButtonLabel,
         negativeButtonLabel = negativeButtonLabel,
     )
+
+    /**
+     * Performs the same action taken by the prompt when the user taps on the positive button.
+     */
+    public suspend fun performAction(nodeId: String) {
+        ReEngagePromptAction.run(
+            phoneDataLayerAppHelper = phoneDataLayerAppHelper,
+            nodeId = nodeId,
+        )
+    }
 }

--- a/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/reengage/ReEngagePromptAction.kt
+++ b/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/reengage/ReEngagePromptAction.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.datalayer.phone.ui.prompt.reengage
+
+import com.google.android.horologist.datalayer.phone.PhoneDataLayerAppHelper
+
+internal object ReEngagePromptAction {
+    suspend fun run(phoneDataLayerAppHelper: PhoneDataLayerAppHelper, nodeId: String) =
+        phoneDataLayerAppHelper.startRemoteOwnApp(nodeId = nodeId)
+}

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/Screen.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/Screen.kt
@@ -26,6 +26,7 @@ sealed class Screen(
     data object ReEngagePromptDemoScreen : Screen("reEngagePromptDemoScreen")
     data object SignInPromptDemoScreen : Screen("signInPromptDemoScreen")
     data object InstallAppCustomPromptDemoScreen : Screen("installAppCustomPromptDemoScreen")
+    data object ReEngageCustomPromptDemoScreen : Screen("reEngageCustomPromptDemoScreen")
     data object SignInCustomPromptDemoScreen : Screen("signInCustomPromptDemoScreen")
     data object CounterScreen : Screen("counterScreen")
 }

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/custom/installapp/InstallAppCustomPromptDemoScreen.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/custom/installapp/InstallAppCustomPromptDemoScreen.kt
@@ -176,3 +176,14 @@ fun InstallAppCustomPromptDemoScreenPreview() {
         onInstallPromptCancel = { },
     )
 }
+
+@Preview(showBackground = true)
+@Composable
+fun InstallAppCustomPromptDemoScreenPreviewWithPrompt() {
+    InstallAppCustomPromptDemoScreen(
+        state = InstallAppCustomPromptDemoScreenState.WatchFound,
+        onRunDemoClick = { },
+        onInstallPromptInstallClick = { },
+        onInstallPromptCancel = { },
+    )
+}

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/custom/reengage/ReEngageCustomPromptDemoScreen.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/custom/reengage/ReEngageCustomPromptDemoScreen.kt
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.google.android.horologist.datalayer.sample.screens.inappprompts.custom.reengage
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Watch
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.google.android.horologist.datalayer.sample.R
+
+@Composable
+fun ReEngageCustomPromptDemoScreen(
+    modifier: Modifier = Modifier,
+    viewModel: ReEngageCustomPromptDemoViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    if (state == ReEngageCustomPromptDemoScreenState.Idle) {
+        SideEffect {
+            viewModel.initialize()
+        }
+    }
+
+    ReEngageCustomPromptDemoScreen(
+        state = state,
+        onRunDemoClick = viewModel::onRunDemoClick,
+        onPromptPositiveButtonClick = viewModel::onPromptPositiveButtonClick,
+        onPromptDismiss = viewModel::onPromptDismiss,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun ReEngageCustomPromptDemoScreen(
+    state: ReEngageCustomPromptDemoScreenState,
+    onRunDemoClick: () -> Unit,
+    onPromptPositiveButtonClick: (nodeId: String) -> Unit,
+    onPromptDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.padding(all = 10.dp),
+    ) {
+        Text(text = stringResource(id = R.string.reengage_custom_prompt_api_call_demo_message))
+
+        Button(
+            onClick = onRunDemoClick,
+            modifier = Modifier
+                .padding(top = 10.dp)
+                .align(Alignment.CenterHorizontally),
+            enabled = state != ReEngageCustomPromptDemoScreenState.ApiNotAvailable,
+        ) {
+            Text(text = stringResource(id = R.string.reengage_custom_prompt_run_demo_button_label))
+        }
+
+        when (state) {
+            ReEngageCustomPromptDemoScreenState.Idle,
+            ReEngageCustomPromptDemoScreenState.Loaded,
+            -> {
+                /* do nothing */
+            }
+
+            ReEngageCustomPromptDemoScreenState.Loading -> {
+                CircularProgressIndicator()
+            }
+
+            is ReEngageCustomPromptDemoScreenState.WatchFound -> {
+                val sheetState = rememberModalBottomSheetState()
+
+                ModalBottomSheet(
+                    onDismissRequest = onPromptDismiss,
+                    modifier = modifier,
+                    sheetState = sheetState,
+                    dragHandle = null,
+                ) {
+                    Column(
+                        modifier = modifier
+                            .padding(16.dp)
+                            .fillMaxWidth()
+                            .verticalScroll(rememberScrollState()),
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .padding(top = 24.dp)
+                                .align(Alignment.CenterHorizontally),
+                        ) {
+                            Icon(imageVector = Icons.Default.Watch, contentDescription = null)
+                        }
+
+                        Text(
+                            text = stringResource(id = R.string.reengage_custom_prompt_demo_prompt_top_message),
+                            modifier = Modifier
+                                .padding(top = 24.dp)
+                                .fillMaxWidth(),
+                            color = MaterialTheme.colorScheme.onSurface,
+                            textAlign = TextAlign.Center,
+                            maxLines = 3,
+                            style = MaterialTheme.typography.titleLarge,
+                        )
+
+                        Text(
+                            text = stringResource(id = R.string.reengage_custom_prompt_demo_prompt_bottom_message),
+                            modifier = Modifier
+                                .padding(top = 16.dp)
+                                .fillMaxWidth(),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center,
+                            maxLines = 3,
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+
+                        Spacer(modifier = Modifier.height(24.dp))
+
+                        Row(
+                            modifier = Modifier
+                                .padding(horizontal = 16.dp)
+                                .fillMaxWidth(),
+                            horizontalArrangement = Arrangement.End,
+                        ) {
+                            TextButton(
+                                onClick = onPromptDismiss,
+                                modifier = Modifier
+                                    .padding(end = 12.dp),
+                            ) {
+                                Text(text = stringResource(id = R.string.reengage_custom_prompt_demo_prompt_dismiss_button_label))
+                            }
+
+                            Button(
+                                onClick = {
+                                    onPromptPositiveButtonClick(state.nodeId)
+                                },
+                            ) {
+                                Text(text = stringResource(id = R.string.reengage_custom_prompt_demo_prompt_confirm_button_label))
+                            }
+                        }
+                    }
+                }
+            }
+
+            ReEngageCustomPromptDemoScreenState.WatchNotFound -> {
+                Text(
+                    stringResource(
+                        id = R.string.reengage_custom_prompt_demo_result_label,
+                        stringResource(id = R.string.reengage_custom_prompt_demo_no_watches_found_label),
+                    ),
+                )
+            }
+
+            ReEngageCustomPromptDemoScreenState.PromptPositiveButtonClicked -> {
+                Text(
+                    stringResource(
+                        id = R.string.reengage_custom_prompt_demo_result_label,
+                        stringResource(id = R.string.reengage_custom_prompt_demo_prompt_positive_result_label),
+                    ),
+                )
+            }
+
+            ReEngageCustomPromptDemoScreenState.PromptDismissed -> {
+                Text(
+                    stringResource(
+                        id = R.string.reengage_custom_prompt_demo_result_label,
+                        stringResource(id = R.string.reengage_custom_prompt_demo_prompt_dismiss_result_label),
+                    ),
+                )
+            }
+
+            ReEngageCustomPromptDemoScreenState.ApiNotAvailable -> {
+                Text(stringResource(id = R.string.wearable_message_api_unavailable))
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ReEngageCustomPromptDemoScreenPreview() {
+    ReEngageCustomPromptDemoScreen(
+        state = ReEngageCustomPromptDemoScreenState.Idle,
+        onRunDemoClick = { },
+        onPromptPositiveButtonClick = { },
+        onPromptDismiss = { },
+    )
+}

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/custom/reengage/ReEngageCustomPromptDemoViewModel.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/custom/reengage/ReEngageCustomPromptDemoViewModel.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.datalayer.sample.screens.inappprompts.custom.reengage
+
+import androidx.annotation.MainThread
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.android.horologist.datalayer.phone.PhoneDataLayerAppHelper
+import com.google.android.horologist.datalayer.phone.ui.prompt.reengage.ReEngagePrompt
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ReEngageCustomPromptDemoViewModel
+    @Inject
+    constructor(
+        private val phoneDataLayerAppHelper: PhoneDataLayerAppHelper,
+        private val reEngagePrompt: ReEngagePrompt,
+    ) : ViewModel() {
+
+        private var initializeCalled = false
+
+        private val _uiState =
+            MutableStateFlow<ReEngageCustomPromptDemoScreenState>(ReEngageCustomPromptDemoScreenState.Idle)
+        public val uiState: StateFlow<ReEngageCustomPromptDemoScreenState> = _uiState
+
+        @MainThread
+        fun initialize() {
+            if (initializeCalled) return
+            initializeCalled = true
+
+            _uiState.value = ReEngageCustomPromptDemoScreenState.Loading
+
+            viewModelScope.launch {
+                if (!phoneDataLayerAppHelper.isAvailable()) {
+                    _uiState.value = ReEngageCustomPromptDemoScreenState.ApiNotAvailable
+                } else {
+                    _uiState.value = ReEngageCustomPromptDemoScreenState.Loaded
+                }
+            }
+        }
+
+        fun onRunDemoClick() {
+            _uiState.value = ReEngageCustomPromptDemoScreenState.Loading
+
+            viewModelScope.launch {
+                val node = reEngagePrompt.shouldDisplayPrompt()
+
+                _uiState.value = if (node != null) {
+                    ReEngageCustomPromptDemoScreenState.WatchFound(node.id)
+                } else {
+                    ReEngageCustomPromptDemoScreenState.WatchNotFound
+                }
+            }
+        }
+
+        fun onPromptPositiveButtonClick(nodeId: String) {
+            viewModelScope.launch {
+                reEngagePrompt.performAction(nodeId = nodeId)
+            }
+
+            _uiState.value = ReEngageCustomPromptDemoScreenState.PromptPositiveButtonClicked
+        }
+
+        fun onPromptDismiss() {
+            _uiState.value = ReEngageCustomPromptDemoScreenState.PromptDismissed
+        }
+    }
+
+sealed class ReEngageCustomPromptDemoScreenState {
+    data object Idle : ReEngageCustomPromptDemoScreenState()
+    data object Loading : ReEngageCustomPromptDemoScreenState()
+    data object Loaded : ReEngageCustomPromptDemoScreenState()
+    data class WatchFound(val nodeId: String) : ReEngageCustomPromptDemoScreenState()
+    data object WatchNotFound : ReEngageCustomPromptDemoScreenState()
+    data object PromptPositiveButtonClicked : ReEngageCustomPromptDemoScreenState()
+    data object PromptDismissed : ReEngageCustomPromptDemoScreenState()
+    data object ApiNotAvailable : ReEngageCustomPromptDemoScreenState()
+}

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/custom/signin/SignInCustomPromptDemoScreen.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/custom/signin/SignInCustomPromptDemoScreen.kt
@@ -169,6 +169,17 @@ fun SignInCustomPromptDemoScreen(
 @Composable
 fun SignInCustomPromptDemoScreenPreview() {
     SignInCustomPromptDemoScreen(
+        state = SignInCustomPromptDemoScreenState.Idle,
+        onRunDemoClick = { },
+        onPromptSignInClick = { },
+        onPromptDismiss = { },
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SignInCustomPromptDemoScreenPreviewWithPrompt() {
+    SignInCustomPromptDemoScreen(
         state = SignInCustomPromptDemoScreenState.WatchFound("nodeId"),
         onRunDemoClick = { },
         onPromptSignInClick = { },

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/custom/signin/SignInCustomPromptDemoViewModel.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/custom/signin/SignInCustomPromptDemoViewModel.kt
@@ -32,7 +32,7 @@ class SignInCustomPromptDemoViewModel
     @Inject
     constructor(
         private val phoneDataLayerAppHelper: PhoneDataLayerAppHelper,
-        val signInCustomPrompt: SignInPrompt,
+        private val signInCustomPrompt: SignInPrompt,
     ) : ViewModel() {
 
         private var initializeCalled = false

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/main/MainScreen.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/main/MainScreen.kt
@@ -31,6 +31,7 @@ import androidx.navigation.compose.rememberNavController
 import com.google.android.horologist.datalayer.sample.screens.Screen
 import com.google.android.horologist.datalayer.sample.screens.counter.CounterScreen
 import com.google.android.horologist.datalayer.sample.screens.inappprompts.custom.installapp.InstallAppCustomPromptDemoScreen
+import com.google.android.horologist.datalayer.sample.screens.inappprompts.custom.reengage.ReEngageCustomPromptDemoScreen
 import com.google.android.horologist.datalayer.sample.screens.inappprompts.custom.signin.SignInCustomPromptDemoScreen
 import com.google.android.horologist.datalayer.sample.screens.inappprompts.installapp.InstallAppPromptDemoScreen
 import com.google.android.horologist.datalayer.sample.screens.inappprompts.reengage.ReEngagePromptDemoScreen
@@ -79,6 +80,9 @@ fun MainScreen(
                 }
                 composable(route = Screen.InstallAppCustomPromptDemoScreen.route) {
                     InstallAppCustomPromptDemoScreen()
+                }
+                composable(route = Screen.ReEngageCustomPromptDemoScreen.route) {
+                    ReEngageCustomPromptDemoScreen()
                 }
                 composable(route = Screen.SignInCustomPromptDemoScreen.route) {
                     SignInCustomPromptDemoScreen()

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/menu/MenuScreen.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/menu/MenuScreen.kt
@@ -69,6 +69,10 @@ fun MenuScreen(
             Text(text = stringResource(id = R.string.menu_screen_install_app_custom_demo_item))
         }
 
+        Button(onClick = { navController.navigate(Screen.ReEngageCustomPromptDemoScreen.route) }) {
+            Text(text = stringResource(id = R.string.menu_screen_reengage_custom_demo_item))
+        }
+
         Button(onClick = { navController.navigate(Screen.SignInCustomPromptDemoScreen.route) }) {
             Text(text = stringResource(id = R.string.menu_screen_signin_custom_demo_item))
         }

--- a/datalayer/sample/phone/src/main/res/values/strings.xml
+++ b/datalayer/sample/phone/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="menu_screen_reengage_demo_item">Re-Engage</string>
     <string name="menu_screen_signin_demo_item">Sign-in</string>
     <string name="menu_screen_install_app_custom_demo_item">Install app (custom prompt)</string>
+    <string name="menu_screen_reengage_custom_demo_item">Re-Engage (custom prompt)</string>
     <string name="menu_screen_signin_custom_demo_item">Sign-in (custom prompt)</string>
     <string name="menu_screen_datalayer_header">Data Layer</string>
     <string name="menu_screen_counter_item">Counter sample</string>
@@ -74,7 +75,7 @@
     <string name="install_app_prompt_demo_prompt_install_result_label">User tapped install on the prompt.</string>
     <string name="install_app_prompt_demo_prompt_cancel_result_label">User dismissed the prompt.</string>
 
-    <!-- In-app prompt - Install App Custom Demo screen -->
+    <!-- In-app prompt - Install App Custom Prompt Demo screen -->
     <string name="install_app_custom_prompt_api_call_demo_message">This demo calls the Horologist API to check if there is a watch connected and the watch does not have the app installed.\nIt then displays a custom prompt asking the user to install the app.\nOnce the user taps install, it uses Horologist API to launch Google Play.\n\nGoogle Play won\'t find this app as it is not published.</string>
     <string name="install_app_custom_prompt_run_demo_button_label">Run demo</string>
     <string name="install_app_custom_prompt_demo_prompt_top_message">Test the interactions between the phone and the watch with the demo app.</string>
@@ -96,23 +97,35 @@
     <string name="reengage_prompt_demo_prompt_positive_result_label">User tapped on the positive button on the prompt.</string>
     <string name="reengage_prompt_demo_prompt_dismiss_result_label">User dismissed the prompt.</string>
 
+    <!-- In-app prompt - Re-Engage Custom Prompt Demo screen -->
+    <string name="reengage_custom_prompt_api_call_demo_message">This demo calls the Horologist API to check if there is a watch connected and the watch has the app already installed.\nIt then displays a custom prompt asking the user to open the watch app.\nOnce the user taps on try, it uses Horologist API to launch the watch app.</string>
+    <string name="reengage_custom_prompt_run_demo_button_label">Run demo</string>
+    <string name="reengage_custom_prompt_demo_prompt_top_message">Test the interactions between the phone and the watch with the demo app.</string>
+    <string name="reengage_custom_prompt_demo_prompt_bottom_message">Open the demo app on your Wear OS watch.</string>
+    <string name="reengage_custom_prompt_demo_prompt_confirm_button_label">Try on watch</string>
+    <string name="reengage_custom_prompt_demo_prompt_dismiss_button_label">Not now</string>
+    <string name="reengage_custom_prompt_demo_result_label">Result: %1$s</string>
+    <string name="reengage_custom_prompt_demo_no_watches_found_label">No watches meeting the required conditions were found.</string>
+    <string name="reengage_custom_prompt_demo_prompt_positive_result_label">User tapped on the positive button on the prompt.</string>
+    <string name="reengage_custom_prompt_demo_prompt_dismiss_result_label">User dismissed the prompt.</string>
+
     <!-- In-app prompt - Sign-in Demo screen -->
     <string name="signin_prompt_api_call_demo_message">This demo calls the Horologist API to show the sign-in prompt for the watch demo app. The API will only display the prompt if there is a watch connected, the watch has the app already installed, and the app is not signed in.</string>
     <string name="signin_prompt_run_demo_button_label">Run demo</string>
     <string name="signin_prompt_demo_prompt_top_message">Test the interactions between the phone and the watch with the demo app.</string>
     <string name="signin_prompt_demo_prompt_bottom_message">Sign in to the demo app on your Wear OS watch.</string>
-    <string name="signin_custom_prompt_demo_prompt_confirm_button_label">Sign in on watch</string>
-    <string name="signin_custom_prompt_demo_prompt_dismiss_button_label">Not now</string>
     <string name="signin_prompt_demo_result_label">Result: %1$s</string>
     <string name="signin_prompt_demo_no_watches_found_label">No watches meeting the required conditions were found.</string>
     <string name="signin_prompt_demo_prompt_positive_result_label">User tapped sign-in on the prompt.</string>
     <string name="signin_prompt_demo_prompt_dismiss_result_label">User dismissed the prompt.</string>
 
-    <!-- In-app prompt - Sign-in Custom Demo screen -->
+    <!-- In-app prompt - Sign-in Custom Prompt Demo screen -->
     <string name="signin_custom_prompt_api_call_demo_message">This demo calls the Horologist API to check if there is a watch connected, the watch has the app already installed, and the app is not signed in.\nIt then displays a custom prompt asking the user to sign in on the watch app.\nOnce the user taps on sign in, it uses Horologist API to launch the watch app.</string>
     <string name="signin_custom_prompt_run_demo_button_label">Run demo</string>
     <string name="signin_custom_prompt_demo_prompt_top_message">Test the interactions between the phone and the watch with the demo app.</string>
     <string name="signin_custom_prompt_demo_prompt_bottom_message">Sign in to the demo app on your Wear OS watch.</string>
+    <string name="signin_custom_prompt_demo_prompt_confirm_button_label">Sign in on watch</string>
+    <string name="signin_custom_prompt_demo_prompt_dismiss_button_label">Not now</string>
     <string name="signin_custom_prompt_demo_result_label">Result: %1$s</string>
     <string name="signin_custom_prompt_demo_no_watches_found_label">No watches meeting the required conditions were found.</string>
     <string name="signin_custom_prompt_demo_prompt_positive_result_label">User tapped sign-in on the prompt.</string>


### PR DESCRIPTION
#### WHAT

Add `performAction` function to `ReEngagePrompt`.
Add sample.

<img src=https://github.com/google/horologist/assets/878134/bf4a167c-3e22-43c6-a374-f92ba7c68371 width=300>

#### WHY

So it can be used with custom prompts.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
