### PR TITLE
Settings button modifier update 

### DIFF
--- a/media/audio-ui/api/current.api
+++ b/media/audio-ui/api/current.api
@@ -111,11 +111,11 @@ package com.google.android.horologist.audio.ui.components.actions {
   }
 
   public final class SetVolumeButtonKt {
-    method @androidx.compose.runtime.Composable public static void SetVolumeButton(kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.audio.ui.VolumeUiState? volumeUiState, optional boolean enabled);
+    method @androidx.compose.runtime.Composable public static void SetVolumeButton(kotlin.jvm.functions.Function0<kotlin.Unit> onVolumeClick, optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.audio.ui.VolumeUiState? volumeUiState, optional boolean enabled, optional androidx.compose.ui.Alignment iconAlignment, optional androidx.compose.foundation.layout.PaddingValues? iconPadding);
   }
 
   public final class SettingsButtonKt {
-    method @androidx.compose.runtime.Composable public static void SettingsButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, androidx.compose.ui.graphics.vector.ImageVector imageVector, String contentDescription, optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.compose.material.IconRtlMode iconRtlMode, optional boolean enabled, optional float iconSize, optional float tapTargetSize);
+    method @androidx.compose.runtime.Composable public static void SettingsButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, androidx.compose.ui.graphics.vector.ImageVector imageVector, String contentDescription, optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.compose.material.IconRtlMode iconRtlMode, optional boolean enabled, optional float iconSize, optional androidx.compose.ui.Alignment iconAlignment, optional androidx.compose.foundation.layout.PaddingValues? iconPadding, optional float tapTargetSize);
   }
 
 }

--- a/media/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
+++ b/media/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SetVolumeButton.kt
@@ -16,11 +16,13 @@
 
 package com.google.android.horologist.audio.ui.components.actions
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.VolumeDown
 import androidx.compose.material.icons.automirrored.filled.VolumeMute
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.google.android.horologist.audio.ui.R
@@ -39,6 +41,8 @@ public fun SetVolumeButton(
     modifier: Modifier = Modifier,
     volumeUiState: VolumeUiState? = null,
     enabled: Boolean = true,
+    iconAlignment: Alignment = Alignment.Center,
+    iconPadding: PaddingValues? = null,
 ) {
     SettingsButton(
         modifier = modifier,
@@ -50,6 +54,8 @@ public fun SetVolumeButton(
             else -> Icons.AutoMirrored.Default.VolumeUp // volumeUiState == null || volumeUiState.isMax == true
         },
         iconRtlMode = IconRtlMode.Mirrored,
+        iconAlignment = iconAlignment,
+        iconPadding = iconPadding,
         contentDescription = stringResource(R.string.horologist_set_volume_content_description),
     )
 }

--- a/media/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SettingsButton.kt
+++ b/media/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SettingsButton.kt
@@ -49,14 +49,8 @@ public fun SettingsButton(
     iconPadding: PaddingValues? = null,
     tapTargetSize: Dp = 52.dp,
 ) {
-    val buttonModifier =
-        if (iconPadding != null) {
-            modifier.padding(iconPadding).size(tapTargetSize)
-        } else {
-            modifier.size(tapTargetSize)
-        }
     UnboundedRippleButton(
-        modifier = buttonModifier,
+        modifier = modifier.size(tapTargetSize),
         onClick = onClick,
         colors = buttonColors(
             backgroundColor = Color.Transparent,
@@ -66,12 +60,13 @@ public fun SettingsButton(
         enabled = enabled,
         rippleRadius = tapTargetSize / 2,
     ) {
+        val iconModifier = if (iconPadding != null) Modifier.padding(iconPadding) else Modifier
         Icon(
             paintable = imageVector.asPaintable(),
             contentDescription = contentDescription,
-            modifier = Modifier
+            modifier = iconModifier
                 .size(iconSize)
-                .align(Alignment.Center),
+                .align(iconAlignment),
             rtlMode = iconRtlMode,
         )
     }

--- a/media/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SettingsButton.kt
+++ b/media/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/actions/SettingsButton.kt
@@ -16,6 +16,8 @@
 
 package com.google.android.horologist.audio.ui.components.actions
 
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -26,16 +28,13 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.ButtonDefaults.buttonColors
 import androidx.wear.compose.material.MaterialTheme
-import com.google.android.horologist.audio.VolumeState
 import com.google.android.horologist.composables.UnboundedRippleButton
 import com.google.android.horologist.compose.material.Icon
 import com.google.android.horologist.compose.material.IconRtlMode
 import com.google.android.horologist.images.base.paintable.ImageVectorPaintable.Companion.asPaintable
 
 /**
- * Button to launch a screen to control the system volume.
- *
- * See [VolumeState]
+ * An icon button to launch a screen to control the system.
  */
 @Composable
 public fun SettingsButton(
@@ -46,10 +45,18 @@ public fun SettingsButton(
     iconRtlMode: IconRtlMode = IconRtlMode.Default,
     enabled: Boolean = true,
     iconSize: Dp = 26.dp,
+    iconAlignment: Alignment = Alignment.Center,
+    iconPadding: PaddingValues? = null,
     tapTargetSize: Dp = 52.dp,
 ) {
+    val buttonModifier =
+        if (iconPadding != null) {
+            modifier.padding(iconPadding).size(tapTargetSize)
+        } else {
+            modifier.size(tapTargetSize)
+        }
     UnboundedRippleButton(
-        modifier = modifier.size(tapTargetSize),
+        modifier = buttonModifier,
         onClick = onClick,
         colors = buttonColors(
             backgroundColor = Color.Transparent,


### PR DESCRIPTION
#### WHAT
Make the settings button more customisable by adding alignment and padding options.

#### WHY
This provides flexibility for caller to customise the button.

#### HOW
Add optional alignment and padding for settings button.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
