### PR TITLE
Fix WearDataLayerAppHelper on robo

### DIFF
--- a/datalayer/phone/build.gradle.kts
+++ b/datalayer/phone/build.gradle.kts
@@ -100,6 +100,8 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.truth)
+    testImplementation(libs.androidx.test.ext.ktx)
+    testImplementation(libs.kotlinx.coroutines.test)
 }
 
 tasks.withType<org.jetbrains.dokka.gradle.DokkaTaskPartial>().configureEach {

--- a/datalayer/phone/build.gradle.kts
+++ b/datalayer/phone/build.gradle.kts
@@ -26,6 +26,8 @@ android {
 
     defaultConfig {
         minSdk = 23
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     compileOptions {

--- a/datalayer/phone/build.gradle.kts
+++ b/datalayer/phone/build.gradle.kts
@@ -104,6 +104,9 @@ dependencies {
     testImplementation(libs.truth)
     testImplementation(libs.androidx.test.ext.ktx)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.androidx.test.ext)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.test.runner)
 }
 
 tasks.withType<org.jetbrains.dokka.gradle.DokkaTaskPartial>().configureEach {

--- a/datalayer/phone/src/test/java/com/google/android/horologist/datalayer/phone/PhoneDataLayerAppHelperTest.kt
+++ b/datalayer/phone/src/test/java/com/google/android/horologist/datalayer/phone/PhoneDataLayerAppHelperTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.datalayer.phone
+
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.android.horologist.data.WearDataLayerRegistry
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class PhoneDataLayerAppHelperTest {
+
+    @Test
+    fun testCreate() = runTest {
+        val scope = CoroutineScope(coroutineContext + Job())
+
+        val context = InstrumentationRegistry.getInstrumentation().context
+        val registry = WearDataLayerRegistry.fromContext(context, scope)
+        val helper = PhoneDataLayerAppHelper(context, registry)
+
+        assertThat(helper.isAvailable()).isFalse()
+
+        scope.cancel()
+    }
+}

--- a/datalayer/watch/build.gradle.kts
+++ b/datalayer/watch/build.gradle.kts
@@ -26,6 +26,8 @@ android {
 
     defaultConfig {
         minSdk = 26
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     compileOptions {
@@ -99,6 +101,11 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime)
     implementation(libs.androidx.wear.remote.interactions)
     implementation(libs.androidx.wear.phone.interactions)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.truth)
+    testImplementation(libs.androidx.test.ext.ktx)
+    testImplementation(libs.kotlinx.coroutines.test)
 }
 
 tasks.withType<org.jetbrains.dokka.gradle.DokkaTaskPartial>().configureEach {

--- a/datalayer/watch/build.gradle.kts
+++ b/datalayer/watch/build.gradle.kts
@@ -106,6 +106,9 @@ dependencies {
     testImplementation(libs.truth)
     testImplementation(libs.androidx.test.ext.ktx)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.androidx.test.ext)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.test.runner)
 }
 
 tasks.withType<org.jetbrains.dokka.gradle.DokkaTaskPartial>().configureEach {

--- a/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
+++ b/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
@@ -62,14 +62,14 @@ public class WearDataLayerAppHelper internal constructor(
     context: Context,
     registry: WearDataLayerRegistry,
     private val appStoreUri: String?,
-    surfacesInfoDataStoreFn: () -> DataStore<SurfacesInfo>
+    surfacesInfoDataStoreFn: () -> DataStore<SurfacesInfo>,
 ) : DataLayerAppHelper(context, registry) {
     constructor(
         context: Context,
         registry: WearDataLayerRegistry,
         scope: CoroutineScope,
         appStoreUri: String? = null,
-        ) : this(context, registry, appStoreUri, {
+    ) : this(context, registry, appStoreUri, {
         registry.protoDataStore(
             path = SURFACE_INFO_PATH,
             coroutineScope = scope,

--- a/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
+++ b/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
@@ -64,7 +64,7 @@ public class WearDataLayerAppHelper internal constructor(
     private val appStoreUri: String?,
     surfacesInfoDataStoreFn: () -> DataStore<SurfacesInfo>,
 ) : DataLayerAppHelper(context, registry) {
-    constructor(
+    public constructor(
         context: Context,
         registry: WearDataLayerRegistry,
         scope: CoroutineScope,

--- a/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
+++ b/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
@@ -75,7 +75,9 @@ public class WearDataLayerAppHelper(
     /**
      * Return the [SurfacesInfo] of this node.
      */
-    public val surfacesInfo: Flow<SurfacesInfo> = surfacesInfoDataStore.data
+    public val surfacesInfo: Flow<SurfacesInfo> by lazy {
+        surfacesInfoDataStore.data
+    }
 
     override val connectedAndInstalledNodes: Flow<Set<Node>>
         get() = connectedAndInstalledNodes(PHONE_CAPABILITY)

--- a/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
+++ b/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
@@ -21,6 +21,7 @@ import android.content.Intent
 import android.net.Uri
 import androidx.annotation.CheckResult
 import androidx.concurrent.futures.await
+import androidx.datastore.core.DataStore
 import androidx.wear.phone.interactions.PhoneTypeHelper
 import androidx.wear.remote.interactions.RemoteActivityHelper
 import androidx.wear.watchface.complications.data.ComplicationType
@@ -57,27 +58,31 @@ private const val TAG = "DataLayerAppHelper"
  * device.
  */
 @ExperimentalHorologistApi
-public class WearDataLayerAppHelper(
+public class WearDataLayerAppHelper internal constructor(
     context: Context,
     registry: WearDataLayerRegistry,
-    scope: CoroutineScope,
-    private val appStoreUri: String? = null,
+    private val appStoreUri: String?,
+    surfacesInfoDataStoreFn: () -> DataStore<SurfacesInfo>
 ) : DataLayerAppHelper(context, registry) {
-
-    private val surfacesInfoDataStore by lazy {
+    constructor(
+        context: Context,
+        registry: WearDataLayerRegistry,
+        scope: CoroutineScope,
+        appStoreUri: String? = null,
+        ) : this(context, registry, appStoreUri, {
         registry.protoDataStore(
             path = SURFACE_INFO_PATH,
             coroutineScope = scope,
             serializer = SurfacesInfoSerializer,
         )
-    }
+    })
+
+    private val surfacesInfoDataStore by lazy { surfacesInfoDataStoreFn() }
 
     /**
      * Return the [SurfacesInfo] of this node.
      */
-    public val surfacesInfo: Flow<SurfacesInfo> by lazy {
-        surfacesInfoDataStore.data
-    }
+    public val surfacesInfo: Flow<SurfacesInfo> by lazy { surfacesInfoDataStore.data }
 
     override val connectedAndInstalledNodes: Flow<Set<Node>>
         get() = connectedAndInstalledNodes(PHONE_CAPABILITY)

--- a/datalayer/watch/src/test/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelperTest.kt
+++ b/datalayer/watch/src/test/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelperTest.kt
@@ -81,14 +81,15 @@ class WearDataLayerAppHelperTest {
             DataStoreFactory.create(
                 scope = this,
                 produceFile = { context.dataStoreFile("testTiles") },
-                serializer = SurfacesInfoSerializer
+                serializer = SurfacesInfoSerializer,
             )
 
         val helper = WearDataLayerAppHelper(
             context = context,
             registry = registry,
             appStoreUri = null,
-            surfacesInfoDataStoreFn = { testDataStore })
+            surfacesInfoDataStoreFn = { testDataStore },
+        )
 
         val infoInitial = testDataStore.data.first()
         assertThat(infoInitial.tilesList).isEmpty()
@@ -114,14 +115,15 @@ class WearDataLayerAppHelperTest {
             DataStoreFactory.create(
                 scope = this,
                 produceFile = { context.dataStoreFile("testComplications") },
-                serializer = SurfacesInfoSerializer
+                serializer = SurfacesInfoSerializer,
             )
 
         val helper = WearDataLayerAppHelper(
             context = context,
             registry = registry,
             appStoreUri = null,
-            surfacesInfoDataStoreFn = { testDataStore })
+            surfacesInfoDataStoreFn = { testDataStore },
+        )
 
         val infoInitial = testDataStore.data.first()
         assertThat(infoInitial.complicationsList).isEmpty()

--- a/datalayer/watch/src/test/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelperTest.kt
+++ b/datalayer/watch/src/test/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelperTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.datalayer.watch
+
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.android.horologist.data.WearDataLayerRegistry
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class WearDataLayerAppHelperTest {
+
+    @Test
+    fun testCreate() = runTest {
+        val scope = CoroutineScope(coroutineContext + Job())
+
+        val context = InstrumentationRegistry.getInstrumentation().context
+        val registry = WearDataLayerRegistry.fromContext(context, scope)
+        val helper = WearDataLayerAppHelper(context, registry)
+
+        assertThat(helper.isAvailable()).isFalse()
+
+        scope.cancel()
+    }
+}


### PR DESCRIPTION
#### WHAT

Fix running on robo

#### WHY

WearDataLayerAppHelper fails on robo, because it starts before an `isAvailable()` check

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
