### PR TITLE
Include alpha in version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ systemProp.org.gradle.internal.http.socketTimeout=120000
 
 GROUP=com.google.android.horologist
 # !! No longer need to update this manually when using a Compose SNAPSHOT
-VERSION_NAME=0.7.0
+VERSION_NAME=0.7.0-alpha
 
 POM_DESCRIPTION=Utilities for Wear OS
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,6 @@ systemProp.org.gradle.internal.publish.checksums.insecure=true
 systemProp.org.gradle.internal.http.socketTimeout=120000
 
 GROUP=com.google.android.horologist
-# !! No longer need to update this manually when using a Compose SNAPSHOT
 VERSION_NAME=0.7.0-alpha
 
 POM_DESCRIPTION=Utilities for Wear OS


### PR DESCRIPTION
#### WHAT

Indicate the stability in the version

#### WHY

Copy the approach from https://github.com/google/accompanist/releases/tag/v0.35.1-alpha, and generally follow the Wear Compose cycle for 1.5 (not released yet)

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
