### PR TITLE
Fix Complication Tracking

### DIFF
--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/tracking/TrackingScreenViewModel.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/tracking/TrackingScreenViewModel.kt
@@ -119,9 +119,7 @@ class TrackingScreenViewModel
                     )
                 } else {
                     wearDataLayerAppHelper.markComplicationAsDeactivated(
-                        complicationName = complication,
                         complicationInstanceId = 1234,
-                        complicationType = ComplicationType.SHORT_TEXT,
                     )
                 }
             }

--- a/datalayer/watch/api/current.api
+++ b/datalayer/watch/api/current.api
@@ -8,7 +8,7 @@ package com.google.android.horologist.datalayer.watch {
     method public suspend Object? installOnNode(String nodeId, kotlin.coroutines.Continuation<? super com.google.android.horologist.data.AppHelperResultCode>);
     method public suspend Object? markActivityLaunchedOnce(kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? markComplicationAsActivated(String complicationName, int complicationInstanceId, androidx.wear.watchface.complications.data.ComplicationType complicationType, kotlin.coroutines.Continuation<? super kotlin.Unit>);
-    method public suspend Object? markComplicationAsDeactivated(String complicationName, int complicationInstanceId, androidx.wear.watchface.complications.data.ComplicationType complicationType, kotlin.coroutines.Continuation<? super kotlin.Unit>);
+    method public suspend Object? markComplicationAsDeactivated(int complicationInstanceId, kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? markSetupComplete(kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? markSetupNoLongerComplete(kotlin.coroutines.Continuation<? super kotlin.Unit>);
     method public suspend Object? markTileAsInstalled(String tileName, kotlin.coroutines.Continuation<? super kotlin.Unit>);

--- a/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
+++ b/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
@@ -278,25 +278,14 @@ public class WearDataLayerAppHelper(
      * Marks a complication as deactivated. Call this in
      * [ComplicationDataSourceService.onComplicationDeactivated].
      *
-     * @param complicationName The name of the complication, to disambiguate from others.
      * @param complicationInstanceId Passed from [ComplicationDataSourceService.onComplicationDeactivated]
-     * @param complicationType Passed from [ComplicationDataSourceService.onComplicationDeactivated]
      */
     public suspend fun markComplicationAsDeactivated(
-        complicationName: String,
         complicationInstanceId: Int,
-        complicationType: ComplicationType,
     ) {
         surfacesInfoDataStore.updateData { info ->
-            val complication = complicationInfo {
-                timestamp = System.currentTimeMillis().toProtoTimestamp()
-
-                name = complicationName
-                instanceId = complicationInstanceId
-                type = complicationType.name
-            }
             info.copy {
-                val filtered = complications.filter { !complication.equalWithoutTimestamp(it) }
+                val filtered = complications.filterNot { it.instanceId == complicationInstanceId }
                 if (filtered.size != complications.size) {
                     complications.clear()
                     complications.addAll(filtered)


### PR DESCRIPTION
#### WHAT

Fix Complication Tracking

#### WHY

Not possible to implement `markComplicationAsDeactivated` without knowing the type.

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
