### PR TITLE
Don't show PositionIndicator for non scrollable dialog content

### DIFF
--- a/sample/src/test/kotlin/com/google/android/horologist/dialog/NonScrollableAlertContent.kt
+++ b/sample/src/test/kotlin/com/google/android/horologist/dialog/NonScrollableAlertContent.kt
@@ -33,21 +33,20 @@ public fun NonScrollableAlertContent(
     message: String? = null,
     okButtonContentDescription: String = stringResource(android.R.string.ok),
     cancelButtonContentDescription: String = stringResource(android.R.string.cancel),
-    showPositionIndicator: Boolean = true,
     content: (ScalingLazyListScope.() -> Unit)? = null,
 ) {
     val columnState = centeredDialogColumnState()
 
     AlertContent(
-        onCancel,
-        onOk,
-        icon,
-        title,
-        message,
-        okButtonContentDescription,
-        cancelButtonContentDescription,
-        columnState,
-        showPositionIndicator,
-        content,
+        onCancel = onCancel,
+        onOk = onOk,
+        icon = icon,
+        title = title,
+        message = message,
+        okButtonContentDescription = okButtonContentDescription,
+        cancelButtonContentDescription = cancelButtonContentDescription,
+        state = columnState,
+        showPositionIndicator = false,
+        content = content,
     )
 }


### PR DESCRIPTION
#### WHAT

Don't show PositionIndicator for non scrollable dialog content

#### WHY

should seem non scrollable

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
