### PR TITLE
Use wear specific pager to remove edgeSwipeToDismiss

### DIFF
--- a/compose-layout/api/current.api
+++ b/compose-layout/api/current.api
@@ -52,7 +52,7 @@ package com.google.android.horologist.compose.layout {
   }
 
   public final class PagerScaffoldKt {
-    method @androidx.compose.runtime.Composable public static void PagerScaffold(optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit>? timeText, optional androidx.compose.foundation.pager.PagerState? pagerState, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.BoxScope,kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable public static void PagerScaffold(optional androidx.compose.ui.Modifier modifier, optional kotlin.jvm.functions.Function0<kotlin.Unit>? timeText, optional androidx.wear.compose.foundation.pager.PagerState? pagerState, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.BoxScope,kotlin.Unit> content);
   }
 
   public final class PlaceholderKt {
@@ -199,7 +199,7 @@ package com.google.android.horologist.compose.pager {
   }
 
   public final class PageScreenIndicatorState implements androidx.wear.compose.material.PageIndicatorState {
-    ctor public PageScreenIndicatorState(androidx.compose.foundation.pager.PagerState state);
+    ctor public PageScreenIndicatorState(androidx.wear.compose.foundation.pager.PagerState state);
     method public int getPageCount();
     method public float getPageOffset();
     method public int getSelectedPage();
@@ -209,7 +209,7 @@ package com.google.android.horologist.compose.pager {
   }
 
   public final class PagerScreenKt {
-    method @androidx.compose.runtime.Composable public static void PagerScreen(androidx.compose.foundation.pager.PagerState state, optional androidx.compose.ui.Modifier modifier, optional int beyondViewportPageCount, optional boolean userScrollEnabled, optional boolean reverseLayout, optional kotlin.jvm.functions.Function1<? super java.lang.Integer,?>? key, optional androidx.compose.ui.input.nestedscroll.NestedScrollConnection pageNestedScrollConnection, kotlin.jvm.functions.Function1<? super java.lang.Integer,kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable public static void PagerScreen(androidx.wear.compose.foundation.pager.PagerState state, optional androidx.compose.ui.Modifier modifier, optional int beyondViewportPageCount, optional boolean userScrollEnabled, optional boolean reverseLayout, optional kotlin.jvm.functions.Function1<? super java.lang.Integer,?>? key, optional androidx.compose.ui.input.nestedscroll.NestedScrollConnection pageNestedScrollConnection, kotlin.jvm.functions.Function1<? super java.lang.Integer,kotlin.Unit> content);
   }
 
   public final class VerticalPageIndicatorKt {
@@ -217,7 +217,7 @@ package com.google.android.horologist.compose.pager {
   }
 
   public final class VerticalPagerScreenKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void VerticalPagerScreen(androidx.compose.foundation.pager.PagerState state, optional androidx.compose.ui.Modifier modifier, optional int beyondViewportPageCount, optional boolean userScrollEnabled, optional boolean reverseLayout, optional kotlin.jvm.functions.Function1<? super java.lang.Integer,?>? key, optional androidx.compose.ui.input.nestedscroll.NestedScrollConnection pageNestedScrollConnection, kotlin.jvm.functions.Function1<? super java.lang.Integer,kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void VerticalPagerScreen(androidx.wear.compose.foundation.pager.PagerState state, optional androidx.compose.ui.Modifier modifier, optional int beyondViewportPageCount, optional boolean userScrollEnabled, optional boolean reverseLayout, optional kotlin.jvm.functions.Function1<? super java.lang.Integer,?>? key, kotlin.jvm.functions.Function1<? super java.lang.Integer,kotlin.Unit> content);
   }
 
 }

--- a/compose-layout/src/debug/java/com/google/android/horologist/compose/pager/VerticalPagerIndicatorPreview.kt
+++ b/compose-layout/src/debug/java/com/google/android/horologist/compose/pager/VerticalPagerIndicatorPreview.kt
@@ -16,8 +16,8 @@
 
 package com.google.android.horologist.compose.pager
 
-import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Composable
+import androidx.wear.compose.foundation.pager.PagerState
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 
 @WearPreviewDevices

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/layout/PagerScaffold.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/layout/PagerScaffold.kt
@@ -14,22 +14,18 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalFoundationApi::class, ExperimentalWearFoundationApi::class)
-
 package com.google.android.horologist.compose.layout
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.foundation.ActiveFocusListener
-import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
+import androidx.wear.compose.foundation.pager.PagerState
 import androidx.wear.compose.material.HorizontalPageIndicator
 import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.TimeText

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/pager/PagerScreen.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/pager/PagerScreen.kt
@@ -22,9 +22,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerDefaults
-import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -37,6 +35,8 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
 import androidx.wear.compose.foundation.HierarchicalFocusCoordinator
+import androidx.wear.compose.foundation.pager.HorizontalPager
+import androidx.wear.compose.foundation.pager.PagerState
 import androidx.wear.compose.material.PageIndicatorState
 import com.google.android.horologist.compose.layout.PagerScaffold
 
@@ -72,7 +72,6 @@ public fun PagerScreen(
             userScrollEnabled = userScrollEnabled,
             reverseLayout = reverseLayout,
             key = key,
-            pageNestedScrollConnection = pageNestedScrollConnection,
             flingBehavior = HorizontalPagerDefaults.flingParams(state),
         ) { page ->
             ClippedBox(state) {

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/pager/VerticalPagerScreen.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/pager/VerticalPagerScreen.kt
@@ -14,22 +14,15 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalFoundationApi::class, ExperimentalWearFoundationApi::class)
-
 package com.google.android.horologist.compose.pager
 
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.pager.PagerDefaults
-import androidx.compose.foundation.pager.PagerState
-import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.unit.dp
-import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
+import androidx.wear.compose.foundation.pager.PagerState
+import androidx.wear.compose.foundation.pager.VerticalPager
 import androidx.wear.compose.foundation.rememberActiveFocusRequester
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.layout.ScreenScaffold
@@ -49,11 +42,7 @@ public fun VerticalPagerScreen(
     userScrollEnabled: Boolean = true,
     reverseLayout: Boolean = false,
     key: ((index: Int) -> Any)? = null,
-    pageNestedScrollConnection: NestedScrollConnection = PagerDefaults.pageNestedScrollConnection(
-        state,
-        Orientation.Vertical,
-    ),
-    content: @Composable ((Int) -> Unit),
+    content: @Composable (Int) -> Unit,
 ) {
     ScreenScaffold(
         modifier = modifier.fillMaxSize(),
@@ -73,7 +62,6 @@ public fun VerticalPagerScreen(
             userScrollEnabled = userScrollEnabled,
             reverseLayout = reverseLayout,
             key = key,
-            pageNestedScrollConnection = pageNestedScrollConnection,
             flingBehavior = HorizontalPagerDefaults.flingParams(state),
         ) { page ->
             ClippedBox(state) {

--- a/compose-layout/src/test/java/com/google/android/horologist/compose/pager/PagerScreenScreenshotTest.kt
+++ b/compose-layout/src/test/java/com/google/android/horologist/compose/pager/PagerScreenScreenshotTest.kt
@@ -18,9 +18,9 @@ package com.google.android.horologist.compose.pager
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.wear.compose.foundation.pager.rememberPagerState
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.screenshots.rng.WearLegacyScreenTest
 import org.junit.Test

--- a/compose-layout/src/test/java/com/google/android/horologist/compose/pager/PagerScreenTest.kt
+++ b/compose-layout/src/test/java/com/google/android/horologist/compose/pager/PagerScreenTest.kt
@@ -26,8 +26,6 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.pager.PagerState
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.ui.Modifier
@@ -40,6 +38,8 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onParent
 import androidx.test.filters.MediumTest
 import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
+import androidx.wear.compose.foundation.pager.PagerState
+import androidx.wear.compose.foundation.pager.rememberPagerState
 import androidx.wear.compose.foundation.rememberActiveFocusRequester
 import androidx.wear.compose.foundation.rotary.RotaryScrollableDefaults.behavior
 import androidx.wear.compose.foundation.rotary.rotaryScrollable

--- a/compose-layout/src/test/java/com/google/android/horologist/compose/pager/VerticalPagerScreenScreenshotTest.kt
+++ b/compose-layout/src/test/java/com/google/android/horologist/compose/pager/VerticalPagerScreenScreenshotTest.kt
@@ -18,9 +18,9 @@ package com.google.android.horologist.compose.pager
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.wear.compose.foundation.pager.rememberPagerState
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.screenshots.rng.WearLegacyScreenTest
 import org.junit.Test

--- a/media/ui/api/current.api
+++ b/media/ui/api/current.api
@@ -457,7 +457,7 @@ package com.google.android.horologist.media.ui.screens.player {
 package com.google.android.horologist.media.ui.screens.playerlibrarypager {
 
   public final class PlayerLibraryPagerScreenKt {
-    method @androidx.compose.runtime.Composable public static void PlayerLibraryPagerScreen(androidx.compose.foundation.pager.PagerState pagerState, kotlin.jvm.functions.Function0<com.google.android.horologist.audio.ui.VolumeUiState> volumeUiState, kotlinx.coroutines.flow.Flow<kotlin.Unit> displayVolumeIndicatorEvents, kotlin.jvm.functions.Function0<kotlin.Unit> playerScreen, kotlin.jvm.functions.Function0<kotlin.Unit> libraryScreen, androidx.navigation.NavBackStackEntry backStack, optional androidx.compose.ui.Modifier modifier);
+    method @androidx.compose.runtime.Composable public static void PlayerLibraryPagerScreen(androidx.wear.compose.foundation.pager.PagerState pagerState, kotlin.jvm.functions.Function0<com.google.android.horologist.audio.ui.VolumeUiState> volumeUiState, kotlinx.coroutines.flow.Flow<kotlin.Unit> displayVolumeIndicatorEvents, kotlin.jvm.functions.Function0<kotlin.Unit> playerScreen, kotlin.jvm.functions.Function0<kotlin.Unit> libraryScreen, androidx.navigation.NavBackStackEntry backStack, optional androidx.compose.ui.Modifier modifier);
   }
 
 }

--- a/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenPreview.kt
+++ b/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenPreview.kt
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalFoundationApi::class)
-
 package com.google.android.horologist.media.ui.screens.player
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -33,6 +29,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.pager.rememberPagerState
 import androidx.wear.compose.material.CircularProgressIndicator
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Scaffold

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/navigation/MediaPlayerScaffold.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/navigation/MediaPlayerScaffold.kt
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalFoundationApi::class)
-
 package com.google.android.horologist.media.ui.navigation
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -30,6 +26,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.toRoute
+import androidx.wear.compose.foundation.pager.rememberPagerState
 import androidx.wear.compose.navigation.SwipeDismissableNavHostState
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavHostState
 import com.google.android.horologist.audio.ui.VolumeScreen

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/playerlibrarypager/PlayerLibraryPagerScreen.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/screens/playerlibrarypager/PlayerLibraryPagerScreen.kt
@@ -14,13 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalFoundationApi::class)
-
 package com.google.android.horologist.media.ui.screens.playerlibrarypager
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -31,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.toRoute
+import androidx.wear.compose.foundation.pager.PagerState
 import com.google.android.horologist.audio.ui.VolumePositionIndicator
 import com.google.android.horologist.audio.ui.VolumeUiState
 import com.google.android.horologist.compose.layout.ScreenScaffold

--- a/media/ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerTestCase.kt
+++ b/media/ui/src/test/java/com/google/android/horologist/media/ui/MediaPlayerTestCase.kt
@@ -21,9 +21,9 @@ package com.google.android.horologist.media.ui
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.wear.compose.foundation.pager.rememberPagerState
 import androidx.wear.compose.material.Colors
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Scaffold

--- a/media/ui/src/test/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenA11yScreenshotTest.kt
+++ b/media/ui/src/test/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenA11yScreenshotTest.kt
@@ -20,7 +20,6 @@ package com.google.android.horologist.media.ui.screens.entity
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.runtime.Composable
@@ -31,6 +30,7 @@ import androidx.core.content.ContextCompat
 import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
 import androidx.wear.compose.foundation.LocalReduceMotion
 import androidx.wear.compose.foundation.ReduceMotion
+import androidx.wear.compose.foundation.pager.rememberPagerState
 import androidx.wear.compose.material.MaterialTheme
 import coil.annotation.ExperimentalCoilApi
 import coil.decode.DataSource

--- a/sample/src/main/java/com/google/android/horologist/audit/PageIndicatorAudit.kt
+++ b/sample/src/main/java/com/google/android/horologist/audit/PageIndicatorAudit.kt
@@ -18,11 +18,11 @@ package com.google.android.horologist.audit
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import androidx.wear.compose.foundation.pager.rememberPagerState
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
 import androidx.wear.compose.ui.tooling.preview.WearPreviewSmallRound

--- a/sample/src/main/java/com/google/android/horologist/navsample/NavWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/navsample/NavWearApp.kt
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalFoundationApi::class)
-
 package com.google.android.horologist.navsample
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -31,6 +27,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.wear.compose.foundation.edgeSwipeToDismiss
+import androidx.wear.compose.foundation.pager.rememberPagerState
 import androidx.wear.compose.foundation.rememberSwipeToDismissBoxState
 import androidx.wear.compose.material.Button
 import androidx.wear.compose.material.Chip

--- a/sample/src/main/java/com/google/android/horologist/pager/SamplePagerScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/pager/SamplePagerScreen.kt
@@ -14,28 +14,22 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalFoundationApi::class)
-
 package com.google.android.horologist.pager
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.wear.compose.foundation.SwipeToDismissBoxState
-import androidx.wear.compose.foundation.edgeSwipeToDismiss
+import androidx.wear.compose.foundation.pager.rememberPagerState
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.compose.pager.PagerScreen
 
 @Composable
-fun SamplePagerScreen(swipeToDismissBoxState: SwipeToDismissBoxState) {
+fun SamplePagerScreen() {
     PagerScreen(
-        modifier = Modifier.edgeSwipeToDismiss(swipeToDismissBoxState),
         state = rememberPagerState {
             10
         },

--- a/sample/src/main/java/com/google/android/horologist/pager/SampleVerticalPagerScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/pager/SampleVerticalPagerScreen.kt
@@ -14,24 +14,17 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalFoundationApi::class)
-
 package com.google.android.horologist.pager
 
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.wear.compose.foundation.SwipeToDismissBoxState
-import androidx.wear.compose.foundation.edgeSwipeToDismiss
+import androidx.wear.compose.foundation.pager.rememberPagerState
 import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.pager.VerticalPagerScreen
 
 @Composable
-fun SampleVerticalPagerScreen(swipeToDismissBoxState: SwipeToDismissBoxState) {
+fun SampleVerticalPagerScreen() {
     ScreenScaffold(timeText = {}) {
         VerticalPagerScreen(
-            modifier = Modifier.edgeSwipeToDismiss(swipeToDismissBoxState),
             state = rememberPagerState {
                 10
             },

--- a/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
-import androidx.wear.compose.foundation.rememberSwipeToDismissBoxState
 import androidx.wear.compose.navigation.SwipeDismissableNavHost
 import androidx.wear.compose.navigation.composable
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
@@ -66,9 +65,8 @@ import java.time.LocalDateTime
 
 @Composable
 fun SampleWearApp() {
-    val swipeToDismissBoxState = rememberSwipeToDismissBoxState()
     val navHostState =
-        rememberSwipeDismissableNavHostState(swipeToDismissBoxState = swipeToDismissBoxState)
+        rememberSwipeDismissableNavHostState()
     val navController = rememberSwipeDismissableNavController()
 
     var time by remember { mutableStateOf(LocalDateTime.now()) }
@@ -362,10 +360,10 @@ fun SampleWearApp() {
                 PagingItemScreen(it.arguments!!.getInt("id"))
             }
             composable(route = Screen.PagerScreen.route) {
-                SamplePagerScreen(swipeToDismissBoxState)
+                SamplePagerScreen()
             }
             composable(route = Screen.VerticalPagerScreen.route) {
-                SampleVerticalPagerScreen(swipeToDismissBoxState)
+                SampleVerticalPagerScreen()
             }
         }
     }

--- a/sample/src/test/kotlin/com/google/android/horologist/screensizes/MediaPlayerLibraryTest.kt
+++ b/sample/src/test/kotlin/com/google/android/horologist/screensizes/MediaPlayerLibraryTest.kt
@@ -19,11 +19,11 @@
 package com.google.android.horologist.screensizes
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.wear.compose.foundation.pager.rememberPagerState
 import coil.annotation.ExperimentalCoilApi
 import coil.test.FakeImageLoaderEngine
 import com.google.android.horologist.compose.layout.AppScaffold

--- a/sample/src/test/kotlin/com/google/android/horologist/screensizes/MediaPlayerTest.kt
+++ b/sample/src/test/kotlin/com/google/android/horologist/screensizes/MediaPlayerTest.kt
@@ -22,9 +22,9 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.wear.compose.foundation.pager.rememberPagerState
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Scaffold
 import com.google.android.horologist.audio.VolumeState


### PR DESCRIPTION
#### WHAT
use the Wear foundation pager

#### WHY
Simplify the code: it includes by default the swipe to dismiss

#### HOW
use the wear component instead of the phone component

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
