### PR TITLE
[0.5.x] Remove unused non-Wear navigation dependencies

### DIFF
--- a/compose-layout/build.gradle.kts
+++ b/compose-layout/build.gradle.kts
@@ -101,8 +101,6 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.compose.ui.toolingpreview)
 
-    implementation(libs.androidx.navigation.compose)
-
     debugImplementation(libs.compose.ui.tooling)
     debugImplementation(projects.composeTools)
     debugImplementation(libs.androidx.activity.compose)

--- a/compose-layout/build.gradle.kts
+++ b/compose-layout/build.gradle.kts
@@ -102,7 +102,6 @@ dependencies {
     implementation(libs.compose.ui.toolingpreview)
 
     implementation(libs.androidx.navigation.compose)
-    implementation(libs.androidx.navigation.ui.ktx)
 
     debugImplementation(libs.compose.ui.tooling)
     debugImplementation(projects.composeTools)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -111,7 +111,6 @@ androidx-mediarouter = "androidx.mediarouter:mediarouter:1.7.0"
 androidx-metrics-performance = "androidx.metrics:metrics-performance:1.0.0-beta01"
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidxNavigation" }
 androidx-navigation-testing = { module = "androidx.navigation:navigation-testing", version.ref = "androidxNavigation" }
-androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidxNavigation" }
 androidx-paging = "androidx.paging:paging-compose:3.2.1"
 androidx-palette-ktx = "androidx.palette:palette-ktx:1.0.0"
 androidx-runtime-tracing = { module = "androidx.compose.runtime:runtime-tracing", version.ref = "runtimeTracing" }


### PR DESCRIPTION
#### WHAT

The compose-layout library in the 0.5.x branch depends on `androidx.navigation:navigation-compose` and `androidx.navigation:navigation-ui-ktx`, two unused phone libraries. This pull request removes these dependencies.

#### WHY

These libraries are designed for Android phones and not Wear devices, which should use `androidx.wear.compose.*` libraries instead. In particular, `androidx.navigation:navigation-ui-ktx` depends on both **AppCompat** and **Material Components**, which bring along a lot of **unwanted resources and dependencies** that the shrinker is unable to discard. As a result, a Wear application apk file grows by about 1MB of unnecessary code.

The horologist code does not reference these libraries so the removal has no impact on it.

#### HOW

Remove implementation declarations in `buid.gradle.kts`.
