### PR TITLE
Use same Tile name in the watch/phonesample

### DIFF
--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/custom/installtile/InstallTileCustomPromptDemoViewModel.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/custom/installtile/InstallTileCustomPromptDemoViewModel.kt
@@ -39,7 +39,7 @@ class InstallTilePromptDemoViewModel
 
         private val _uiState =
             MutableStateFlow<InstallTileCustomPromptDemoScreenState>(InstallTileCustomPromptDemoScreenState.Idle)
-        private val tileName = "com.example.MediaPlayerTile"
+        private val tileName = "com.google.android.horologist.datalayer.sample.SampleTileService"
         public val uiState: StateFlow<InstallTileCustomPromptDemoScreenState> = _uiState
 
         @MainThread

--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/installtile/InstallTilePromptDemoViewModel.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/inappprompts/installtile/InstallTilePromptDemoViewModel.kt
@@ -84,7 +84,7 @@ class InstallTilePromptDemoViewModel
         }
 
         companion object {
-            private const val TILE_NAME = "com.example.MediaPlayerTile"
+            private const val TILE_NAME = "com.google.android.horologist.datalayer.sample.SampleTileService"
         }
     }
 


### PR DESCRIPTION
#### WHAT
Use the same Tile name in the installTile prompts 

#### WHY
The sample cannot correctly demo the use case where the Tile is installed

#### HOW
Match the tile name between the 2 samples

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
