### PR TITLE
Improve Wear Samples to display just the tile name

### DIFF
--- a/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodes/AppHelperNodeStatusCard.kt
+++ b/datalayer/sample/phone/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodes/AppHelperNodeStatusCard.kt
@@ -108,7 +108,7 @@ fun AppHelperNodeStatusCard(
                         style = MaterialTheme.typography.labelMedium,
                         text = stringResource(
                             R.string.node_status_tiles_label,
-                            nodeStatus.surfacesInfo.tilesList.joinToString { it.name },
+                            nodeStatus.surfacesInfo.tilesList.joinToString { it.name.substringAfterLast(".") },
                         ),
                     )
                 }

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/tracking/TrackingScreenViewModel.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/tracking/TrackingScreenViewModel.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.text.substringAfterLast
 
 @HiltViewModel
 class TrackingScreenViewModel
@@ -59,8 +60,12 @@ class TrackingScreenViewModel
                         TrackingScreenUiState.Loading,
                         is TrackingScreenUiState.Loaded,
                         -> {
-                            val tilesMap = realTileList.associateWith { tile ->
-                                surfacesInfo.tilesList.any { it.name == tile }
+                            val tilesMap = mutableMapOf<String, Boolean>()
+                            for (tile in realTileList) {
+                                tilesMap.put(
+                                    tile.substringAfterLast("."),
+                                    surfacesInfo.tilesList.any { it.name == tile },
+                                )
                             }
 
                             val complicationsMap = fakeComplicationList.associateWith { complication ->

--- a/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
+++ b/datalayer/watch/src/main/java/com/google/android/horologist/datalayer/watch/WearDataLayerAppHelper.kt
@@ -174,9 +174,7 @@ public class WearDataLayerAppHelper internal constructor(
     }
 
     /**
-     * Updates the installed tiles
-     *
-     * Gets all the installed tiles async and updates them.
+     * Updates the list of currently installed tiles on this watch.
      *
      * This function has some limitations on older SDK versions, please see
      * the docs for [TileService#getActiveTilesAsync](https://developer.android.com/reference/androidx/wear/tiles/TileService#getActiveTilesAsync(android.content.Context,java.util.concurrent.Executor))


### PR DESCRIPTION
#### WHAT

Improve Wear Samples to display just the class name as the tile name.

| ![Screenshot_20241031_083842](https://github.com/user-attachments/assets/1dc33810-bc77-471d-9a5d-98d6f84931c9) | ![Screenshot_20241031_083851](https://github.com/user-attachments/assets/27c2cb7d-f8d6-4356-93b9-59d50793a01b) |
|--------|--------|

#### WHY

It was displaying the class with the package as a tile name.

#### Checklist :clipboard:
- [N/A] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [N/A] Update metalava's signature text files
