### PR TITLE
Disabling android test workflows on PR

### DIFF
--- a/.github/workflows/android_test.yml
+++ b/.github/workflows/android_test.yml
@@ -1,11 +1,6 @@
 name: Android Test
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - '**.md'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Run manually if you want, but otherwise they continually fail

#### WHAT


#### WHY


#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
