### PR TITLE
For media sample, declare required permissions to run FGS on Wear5

### DIFF
--- a/media/sample/src/main/AndroidManifest.xml
+++ b/media/sample/src/main/AndroidManifest.xml
@@ -18,6 +18,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.google.android.horologist.mediasample">
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+
     <uses-feature android:name="android.hardware.type.watch" />
 
     <uses-feature


### PR DESCRIPTION
An app must declare a specific permission based on the foreground service type on Wear 5

