### PR TITLE
Change Card content type to match Wear Material Card

### DIFF
--- a/compose-material/api/current.api
+++ b/compose-material/api/current.api
@@ -47,7 +47,7 @@ package com.google.android.horologist.compose.material {
   }
 
   public final class CardKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void Card(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onLongClick, optional androidx.compose.ui.graphics.painter.Painter backgroundPainter, optional long contentColor, optional boolean enabled, optional androidx.compose.foundation.layout.PaddingValues contentPadding, optional androidx.compose.ui.graphics.Shape shape, optional androidx.compose.ui.semantics.Role? role, kotlin.jvm.functions.Function0<kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void Card(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onLongClick, optional androidx.compose.ui.graphics.painter.Painter backgroundPainter, optional long contentColor, optional boolean enabled, optional androidx.compose.foundation.layout.PaddingValues contentPadding, optional androidx.compose.ui.graphics.Shape shape, optional androidx.compose.ui.semantics.Role? role, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.ColumnScope,kotlin.Unit> content);
   }
 
   public final class ChipIconWithProgressKt {

--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/Card.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/Card.kt
@@ -21,7 +21,8 @@ package com.google.android.horologist.compose.material
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -53,7 +54,7 @@ public fun Card(
     contentPadding: PaddingValues = CardDefaults.ContentPadding,
     shape: Shape = MaterialTheme.shapes.large,
     role: Role? = null,
-    content: @Composable () -> Unit,
+    content: @Composable ColumnScope.() -> Unit,
 ) {
     if (onLongClick != null) {
         val interactionSource = remember { MutableInteractionSource() }
@@ -68,7 +69,7 @@ public fun Card(
             interactionSource = interactionSource,
             role = role,
         ) {
-            Box(
+            Column(
                 modifier = Modifier
                     .fillMaxSize()
                     .combinedClickable(


### PR DESCRIPTION
#### WHAT
Change Card content type to match Wear Material Card

#### WHY
resolves #2359 

#### HOW
Changing the card content type to a `@Composable ColumnScope.() -> Unit` and changing `Box` to `Column` in the long click one

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [ ] Run tests
- [x] Update metalava's signature text files
