### PR TITLE
Fix media app bug

### DIFF
--- a/datalayer/phone/api/current.api
+++ b/datalayer/phone/api/current.api
@@ -6,8 +6,8 @@ package com.google.android.horologist.datalayer.phone {
     method public com.google.android.horologist.data.AppHelperResultCode? checkCompanionVersionSupportTileEditing();
     method public suspend Object? findWatchToInstallTile(kotlin.coroutines.Continuation<? super com.google.android.horologist.data.apphelper.AppHelperNodeStatus>);
     method public kotlinx.coroutines.flow.Flow<java.util.Set<com.google.android.gms.wearable.Node>> getConnectedAndInstalledNodes();
-    method public suspend Object? installOnNode(String nodeId, kotlin.coroutines.Continuation<?super com.google.android.horologist.data.AppHelperResultCode>);
-    method @CheckResult public suspend Object? startCompanion(String nodeId, kotlin.coroutines.Continuation<?super com.google.android.horologist.data.AppHelperResultCode>);
+    method public suspend Object? installOnNode(String nodeId, kotlin.coroutines.Continuation<? super com.google.android.horologist.data.AppHelperResultCode>);
+    method @CheckResult public suspend Object? startCompanion(String nodeId, kotlin.coroutines.Continuation<? super com.google.android.horologist.data.AppHelperResultCode>);
     property public kotlinx.coroutines.flow.Flow<java.util.Set<com.google.android.gms.wearable.Node>> connectedAndInstalledNodes;
     field public static final com.google.android.horologist.datalayer.phone.PhoneDataLayerAppHelper.Companion Companion;
   }

--- a/media/ui/api/current.api
+++ b/media/ui/api/current.api
@@ -256,7 +256,7 @@ package com.google.android.horologist.media.ui.navigation {
   }
 
   @kotlinx.serialization.Serializable public static final class NavigationScreen.Collection implements com.google.android.horologist.media.ui.navigation.NavigationScreen {
-    ctor public NavigationScreen.Collection(String id, String? name);
+    ctor public NavigationScreen.Collection(String id, optional String? name);
     method public String component1();
     method public String? component2();
     method public com.google.android.horologist.media.ui.navigation.NavigationScreen.Collection copy(String id, String? name);
@@ -293,12 +293,14 @@ package com.google.android.horologist.media.ui.navigation {
   }
 
   @kotlinx.serialization.Serializable public static final class NavigationScreen.Player implements com.google.android.horologist.media.ui.navigation.NavigationScreen {
-    ctor public NavigationScreen.Player(optional Integer? page);
-    method public Integer? component1();
-    method public com.google.android.horologist.media.ui.navigation.NavigationScreen.Player copy(Integer? page);
-    method public Integer? getPage();
-    property public final Integer? page;
+    ctor public NavigationScreen.Player(optional int page);
+    method public int component1();
+    method public com.google.android.horologist.media.ui.navigation.NavigationScreen.Player copy(int page);
+    method public int getPage();
+    property public final int page;
     field public static final com.google.android.horologist.media.ui.navigation.NavigationScreen.Player.Companion Companion;
+    field public static final int Library = 1; // 0x1
+    field public static final int Player = 0; // 0x0
   }
 
   public static final class NavigationScreen.Player.Companion {

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/navigation/NavigationScreen.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/navigation/NavigationScreen.kt
@@ -25,7 +25,7 @@ import kotlinx.serialization.Serializable
  */
 public interface NavigationScreen {
     @Serializable
-    public data class Player(val page: Int? = null) : NavigationScreen {
+    public data class Player(val page: Int = -1) : NavigationScreen {
         public companion object {
             public fun deepLinks(deepLinkPrefix: String): List<NavDeepLink> = listOf(
                 navDeepLink {

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/playerlibrarypager/PlayerLibraryPagerScreen.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/playerlibrarypager/PlayerLibraryPagerScreen.kt
@@ -58,7 +58,7 @@ public fun PlayerLibraryPagerScreen(
     var pageApplied by rememberSaveable(backStack) { mutableStateOf(false) }
 
     LaunchedEffect(route.page) {
-        if (route.page != null && !pageApplied) {
+        if (route.page != -1 && !pageApplied) {
             try {
                 pagerState.animateScrollToPage(route.page)
             } catch (e: CancellationException) {


### PR DESCRIPTION
#### WHAT

Fix media app bug

#### WHY

Crashing

```
Process: com.google.android.horologist.mediasample.debug, PID: 28401
  java.lang.IllegalArgumentException: integer does not allow nullable values
    at androidx.navigation.NavArgument.<init>(NavArgument.kt:210)
    at androidx.navigation.NavArgument$Builder.build(NavArgument.kt:199)
```

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
