### PR TITLE
Expose Roborazzi options

### DIFF
--- a/roboscreenshots/api/current.api
+++ b/roboscreenshots/api/current.api
@@ -129,6 +129,7 @@ package com.google.android.horologist.screenshots.rng {
     method public coil.test.FakeImageLoaderEngine? getImageLoader();
     method @org.junit.Rule public final org.junit.rules.TestName getTestInfo();
     method public float getTolerance();
+    method public com.github.takahirom.roborazzi.RoborazziOptions roborazziOptions(optional boolean applyDeviceCrop);
     method public final void runTest(optional String? suffix, optional com.google.android.horologist.screenshots.rng.WearDevice? device, optional boolean applyDeviceConfig, optional boolean captureScreenshot, kotlin.jvm.functions.Function0<kotlin.Unit> content);
     method public String testName(String suffix);
     property @org.junit.Rule public final androidx.compose.ui.test.junit4.ComposeContentTestRule composeRule;

--- a/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/rng/WearScreenshotTest.kt
+++ b/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/rng/WearScreenshotTest.kt
@@ -74,7 +74,7 @@ public abstract class WearScreenshotTest {
 
     public open val imageLoader: FakeImageLoaderEngine? = null
 
-    open fun roborazziOptions(applyDeviceCrop: Boolean = true) = RoborazziOptions(
+    public open fun roborazziOptions(applyDeviceCrop: Boolean = true) = RoborazziOptions(
         recordOptions = RoborazziOptions.RecordOptions(
             applyDeviceCrop = applyDeviceCrop,
         ),

--- a/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/rng/WearScreenshotTest.kt
+++ b/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/rng/WearScreenshotTest.kt
@@ -74,6 +74,15 @@ public abstract class WearScreenshotTest {
 
     public open val imageLoader: FakeImageLoaderEngine? = null
 
+    open fun roborazziOptions(applyDeviceCrop: Boolean = true) = RoborazziOptions(
+        recordOptions = RoborazziOptions.RecordOptions(
+            applyDeviceCrop = applyDeviceCrop,
+        ),
+        compareOptions = RoborazziOptions.CompareOptions(
+            resultValidator = ThresholdValidator(tolerance),
+        ),
+    )
+
     public fun runTest(
         suffix: String? = null,
         device: WearDevice? = this.device,
@@ -101,14 +110,7 @@ public abstract class WearScreenshotTest {
     public fun captureScreenshot(suffix: String = "") {
         captureScreenRoboImage(
             filePath = testName(suffix),
-            roborazziOptions = RoborazziOptions(
-                recordOptions = RoborazziOptions.RecordOptions(
-                    applyDeviceCrop = true,
-                ),
-                compareOptions = RoborazziOptions.CompareOptions(
-                    resultValidator = ThresholdValidator(tolerance),
-                ),
-            ),
+            roborazziOptions = roborazziOptions(),
         )
     }
 

--- a/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/rng/WearScreenshotTest.kt
+++ b/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/rng/WearScreenshotTest.kt
@@ -74,14 +74,15 @@ public abstract class WearScreenshotTest {
 
     public open val imageLoader: FakeImageLoaderEngine? = null
 
-    public open fun roborazziOptions(applyDeviceCrop: Boolean = true) = RoborazziOptions(
-        recordOptions = RoborazziOptions.RecordOptions(
-            applyDeviceCrop = applyDeviceCrop,
-        ),
-        compareOptions = RoborazziOptions.CompareOptions(
-            resultValidator = ThresholdValidator(tolerance),
-        ),
-    )
+    public open fun roborazziOptions(applyDeviceCrop: Boolean = true): RoborazziOptions =
+        RoborazziOptions(
+            recordOptions = RoborazziOptions.RecordOptions(
+                applyDeviceCrop = applyDeviceCrop,
+            ),
+            compareOptions = RoborazziOptions.CompareOptions(
+                resultValidator = ThresholdValidator(tolerance),
+            ),
+        )
 
     public fun runTest(
         suffix: String? = null,


### PR DESCRIPTION
#### WHAT

Extract RoborazziOptions to a function

Extracts the `RoborazziOptions` configuration into a separate function `roborazziOptions` to improve code
 readability and reusability. 

#### WHY

This allows for easier customization of the options in different test scenarios.

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
