### PR TITLE
Only publish docs on main branch releases

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -3,7 +3,7 @@ name: Publish docs
 on:
   push:
     tags:
-      - v*
+      - v0.6.*
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
#### WHAT

Only publish docs on main branch releases

#### WHY

https://github.com/google/horologist/issues/2091

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
