### PR TITLE
Avoid using ScalingLazyColumnState initialScrollPosition for two things.

### DIFF
--- a/compose-layout/api/current.api
+++ b/compose-layout/api/current.api
@@ -95,7 +95,7 @@ package com.google.android.horologist.compose.layout {
   }
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public final class ScalingLazyColumnState implements androidx.compose.foundation.gestures.ScrollableState {
-    ctor public ScalingLazyColumnState(optional com.google.android.horologist.compose.layout.ScalingLazyColumnState.ScrollPosition initialScrollPosition, optional androidx.wear.compose.foundation.lazy.AutoCenteringParams? autoCentering, optional int anchorType, optional androidx.compose.foundation.layout.PaddingValues contentPadding, optional com.google.android.horologist.compose.layout.ScalingLazyColumnState.RotaryMode? rotaryMode, optional boolean reverseLayout, optional androidx.compose.foundation.layout.Arrangement.Vertical verticalArrangement, optional androidx.compose.ui.Alignment.Horizontal horizontalAlignment, optional boolean userScrollEnabled, optional androidx.wear.compose.foundation.lazy.ScalingParams scalingParams, optional boolean hapticsEnabled);
+    ctor public ScalingLazyColumnState(optional com.google.android.horologist.compose.layout.ScalingLazyColumnState.ScrollPosition initialScrollPosition, optional com.google.android.horologist.compose.layout.ScalingLazyColumnState.ScrollPosition timeTextHomeOffset, optional androidx.wear.compose.foundation.lazy.AutoCenteringParams? autoCentering, optional int anchorType, optional androidx.compose.foundation.layout.PaddingValues contentPadding, optional com.google.android.horologist.compose.layout.ScalingLazyColumnState.RotaryMode? rotaryMode, optional boolean reverseLayout, optional androidx.compose.foundation.layout.Arrangement.Vertical verticalArrangement, optional androidx.compose.ui.Alignment.Horizontal horizontalAlignment, optional boolean userScrollEnabled, optional androidx.wear.compose.foundation.lazy.ScalingParams scalingParams, optional boolean hapticsEnabled);
     method public float dispatchRawDelta(float delta);
     method public int getAnchorType();
     method public androidx.wear.compose.foundation.lazy.AutoCenteringParams? getAutoCentering();
@@ -107,6 +107,7 @@ package com.google.android.horologist.compose.layout {
     method public com.google.android.horologist.compose.layout.ScalingLazyColumnState.RotaryMode? getRotaryMode();
     method public androidx.wear.compose.foundation.lazy.ScalingParams getScalingParams();
     method public androidx.wear.compose.foundation.lazy.ScalingLazyListState getState();
+    method public com.google.android.horologist.compose.layout.ScalingLazyColumnState.ScrollPosition getTimeTextHomeOffset();
     method public boolean getUserScrollEnabled();
     method public androidx.compose.foundation.layout.Arrangement.Vertical getVerticalArrangement();
     method public boolean isScrollInProgress();
@@ -125,6 +126,7 @@ package com.google.android.horologist.compose.layout {
     property public final com.google.android.horologist.compose.layout.ScalingLazyColumnState.RotaryMode? rotaryMode;
     property public final androidx.wear.compose.foundation.lazy.ScalingParams scalingParams;
     property public final androidx.wear.compose.foundation.lazy.ScalingLazyListState state;
+    property public final com.google.android.horologist.compose.layout.ScalingLazyColumnState.ScrollPosition timeTextHomeOffset;
     property public final boolean userScrollEnabled;
     property public final androidx.compose.foundation.layout.Arrangement.Vertical verticalArrangement;
   }

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/layout/ScalingLazyColumnState.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/layout/ScalingLazyColumnState.kt
@@ -44,6 +44,7 @@ import androidx.wear.compose.foundation.rotary.RotaryScrollableDefaults.snapBeha
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults.responsiveScalingParams
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState.RotaryMode
+import com.google.android.horologist.compose.layout.ScalingLazyColumnState.ScrollPosition
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumnDefaults as WearScalingLazyColumnDefaults
 
 /**
@@ -53,6 +54,7 @@ import androidx.wear.compose.foundation.lazy.ScalingLazyColumnDefaults as WearSc
 @ExperimentalHorologistApi
 public class ScalingLazyColumnState(
     public val initialScrollPosition: ScrollPosition = ScrollPosition(1, 0),
+    public val timeTextHomeOffset: ScrollPosition = initialScrollPosition,
     public val autoCentering: AutoCenteringParams? = AutoCenteringParams(
         initialScrollPosition.index,
         initialScrollPosition.offsetPx,
@@ -162,13 +164,19 @@ public fun rememberResponsiveColumnState(
     val topPaddingPx = with(density) { contentPaddingCalculated.calculateTopPadding().roundToPx() }
     val topScreenOffsetPx = screenHeightPx / 2 - topPaddingPx
 
-    val initialScrollPosition = ScalingLazyColumnState.ScrollPosition(
+    // Calculate the offset from which TimeText scrollAway should move
+    val timeTextHomeOffset = ScrollPosition(
         index = 0,
         offsetPx = topScreenOffsetPx,
     )
 
+    // Try to put the top of the first item in the centre, but rely on
+    // ScalingLazyColumn to stick to the ContentPadding.
+    val initialScrollPosition = ScrollPosition(0, 0)
+
     val columnState = ScalingLazyColumnState(
         initialScrollPosition = initialScrollPosition,
+        timeTextHomeOffset = timeTextHomeOffset,
         autoCentering = null,
         anchorType = ScalingLazyListAnchorType.ItemStart,
         rotaryMode = rotaryMode,

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/layout/ScrollAway.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/layout/ScrollAway.kt
@@ -70,12 +70,13 @@ public fun Modifier.scrollAway(
 ): Modifier = scrollAwayImpl {
     when (val scrollState = scrollableState()) {
         is ScalingLazyColumnState -> {
-            val initialOffsetDp = scrollState.initialScrollPosition.offsetPx.toDp()
+            val timeTextHomeOffset = scrollState.timeTextHomeOffset
+            val initialOffsetDp = timeTextHomeOffset.offsetPx.toDp()
 
             ScrollParams(
-                valid = scrollState.initialScrollPosition.index < scrollState.state.layoutInfo.totalItemsCount,
+                valid = timeTextHomeOffset.index < scrollState.state.layoutInfo.totalItemsCount,
                 isScrollInProgress = scrollState.isScrollInProgress,
-                yPx = scrollState.state.layoutInfo.visibleItemsInfo.find { it.index == scrollState.initialScrollPosition.index }
+                yPx = scrollState.state.layoutInfo.visibleItemsInfo.find { it.index == timeTextHomeOffset.index }
                     ?.let {
                         -it.offset - initialOffsetDp.toPx()
                     },

--- a/media/ui/src/test/java/com/google/android/horologist/media/ui/screens/browse/PlaylistDownloadBrowseScreenA11yTallScreenshotTest.kt
+++ b/media/ui/src/test/java/com/google/android/horologist/media/ui/screens/browse/PlaylistDownloadBrowseScreenA11yTallScreenshotTest.kt
@@ -69,14 +69,15 @@ class PlaylistDownloadBrowseScreenA11yTallScreenshotTest : WearLegacyA11yTest() 
 }
 
 public fun ScalingLazyColumnState.copy(scalingParams: ScalingParams): ScalingLazyColumnState = ScalingLazyColumnState(
-    initialScrollPosition,
-    autoCentering,
-    anchorType,
-    contentPadding,
-    rotaryMode,
-    reverseLayout,
-    verticalArrangement,
-    horizontalAlignment,
-    userScrollEnabled,
-    scalingParams,
+    initialScrollPosition = initialScrollPosition,
+    timeTextHomeOffset = timeTextHomeOffset,
+    autoCentering = autoCentering,
+    anchorType = anchorType,
+    contentPadding = contentPadding,
+    rotaryMode = rotaryMode,
+    reverseLayout = reverseLayout,
+    verticalArrangement = verticalArrangement,
+    horizontalAlignment = horizontalAlignment,
+    userScrollEnabled = userScrollEnabled,
+    scalingParams = scalingParams,
 )

--- a/sample/src/main/java/com/google/android/horologist/materialcomponents/SampleAlertDialog.kt
+++ b/sample/src/main/java/com/google/android/horologist/materialcomponents/SampleAlertDialog.kt
@@ -28,12 +28,10 @@ import androidx.compose.ui.Modifier
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Icon
-import androidx.wear.compose.material.ListHeader
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults.padding
-import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
 import com.google.android.horologist.compose.material.AlertDialog
@@ -49,8 +47,8 @@ internal fun SampleAlertDialog(
     val columnState = rememberResponsiveColumnState(
         contentPadding = padding(
             first = ScalingLazyColumnDefaults.ItemType.Text,
-            last = ScalingLazyColumnDefaults.ItemType.Chip
-        )
+            last = ScalingLazyColumnDefaults.ItemType.Chip,
+        ),
     )
 
     var showSimpleDialog by remember { mutableStateOf(false) }

--- a/sample/src/main/java/com/google/android/horologist/materialcomponents/SampleAlertDialog.kt
+++ b/sample/src/main/java/com/google/android/horologist/materialcomponents/SampleAlertDialog.kt
@@ -31,8 +31,13 @@ import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.ListHeader
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
+import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults.padding
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.layout.ScreenScaffold
+import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
 import com.google.android.horologist.compose.material.AlertDialog
+import com.google.android.horologist.compose.material.Title
 import com.google.android.horologist.compose.material.ToggleChip
 import com.google.android.horologist.compose.material.ToggleChipToggleControl
 import com.google.android.horologist.compose.material.centeredDialogColumnState
@@ -40,52 +45,59 @@ import com.google.android.horologist.compose.material.centeredDialogColumnState
 @Composable
 internal fun SampleAlertDialog(
     modifier: Modifier = Modifier,
-    columnState: ScalingLazyColumnState,
 ) {
+    val columnState = rememberResponsiveColumnState(
+        contentPadding = padding(
+            first = ScalingLazyColumnDefaults.ItemType.Text,
+            last = ScalingLazyColumnDefaults.ItemType.Chip
+        )
+    )
+
     var showSimpleDialog by remember { mutableStateOf(false) }
     var showBedtimeModeDialog by remember { mutableStateOf(false) }
     var showAllowDebuggingDialog by remember { mutableStateOf(false) }
     var showCenteredDialog by remember { mutableStateOf(false) }
-    ScalingLazyColumn(
-        columnState = columnState,
-        modifier = modifier,
-    ) {
-        item {
-            ListHeader {
-                Text("AlertDialog samples")
+
+    ScreenScaffold(scrollState = columnState) {
+        ScalingLazyColumn(
+            columnState = columnState,
+            modifier = modifier,
+        ) {
+            item {
+                Title("AlertDialog samples")
             }
-        }
-        item {
-            Chip(
-                onClick = { showSimpleDialog = true },
-                label = { Text("Simple alert") },
-                colors = ChipDefaults.secondaryChipColors(),
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
-        item {
-            Chip(
-                onClick = { showCenteredDialog = true },
-                label = { Text("Centered alert") },
-                colors = ChipDefaults.secondaryChipColors(),
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
-        item {
-            Chip(
-                onClick = { showBedtimeModeDialog = true },
-                label = { Text("Bedtime Mode") },
-                colors = ChipDefaults.secondaryChipColors(),
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
-        item {
-            Chip(
-                onClick = { showAllowDebuggingDialog = true },
-                label = { Text("Allow debugging") },
-                colors = ChipDefaults.secondaryChipColors(),
-                modifier = Modifier.fillMaxWidth(),
-            )
+            item {
+                Chip(
+                    onClick = { showSimpleDialog = true },
+                    label = { Text("Simple alert") },
+                    colors = ChipDefaults.secondaryChipColors(),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            item {
+                Chip(
+                    onClick = { showCenteredDialog = true },
+                    label = { Text("Centered alert") },
+                    colors = ChipDefaults.secondaryChipColors(),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            item {
+                Chip(
+                    onClick = { showBedtimeModeDialog = true },
+                    label = { Text("Bedtime Mode") },
+                    colors = ChipDefaults.secondaryChipColors(),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            item {
+                Chip(
+                    onClick = { showAllowDebuggingDialog = true },
+                    label = { Text("Allow debugging") },
+                    colors = ChipDefaults.secondaryChipColors(),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
         }
     }
 

--- a/sample/src/main/java/com/google/android/horologist/networks/NetworkScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/networks/NetworkScreen.kt
@@ -27,61 +27,73 @@ import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ListHeader
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
+import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults.padding
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.layout.ScreenScaffold
+import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
 
 @Composable
 fun NetworkScreen(
     viewModel: NetworkScreenViewModel = viewModel(factory = NetworkScreenViewModel.Factory),
-    columnState: ScalingLazyColumnState,
 ) {
     val uiState by viewModel.state.collectAsStateWithLifecycle()
 
-    ScalingLazyColumn(
-        columnState = columnState,
-    ) {
-        item {
-            Chip(
-                modifier = Modifier.fillMaxWidth(),
-                onClick = { viewModel.makeRequests() },
-                label = {
-                    Text("Requests")
-                },
-            )
-        }
-        items(uiState.responses.entries.toList()) { (name, response) ->
-            Text(text = "$name: $response")
-        }
+    val columnState = rememberResponsiveColumnState(
+        contentPadding = padding(
+            first = ScalingLazyColumnDefaults.ItemType.Chip,
+            last = ScalingLazyColumnDefaults.ItemType.Text
+        )
+    )
 
-        item {
-            ListHeader {
-                Text("Networks")
+    ScreenScaffold(scrollState = columnState) {
+        ScalingLazyColumn(
+            columnState = columnState,
+        ) {
+            item {
+                Chip(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = { viewModel.makeRequests() },
+                    label = {
+                        Text("Requests")
+                    },
+                )
             }
-        }
-        items(uiState.networks.networks) {
-            val downloads = uiState.dataUsage.dataByType[it.networkInfo.type] ?: 0
-            Chip(
-
-                modifier = Modifier.fillMaxWidth(),
-                label = {
-                    Text(text = "${it.id} ${it.networkInfo.type} ${it.status}")
-                },
-                onClick = { },
-                secondaryLabel = {
-                    Text(text = "bytes: $downloads")
-                },
-            )
-        }
-
-        item {
-            ListHeader {
-                Text("Events")
+            items(uiState.responses.entries.toList()) { (name, response) ->
+                Text(text = "$name: $response")
             }
-        }
-        items(uiState.requests.takeLast(5).reversed()) {
-            if (it is InMemoryStatusLogger.Event.NetworkResponse) {
-                Text(text = "Network: ${it.networkInfo.type} ${it.bytesTransferred}")
-            } else {
-                Text(text = it.message)
+
+            item {
+                ListHeader {
+                    Text("Networks")
+                }
+            }
+            items(uiState.networks.networks) {
+                val downloads = uiState.dataUsage.dataByType[it.networkInfo.type] ?: 0
+                Chip(
+
+                    modifier = Modifier.fillMaxWidth(),
+                    label = {
+                        Text(text = "${it.id} ${it.networkInfo.type} ${it.status}")
+                    },
+                    onClick = { },
+                    secondaryLabel = {
+                        Text(text = "bytes: $downloads")
+                    },
+                )
+            }
+
+            item {
+                ListHeader {
+                    Text("Events")
+                }
+            }
+            items(uiState.requests.takeLast(5).reversed()) {
+                if (it is InMemoryStatusLogger.Event.NetworkResponse) {
+                    Text(text = "Network: ${it.networkInfo.type} ${it.bytesTransferred}")
+                } else {
+                    Text(text = it.message)
+                }
             }
         }
     }

--- a/sample/src/main/java/com/google/android/horologist/networks/NetworkScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/networks/NetworkScreen.kt
@@ -29,7 +29,6 @@ import androidx.wear.compose.material.Text
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults.padding
-import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
 
@@ -42,8 +41,8 @@ fun NetworkScreen(
     val columnState = rememberResponsiveColumnState(
         contentPadding = padding(
             first = ScalingLazyColumnDefaults.ItemType.Chip,
-            last = ScalingLazyColumnDefaults.ItemType.Text
-        )
+            last = ScalingLazyColumnDefaults.ItemType.Text,
+        ),
     )
 
     ScreenScaffold(scrollState = columnState) {

--- a/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
@@ -47,8 +47,8 @@ fun MenuScreen(
     val columnState = rememberResponsiveColumnState(
         contentPadding = padding(
             first = ScalingLazyColumnDefaults.ItemType.Text,
-            last = ScalingLazyColumnDefaults.ItemType.Chip
-        )
+            last = ScalingLazyColumnDefaults.ItemType.Chip,
+        ),
     )
 
     ScreenScaffold(scrollState = columnState) {

--- a/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
@@ -30,9 +30,12 @@ import androidx.wear.compose.material.ListHeader
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
-import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
+import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults.padding
+import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
 import com.google.android.horologist.compose.material.Chip
+import com.google.android.horologist.compose.material.SecondaryTitle
 import java.time.LocalDateTime
 
 @Composable
@@ -40,219 +43,219 @@ fun MenuScreen(
     modifier: Modifier = Modifier,
     navigateToRoute: (String) -> Unit,
     time: LocalDateTime,
-    columnState: ScalingLazyColumnState,
 ) {
-    ScalingLazyColumn(
-        columnState = columnState,
-        modifier = modifier,
-    ) {
-        item {
-            ListHeader {
-                Text(text = "Samples")
-            }
-        }
-        item {
-            NetworkChip { navigateToRoute(Screen.Network.route) }
-        }
-        item {
-            FillMaxRectangleChip(navigateToRoute)
-        }
-        item {
-            VolumeScreenChip(navigateToRoute)
-        }
-        item {
-            ListHeader {
-                Text(text = "Scroll Away")
-            }
-        }
-        item {
-            ScrollAwayChip("Scroll Away") { navigateToRoute(Screen.ScrollAway.route) }
-        }
-        item {
-            ScrollAwayChip("Scroll Away SLC") { navigateToRoute(Screen.ScrollAwaySLC.route) }
-        }
-        item {
-            ScrollAwayChip("Scroll Away Column") { navigateToRoute(Screen.ScrollAwayColumn.route) }
-        }
-        item {
-            ListHeader {
-                Text(text = "Composables")
-            }
-        }
-        item {
-            TimePickerChip(time) { navigateToRoute(Screen.TimePicker.route) }
-        }
-        item {
-            DatePickerChip(time) { navigateToRoute(Screen.DatePicker.route) }
-        }
-        item {
-            FromDatePickerChip(time) { navigateToRoute(Screen.FromDatePicker.route) }
-        }
-        item {
-            ToDatePickerChip(time) { navigateToRoute(Screen.ToDatePicker.route) }
-        }
-        item {
-            TimeWithSecondsPickerChip(time) { navigateToRoute(Screen.TimeWithSecondsPicker.route) }
-        }
-        item {
-            TimeWithoutSecondsPickerChip(time) { navigateToRoute(Screen.TimeWithoutSecondsPicker.route) }
-        }
+    val columnState = rememberResponsiveColumnState(
+        contentPadding = padding(
+            first = ScalingLazyColumnDefaults.ItemType.Text,
+            last = ScalingLazyColumnDefaults.ItemType.Chip
+        )
+    )
 
-        item {
-            Chip(
-                label = stringResource(id = R.string.sectionedlist_samples_menu),
-                modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.SectionedListMenuScreen.route) },
-            )
-        }
+    ScreenScaffold(scrollState = columnState) {
+        ScalingLazyColumn(
+            columnState = columnState,
+            modifier = modifier,
+        ) {
+            item {
+                ListHeader {
+                    Text(text = "Samples")
+                }
+            }
+            item {
+                NetworkChip { navigateToRoute(Screen.Network.route) }
+            }
+            item {
+                FillMaxRectangleChip(navigateToRoute)
+            }
+            item {
+                VolumeScreenChip(navigateToRoute)
+            }
+            item {
+                SecondaryTitle("Scroll Away")
+            }
+            item {
+                ScrollAwayChip("Scroll Away") { navigateToRoute(Screen.ScrollAway.route) }
+            }
+            item {
+                ScrollAwayChip("Scroll Away SLC") { navigateToRoute(Screen.ScrollAwaySLC.route) }
+            }
+            item {
+                ScrollAwayChip("Scroll Away Column") { navigateToRoute(Screen.ScrollAwayColumn.route) }
+            }
+            item {
+                SecondaryTitle("Composables")
+            }
+            item {
+                TimePickerChip(time) { navigateToRoute(Screen.TimePicker.route) }
+            }
+            item {
+                DatePickerChip(time) { navigateToRoute(Screen.DatePicker.route) }
+            }
+            item {
+                FromDatePickerChip(time) { navigateToRoute(Screen.FromDatePicker.route) }
+            }
+            item {
+                ToDatePickerChip(time) { navigateToRoute(Screen.ToDatePicker.route) }
+            }
+            item {
+                TimeWithSecondsPickerChip(time) { navigateToRoute(Screen.TimeWithSecondsPicker.route) }
+            }
+            item {
+                TimeWithoutSecondsPickerChip(time) { navigateToRoute(Screen.TimeWithoutSecondsPicker.route) }
+            }
 
-        item {
-            ListHeader {
-                Text(text = "Material Components")
+            item {
+                Chip(
+                    label = stringResource(id = R.string.sectionedlist_samples_menu),
+                    modifier = modifier.fillMaxWidth(),
+                    onClick = { navigateToRoute(Screen.SectionedListMenuScreen.route) },
+                )
             }
-        }
-        item {
-            Chip(
-                label = stringResource(id = R.string.sample_material_alert_dialog),
-                modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.MaterialAlertDialog.route) },
-            )
-        }
-        item {
-            Chip(
-                label = stringResource(id = R.string.sample_material_animated_components),
-                modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.MaterialAnimatedComponents.route) },
-            )
-        }
-        item {
-            Chip(
-                label = stringResource(id = R.string.sample_material_buttons),
-                modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.MaterialButtonsScreen.route) },
-            )
-        }
-        item {
-            Chip(
-                label = stringResource(id = R.string.sample_material_cards),
-                modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.MaterialCardsScreen.route) },
-            )
-        }
-        item {
-            Chip(
-                label = stringResource(id = R.string.sample_material_chips),
-                modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.MaterialChipsScreen.route) },
-            )
-        }
-        item {
-            Chip(
-                label = stringResource(id = R.string.sample_material_chip_icon_with_progress),
-                modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.MaterialChipIconWithProgressScreen.route) },
-            )
-        }
-        item {
-            Chip(
-                label = stringResource(id = R.string.sample_material_compact_chip),
-                modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.MaterialCompactChipsScreen.route) },
-            )
-        }
-        item {
-            Chip(
-                label = stringResource(id = R.string.sample_material_confirmation_screen),
-                modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.MaterialConfirmationScreen.route) },
-            )
-        }
-        item {
-            Chip(
-                label = stringResource(id = R.string.sample_material_confirmation_launcher),
-                modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.MaterialConfirmationLauncher.route) },
-            )
-        }
-        item {
-            Chip(
-                label = stringResource(id = R.string.sample_material_icon),
-                modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.MaterialIconScreen.route) },
-            )
-        }
-        item {
-            Chip(
-                label = stringResource(id = R.string.sample_material_outlined_chips),
-                modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.MaterialOutlinedChipScreen.route) },
-            )
-        }
-        item {
-            Chip(
-                label = stringResource(id = R.string.sample_material_outlined_compact_chips),
-                modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.MaterialOutlinedCompactChipScreen.route) },
-            )
-        }
-        item {
-            Chip(
-                label = stringResource(id = R.string.sample_material_split_toggle_chips),
-                modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.MaterialSplitToggleChipScreen.route) },
-            )
-        }
-        item {
-            Chip(
-                label = stringResource(id = R.string.sample_material_stepper),
-                modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.MaterialStepperScreen.route) },
-            )
-        }
-        item {
-            Chip(
-                label = stringResource(id = R.string.sample_material_title),
-                modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.MaterialTitleScreen.route) },
-            )
-        }
-        item {
-            Chip(
-                label = stringResource(id = R.string.sample_material_toggle_button),
-                modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.MaterialToggleButtonScreen.route) },
-            )
-        }
-        item {
-            Chip(
-                label = stringResource(id = R.string.sample_material_toggle_chip),
-                modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.MaterialToggleChipScreen.route) },
-            )
-        }
-        item {
-            ListHeader {
-                Text(text = "Rotary Scrolling")
+
+            item {
+                SecondaryTitle("Material Components")
             }
-        }
-        item {
-            androidx.wear.compose.material.Chip(
-                label = {
-                    Text(text = "Rotary scroll")
-                },
-                modifier = modifier.fillMaxWidth(),
-                onClick = { navigateToRoute(Screen.RotaryMenuScreen.route) },
-                colors = ChipDefaults.primaryChipColors(),
-            )
-        }
-        item {
-            PagingChip { navigateToRoute(Screen.Paging.route) }
-        }
-        item {
-            PagerScreenChip { navigateToRoute(Screen.PagerScreen.route) }
-        }
-        item {
-            VerticalPagerScreenChip { navigateToRoute(Screen.VerticalPagerScreen.route) }
+            item {
+                Chip(
+                    label = stringResource(id = R.string.sample_material_alert_dialog),
+                    modifier = modifier.fillMaxWidth(),
+                    onClick = { navigateToRoute(Screen.MaterialAlertDialog.route) },
+                )
+            }
+            item {
+                Chip(
+                    label = stringResource(id = R.string.sample_material_animated_components),
+                    modifier = modifier.fillMaxWidth(),
+                    onClick = { navigateToRoute(Screen.MaterialAnimatedComponents.route) },
+                )
+            }
+            item {
+                Chip(
+                    label = stringResource(id = R.string.sample_material_buttons),
+                    modifier = modifier.fillMaxWidth(),
+                    onClick = { navigateToRoute(Screen.MaterialButtonsScreen.route) },
+                )
+            }
+            item {
+                Chip(
+                    label = stringResource(id = R.string.sample_material_cards),
+                    modifier = modifier.fillMaxWidth(),
+                    onClick = { navigateToRoute(Screen.MaterialCardsScreen.route) },
+                )
+            }
+            item {
+                Chip(
+                    label = stringResource(id = R.string.sample_material_chips),
+                    modifier = modifier.fillMaxWidth(),
+                    onClick = { navigateToRoute(Screen.MaterialChipsScreen.route) },
+                )
+            }
+            item {
+                Chip(
+                    label = stringResource(id = R.string.sample_material_chip_icon_with_progress),
+                    modifier = modifier.fillMaxWidth(),
+                    onClick = { navigateToRoute(Screen.MaterialChipIconWithProgressScreen.route) },
+                )
+            }
+            item {
+                Chip(
+                    label = stringResource(id = R.string.sample_material_compact_chip),
+                    modifier = modifier.fillMaxWidth(),
+                    onClick = { navigateToRoute(Screen.MaterialCompactChipsScreen.route) },
+                )
+            }
+            item {
+                Chip(
+                    label = stringResource(id = R.string.sample_material_confirmation_screen),
+                    modifier = modifier.fillMaxWidth(),
+                    onClick = { navigateToRoute(Screen.MaterialConfirmationScreen.route) },
+                )
+            }
+            item {
+                Chip(
+                    label = stringResource(id = R.string.sample_material_confirmation_launcher),
+                    modifier = modifier.fillMaxWidth(),
+                    onClick = { navigateToRoute(Screen.MaterialConfirmationLauncher.route) },
+                )
+            }
+            item {
+                Chip(
+                    label = stringResource(id = R.string.sample_material_icon),
+                    modifier = modifier.fillMaxWidth(),
+                    onClick = { navigateToRoute(Screen.MaterialIconScreen.route) },
+                )
+            }
+            item {
+                Chip(
+                    label = stringResource(id = R.string.sample_material_outlined_chips),
+                    modifier = modifier.fillMaxWidth(),
+                    onClick = { navigateToRoute(Screen.MaterialOutlinedChipScreen.route) },
+                )
+            }
+            item {
+                Chip(
+                    label = stringResource(id = R.string.sample_material_outlined_compact_chips),
+                    modifier = modifier.fillMaxWidth(),
+                    onClick = { navigateToRoute(Screen.MaterialOutlinedCompactChipScreen.route) },
+                )
+            }
+            item {
+                Chip(
+                    label = stringResource(id = R.string.sample_material_split_toggle_chips),
+                    modifier = modifier.fillMaxWidth(),
+                    onClick = { navigateToRoute(Screen.MaterialSplitToggleChipScreen.route) },
+                )
+            }
+            item {
+                Chip(
+                    label = stringResource(id = R.string.sample_material_stepper),
+                    modifier = modifier.fillMaxWidth(),
+                    onClick = { navigateToRoute(Screen.MaterialStepperScreen.route) },
+                )
+            }
+            item {
+                Chip(
+                    label = stringResource(id = R.string.sample_material_title),
+                    modifier = modifier.fillMaxWidth(),
+                    onClick = { navigateToRoute(Screen.MaterialTitleScreen.route) },
+                )
+            }
+            item {
+                Chip(
+                    label = stringResource(id = R.string.sample_material_toggle_button),
+                    modifier = modifier.fillMaxWidth(),
+                    onClick = { navigateToRoute(Screen.MaterialToggleButtonScreen.route) },
+                )
+            }
+            item {
+                Chip(
+                    label = stringResource(id = R.string.sample_material_toggle_chip),
+                    modifier = modifier.fillMaxWidth(),
+                    onClick = { navigateToRoute(Screen.MaterialToggleChipScreen.route) },
+                )
+            }
+            item {
+                SecondaryTitle("Rotary Scrolling")
+            }
+            item {
+                androidx.wear.compose.material.Chip(
+                    label = {
+                        Text(text = "Rotary scroll")
+                    },
+                    modifier = modifier.fillMaxWidth(),
+                    onClick = { navigateToRoute(Screen.RotaryMenuScreen.route) },
+                    colors = ChipDefaults.primaryChipColors(),
+                )
+            }
+            item {
+                PagingChip { navigateToRoute(Screen.Paging.route) }
+            }
+            item {
+                PagerScreenChip { navigateToRoute(Screen.PagerScreen.route) }
+            }
+            item {
+                VerticalPagerScreenChip { navigateToRoute(Screen.VerticalPagerScreen.route) }
+            }
         }
     }
 }
@@ -287,6 +290,5 @@ fun MenuScreenPreview() {
         modifier = Modifier.fillMaxSize(),
         navigateToRoute = {},
         time = LocalDateTime.now(),
-        columnState = rememberResponsiveColumnState(),
     )
 }

--- a/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
@@ -35,9 +35,12 @@ import com.google.android.horologist.composables.DatePicker
 import com.google.android.horologist.composables.TimePicker
 import com.google.android.horologist.composables.TimePickerWith12HourClock
 import com.google.android.horologist.compose.layout.AppScaffold
+import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
+import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults.padding
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState.RotaryMode
 import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.layout.rememberColumnState
+import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
 import com.google.android.horologist.materialcomponents.SampleAlertDialog
 import com.google.android.horologist.materialcomponents.SampleAnimatedComponents
 import com.google.android.horologist.materialcomponents.SampleButtonScreen
@@ -87,26 +90,15 @@ fun SampleWearApp() {
             composable(
                 route = Screen.Menu.route,
             ) {
-                val columnState = rememberColumnState()
-
-                ScreenScaffold(scrollState = columnState) {
                     MenuScreen(
                         navigateToRoute = { route -> navController.navigate(route) },
                         time = time,
-                        columnState = columnState,
                     )
-                }
             }
             composable(
                 Screen.Network.route,
             ) {
-                val columnState = rememberColumnState()
-
-                ScreenScaffold(scrollState = columnState) {
-                    NetworkScreen(
-                        columnState = columnState,
-                    )
-                }
+                NetworkScreen()
             }
             composable(Screen.FillMaxRectangle.route) {
                 FillMaxRectangleScreen()
@@ -125,7 +117,12 @@ fun SampleWearApp() {
             composable(
                 Screen.ScrollAwaySLC.route,
             ) {
-                val columnState = rememberColumnState()
+                val columnState = rememberResponsiveColumnState(
+                    contentPadding = padding(
+                        first = ScalingLazyColumnDefaults.ItemType.Card,
+                        last = ScalingLazyColumnDefaults.ItemType.Card
+                    )
+                )
 
                 ScreenScaffold(scrollState = columnState) {
                     ScrollAwayScreenScalingLazyColumn(
@@ -205,11 +202,7 @@ fun SampleWearApp() {
             composable(
                 route = Screen.MaterialAlertDialog.route,
             ) {
-                val columnState = rememberColumnState()
-
-                ScreenScaffold(timeText = {}, scrollState = columnState) {
-                    SampleAlertDialog(columnState = columnState)
-                }
+                SampleAlertDialog()
             }
             composable(
                 route = Screen.MaterialAnimatedComponents.route,

--- a/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
@@ -90,10 +90,10 @@ fun SampleWearApp() {
             composable(
                 route = Screen.Menu.route,
             ) {
-                    MenuScreen(
-                        navigateToRoute = { route -> navController.navigate(route) },
-                        time = time,
-                    )
+                MenuScreen(
+                    navigateToRoute = { route -> navController.navigate(route) },
+                    time = time,
+                )
             }
             composable(
                 Screen.Network.route,
@@ -120,8 +120,8 @@ fun SampleWearApp() {
                 val columnState = rememberResponsiveColumnState(
                     contentPadding = padding(
                         first = ScalingLazyColumnDefaults.ItemType.Card,
-                        last = ScalingLazyColumnDefaults.ItemType.Card
-                    )
+                        last = ScalingLazyColumnDefaults.ItemType.Card,
+                    ),
                 )
 
                 ScreenScaffold(scrollState = columnState) {


### PR DESCRIPTION
#### WHAT

Avoid using ScalingLazyColumnState initialScrollPosition for two things.

#### WHY

Was both the initial position and the time text scroll away offset, so impossible to start at a different place.

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
