### PR TITLE
Used dated version codes for sample

### DIFF
--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -1,7 +1,3 @@
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter.ofPattern
-import java.util.Locale
-
 /*
  * Copyright 2022 The Android Open Source Project
  *
@@ -17,6 +13,10 @@ import java.util.Locale
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter.ofPattern
+import java.util.Locale
 
 plugins {
     id("com.android.application")

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -1,3 +1,7 @@
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter.ofPattern
+import java.util.Locale
+
 /*
  * Copyright 2022 The Android Open Source Project
  *
@@ -29,8 +33,10 @@ android {
         minSdk = 26
         targetSdk = 34
 
-        versionCode = 1
-        versionName = "1.0"
+        val date = LocalDate.now()
+
+        versionCode = date.format(ofPattern("yyyyMMdd", Locale.ROOT)).toInt()
+        versionName = date.toString()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
#### WHAT

Used dated version codes for sample.

```
20240528
2024-05-28
```

#### WHY

easier to identify build when tested

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
