### PR TITLE
Makes progress prediction only happen when the lifecycle is resumed

### DIFF
--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/state/ProgressStateHolder.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/state/ProgressStateHolder.kt
@@ -21,9 +21,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.withFrameMillis
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.media.model.TimestampProvider
 import com.google.android.horologist.media.ui.animation.PlaybackProgressAnimation.PLAYBACK_PROGRESS_ANIMATION_SPEC
@@ -43,13 +46,13 @@ internal class ProgressStateHolder(
     initial: Float,
     private val timestampProvider: TimestampProvider,
 ) {
-    private val actual = mutableStateOf(initial)
+    private val actual = mutableFloatStateOf(initial)
     private val animatable = Animatable(0f)
-    val state = derivedStateOf { actual.value + animatable.value - animatable.targetValue }
+    val state = derivedStateOf { actual.floatValue + animatable.value - animatable.targetValue }
 
     suspend fun setProgress(percent: Float, canAnimate: Boolean) = coroutineScope {
-        val offset = percent - actual.value
-        actual.value = percent
+        val offset = percent - actual.floatValue
+        actual.floatValue = percent
         if (!canAnimate || animatable.isRunning || abs(offset) < ANIMATION_THRESHOLD) {
             return@coroutineScope
         }
@@ -63,7 +66,7 @@ internal class ProgressStateHolder(
         val initialFrameTime = withFrameMillis { timestampProvider.getTimestamp() - it }
         do {
             withFrameMillis {
-                actual.value = predictor(initialFrameTime + it)
+                actual.floatValue = predictor(initialFrameTime + it)
             }
         } while (isActive)
     }
@@ -74,13 +77,20 @@ internal class ProgressStateHolder(
 
         @Composable
         fun fromTrackPositionUiModel(trackPositionUiModel: TrackPositionUiModel): State<Float> {
+            val lifecycleOwner = LocalLifecycleOwner.current
             val timestampProvider = LocalTimestampProvider.current
-            val percent = trackPositionUiModel.getCurrentPercent(timestampProvider.getTimestamp())
-            val stateHolder = remember { ProgressStateHolder(percent, timestampProvider) }
-            LaunchedEffect(trackPositionUiModel) {
+            val stateHolder = remember {
+                val initial = trackPositionUiModel.getCurrentPercent(timestampProvider.getTimestamp())
+                ProgressStateHolder(initial, timestampProvider)
+            }
+            LaunchedEffect(trackPositionUiModel, lifecycleOwner) {
+                val percent = trackPositionUiModel.getCurrentPercent(timestampProvider.getTimestamp())
                 stateHolder.setProgress(percent, trackPositionUiModel.shouldAnimate)
                 if (trackPositionUiModel is TrackPositionUiModel.Predictive) {
-                    stateHolder.predictProgress(trackPositionUiModel.predictor::predictPercent)
+                    // Prediction only happens when the UI is visible.
+                    lifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                        stateHolder.predictProgress(trackPositionUiModel.predictor::predictPercent)
+                    }
                 }
             }
             return stateHolder.state


### PR DESCRIPTION
#### WHAT
Makes `ProgressStateHolder` suspend when the view is paused.

#### WHY
To reduce CPU usage when the composable is backgrounded or otherwise not visible.

#### HOW
Via `lifecycleOwner.repeatOnLifecycle`.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
