### PR TITLE
Update renovate.json to avoid AGP 8.3.0

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,12 @@
         "com.google.devtools.ksp"
       ],
       "groupName": "kotlin"
+    },
+    {
+      "matchPackagePatterns": [
+        "com.android.tools.build:gradle"
+      ],
+      "allowedVersions": "<8.3.0"
     }
   ]
 }


### PR DESCRIPTION
#### WHAT


#### WHY


#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
