### PR TITLE
Use DateTimeFormatter to produce localized AM/PM labels for TimePicker

### DIFF
--- a/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
@@ -87,6 +87,7 @@ import androidx.wear.compose.material.rememberPickerState
 import com.google.android.horologist.compose.layout.FontScaleIndependent
 import com.google.android.horologist.compose.layout.ScreenScaffold
 import java.time.LocalTime
+import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoField
 
 /**
@@ -408,8 +409,14 @@ public fun TimePickerWith12HourClock(
         R.plurals.horologist_time_picker_minutes_content_description,
     )
 
-    val amString = stringResource(R.string.horologist_time_picker_am)
-    val pmString = stringResource(R.string.horologist_time_picker_pm)
+    val primaryLocale = LocalConfiguration.current.locales[0]
+    val (amString, pmString) =
+        remember(primaryLocale) {
+            DateTimeFormatter.ofPattern("a", primaryLocale).let { formatter ->
+                LocalTime.of(0, 0).format(formatter) to LocalTime.of(12, 0).format(formatter)
+            }
+        }
+
     val periodContentDescription by remember(
         pickerGroupState.selectedIndex,
         periodState.selectedOption,

--- a/composables/src/main/res/values-af/strings.xml
+++ b/composables/src/main/res/values-af/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min.</string>
   <string name="horologist_time_picker_period">Tydperk</string>
-  <string name="horologist_time_picker_am">vm.</string>
-  <string name="horologist_time_picker_pm">nm.</string>
   <string name="horologist_picker_day">Dag</string>
   <string name="horologist_picker_month">Maand</string>
   <string name="horologist_picker_year">Jaar</string>

--- a/composables/src/main/res/values-am/strings.xml
+++ b/composables/src/main/res/values-am/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">ደቂቃ</string>
   <string name="horologist_time_picker_period">ክፍለ-ጊዜ</string>
-  <string name="horologist_time_picker_am">ጠዋት</string>
-  <string name="horologist_time_picker_pm">ከሰዓት</string>
   <string name="horologist_picker_day">ቀን</string>
   <string name="horologist_picker_month">ወር</string>
   <string name="horologist_picker_year">ዓመት</string>

--- a/composables/src/main/res/values-ar/strings.xml
+++ b/composables/src/main/res/values-ar/strings.xml
@@ -44,8 +44,6 @@
   </plurals>
   <string name="horologist_time_picker_min">الدقيقة</string>
   <string name="horologist_time_picker_period">المدة</string>
-  <string name="horologist_time_picker_am">ص</string>
-  <string name="horologist_time_picker_pm">م</string>
   <string name="horologist_picker_day">اليوم</string>
   <string name="horologist_picker_month">الشهر</string>
   <string name="horologist_picker_year">السنة</string>

--- a/composables/src/main/res/values-as/strings.xml
+++ b/composables/src/main/res/values-as/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">মিনিট</string>
   <string name="horologist_time_picker_period">সময় অৱধি</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">দিন</string>
   <string name="horologist_picker_month">মাহ</string>
   <string name="horologist_picker_year">বছৰ</string>

--- a/composables/src/main/res/values-az/strings.xml
+++ b/composables/src/main/res/values-az/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Dəq</string>
   <string name="horologist_time_picker_period">Müddət</string>
-  <string name="horologist_time_picker_am">G.Ə.</string>
-  <string name="horologist_time_picker_pm">G.S.</string>
   <string name="horologist_picker_day">Gün</string>
   <string name="horologist_picker_month">Ay</string>
   <string name="horologist_picker_year">İl</string>

--- a/composables/src/main/res/values-b+es+419/strings.xml
+++ b/composables/src/main/res/values-b+es+419/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min</string>
   <string name="horologist_time_picker_period">Período</string>
-  <string name="horologist_time_picker_am">a.m.</string>
-  <string name="horologist_time_picker_pm">p.m.</string>
   <string name="horologist_picker_day">Día</string>
   <string name="horologist_picker_month">Mes</string>
   <string name="horologist_picker_year">Año</string>

--- a/composables/src/main/res/values-be/strings.xml
+++ b/composables/src/main/res/values-be/strings.xml
@@ -38,8 +38,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Хв</string>
   <string name="horologist_time_picker_period">Кропка</string>
-  <string name="horologist_time_picker_am">да паўдня</string>
-  <string name="horologist_time_picker_pm">пасля паўдня</string>
   <string name="horologist_picker_day">Дні</string>
   <string name="horologist_picker_month">Месяцы</string>
   <string name="horologist_picker_year">Гады</string>

--- a/composables/src/main/res/values-bg/strings.xml
+++ b/composables/src/main/res/values-bg/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Мин</string>
   <string name="horologist_time_picker_period">Период</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Ден</string>
   <string name="horologist_picker_month">Месец</string>
   <string name="horologist_picker_year">Година</string>

--- a/composables/src/main/res/values-bn/strings.xml
+++ b/composables/src/main/res/values-bn/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">মিনিট</string>
   <string name="horologist_time_picker_period">সময়সীমা</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">দিন</string>
   <string name="horologist_picker_month">মাস</string>
   <string name="horologist_picker_year">বছর</string>

--- a/composables/src/main/res/values-bs/strings.xml
+++ b/composables/src/main/res/values-bs/strings.xml
@@ -35,8 +35,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min</string>
   <string name="horologist_time_picker_period">Period</string>
-  <string name="horologist_time_picker_am">prijepodne</string>
-  <string name="horologist_time_picker_pm">poslijepodne</string>
   <string name="horologist_picker_day">Dan</string>
   <string name="horologist_picker_month">Mjesec</string>
   <string name="horologist_picker_year">Godina</string>

--- a/composables/src/main/res/values-ca/strings.xml
+++ b/composables/src/main/res/values-ca/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min</string>
   <string name="horologist_time_picker_period">Període</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Dia</string>
   <string name="horologist_picker_month">Mes</string>
   <string name="horologist_picker_year">Any</string>

--- a/composables/src/main/res/values-cs/strings.xml
+++ b/composables/src/main/res/values-cs/strings.xml
@@ -38,8 +38,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min</string>
   <string name="horologist_time_picker_period">Období</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Den</string>
   <string name="horologist_picker_month">Měsíc</string>
   <string name="horologist_picker_year">Rok</string>

--- a/composables/src/main/res/values-da/strings.xml
+++ b/composables/src/main/res/values-da/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min.</string>
   <string name="horologist_time_picker_period">Periode</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Dag</string>
   <string name="horologist_picker_month">Måned</string>
   <string name="horologist_picker_year">År</string>

--- a/composables/src/main/res/values-de/strings.xml
+++ b/composables/src/main/res/values-de/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Minute</string>
   <string name="horologist_time_picker_period">Zeitraum</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">Nachmittags</string>
   <string name="horologist_picker_day">Tag</string>
   <string name="horologist_picker_month">Monat</string>
   <string name="horologist_picker_year">Jahr</string>

--- a/composables/src/main/res/values-el/strings.xml
+++ b/composables/src/main/res/values-el/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Λεπ.</string>
   <string name="horologist_time_picker_period">Περίοδος</string>
-  <string name="horologist_time_picker_am">π.μ.</string>
-  <string name="horologist_time_picker_pm">μ.μ.</string>
   <string name="horologist_picker_day">Ημέρα</string>
   <string name="horologist_picker_month">Μήνας</string>
   <string name="horologist_picker_year">Έτος</string>

--- a/composables/src/main/res/values-en-rGB/strings.xml
+++ b/composables/src/main/res/values-en-rGB/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min</string>
   <string name="horologist_time_picker_period">Full stop</string>
-  <string name="horologist_time_picker_am">a.m.</string>
-  <string name="horologist_time_picker_pm">p.m.</string>
   <string name="horologist_picker_day">Day</string>
   <string name="horologist_picker_month">Month</string>
   <string name="horologist_picker_year">Year</string>

--- a/composables/src/main/res/values-en-rIE/strings.xml
+++ b/composables/src/main/res/values-en-rIE/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min</string>
   <string name="horologist_time_picker_period">Full stop</string>
-  <string name="horologist_time_picker_am">a.m.</string>
-  <string name="horologist_time_picker_pm">p.m.</string>
   <string name="horologist_picker_day">Day</string>
   <string name="horologist_picker_month">Month</string>
   <string name="horologist_picker_year">Year</string>

--- a/composables/src/main/res/values-es-rUS/strings.xml
+++ b/composables/src/main/res/values-es-rUS/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min</string>
   <string name="horologist_time_picker_period">Período</string>
-  <string name="horologist_time_picker_am">a.m.</string>
-  <string name="horologist_time_picker_pm">p.m.</string>
   <string name="horologist_picker_day">Día</string>
   <string name="horologist_picker_month">Mes</string>
   <string name="horologist_picker_year">Año</string>

--- a/composables/src/main/res/values-es/strings.xml
+++ b/composables/src/main/res/values-es/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min</string>
   <string name="horologist_time_picker_period">Periodo</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Día</string>
   <string name="horologist_picker_month">Mes</string>
   <string name="horologist_picker_year">Año</string>

--- a/composables/src/main/res/values-et/strings.xml
+++ b/composables/src/main/res/values-et/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min</string>
   <string name="horologist_time_picker_period">Periood</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Päev</string>
   <string name="horologist_picker_month">Kuu</string>
   <string name="horologist_picker_year">Aasta</string>

--- a/composables/src/main/res/values-eu/strings.xml
+++ b/composables/src/main/res/values-eu/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Minutuak</string>
   <string name="horologist_time_picker_period">Tartea</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Eguna</string>
   <string name="horologist_picker_month">Hilabetea</string>
   <string name="horologist_picker_year">Urtea</string>

--- a/composables/src/main/res/values-fa/strings.xml
+++ b/composables/src/main/res/values-fa/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">دقیقه</string>
   <string name="horologist_time_picker_period">دوره زمانی</string>
-  <string name="horologist_time_picker_am">ق.ظ.</string>
-  <string name="horologist_time_picker_pm">ب.ظ.</string>
   <string name="horologist_picker_day">روز</string>
   <string name="horologist_picker_month">ماه</string>
   <string name="horologist_picker_year">سال</string>

--- a/composables/src/main/res/values-fi/strings.xml
+++ b/composables/src/main/res/values-fi/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min</string>
   <string name="horologist_time_picker_period">Piste</string>
-  <string name="horologist_time_picker_am">Aamu</string>
-  <string name="horologist_time_picker_pm">Ilta</string>
   <string name="horologist_picker_day">Päivä</string>
   <string name="horologist_picker_month">Kuukausi</string>
   <string name="horologist_picker_year">Vuosi</string>

--- a/composables/src/main/res/values-fil/strings.xml
+++ b/composables/src/main/res/values-fil/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min</string>
   <string name="horologist_time_picker_period">Oras</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Araw</string>
   <string name="horologist_picker_month">Buwan</string>
   <string name="horologist_picker_year">Taon</string>

--- a/composables/src/main/res/values-fr-rCA/strings.xml
+++ b/composables/src/main/res/values-fr-rCA/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min</string>
   <string name="horologist_time_picker_period">Période</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Jour</string>
   <string name="horologist_picker_month">Mois</string>
   <string name="horologist_picker_year">Année</string>

--- a/composables/src/main/res/values-fr/strings.xml
+++ b/composables/src/main/res/values-fr/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min</string>
   <string name="horologist_time_picker_period">Point</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Jour</string>
   <string name="horologist_picker_month">Mois</string>
   <string name="horologist_picker_year">Année</string>

--- a/composables/src/main/res/values-gl/strings.xml
+++ b/composables/src/main/res/values-gl/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Minuto</string>
   <string name="horologist_time_picker_period">Período</string>
-  <string name="horologist_time_picker_am">a.m.</string>
-  <string name="horologist_time_picker_pm">p.m.</string>
   <string name="horologist_picker_day">Día</string>
   <string name="horologist_picker_month">Mes</string>
   <string name="horologist_picker_year">Ano</string>

--- a/composables/src/main/res/values-gu/strings.xml
+++ b/composables/src/main/res/values-gu/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">મિનિટ</string>
   <string name="horologist_time_picker_period">સમયગાળો</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">દિવસ</string>
   <string name="horologist_picker_month">મહિનો</string>
   <string name="horologist_picker_year">વર્ષ</string>

--- a/composables/src/main/res/values-hi/strings.xml
+++ b/composables/src/main/res/values-hi/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">मिनट</string>
   <string name="horologist_time_picker_period">पीरियड</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">दिन</string>
   <string name="horologist_picker_month">महीना</string>
   <string name="horologist_picker_year">साल</string>

--- a/composables/src/main/res/values-hr/strings.xml
+++ b/composables/src/main/res/values-hr/strings.xml
@@ -35,8 +35,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Minuta</string>
   <string name="horologist_time_picker_period">Razdoblje</string>
-  <string name="horologist_time_picker_am">Prijepodne</string>
-  <string name="horologist_time_picker_pm">Poslijepodne</string>
   <string name="horologist_picker_day">Dan</string>
   <string name="horologist_picker_month">Mjesec</string>
   <string name="horologist_picker_year">Godina</string>

--- a/composables/src/main/res/values-hu/strings.xml
+++ b/composables/src/main/res/values-hu/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Perc</string>
   <string name="horologist_time_picker_period">Időszak</string>
-  <string name="horologist_time_picker_am">de.</string>
-  <string name="horologist_time_picker_pm">du.</string>
   <string name="horologist_picker_day">Nap</string>
   <string name="horologist_picker_month">Hónap</string>
   <string name="horologist_picker_year">Év</string>

--- a/composables/src/main/res/values-hy/strings.xml
+++ b/composables/src/main/res/values-hy/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Նվազ․</string>
   <string name="horologist_time_picker_period">Ժամանակահատված</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Օր</string>
   <string name="horologist_picker_month">Ամիս</string>
   <string name="horologist_picker_year">Տարի</string>

--- a/composables/src/main/res/values-in/strings.xml
+++ b/composables/src/main/res/values-in/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Mnt</string>
   <string name="horologist_time_picker_period">Periode</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Hari</string>
   <string name="horologist_picker_month">Bulan</string>
   <string name="horologist_picker_year">Tahun</string>

--- a/composables/src/main/res/values-is/strings.xml
+++ b/composables/src/main/res/values-is/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Mín.</string>
   <string name="horologist_time_picker_period">Tímabil</string>
-  <string name="horologist_time_picker_am">f.h.</string>
-  <string name="horologist_time_picker_pm">e.h.</string>
   <string name="horologist_picker_day">Dagur</string>
   <string name="horologist_picker_month">Mánuður</string>
   <string name="horologist_picker_year">Ár</string>

--- a/composables/src/main/res/values-it/strings.xml
+++ b/composables/src/main/res/values-it/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min</string>
   <string name="horologist_time_picker_period">Periodo</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Giorno</string>
   <string name="horologist_picker_month">Mese</string>
   <string name="horologist_picker_year">Anno</string>

--- a/composables/src/main/res/values-iw/strings.xml
+++ b/composables/src/main/res/values-iw/strings.xml
@@ -35,8 +35,6 @@
   </plurals>
   <string name="horologist_time_picker_min">דקות</string>
   <string name="horologist_time_picker_period">תקופה</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">יום</string>
   <string name="horologist_picker_month">חודש</string>
   <string name="horologist_picker_year">שנה</string>

--- a/composables/src/main/res/values-ja/strings.xml
+++ b/composables/src/main/res/values-ja/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">分</string>
   <string name="horologist_time_picker_period">ピリオド</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">日</string>
   <string name="horologist_picker_month">月</string>
   <string name="horologist_picker_year">年</string>

--- a/composables/src/main/res/values-ka/strings.xml
+++ b/composables/src/main/res/values-ka/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">წთ</string>
   <string name="horologist_time_picker_period">წერტილი</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">დღე</string>
   <string name="horologist_picker_month">თვე</string>
   <string name="horologist_picker_year">წელი</string>

--- a/composables/src/main/res/values-kk/strings.xml
+++ b/composables/src/main/res/values-kk/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Мин</string>
   <string name="horologist_time_picker_period">Кезең</string>
-  <string name="horologist_time_picker_am">түске дейін</string>
-  <string name="horologist_time_picker_pm">түстен кейін</string>
   <string name="horologist_picker_day">Күн</string>
   <string name="horologist_picker_month">Ай</string>
   <string name="horologist_picker_year">Жыл</string>

--- a/composables/src/main/res/values-km/strings.xml
+++ b/composables/src/main/res/values-km/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">ន</string>
   <string name="horologist_time_picker_period">អំឡុងពេល</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">ថ្ងៃ</string>
   <string name="horologist_picker_month">ខែ</string>
   <string name="horologist_picker_year">ឆ្នាំ</string>

--- a/composables/src/main/res/values-kn/strings.xml
+++ b/composables/src/main/res/values-kn/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">ನಿಮಿಷ</string>
   <string name="horologist_time_picker_period">ಪೂರ್ಣ ವಿರಾಮ</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">ದಿನ</string>
   <string name="horologist_picker_month">ತಿಂಗಳು</string>
   <string name="horologist_picker_year">ವರ್ಷ</string>

--- a/composables/src/main/res/values-ko/strings.xml
+++ b/composables/src/main/res/values-ko/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">분</string>
   <string name="horologist_time_picker_period">기간</string>
-  <string name="horologist_time_picker_am">오전</string>
-  <string name="horologist_time_picker_pm">오후</string>
   <string name="horologist_picker_day">일</string>
   <string name="horologist_picker_month">월</string>
   <string name="horologist_picker_year">연도</string>

--- a/composables/src/main/res/values-ky/strings.xml
+++ b/composables/src/main/res/values-ky/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Мүн.</string>
   <string name="horologist_time_picker_period">Убакыт аралыгы</string>
-  <string name="horologist_time_picker_am">түшкө чейин</string>
-  <string name="horologist_time_picker_pm">түштөн кийин</string>
   <string name="horologist_picker_day">Күн</string>
   <string name="horologist_picker_month">Ай</string>
   <string name="horologist_picker_year">Жыл</string>

--- a/composables/src/main/res/values-lo/strings.xml
+++ b/composables/src/main/res/values-lo/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">ນທ</string>
   <string name="horologist_time_picker_period">ໄລຍະເວລາ</string>
-  <string name="horologist_time_picker_am">ກ່ອນທ່ຽງ</string>
-  <string name="horologist_time_picker_pm">ຫຼັງທ່ຽງ</string>
   <string name="horologist_picker_day">ມື້</string>
   <string name="horologist_picker_month">ເດືອນ</string>
   <string name="horologist_picker_year">ປີ</string>

--- a/composables/src/main/res/values-lt/strings.xml
+++ b/composables/src/main/res/values-lt/strings.xml
@@ -38,8 +38,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min.</string>
   <string name="horologist_time_picker_period">Laikotarpis</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Diena</string>
   <string name="horologist_picker_month">Mėnuo</string>
   <string name="horologist_picker_year">Metai</string>

--- a/composables/src/main/res/values-lv/strings.xml
+++ b/composables/src/main/res/values-lv/strings.xml
@@ -35,8 +35,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min</string>
   <string name="horologist_time_picker_period">Periods</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Diena</string>
   <string name="horologist_picker_month">Mēnesis</string>
   <string name="horologist_picker_year">Gads</string>

--- a/composables/src/main/res/values-mk/strings.xml
+++ b/composables/src/main/res/values-mk/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Мин.</string>
   <string name="horologist_time_picker_period">Период</string>
-  <string name="horologist_time_picker_am">ПРЕТПЛАДНЕ</string>
-  <string name="horologist_time_picker_pm">ПОПЛАДНЕ</string>
   <string name="horologist_picker_day">Ден</string>
   <string name="horologist_picker_month">Месец</string>
   <string name="horologist_picker_year">Година</string>

--- a/composables/src/main/res/values-ml/strings.xml
+++ b/composables/src/main/res/values-ml/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">മിനിറ്റ്</string>
   <string name="horologist_time_picker_period">കാലയളവ്</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">ദിവസം</string>
   <string name="horologist_picker_month">മാസം</string>
   <string name="horologist_picker_year">വർഷം</string>

--- a/composables/src/main/res/values-mn/strings.xml
+++ b/composables/src/main/res/values-mn/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Мин</string>
   <string name="horologist_time_picker_period">Хугацаа</string>
-  <string name="horologist_time_picker_am">ҮӨ</string>
-  <string name="horologist_time_picker_pm">ҮХ</string>
   <string name="horologist_picker_day">Өдөр</string>
   <string name="horologist_picker_month">Сар</string>
   <string name="horologist_picker_year">Он</string>

--- a/composables/src/main/res/values-mr/strings.xml
+++ b/composables/src/main/res/values-mr/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">मिनिट</string>
   <string name="horologist_time_picker_period">कालावधी</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">दिवस</string>
   <string name="horologist_picker_month">महिना</string>
   <string name="horologist_picker_year">वर्ष</string>

--- a/composables/src/main/res/values-ms/strings.xml
+++ b/composables/src/main/res/values-ms/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min</string>
   <string name="horologist_time_picker_period">Noktah</string>
-  <string name="horologist_time_picker_am">PG</string>
-  <string name="horologist_time_picker_pm">P/M</string>
   <string name="horologist_picker_day">Hari</string>
   <string name="horologist_picker_month">Bulan</string>
   <string name="horologist_picker_year">Tahun</string>

--- a/composables/src/main/res/values-my/strings.xml
+++ b/composables/src/main/res/values-my/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">မိနစ်</string>
   <string name="horologist_time_picker_period">ကာလ</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">ရက်</string>
   <string name="horologist_picker_month">လ</string>
   <string name="horologist_picker_year">ခုနှစ်</string>

--- a/composables/src/main/res/values-nb/strings.xml
+++ b/composables/src/main/res/values-nb/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min.</string>
   <string name="horologist_time_picker_period">Punktum</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Dag</string>
   <string name="horologist_picker_month">Måned</string>
   <string name="horologist_picker_year">År</string>

--- a/composables/src/main/res/values-ne/strings.xml
+++ b/composables/src/main/res/values-ne/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">मिनेट</string>
   <string name="horologist_time_picker_period">अवधि</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">दिन</string>
   <string name="horologist_picker_month">महिना</string>
   <string name="horologist_picker_year">साल</string>

--- a/composables/src/main/res/values-nl/strings.xml
+++ b/composables/src/main/res/values-nl/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min</string>
   <string name="horologist_time_picker_period">Periode</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Dag</string>
   <string name="horologist_picker_month">Maand</string>
   <string name="horologist_picker_year">Jaar</string>

--- a/composables/src/main/res/values-no/strings.xml
+++ b/composables/src/main/res/values-no/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min.</string>
   <string name="horologist_time_picker_period">Punktum</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Dag</string>
   <string name="horologist_picker_month">Måned</string>
   <string name="horologist_picker_year">År</string>

--- a/composables/src/main/res/values-or/strings.xml
+++ b/composables/src/main/res/values-or/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">ମିନିଟ</string>
   <string name="horologist_time_picker_period">ପୂର୍ଣ୍ଣଚ୍ଛେଦ</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">ଦିନ</string>
   <string name="horologist_picker_month">ମାସ</string>
   <string name="horologist_picker_year">ବର୍ଷ</string>

--- a/composables/src/main/res/values-pa/strings.xml
+++ b/composables/src/main/res/values-pa/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">ਮਿੰ.</string>
   <string name="horologist_time_picker_period">ਮਿਆਦ</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">ਦਿਨ</string>
   <string name="horologist_picker_month">ਮਹੀਨਾ</string>
   <string name="horologist_picker_year">ਸਾਲ</string>

--- a/composables/src/main/res/values-pl/strings.xml
+++ b/composables/src/main/res/values-pl/strings.xml
@@ -38,8 +38,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min</string>
   <string name="horologist_time_picker_period">Przedział</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Dzień</string>
   <string name="horologist_picker_month">Miesiąc</string>
   <string name="horologist_picker_year">Rok</string>

--- a/composables/src/main/res/values-pt-rBR/strings.xml
+++ b/composables/src/main/res/values-pt-rBR/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min</string>
   <string name="horologist_time_picker_period">Período</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Dia</string>
   <string name="horologist_picker_month">Mês</string>
   <string name="horologist_picker_year">Ano</string>

--- a/composables/src/main/res/values-pt-rPT/strings.xml
+++ b/composables/src/main/res/values-pt-rPT/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min</string>
   <string name="horologist_time_picker_period">Período</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Dia</string>
   <string name="horologist_picker_month">Mês</string>
   <string name="horologist_picker_year">Ano</string>

--- a/composables/src/main/res/values-ro/strings.xml
+++ b/composables/src/main/res/values-ro/strings.xml
@@ -35,8 +35,6 @@
   </plurals>
   <string name="horologist_time_picker_min">min.</string>
   <string name="horologist_time_picker_period">Perioada</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Zi</string>
   <string name="horologist_picker_month">Lună</string>
   <string name="horologist_picker_year">An</string>

--- a/composables/src/main/res/values-ru/strings.xml
+++ b/composables/src/main/res/values-ru/strings.xml
@@ -38,8 +38,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Минуты</string>
   <string name="horologist_time_picker_period">Период</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">День</string>
   <string name="horologist_picker_month">Месяц</string>
   <string name="horologist_picker_year">Год</string>

--- a/composables/src/main/res/values-si/strings.xml
+++ b/composables/src/main/res/values-si/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">මිනි</string>
   <string name="horologist_time_picker_period">කාලච්ඡේදය</string>
-  <string name="horologist_time_picker_am">පෙ.ව.</string>
-  <string name="horologist_time_picker_pm">ප.ව.</string>
   <string name="horologist_picker_day">දිනය</string>
   <string name="horologist_picker_month">මාසය</string>
   <string name="horologist_picker_year">වර්ෂය</string>

--- a/composables/src/main/res/values-sk/strings.xml
+++ b/composables/src/main/res/values-sk/strings.xml
@@ -38,8 +38,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min</string>
   <string name="horologist_time_picker_period">Obdobie</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Deň</string>
   <string name="horologist_picker_month">Mesiac</string>
   <string name="horologist_picker_year">Rok</string>

--- a/composables/src/main/res/values-sl/strings.xml
+++ b/composables/src/main/res/values-sl/strings.xml
@@ -38,8 +38,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min</string>
   <string name="horologist_time_picker_period">Obdobje</string>
-  <string name="horologist_time_picker_am">dop.</string>
-  <string name="horologist_time_picker_pm">pop.</string>
   <string name="horologist_picker_day">Dan</string>
   <string name="horologist_picker_month">Mesec</string>
   <string name="horologist_picker_year">Leto</string>

--- a/composables/src/main/res/values-sq/strings.xml
+++ b/composables/src/main/res/values-sq/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min.</string>
   <string name="horologist_time_picker_period">Periudha</string>
-  <string name="horologist_time_picker_am">paradite</string>
-  <string name="horologist_time_picker_pm">pasdite</string>
   <string name="horologist_picker_day">Dita</string>
   <string name="horologist_picker_month">Muaji</string>
   <string name="horologist_picker_year">Viti</string>

--- a/composables/src/main/res/values-sr/strings.xml
+++ b/composables/src/main/res/values-sr/strings.xml
@@ -35,8 +35,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Минут</string>
   <string name="horologist_time_picker_period">Период</string>
-  <string name="horologist_time_picker_am">пр</string>
-  <string name="horologist_time_picker_pm">по</string>
   <string name="horologist_picker_day">Дан</string>
   <string name="horologist_picker_month">Месец</string>
   <string name="horologist_picker_year">Година</string>

--- a/composables/src/main/res/values-sv/strings.xml
+++ b/composables/src/main/res/values-sv/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Min</string>
   <string name="horologist_time_picker_period">Period</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Dag</string>
   <string name="horologist_picker_month">Månad</string>
   <string name="horologist_picker_year">År</string>

--- a/composables/src/main/res/values-sw/strings.xml
+++ b/composables/src/main/res/values-sw/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Dak</string>
   <string name="horologist_time_picker_period">Nukta</string>
-  <string name="horologist_time_picker_am">Asubuhi</string>
-  <string name="horologist_time_picker_pm">Jioni</string>
   <string name="horologist_picker_day">Siku</string>
   <string name="horologist_picker_month">Mwezi</string>
   <string name="horologist_picker_year">Mwaka</string>

--- a/composables/src/main/res/values-ta/strings.xml
+++ b/composables/src/main/res/values-ta/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">நிமி</string>
   <string name="horologist_time_picker_period">மணிநேரம்</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">நாள்</string>
   <string name="horologist_picker_month">மாதம்</string>
   <string name="horologist_picker_year">ஆண்டு</string>

--- a/composables/src/main/res/values-te/strings.xml
+++ b/composables/src/main/res/values-te/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">కనిష్టం</string>
   <string name="horologist_time_picker_period">వ్యవధి</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">రోజు</string>
   <string name="horologist_picker_month">నెల</string>
   <string name="horologist_picker_year">సంవత్సరం</string>

--- a/composables/src/main/res/values-th/strings.xml
+++ b/composables/src/main/res/values-th/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">นาที</string>
   <string name="horologist_time_picker_period">ระยะเวลา</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">วัน</string>
   <string name="horologist_picker_month">เดือน</string>
   <string name="horologist_picker_year">ปี</string>

--- a/composables/src/main/res/values-tr/strings.xml
+++ b/composables/src/main/res/values-tr/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Dak.</string>
   <string name="horologist_time_picker_period">Dönem</string>
-  <string name="horologist_time_picker_am">ÖÖ</string>
-  <string name="horologist_time_picker_pm">ÖS</string>
   <string name="horologist_picker_day">Gün</string>
   <string name="horologist_picker_month">Ay</string>
   <string name="horologist_picker_year">Yıl</string>

--- a/composables/src/main/res/values-uk/strings.xml
+++ b/composables/src/main/res/values-uk/strings.xml
@@ -38,8 +38,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Хв</string>
   <string name="horologist_time_picker_period">Період</string>
-  <string name="horologist_time_picker_am">дп</string>
-  <string name="horologist_time_picker_pm">пп</string>
   <string name="horologist_picker_day">День</string>
   <string name="horologist_picker_month">Місяць</string>
   <string name="horologist_picker_year">Рік</string>

--- a/composables/src/main/res/values-ur/strings.xml
+++ b/composables/src/main/res/values-ur/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">منٹ</string>
   <string name="horologist_time_picker_period">وقفہ</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">دن</string>
   <string name="horologist_picker_month">ماہ</string>
   <string name="horologist_picker_year">سال</string>

--- a/composables/src/main/res/values-uz/strings.xml
+++ b/composables/src/main/res/values-uz/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Daq</string>
   <string name="horologist_time_picker_period">Davr</string>
-  <string name="horologist_time_picker_am">TO</string>
-  <string name="horologist_time_picker_pm">TK</string>
   <string name="horologist_picker_day">Kun</string>
   <string name="horologist_picker_month">Oy</string>
   <string name="horologist_picker_year">Yil</string>

--- a/composables/src/main/res/values-vi/strings.xml
+++ b/composables/src/main/res/values-vi/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Phút</string>
   <string name="horologist_time_picker_period">Giai đoạn</string>
-  <string name="horologist_time_picker_am">SA</string>
-  <string name="horologist_time_picker_pm">CH</string>
   <string name="horologist_picker_day">Ngày</string>
   <string name="horologist_picker_month">Tháng</string>
   <string name="horologist_picker_year">Năm</string>

--- a/composables/src/main/res/values-zh-rCN/strings.xml
+++ b/composables/src/main/res/values-zh-rCN/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">分</string>
   <string name="horologist_time_picker_period">时间段</string>
-  <string name="horologist_time_picker_am">上午</string>
-  <string name="horologist_time_picker_pm">下午</string>
   <string name="horologist_picker_day">日</string>
   <string name="horologist_picker_month">月</string>
   <string name="horologist_picker_year">年</string>

--- a/composables/src/main/res/values-zh-rHK/strings.xml
+++ b/composables/src/main/res/values-zh-rHK/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">分鐘</string>
   <string name="horologist_time_picker_period">時段</string>
-  <string name="horologist_time_picker_am">上午</string>
-  <string name="horologist_time_picker_pm">下午</string>
   <string name="horologist_picker_day">日</string>
   <string name="horologist_picker_month">月</string>
   <string name="horologist_picker_year">年</string>

--- a/composables/src/main/res/values-zh-rTW/strings.xml
+++ b/composables/src/main/res/values-zh-rTW/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">分</string>
   <string name="horologist_time_picker_period">時段</string>
-  <string name="horologist_time_picker_am">上午</string>
-  <string name="horologist_time_picker_pm">下午</string>
   <string name="horologist_picker_day">日</string>
   <string name="horologist_picker_month">月</string>
   <string name="horologist_picker_year">年</string>

--- a/composables/src/main/res/values-zu/strings.xml
+++ b/composables/src/main/res/values-zu/strings.xml
@@ -32,8 +32,6 @@
   </plurals>
   <string name="horologist_time_picker_min">Umzuzo</string>
   <string name="horologist_time_picker_period">Isikhathi</string>
-  <string name="horologist_time_picker_am">AM</string>
-  <string name="horologist_time_picker_pm">PM</string>
   <string name="horologist_picker_day">Usuku</string>
   <string name="horologist_picker_month">Inyanga</string>
   <string name="horologist_picker_year">Unyaka</string>

--- a/composables/src/main/res/values/strings.xml
+++ b/composables/src/main/res/values/strings.xml
@@ -32,8 +32,6 @@
     </plurals>
     <string description="Lets the user know that this picker is to change the value of the minute time unit. Appears on the TimePickerWith12HourClock component, on top of the minute picker. [CHAR_LIMIT=8]" name="horologist_time_picker_min">Min</string>
     <string description="Content description of the period picker in TimePickerWith12HourClock. It lets the user select the period for 12H time format. [CHAR_LIMIT=NONE]" name="horologist_time_picker_period">Period</string>
-    <string description="Content description of the period before noon in TimePickerWith12HourClock. [CHAR_LIMIT=4]" name="horologist_time_picker_am">AM</string>
-    <string description="Content description of the period after noon in TimePickerWith12HourClock. [CHAR_LIMIT=4]" name="horologist_time_picker_pm">PM</string>
     <string description="Lets the user know that this picker is to change the value of the day date unit. Appears on the DatePicker component, on top of the day picker. [CHAR_LIMIT=8]" name="horologist_picker_day">Day</string>
     <string description="Lets the user know that this picker is to change the value of the month date unit. Appears on the DatePicker component, on top of the month picker. [CHAR_LIMIT=8]" name="horologist_picker_month">Month</string>
     <string description="Lets the user know that this picker is to change the value of the year date unit. Appears on the DatePicker component, on top of the year picker. [CHAR_LIMIT=8]" name="horologist_picker_year">Year</string>

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/TimePicker12hTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/TimePicker12hTest.kt
@@ -56,4 +56,15 @@ class TimePicker12hTest : WearLegacyScreenTest() {
             )
         }
     }
+
+    @Test
+    @Config(qualifiers = "+en-rGB")
+    fun localeEnGb() {
+        runTest {
+            TimePickerWith12HourClock(
+                time = LocalTime.of(10, 10, 0),
+                onTimeConfirm = {},
+            )
+        }
+    }
 }

--- a/composables/src/test/snapshots/images/com.google.android.horologist.composables_TimePicker12hTest_localeEnGb.png
+++ b/composables/src/test/snapshots/images/com.google.android.horologist.composables_TimePicker12hTest_localeEnGb.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60a220c5c174ce6c4a64189b79b6ea266dd05dba24a09801f1cd0b7d8ad625cd
+size 20536


### PR DESCRIPTION
#### WHAT
Use DateTimeFormatter to produce localized AM/PM labels for TimePicker instead of string resource with translation.

#### WHY
In some languages, the translated AM/PM labels are too long for a watch screen.

#### HOW

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
