### PR TITLE
Expose icon tint for ToggleChip composable

### DIFF
--- a/compose-material/api/current.api
+++ b/compose-material/api/current.api
@@ -139,7 +139,7 @@ package com.google.android.horologist.compose.material {
   }
 
   public final class ToggleChipKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void ToggleChip(boolean checked, kotlin.jvm.functions.Function1<? super java.lang.Boolean,kotlin.Unit> onCheckedChanged, String label, com.google.android.horologist.compose.material.ToggleChipToggleControl toggleControl, optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.images.base.paintable.PaintableIcon? icon, optional String? secondaryLabel, optional androidx.wear.compose.material.ToggleChipColors colors, optional boolean enabled, optional androidx.compose.foundation.interaction.MutableInteractionSource? interactionSource);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void ToggleChip(boolean checked, kotlin.jvm.functions.Function1<? super java.lang.Boolean,kotlin.Unit> onCheckedChanged, String label, com.google.android.horologist.compose.material.ToggleChipToggleControl toggleControl, optional androidx.compose.ui.Modifier modifier, optional com.google.android.horologist.images.base.paintable.PaintableIcon? icon, optional String? secondaryLabel, optional androidx.wear.compose.material.ToggleChipColors colors, optional boolean enabled, optional androidx.compose.foundation.interaction.MutableInteractionSource? interactionSource, optional long iconTint);
   }
 
   @com.google.android.horologist.annotations.ExperimentalHorologistApi public enum ToggleChipToggleControl {

--- a/compose-material/src/main/java/com/google/android/horologist/compose/material/ToggleChip.kt
+++ b/compose-material/src/main/java/com/google/android/horologist/compose/material/ToggleChip.kt
@@ -26,6 +26,8 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
@@ -34,6 +36,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.wear.compose.material.ChipDefaults
+import androidx.wear.compose.material.LocalContentAlpha
+import androidx.wear.compose.material.LocalContentColor
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.ToggleChip
@@ -63,6 +67,7 @@ public fun ToggleChip(
     colors: ToggleChipColors = ToggleChipDefaults.toggleChipColors(),
     enabled: Boolean = true,
     interactionSource: MutableInteractionSource? = null,
+    iconTint: Color = Color.Unspecified,
 ) {
     val hasSecondaryLabel = secondaryLabel != null
 
@@ -112,6 +117,9 @@ public fun ToggleChip(
                         modifier = Modifier
                             .size(ChipDefaults.IconSize)
                             .clip(CircleShape),
+                        tint = iconTint.takeOrElse {
+                            LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
+                        },
                     )
                 }
             }


### PR DESCRIPTION
#### WHAT
Expose icon tint for ToggleChip composable

#### WHY
resolves #2370 

#### HOW
Exposing the icon tint as a pram for ToggleChip

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
