### PR TITLE
Bump to Compose alpha September release for 1.7.x track

### DIFF
--- a/ai/sample/core/build.gradle.kts
+++ b/ai/sample/core/build.gradle.kts
@@ -117,6 +117,7 @@ dependencies {
     implementation(projects.datalayer.grpc)
     ksp(libs.dagger.hiltandroidcompiler)
 
+    implementation(platform(libs.compose.bom))
     implementation(libs.kotlin.stdlib)
     implementation(libs.kotlinx.coroutines.core)
 

--- a/ai/sample/wear-core/build.gradle.kts
+++ b/ai/sample/wear-core/build.gradle.kts
@@ -74,6 +74,8 @@ android {
 dependencies {
     api(projects.annotations)
 
+    implementation(platform(libs.compose.bom))
+
     implementation(projects.ai.sample.core)
 
     implementation(libs.dagger.hiltandroid)

--- a/ai/sample/wear-gemini/build.gradle.kts
+++ b/ai/sample/wear-gemini/build.gradle.kts
@@ -122,6 +122,7 @@ android {
 dependencies {
     api(projects.annotations)
 
+    implementation(platform(libs.compose.bom))
     implementation(projects.ai.ui)
     implementation(projects.ai.sample.core)
     implementation(projects.ai.sample.wearCore)

--- a/ai/sample/wear-prompt-app/build.gradle.kts
+++ b/ai/sample/wear-prompt-app/build.gradle.kts
@@ -85,6 +85,8 @@ android {
 dependencies {
     api(projects.annotations)
 
+    implementation(platform(libs.compose.bom))
+
     implementation(projects.ai.sample.wearCore)
 
     implementation(projects.ai.ui)

--- a/auth/sample/wear/build.gradle.kts
+++ b/auth/sample/wear/build.gradle.kts
@@ -91,6 +91,7 @@ android {
 dependencies {
     api(projects.annotations)
 
+    implementation(platform(libs.compose.bom))
     implementation(projects.auth.composables)
     implementation(projects.auth.data)
     implementation(projects.auth.sample.shared)

--- a/composables/build.gradle.kts
+++ b/composables/build.gradle.kts
@@ -96,6 +96,8 @@ dependencies {
     api(projects.annotations)
     api(projects.images.base)
 
+    implementation(platform(libs.compose.bom))
+
     implementation(projects.composeLayout)
     implementation(libs.androidx.wear)
     api(libs.wearcompose.material)

--- a/datalayer/core/build.gradle.kts
+++ b/datalayer/core/build.gradle.kts
@@ -125,6 +125,7 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.robolectric)
 
+    androidTestImplementation(platform(libs.compose.bom))
     androidTestImplementation(libs.compose.ui.test.junit4)
     androidTestImplementation(libs.androidx.test.espressocore)
     androidTestImplementation(libs.junit)

--- a/datalayer/sample/wear/build.gradle.kts
+++ b/datalayer/sample/wear/build.gradle.kts
@@ -142,6 +142,7 @@ dependencies {
     implementation(projects.tiles)
     implementation(libs.androidx.wear.protolayout.material)
 
+    implementation(platform(libs.compose.bom))
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.complications.data)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
@@ -170,6 +171,7 @@ dependencies {
     ksp(libs.dagger.hiltandroidcompiler)
     implementation(libs.hilt.navigationcompose)
 
+    testImplementation(platform(libs.compose.bom))
     testImplementation(libs.androidx.navigation.testing)
     testImplementation(libs.androidx.test.espressocore)
     testImplementation(libs.compose.ui.test)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ androidx-test-runner = "1.6.2"
 androidx-wear-watchface = "1.2.1"
 androidxActivity = "1.9.2"
 androidxCore = "1.13.1"
+androidxComposeBom = "2024.09.00-alpha"
 androidxLifecycle = "2.8.5"
 androidxNavigation = "2.8.0"
 androidxPhoneInteractions = "1.1.0-alpha04"
@@ -28,7 +29,6 @@ annotation = "1.0.1"
 app-cash-turbine = "1.1.0"
 com-squareup-okhttp3 = "5.0.0-alpha.14"
 com-squareup-retrofit2 = "2.11.0"
-compose = "1.7.0"
 compose-material3 = "1.3.0"
 composesnapshot = "-"
 dependencyAnalysis = "2.0.1"
@@ -138,25 +138,25 @@ coil-test = { module = "io.coil-kt:coil-test", version.ref = "io-coil-kt" }
 com-squareup-okhttp3-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "com-squareup-okhttp3" }
 com-squareup-okhttp3-okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "com-squareup-okhttp3" }
 com-squareup-okhttp3-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "com-squareup-okhttp3" }
-compose-bom = "androidx.compose:compose-bom:2024.09.00-alpha"
-compose-animation-animationgraphics = { module = "androidx.compose.animation:animation-graphics", version.ref = "compose" }
-compose-foundation-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
-compose-foundation-foundation-layout = { module = "androidx.compose.foundation:foundation-layout", version.ref = "compose" }
-compose-material-iconscore = { module = "androidx.compose.material:material-icons-core", version.ref = "compose" }
-compose-material-iconsext = { module = "androidx.compose.material:material-icons-extended", version.ref = "compose" }
-compose-material-ripple = { module = "androidx.compose.material:material-ripple", version.ref = "compose" }
+compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
+compose-animation-animationgraphics = { group = "androidx.compose.animation", name = "animation-graphics" }
+compose-foundation-foundation = { group = "androidx.compose.foundation", name = "foundation" }
+compose-foundation-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout" }
+compose-material-iconscore = { group = "androidx.compose.material", name = "material-icons-core" }
+compose-material-iconsext = { group = "androidx.compose.material", name = "material-icons-extended" }
+compose-material-ripple = { group = "androidx.compose.material", name = "material-ripple" }
 compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "compose-material3" } # version 2023.10.01 from BOM is crashing
-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
-compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics", version.ref = "compose" }
-compose-ui-test = { module = "androidx.compose.ui:ui-test", version.ref = "compose" }
-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose" }
-compose-ui-text = { module = "androidx.compose.ui:ui-text", version.ref = "compose" }
-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
-compose-ui-toolingpreview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
-compose-ui-unit = { module = "androidx.compose.ui:ui-unit", version.ref = "compose" }
-compose-ui-util = { module = "androidx.compose.ui:ui-util", version.ref = "compose" }
+compose-runtime = { group = "androidx.compose.runtime", name = "runtime" }
+compose-ui = { group = "androidx.compose.ui", name = "ui" }
+compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
+compose-ui-test = { group = "androidx.compose.ui", name = "ui-test" }
+compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
+compose-ui-text = { group = "androidx.compose.ui", name = "ui-text" }
+compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+compose-ui-toolingpreview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+compose-ui-unit = { group = "androidx.compose.ui", name = "ui-unit" }
+compose-ui-util = { group = "androidx.compose.ui", name = "ui-util" }
 dagger-hiltandroid = { module = "com.google.dagger:hilt-android", version.ref = "googledagger" }
 dagger-hiltandroidcompiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "googledagger" }
 dagger-hiltandroidplugin = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "googledagger" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -138,7 +138,7 @@ coil-test = { module = "io.coil-kt:coil-test", version.ref = "io-coil-kt" }
 com-squareup-okhttp3-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "com-squareup-okhttp3" }
 com-squareup-okhttp3-okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "com-squareup-okhttp3" }
 com-squareup-okhttp3-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "com-squareup-okhttp3" }
-compose-bom = "androidx.compose:compose-bom:2024.09.00"
+compose-bom = "androidx.compose:compose-bom:2024.09.00-alpha"
 compose-animation-animationgraphics = { module = "androidx.compose.animation:animation-graphics", version.ref = "compose" }
 compose-foundation-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
 compose-foundation-foundation-layout = { module = "androidx.compose.foundation:foundation-layout", version.ref = "compose" }

--- a/images/base/build.gradle.kts
+++ b/images/base/build.gradle.kts
@@ -91,6 +91,8 @@ metalava {
 }
 
 dependencies {
+    implementation(platform(libs.compose.bom))
+
     api(projects.annotations)
     api(libs.compose.ui.graphics)
     api(libs.compose.runtime)

--- a/media/audio/build.gradle.kts
+++ b/media/audio/build.gradle.kts
@@ -92,10 +92,13 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime)
     implementation(libs.kotlinx.coroutines.android)
 
+    testImplementation(platform(libs.compose.bom))
     testImplementation(libs.androidx.lifecycle.testing)
     testImplementation(libs.androidx.test.rules)
     testImplementation(libs.truth)
     testImplementation(libs.compose.ui.test.junit4)
+
+    debugImplementation(platform(libs.compose.bom))
     debugImplementation(libs.compose.ui.test.manifest)
     testImplementation(libs.androidx.test.espressocore)
     testImplementation(libs.junit)

--- a/media/backend-media3/build.gradle.kts
+++ b/media/backend-media3/build.gradle.kts
@@ -87,6 +87,8 @@ metalava {
 }
 
 dependencies {
+    implementation(platform(libs.compose.bom))
+
     api(projects.annotations)
 
     api(projects.media.audio)

--- a/media/media3-logging/build.gradle.kts
+++ b/media/media3-logging/build.gradle.kts
@@ -88,6 +88,7 @@ metalava {
 dependencies {
     api(projects.annotations)
 
+    implementation(platform(libs.compose.bom))
     implementation(projects.media.audio)
     implementation(projects.media.core)
     implementation(libs.kotlinx.coroutines.core)

--- a/media/media3-outputswitcher/build.gradle.kts
+++ b/media/media3-outputswitcher/build.gradle.kts
@@ -88,6 +88,7 @@ metalava {
 dependencies {
     api(projects.annotations)
 
+    implementation(platform(libs.compose.bom))
     implementation(projects.media.audio)
     implementation(projects.media.core)
     implementation(projects.media.media3Logging)

--- a/media/sample/build.gradle.kts
+++ b/media/sample/build.gradle.kts
@@ -178,6 +178,7 @@ dependencies {
         libs.androidx.media3.ui,
     )
 
+    implementation(platform(libs.compose.bom))
     implementation(libs.compose.ui.util)
 
     implementation(libs.compose.foundation.foundation)
@@ -251,6 +252,7 @@ dependencies {
     debugImplementation(libs.androidx.wear.tiles.tooling.preview)
     debugImplementation(libs.androidx.wear.tiles.tooling)
 
+    testImplementation(platform(libs.compose.bom))
     testImplementation(libs.junit)
     testImplementation(libs.truth)
     testImplementation(libs.androidx.test.ext.ktx)
@@ -262,6 +264,7 @@ dependencies {
     kspTest(libs.dagger.hiltandroidcompiler)
     testImplementation(libs.androidx.work.testing)
 
+    androidTestImplementation(platform(libs.compose.bom))
     androidTestImplementation(libs.compose.ui.test.junit4)
     androidTestImplementation(libs.androidx.test.espressocore)
     androidTestImplementation(libs.junit)

--- a/network-awareness/db/build.gradle.kts
+++ b/network-awareness/db/build.gradle.kts
@@ -99,14 +99,17 @@ dependencies {
 
     implementation(libs.androidx.tracing.ktx)
 
+    debugImplementation(platform(libs.compose.bom))
     debugImplementation(libs.compose.ui.test.manifest)
 
+    testImplementation(platform(libs.compose.bom))
     testImplementation(libs.junit)
     testImplementation(libs.truth)
     testImplementation(libs.androidx.test.ext.ktx)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.robolectric)
 
+    androidTestImplementation(platform(libs.compose.bom))
     androidTestImplementation(libs.compose.ui.test.junit4)
     androidTestImplementation(libs.androidx.test.espressocore)
     androidTestImplementation(libs.junit)

--- a/network-awareness/ui/build.gradle.kts
+++ b/network-awareness/ui/build.gradle.kts
@@ -92,6 +92,7 @@ dependencies {
     api(projects.networkAwareness.core)
     api(projects.composeLayout)
 
+    implementation(platform(libs.compose.bom))
     implementation(libs.kotlin.stdlib)
     implementation(libs.androidx.wear)
     implementation(libs.wearcompose.material)
@@ -112,6 +113,7 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.robolectric)
 
+    androidTestImplementation(platform(libs.compose.bom))
     androidTestImplementation(libs.compose.ui.test.junit4)
     androidTestImplementation(libs.androidx.test.espressocore)
     androidTestImplementation(libs.junit)

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -104,6 +104,7 @@ android {
 dependencies {
     api(projects.annotations)
 
+    implementation(platform(libs.compose.bom))
     implementation(projects.composeLayout)
     implementation(projects.media.audio)
     implementation(projects.media.audioUi)
@@ -156,6 +157,7 @@ dependencies {
     debugImplementation(libs.androidx.wear.tiles.tooling)
     releaseCompileOnly(projects.composeTools)
 
+    testImplementation(platform(libs.compose.bom))
     testImplementation(libs.junit)
     testImplementation(libs.truth)
     testImplementation(projects.composeTools)
@@ -163,6 +165,7 @@ dependencies {
     testImplementation(projects.roboscreenshots)
     testImplementation(libs.robolectric)
 
+    androidTestImplementation(platform(libs.compose.bom))
     androidTestImplementation(libs.compose.ui.test.junit4)
     androidTestImplementation(libs.androidx.test.espressocore)
     androidTestImplementation(libs.junit)


### PR DESCRIPTION
#### WHAT
Bump to Compose alpha track for 1.7.x releases

#### WHY
resolves #2374 

#### HOW
Bumping the version, running the sample apps and the tasks in contribution.md

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
