### PR TITLE
Update doc for location of audio now under media

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,15 @@ The toolkit includes:
   such as avoiding playing music on the watch speaker.
 - [media sample](https://google.github.io/horologist/media-sample): sample app to listen to
   downloaded music.
+- [audio](https://google.github.io/horologist/audio): domain model for Audio related functionality,
+  such as Volume Control and Output switching, subscribing to a Flow of changes in audio or output.
+- [audio-ui](https://google.github.io/horologist/audio-ui): UI components for Audio related functionality,
+  such as Volume Control and Output switching
 
-Player Screen | Browse Screen | Entity Screen
-:------------:|:-------------:|:-------------:
-<img src="https://media.githubusercontent.com/media/google/horologist/main/docs/media-ui/playerscreen.png" height="120" width="120" > | <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/media-ui/browse.png" height="120" width="120" > | <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/media-ui/detail.png" height="120" width="120" >
+Player Screen | Browse Screen | Entity Screen | Volume Screen
+:------------:|:-------------:|:-------------:|:-------------:
+<img src="https://media.githubusercontent.com/media/google/horologist/main/docs/media-ui/playerscreen.png" height="120" width="120" > | <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/media-ui/browse.png" height="120" width="120" > | <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/media-ui/detail.png" height="120" width="120" > | <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/audio-ui/volume_screen.png" height="120" width="120" > |
+
 
 ## 📅 Composables
 
@@ -80,18 +85,6 @@ of [Wear Material Design Kit](https://developer.android.com/design/ui/wear/guide
 .
 
 - [horologist-compose-material](https://google.github.io/horologist/compose-material)
-
-## 🔊 Audio and UI
-
-Domain model for Audio related functionality. Volume Control, Output switching.
-Subscribing to a Flow of changes in audio or output.
-
-- [horologist-audio](https://google.github.io/horologist/audio)
-- [horologist-audio-ui](https://google.github.io/horologist/audio-ui)
-
-|                                                              VolumeScreen                                                              |
-|:--------------------------------------------------------------------------------------------------------------------------------------:|
-| <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/audio-ui/volume_screen.png" height="120" width="120" > |
 
 ## 🔐 Auth
 

--- a/docs/media-toolkit.md
+++ b/docs/media-toolkit.md
@@ -14,6 +14,11 @@ The following modules in the Horologist project are part of the toolkit:
 - [media3-backend](media3-backend.md): `Player` on top of Media3 including functionalities such as
   avoiding playing music on the watch speaker.
 - [media-sample](media-sample.md): sample app to listen to downloaded music.
+- [audio](audio.md): domain model for Audio related functionality,
+    such as Volume Control and Output switching, subscribing to a Flow of changes in audio or output.
+- [audio-ui](audio-ui.md): UI components for Audio related functionality,
+  such as Volume Control and Output switching
+
 
 ## Architecture overview
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,9 +25,6 @@ nav:
       - 'Auth Data Phone lib': auth-data-phone.md
       - 'Token sharing guide': auth-tokenshare-guide.md
       - 'Google Sign-In guide': auth-googlesignin-guide.md
-  - 'Audio':
-      - 'Audio Guide': audio.md
-      - 'Audio UI Guide': audio-ui.md
   - 'Composables':
       - 'Guide': composables.md
   - 'Compose Layout':
@@ -48,6 +45,8 @@ nav:
       - 'Media3 Backend lib': media3-backend.md
       - 'Media sample app': media-sample.md
       - 'Stateful PlayerScreen Guide': media-playerscreen.md
+      - 'Audio Guide': audio.md
+      - 'Audio UI Guide': audio-ui.md
   - 'Network Awareness':
       - 'Guide': network-awareness.md
   - 'Tiles':


### PR DESCRIPTION
#### WHAT
Audio ui and model now live under media, this PR updates the doc to reflect the change

#### WHY
To make the doc more accurate

#### HOW
Move audio ui and model under media documentation

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
