### PR TITLE
Fix publishing and deps

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,7 @@
 import com.android.build.gradle.LibraryExtension
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.JavaLibrary
+import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.net.URL
@@ -71,6 +74,15 @@ allprojects {
 
     plugins.withId("com.vanniktech.maven.publish") {
         mavenPublishing {
+            if (project.plugins.hasPlugin("com.android.library")) {
+                configure(AndroidSingleVariantLibrary(
+                    variant = "release",
+                    sourcesJar = true,
+                    publishJavadocJar = false
+                ))
+            } else if (project.plugins.hasPlugin("java-library")) {
+                configure(JavaLibrary(javadocJar = JavadocJar.Empty(), sourcesJar = true))
+            }
             publishToMavenCentral(SonatypeHost("https://google.oss.sonatype.org"))
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,27 +15,26 @@ androidx-wear-watchface = "1.2.1"
 androidxActivity = "1.9.1"
 androidxCore = "1.13.1"
 androidxLifecycle = "2.8.4"
-androidxNavigation = "2.8.0-beta06"
+androidxNavigation = "2.8.0-beta07"
 androidxPhoneInteractions = "1.1.0-alpha04"
 androidxRemoteInteractions = "1.1.0-beta01"
 androidxStartup = "1.1.1"
 androidxTracing = "1.2.0"
 androidxWear = "1.3.0"
-androidxWork = "2.9.0"
-androidxprotolayout = "1.2.0-rc01"
-androidxtiles = "1.4.0-rc01"
+androidxWork = "2.9.1"
+androidxprotolayout = "1.2.0"
+androidxtiles = "1.4.0"
 annotation = "1.0.1"
 app-cash-turbine = "1.1.0"
 com-squareup-okhttp3 = "5.0.0-alpha.14"
 com-squareup-retrofit2 = "2.11.0"
-compose = "1.7.0-beta06"
-compose-compiler = "1.5.14"
+compose = "1.7.0-beta07"
 compose-material3 = "1.3.0-beta05"
 composesnapshot = "-"
 dependencyAnalysis = "1.33.0"
 dokka = "1.9.20"
 googledagger = "2.52"
-gradlePlugin = "8.4.2"
+gradlePlugin = "8.6.0-rc01"
 gradlePublishPlugin = "0.29.0"
 io-coil-kt = "2.7.0"
 junit = "4.13.2"
@@ -54,7 +53,7 @@ roborazzi = "1.26.0"
 room = "2.6.1"
 runtimeTracing = "1.0.0-beta01"
 spotless = "6.25.0"
-tiles-tooling-preview = "1.4.0-rc01"
+tiles-tooling-preview = "1.4.0"
 truth = "1.4.4"
 wearcompose = "1.4.0-beta03"
 wearToolingPreview = "1.0.0"
@@ -68,7 +67,7 @@ android-tools-build-gradle = { module = "com.android.tools.build:gradle", versio
 androidx-activity = { module = "androidx.activity:activity", version.ref = "androidxActivity" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidxActivity" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
-androidx-annotation = "androidx.annotation:annotation:1.8.1"
+androidx-annotation = "androidx.annotation:annotation:1.8.2"
 androidx-benchmark-junit4 = { module = "androidx.benchmark:benchmark-junit4", version.ref = "androidx-benchmark" }
 androidx-benchmark-macro-junit4 = { module = "androidx.benchmark:benchmark-macro-junit4", version.ref = "androidx-benchmark" }
 androidx-complications-data = { module = "androidx.wear.watchface:watchface-complications-data", version.ref = "androidx-complications-data" }
@@ -108,7 +107,7 @@ androidx-metrics-performance = "androidx.metrics:metrics-performance:1.0.0-beta0
 androidx-navigation-runtime = { module = "androidx.navigation:navigation-runtime", version.ref = "androidxNavigation" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidxNavigation" }
 androidx-navigation-testing = { module = "androidx.navigation:navigation-testing", version.ref = "androidxNavigation" }
-androidx-paging = "androidx.paging:paging-compose:3.3.1"
+androidx-paging = "androidx.paging:paging-compose:3.3.2"
 androidx-palette-ktx = "androidx.palette:palette-ktx:1.0.0"
 androidx-runtime-tracing = { module = "androidx.compose.runtime:runtime-tracing", version.ref = "runtimeTracing" }
 androidx-startup = { module = "androidx.startup:startup-runtime", version.ref = "androidxStartup" }

--- a/renovate.json
+++ b/renovate.json
@@ -18,34 +18,25 @@
       "matchPackagePatterns": [
         "org.jetbrains.kotlin.*"
       ],
-      "groupName": "kotlin",
-      "allowedVersions": "<2.0.0"
+      "groupName": "kotlin"
     },
     {
       "matchPackagePatterns": [
         "com.google.devtools.ksp"
       ],
-      "groupName": "kotlin",
-      "allowedVersions": "<2.0.0"
+      "groupName": "kotlin"
     },
     {
       "matchPackagePatterns": [
-        "com.android.tools.build:gradle"
+        "org.jetbrains.kotlinx:kotlinx-serialization-.*"
       ],
-      "allowedVersions": "<8.3.0"
+      "groupName": "kotlin"
     },
     {
       "matchPackagePatterns": [
         "com.mikepenz:multiplatform-markdown-renderer"
       ],
       "allowedVersions": "/coil2/"
-    },
-    {
-      "matchPackagePatterns": [
-        "org.jetbrains.kotlinx:kotlinx-serialization-.*"
-      ],
-      "groupName": "kotlin",
-      "allowedVersions": "<1.7.0"
     }
   ]
 }


### PR DESCRIPTION
#### WHAT

Fix publishing and deps

#### WHY

JDK 17 fails in AGP javadoc generation, bump to recent AGP but still need to disable dokka from AGP.

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
