### PR TITLE
Adds basic docs for install Tile

### DIFF
--- a/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/installtile/InstallTilePrompt.kt
+++ b/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/installtile/InstallTilePrompt.kt
@@ -91,4 +91,13 @@ public class InstallTilePrompt(private val phoneDataLayerAppHelper: PhoneDataLay
         topMessage = topMessage,
         bottomMessage = bottomMessage,
     )
+
+    /**
+     * Performs the same action taken by the prompt when the user taps on the positive button.
+     */
+    public fun performAction(context: Context) {
+        InstallTilePromptAction.run(
+            context = context,
+        )
+    }
 }

--- a/docs/datalayer-helpers-guide.md
+++ b/docs/datalayer-helpers-guide.md
@@ -201,6 +201,13 @@ In `onTileRemoveEvent`:
 wearAppHelper.markTileAsRemoved("SummaryTile")
 ```
 
+## Deeplink into Tiles settings editor to install a Tile (phone only)
+
+If you want to open the Tile Settings editor on your phone, you can use
+`phoneDataLayerAppHelper.checkCompanionVersionSupportTileEditing` to check that the Companion version
+supports deeplink into Tiles Settings editor and `phoneDataLayerAppHelper.findWatchToInstallTile`
+to check if there is a connected watch where the Tile can be installed.
+
 ## Tracking Complication installation (Wear-only)
 
 To determine whether your Complication(s) are in-use, add the following to

--- a/docs/datalayer-phone-ui.md
+++ b/docs/datalayer-phone-ui.md
@@ -110,6 +110,30 @@ following conditions:
 - the app was not marked as "setup complete" (see "Tracking the app has been set up"
   in [Datalayer App Helper](datalayer-helpers-guide.md) guide)
 
+## Install Tile prompt
+Use the
+[InstallTilePrompt](https://google.github.io/horologist/api/datalayer/phone-ui/com.google.android.horologist.datalayer.phone.ui.prompt.installtile/-install-tile-prompt/index.html)
+to build the UI of a prompt to ask the user to install a Tile of your choice on the
+watch. If the user decides to install the Tile, they will be redirected to the Tile settings editor 
+screen where they can select and add the Tile to the watchface.
+Please note that this feature is only supported on Pixel watches.
+
+The `shouldDisplayPrompt` method allows to check if the prompt should be displayed, based on the
+following conditions:
+- the Wear app is installed and it's tracking the status of installed Tiles. See
+[trackInstalledTiles](https://github.com/google/horologist/blob/main/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/TileSync.kt#L35)
+in the sample app. The `trackInstalledTiles` has to be called when the app is launched, on 
+`TileService.onTileAddEvent` and `TileService.onTileRemoveEvent`. After the Wear app has been updated
+to support `trackInstalledTiles`, it has to be launched at least once before being able to track the 
+Tile installation status.
+- Wear OS companion app has version of 2.1.0.576785526 or above. This version was rolled out in
+November 2023.
+- We are using `getActiveTilesAsync` method which could omit some Tiles, 
+see more in the [doc](https://developer.android.com/reference/androidx/wear/tiles/TileService#getActiveTilesAsync(android.content.Context,java.util.concurrent.Executor)).
+
+Also note that, if the user has more than one Pixel watches paired with the phone, the prompt
+will always redirect to the Tile settings editor of the first paired watch.
+
 ## Custom prompts
 
 If desired to display your own custom prompt, this API can still be helpful. 


### PR DESCRIPTION
#### WHAT
Add docs for Tile prompts

#### WHY
To promote this feature with developers

#### HOW
Add docs

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
