### PR TITLE
Make marquee text maintain talkback focus during marquee animation.

### DIFF
--- a/composables/src/main/java/com/google/android/horologist/composables/MarqueeText.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/MarqueeText.kt
@@ -40,6 +40,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.layout
+import androidx.compose.ui.semantics.focused
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
@@ -100,6 +102,7 @@ public fun MarqueeText(
         inlineContent = inlineContent,
         modifier = modifier
             .then(controller.outsideMarqueeModifier)
+            .semantics { focused = true }
             .basicMarquee(
                 iterations = Int.MAX_VALUE,
                 delayMillis = pauseTime.inWholeMilliseconds.toInt(),


### PR DESCRIPTION
#### WHAT
Make marquee text maintain talkback focus during marquee animation.

#### WHY
Currently, when Talkback focuses on the marquee title, the marquee loses focus after completing its first round of animation.

#### HOW
Add `Modifier.semantics { focused = true }` to the marquee text.


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
