### PR TITLE
Use metalava plugin from version catalog

### DIFF
--- a/ai/ui/build.gradle.kts
+++ b/ai/ui/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
     alias(libs.plugins.roborazzi)
     alias(libs.plugins.compose.compiler)

--- a/annotations/build.gradle.kts
+++ b/annotations/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("java-library")
     id("org.jetbrains.kotlin.jvm")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
 }
 
 java {

--- a/auth/composables/build.gradle.kts
+++ b/auth/composables/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     alias(libs.plugins.dependencyAnalysis)
     kotlin("android")
     alias(libs.plugins.roborazzi)

--- a/auth/data-phone/build.gradle.kts
+++ b/auth/data-phone/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     alias(libs.plugins.dependencyAnalysis)
 }
 

--- a/auth/data/build.gradle.kts
+++ b/auth/data/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
     id("com.google.devtools.ksp")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     alias(libs.plugins.dependencyAnalysis)
     kotlin("android")
 }

--- a/auth/ui/build.gradle.kts
+++ b/auth/ui/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     alias(libs.plugins.dependencyAnalysis)
     kotlin("android")
     alias(libs.plugins.roborazzi)

--- a/composables/build.gradle.kts
+++ b/composables/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
     alias(libs.plugins.roborazzi)
     alias(libs.plugins.compose.compiler)

--- a/compose-layout/build.gradle.kts
+++ b/compose-layout/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
     alias(libs.plugins.roborazzi)
     alias(libs.plugins.compose.compiler)

--- a/compose-material/build.gradle.kts
+++ b/compose-material/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     alias(libs.plugins.dependencyAnalysis)
     kotlin("android")
     alias(libs.plugins.roborazzi)

--- a/compose-tools/build.gradle.kts
+++ b/compose-tools/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
     alias(libs.plugins.compose.compiler)
 }

--- a/datalayer/core/build.gradle.kts
+++ b/datalayer/core/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
     id("org.jetbrains.dokka")
     id("com.google.protobuf")
     kotlin("android")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
 }
 
 android {

--- a/datalayer/grpc/build.gradle.kts
+++ b/datalayer/grpc/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-//    id("me.tylerbwong.gradle.metalava")
+    //alias(libs.plugins.metalavaGradle)
     kotlin("android")
     id("com.google.protobuf")
 }

--- a/datalayer/phone-ui/build.gradle.kts
+++ b/datalayer/phone-ui/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     alias(libs.plugins.dependencyAnalysis)
     kotlin("android")
     alias(libs.plugins.compose.compiler)

--- a/datalayer/phone/build.gradle.kts
+++ b/datalayer/phone/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
 }
 

--- a/datalayer/watch/build.gradle.kts
+++ b/datalayer/watch/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
 }
 

--- a/health/composables/build.gradle.kts
+++ b/health/composables/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
     alias(libs.plugins.roborazzi)
     alias(libs.plugins.compose.compiler)

--- a/health/service/build.gradle.kts
+++ b/health/service/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
 }
 

--- a/images/base/build.gradle.kts
+++ b/images/base/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
     alias(libs.plugins.compose.compiler)
 }

--- a/images/coil/build.gradle.kts
+++ b/images/coil/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
     alias(libs.plugins.roborazzi)
     alias(libs.plugins.compose.compiler)

--- a/media/audio-ui/build.gradle.kts
+++ b/media/audio-ui/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
     alias(libs.plugins.roborazzi)
     alias(libs.plugins.compose.compiler)

--- a/media/audio/build.gradle.kts
+++ b/media/audio/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
 }
 

--- a/media/backend-media3/build.gradle.kts
+++ b/media/backend-media3/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
 }
 

--- a/media/benchmark/build.gradle.kts
+++ b/media/benchmark/build.gradle.kts
@@ -16,7 +16,7 @@
 
 plugins {
     id("com.android.library")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
 }
 

--- a/media/core/build.gradle.kts
+++ b/media/core/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("java-library")
     id("org.jetbrains.kotlin.jvm")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
 }
 
 java {

--- a/media/data/build.gradle.kts
+++ b/media/data/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("com.android.library")
     id("com.google.devtools.ksp")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
 }
 

--- a/media/media3-logging/build.gradle.kts
+++ b/media/media3-logging/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
 }
 

--- a/media/media3-outputswitcher/build.gradle.kts
+++ b/media/media3-outputswitcher/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
 }
 

--- a/media/sync/build.gradle.kts
+++ b/media/sync/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     id("com.google.devtools.ksp")
     kotlin("android")
 }

--- a/media/ui/build.gradle.kts
+++ b/media/ui/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
     alias(libs.plugins.roborazzi)
     kotlin("plugin.serialization")

--- a/network-awareness/core/build.gradle.kts
+++ b/network-awareness/core/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("org.jetbrains.dokka")
 
     id("com.google.devtools.ksp")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
 }
 

--- a/network-awareness/db/build.gradle.kts
+++ b/network-awareness/db/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
     id("com.google.devtools.ksp")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
 }
 

--- a/network-awareness/okhttp/build.gradle.kts
+++ b/network-awareness/okhttp/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
     id("com.google.devtools.ksp")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
 }
 

--- a/network-awareness/ui/build.gradle.kts
+++ b/network-awareness/ui/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
     id("com.google.devtools.ksp")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
     alias(libs.plugins.compose.compiler)
 }

--- a/roboscreenshots/build.gradle.kts
+++ b/roboscreenshots/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
     alias(libs.plugins.compose.compiler)
 }

--- a/tiles/build.gradle.kts
+++ b/tiles/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    alias(libs.plugins.metalavaGradle)
     kotlin("android")
     alias(libs.plugins.roborazzi)
     alias(libs.plugins.compose.compiler)


### PR DESCRIPTION
#### WHAT
Use metalava plugin from version catalog instead of hardcoding the string with the id.

#### WHY


#### HOW
Replace all usages with alias

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
