### PR TITLE
Update CombinedInferenceServiceRegistry.kt

### DIFF
--- a/ai/sample/core/src/main/java/com/google/android/horologist/ai/core/registry/CombinedInferenceServiceRegistry.kt
+++ b/ai/sample/core/src/main/java/com/google/android/horologist/ai/core/registry/CombinedInferenceServiceRegistry.kt
@@ -24,8 +24,9 @@ class CombinedInferenceServiceRegistry(
     val registries: List<InferenceServiceRegistry>,
 ) : InferenceServiceRegistry {
     override fun models(): Flow<List<InferenceServiceGrpcKt.InferenceServiceCoroutineImplBase>> {
-        return combine(registries.map { registry -> registry.models() }) {
-            it.toList().flatten()
-        }
+        return registries.asFlow()
+            .flatMapConcat { registry -> registry.models() }
+            .toList()
+            .asFlow()
     }
 }


### PR DESCRIPTION
#### WHAT
**Use flatMap for Combining Flows**: Instead of using combine and then flattening the result, we can use flatMapConcat, which is more efficient for this use case.

#### WHY
**Performance Improvement**: Using flatMapConcat is generally more efficient than combining and flattening lists afterward.

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
