### PR TITLE
Removes Square screenshot from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ DatePicker             |  TimePickerWith12HourClock |  TimePicker
 :-------------------------:|:-------------------------:|:-------------------------:
 <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/composables/date_picker.png" height="120" width="120" >  |  <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/composables/time_12h_picker.png" height="120" width="120"> | <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/composables/time_24h_picker.png" height="120" width="120">
 
-SegmentedProgressIndicator | SquareSegmentedProgressIndicator
-:-------------------------:|:--------------------------------:
-<img src="https://media.githubusercontent.com/media/google/horologist/main/docs/composables/segmented_progress_indicator.png" height="120" width="120">  | <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/composables/square_segmented_progress_indicator.png" height="120" width="120">
+SegmentedProgressIndicator 
+:-------------------------:
+<img src="https://media.githubusercontent.com/media/google/horologist/main/docs/composables/segmented_progress_indicator.png" height="120" width="120">
 
 ## 📐 Compose Layout
 

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ DatePicker             |  TimePickerWith12HourClock |  TimePicker
 :-------------------------:|:-------------------------:|:-------------------------:
 <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/composables/date_picker.png" height="120" width="120" >  |  <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/composables/time_12h_picker.png" height="120" width="120"> | <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/composables/time_24h_picker.png" height="120" width="120">
 
-SegmentedProgressIndicator 
-:-------------------------:
-<img src="https://media.githubusercontent.com/media/google/horologist/main/docs/composables/segmented_progress_indicator.png" height="120" width="120">
+| SegmentedProgressIndicator |
+| :-------------------------: |
+| <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/composables/segmented_progress_indicator.png" height="120" width="120"> |
 
 ## 📐 Compose Layout
 

--- a/docs/composables/square_segmented_progress_indicator.png
+++ b/docs/composables/square_segmented_progress_indicator.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:736355629745992ced92abee1ab3a21d89e921d5f2eed03265125fba64d7d84d
-size 11946


### PR DESCRIPTION
#### WHAT
Removes Square screenshot from README

#### WHY
There are no square devices supporting latest versions of Wear OS

#### HOW
Remove the file and the link from the README

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
