### PR TITLE
Export AmbientLifecycleObserver

### DIFF
--- a/compose-layout/build.gradle.kts
+++ b/compose-layout/build.gradle.kts
@@ -93,9 +93,9 @@ dependencies {
 
     api(libs.androidx.lifecycle.runtime.compose)
     api(libs.androidx.paging)
+    api(libs.androidx.wear)
 
     implementation(libs.compose.ui.util)
-    implementation(libs.androidx.wear)
 
     implementation(libs.compose.ui.tooling)
     implementation(libs.compose.ui.toolingpreview)


### PR DESCRIPTION
This is necessary to make the AmbientAware sample code in https://github.com/google/horologist/pull/2194/commits/60588931d07e62d8f585ef532dc8e68c0700943e compile without requiring the app to depend directly on `androidx.wear:wear`.