### PR TITLE
Add result logic to ActivityResultImplementation for VoiceInput

### DIFF
--- a/ai/sample/wear-prompt-app/src/main/java/com/google/android/horologist/ai/sample/wear/prompt/prompt/SamplePromptScreen.kt
+++ b/ai/sample/wear-prompt-app/src/main/java/com/google/android/horologist/ai/sample/wear/prompt/prompt/SamplePromptScreen.kt
@@ -19,7 +19,6 @@ package com.google.android.horologist.ai.sample.wear.prompt.prompt
 import android.content.Intent
 import android.speech.RecognizerIntent
 import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -66,18 +65,19 @@ fun SamplePromptScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    val voiceLauncher =
-        rememberLauncherForActivityResult(
-            ActivityResultContracts.StartActivityForResult(),
-        ) {
-            it.data?.let { data ->
-                val results = data.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)
-                val enteredPrompt = results?.get(0)
-                if (!enteredPrompt.isNullOrBlank()) {
-                    viewModel.askQuestion(enteredPrompt)
-                }
+    val voiceLauncher = rememberLauncherForActivityResult(
+        VoiceContract(),
+    ) {
+        when (it) {
+            VoiceContract.Result.Empty -> {
+                /* NO-OP */
+            }
+
+            is VoiceContract.Result.EnteredPrompt -> {
+                viewModel.askQuestion(it.prompt)
             }
         }
+    }
 
     val voiceIntent: Intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
         putExtra(

--- a/ai/sample/wear-prompt-app/src/main/java/com/google/android/horologist/ai/sample/wear/prompt/prompt/VoiceContract.kt
+++ b/ai/sample/wear-prompt-app/src/main/java/com/google/android/horologist/ai/sample/wear/prompt/prompt/VoiceContract.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.ai.sample.wear.prompt.prompt
+
+import android.content.Context
+import android.content.Intent
+import android.speech.RecognizerIntent
+import androidx.activity.result.contract.ActivityResultContract
+
+class VoiceContract : ActivityResultContract<Intent, VoiceContract.Result>() {
+    override fun createIntent(context: Context, input: Intent): Intent = input
+
+    override fun parseResult(resultCode: Int, intent: Intent?): Result {
+        val res = intent?.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)
+        val enteredPrompt = res?.get(0)
+        return if (!enteredPrompt.isNullOrBlank()) {
+            Result.EnteredPrompt(enteredPrompt)
+        } else {
+            Result.Empty
+        }
+    }
+
+    sealed class Result {
+        data class EnteredPrompt(val prompt: String) : Result()
+        data object Empty : Result()
+    }
+}


### PR DESCRIPTION
#### WHAT
Add result logic to ActivityResultImplementation for SamplePromptScreen

#### WHY
resolves #1958 

#### HOW
Adding a an implementation of `ActivityResultContract` and extracting the logic into this.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [ ] Run tests
- [x] Update metalava's signature text files
