### PR TITLE
Pin main to alpha compose

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,12 @@
     },
     {
       "matchPackagePatterns": [
+        "androidx.compose:compose-bom"
+      ],
+      "allowedVersions": "/-alpha/"
+    },
+    {
+      "matchPackagePatterns": [
         "org.jetbrains.kotlin.*"
       ],
       "groupName": "kotlin"


### PR DESCRIPTION
#### WHAT

Pin main to alpha compose

#### WHY

androidxComposeBom = "2024.09.00-alpha"
is suggested to update to 2024.09.00.

Until a fix is available, this will be annoying.

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
