### PR TITLE
update doc to mention Wear OutputSwitcher

### DIFF
--- a/docs/media-sample.md
+++ b/docs/media-sample.md
@@ -17,7 +17,7 @@ The app showcases the implementation of the following features:
 
 - Media playback, restricted to paired Bluetooth devices.
   This is achieved by calling [`setSuppressPlaybackOnUnsuitableOutput`](https://developer.android.com/reference/androidx/media3/exoplayer/ExoPlayer.Builder#setSuppressPlaybackOnUnsuitableOutput(boolean)) method on the `Exoplayer` instance.
-- Launch of Bluetooth settings to connect devices for media playback
+- Launch of Wear Output Switcher to connect devices for media playback
 - Volume control
 - Radial background based on media artwork color palette
 - Download media


### PR DESCRIPTION
#### WHAT
Nit on documantion to mention OutputSwitcher instead of BT settings fragment

#### WHY
Wear 5 launched the Wear OutputSwitcher to choose connected BT devices

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
