### PR TITLE
Fix tall browse screenshot

### DIFF
--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/browse/PlaylistDownloadBrowseScreen.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/browse/PlaylistDownloadBrowseScreen.kt
@@ -54,80 +54,100 @@ public fun PlaylistDownloadBrowseScreen(
     BrowseScreen(
         modifier = modifier,
     ) {
-        val downloadsSectionState = when (browseScreenState) {
-            BrowseScreenState.Loading -> Section.State.Loading
-            is BrowseScreenState.Loaded -> {
-                if (browseScreenState.downloadList.isEmpty()) {
-                    Section.State.Empty
-                } else {
-                    Section.State.Loaded(browseScreenState.downloadList)
-                }
-            }
-
-            BrowseScreenState.Failed ->
-                // display empty state
-                Section.State.Empty
-        }
-
-        downloadsSection(state = downloadsSectionState) {
-            loading {
-                PlaceholderChip(colors = ChipDefaults.secondaryChipColors())
-            }
-
-            loaded { download: PlaylistDownloadUiModel ->
-                when (download) {
-                    is PlaylistDownloadUiModel.Completed -> {
-                        Chip(
-                            label = download.playlistUiModel.title,
-                            onClick = { onDownloadItemClick(download) },
-                            icon = CoilPaintable(
-                                download.playlistUiModel.artworkUri,
-                                downloadItemArtworkPlaceholder,
-                            ),
-                            largeIcon = true,
-                            colors = ChipDefaults.secondaryChipColors(),
-                        )
-                    }
-
-                    is PlaylistDownloadUiModel.InProgress -> {
-                        val customModifier = onDownloadItemInProgressClickActionLabel?.let {
-                            Modifier.semantics {
-                                onClick(
-                                    label = onDownloadItemInProgressClickActionLabel,
-                                    action = null,
-                                )
-                            }
-                        } ?: Modifier
-
-                        Chip(
-                            label = download.playlistUiModel.title,
-                            onClick = { onDownloadItemInProgressClick(download) },
-                            modifier = customModifier,
-                            secondaryLabel = stringResource(
-                                id = R.string.horologist_browse_downloads_progress,
-                                download.percentage,
-                            ),
-                            icon = Icons.Default.Downloading.asPaintable(),
-                            colors = ChipDefaults.secondaryChipColors(),
-                        )
-                    }
-                }
-            }
-        }
-
-        playlistsSection(
-            buttons = listOf(
-                BrowseScreenPlaylistsSectionButton(
-                    textId = R.string.horologist_browse_library_playlists_button,
-                    icon = Icons.AutoMirrored.Default.PlaylistPlay,
-                    onClick = onPlaylistsClick,
-                ),
-                BrowseScreenPlaylistsSectionButton(
-                    textId = R.string.horologist_browse_library_settings_button,
-                    icon = Icons.Default.Settings,
-                    onClick = onSettingsClick,
-                ),
-            ),
+        PlaylistDownloadBrowseScreenContent(
+            browseScreenState,
+            onDownloadItemClick,
+            onDownloadItemInProgressClick,
+            onPlaylistsClick,
+            onSettingsClick,
+            downloadItemArtworkPlaceholder,
+            onDownloadItemInProgressClickActionLabel
         )
     }
+}
+
+internal fun BrowseScreenScope.PlaylistDownloadBrowseScreenContent(
+    browseScreenState: BrowseScreenState,
+    onDownloadItemClick: (PlaylistDownloadUiModel) -> Unit,
+    onDownloadItemInProgressClick: (PlaylistDownloadUiModel) -> Unit,
+    onPlaylistsClick: () -> Unit,
+    onSettingsClick: () -> Unit,
+    downloadItemArtworkPlaceholder: Painter? = null,
+    onDownloadItemInProgressClickActionLabel: String? = null,
+) {
+    val downloadsSectionState = when (browseScreenState) {
+        BrowseScreenState.Loading -> Section.State.Loading
+        is BrowseScreenState.Loaded -> {
+            if (browseScreenState.downloadList.isEmpty()) {
+                Section.State.Empty
+            } else {
+                Section.State.Loaded(browseScreenState.downloadList)
+            }
+        }
+
+        BrowseScreenState.Failed ->
+            // display empty state
+            Section.State.Empty
+    }
+
+    downloadsSection(state = downloadsSectionState) {
+        loading {
+            PlaceholderChip(colors = ChipDefaults.secondaryChipColors())
+        }
+
+        loaded { download: PlaylistDownloadUiModel ->
+            when (download) {
+                is PlaylistDownloadUiModel.Completed -> {
+                    Chip(
+                        label = download.playlistUiModel.title,
+                        onClick = { onDownloadItemClick(download) },
+                        icon = CoilPaintable(
+                            download.playlistUiModel.artworkUri,
+                            downloadItemArtworkPlaceholder,
+                        ),
+                        largeIcon = true,
+                        colors = ChipDefaults.secondaryChipColors(),
+                    )
+                }
+
+                is PlaylistDownloadUiModel.InProgress -> {
+                    val customModifier = onDownloadItemInProgressClickActionLabel?.let {
+                        Modifier.semantics {
+                            onClick(
+                                label = onDownloadItemInProgressClickActionLabel,
+                                action = null,
+                            )
+                        }
+                    } ?: Modifier
+
+                    Chip(
+                        label = download.playlistUiModel.title,
+                        onClick = { onDownloadItemInProgressClick(download) },
+                        modifier = customModifier,
+                        secondaryLabel = stringResource(
+                            id = R.string.horologist_browse_downloads_progress,
+                            download.percentage,
+                        ),
+                        icon = Icons.Default.Downloading.asPaintable(),
+                        colors = ChipDefaults.secondaryChipColors(),
+                    )
+                }
+            }
+        }
+    }
+
+    playlistsSection(
+        buttons = listOf(
+            BrowseScreenPlaylistsSectionButton(
+                textId = R.string.horologist_browse_library_playlists_button,
+                icon = Icons.AutoMirrored.Default.PlaylistPlay,
+                onClick = onPlaylistsClick,
+            ),
+            BrowseScreenPlaylistsSectionButton(
+                textId = R.string.horologist_browse_library_settings_button,
+                icon = Icons.Default.Settings,
+                onClick = onSettingsClick,
+            ),
+        ),
+    )
 }

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/browse/PlaylistDownloadBrowseScreen.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/browse/PlaylistDownloadBrowseScreen.kt
@@ -61,7 +61,7 @@ public fun PlaylistDownloadBrowseScreen(
             onPlaylistsClick,
             onSettingsClick,
             downloadItemArtworkPlaceholder,
-            onDownloadItemInProgressClickActionLabel
+            onDownloadItemInProgressClickActionLabel,
         )
     }
 }

--- a/media/ui/src/test/java/com/google/android/horologist/media/ui/screens/browse/PlaylistDownloadBrowseScreenA11yTallScreenshotTest.kt
+++ b/media/ui/src/test/java/com/google/android/horologist/media/ui/screens/browse/PlaylistDownloadBrowseScreenA11yTallScreenshotTest.kt
@@ -20,16 +20,18 @@ package com.google.android.horologist.media.ui.screens.browse
 
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumnDefaults.scalingParams
 import androidx.wear.compose.foundation.lazy.ScalingParams
+import com.google.android.horologist.composables.SectionedList
+import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
-import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
-import com.google.android.horologist.media.ui.PlayerLibraryPreview
+import com.google.android.horologist.compose.layout.ScreenScaffold
+import com.google.android.horologist.compose.layout.rememberColumnState
 import com.google.android.horologist.screenshots.rng.WearLegacyA11yTest
 import org.junit.Test
 import org.robolectric.annotation.Config
 
 @Config(
     sdk = [33],
-    qualifiers = "w227dp-h400dp-small-notlong-notround-watch-xhdpi-keyshidden-nonav",
+    qualifiers = "w227dp-h330dp-small-notlong-notround-watch-xhdpi-keyshidden-nonav",
 )
 class PlaylistDownloadBrowseScreenA11yTallScreenshotTest : WearLegacyA11yTest() {
 
@@ -38,21 +40,28 @@ class PlaylistDownloadBrowseScreenA11yTallScreenshotTest : WearLegacyA11yTest() 
         val screenState = BrowseScreenState.Loaded(downloadList)
 
         runScreenTest {
-            val columnState: ScalingLazyColumnState = rememberResponsiveColumnState().copy(
+            val columnState = rememberColumnState(
+                factory = ScalingLazyColumnDefaults.belowTimeText()
+            ).copy(
                 scalingParams = scalingParams(
                     edgeScale = 1f,
                     edgeAlpha = 1f,
                 ),
             )
 
-            PlayerLibraryPreview(columnState = columnState, round = false) {
-                PlaylistDownloadBrowseScreen(
-                    browseScreenState = screenState,
-                    onDownloadItemClick = { },
-                    onDownloadItemInProgressClick = { },
-                    onPlaylistsClick = { },
-                    onSettingsClick = { },
-                    onDownloadItemInProgressClickActionLabel = "cancel",
+            ScreenScaffold(scrollState = columnState) {
+                SectionedList(
+                    columnState = columnState,
+                    sections = BrowseScreenScope().apply {
+                        PlaylistDownloadBrowseScreenContent(
+                            browseScreenState = screenState,
+                            onDownloadItemClick = { },
+                            onDownloadItemInProgressClick = { },
+                            onPlaylistsClick = { },
+                            onSettingsClick = { },
+                            onDownloadItemInProgressClickActionLabel = "cancel",
+                        )
+                    }.sections,
                 )
             }
         }

--- a/media/ui/src/test/java/com/google/android/horologist/media/ui/screens/browse/PlaylistDownloadBrowseScreenA11yTallScreenshotTest.kt
+++ b/media/ui/src/test/java/com/google/android/horologist/media/ui/screens/browse/PlaylistDownloadBrowseScreenA11yTallScreenshotTest.kt
@@ -41,7 +41,7 @@ class PlaylistDownloadBrowseScreenA11yTallScreenshotTest : WearLegacyA11yTest() 
 
         runScreenTest {
             val columnState = rememberColumnState(
-                factory = ScalingLazyColumnDefaults.belowTimeText()
+                factory = ScalingLazyColumnDefaults.belowTimeText(),
             ).copy(
                 scalingParams = scalingParams(
                     edgeScale = 1f,

--- a/media/ui/src/test/snapshots/images/com.google.android.horologist.media.ui.screens.browse_PlaylistDownloadBrowseScreenA11yTallScreenshotTest_browseScreen.png
+++ b/media/ui/src/test/snapshots/images/com.google.android.horologist.media.ui.screens.browse_PlaylistDownloadBrowseScreenA11yTallScreenshotTest_browseScreen.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8c9b96d89e46d1396a1ae8a19fe9cf49c4099d544f6ca7b8484303b978ed23f4
-size 62901
+oid sha256:c93624cd3b45268fa2acb5f71bceae79b994370fc297fb5a122e364a8fad58bd
+size 59811

--- a/media/ui/src/test/snapshots/images/com.google.android.horologist.media.ui.screens.browse_PlaylistDownloadBrowseScreenA11yTallScreenshotTest_browseScreen.png
+++ b/media/ui/src/test/snapshots/images/com.google.android.horologist.media.ui.screens.browse_PlaylistDownloadBrowseScreenA11yTallScreenshotTest_browseScreen.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c93624cd3b45268fa2acb5f71bceae79b994370fc297fb5a122e364a8fad58bd
-size 59811
+oid sha256:660c2f0542b560f1e5a387b2867be9e88707ffec3f05e5d7921fb65dc12308b3
+size 59913


### PR DESCRIPTION
#### WHAT

Fix tall browse screenshot

#### WHY

Broken in a premature commit, after thinking I'd fixed screenshots.

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
