### PR TITLE
Refactor: AmbientAware API change

### DIFF
--- a/compose-layout/api/current.api
+++ b/compose-layout/api/current.api
@@ -2,37 +2,50 @@
 package com.google.android.horologist.compose.ambient {
 
   public final class AmbientAwareKt {
-    method @androidx.compose.runtime.Composable public static void AmbientAware(optional boolean isAlwaysOnScreen, kotlin.jvm.functions.Function1<? super com.google.android.horologist.compose.ambient.AmbientStateUpdate,kotlin.Unit> block);
+    method @androidx.compose.runtime.Composable public static void AmbientAware(kotlin.jvm.functions.Function1<? super com.google.android.horologist.compose.ambient.AmbientState,kotlin.Unit> content);
+    method public static androidx.compose.runtime.ProvidableCompositionLocal<com.google.android.horologist.compose.ambient.AmbientState> getLocalAmbientState();
+    property public static final androidx.compose.runtime.ProvidableCompositionLocal<com.google.android.horologist.compose.ambient.AmbientState> LocalAmbientState;
   }
 
   public final class AmbientAwareTimeKt {
-    method @RequiresApi(android.os.Build.VERSION_CODES.O) @androidx.compose.runtime.Composable public static void AmbientAwareTime(com.google.android.horologist.compose.ambient.AmbientStateUpdate stateUpdate, optional long updatePeriodMillis, kotlin.jvm.functions.Function2<? super java.time.ZonedDateTime,? super java.lang.Boolean,kotlin.Unit> block);
+    method @RequiresApi(android.os.Build.VERSION_CODES.O) @androidx.compose.runtime.Composable public static void AmbientAwareTime(com.google.android.horologist.compose.ambient.AmbientState stateUpdate, optional long updatePeriodMillis, kotlin.jvm.functions.Function2<? super java.time.ZonedDateTime,? super java.lang.Boolean,kotlin.Unit> block);
   }
 
-  public sealed interface AmbientState {
+  @androidx.compose.runtime.Immutable public sealed interface AmbientState {
+    method public String getName();
+    method public default boolean isAmbient();
+    method public default boolean isInteractive();
+    property public default boolean isAmbient;
+    property public default boolean isInteractive;
+    property public abstract String name;
   }
 
   public static final class AmbientState.Ambient implements com.google.android.horologist.compose.ambient.AmbientState {
-    ctor public AmbientState.Ambient(optional androidx.wear.ambient.AmbientLifecycleObserver.AmbientDetails? ambientDetails);
-    method public androidx.wear.ambient.AmbientLifecycleObserver.AmbientDetails? component1();
-    method public com.google.android.horologist.compose.ambient.AmbientState.Ambient copy(androidx.wear.ambient.AmbientLifecycleObserver.AmbientDetails? ambientDetails);
-    method public androidx.wear.ambient.AmbientLifecycleObserver.AmbientDetails? getAmbientDetails();
-    property public final androidx.wear.ambient.AmbientLifecycleObserver.AmbientDetails? ambientDetails;
+    ctor public AmbientState.Ambient(optional boolean burnInProtectionRequired, optional boolean deviceHasLowBitAmbient, optional long updateTimeMillis);
+    method public boolean component1();
+    method public boolean component2();
+    method public long component3();
+    method public com.google.android.horologist.compose.ambient.AmbientState.Ambient copy(boolean burnInProtectionRequired, boolean deviceHasLowBitAmbient, long updateTimeMillis);
+    method public boolean getBurnInProtectionRequired();
+    method public boolean getDeviceHasLowBitAmbient();
+    method public String getName();
+    method public long getUpdateTimeMillis();
+    property public final boolean burnInProtectionRequired;
+    property public final boolean deviceHasLowBitAmbient;
+    property public String name;
+    property public final long updateTimeMillis;
+  }
+
+  public static final class AmbientState.Inactive implements com.google.android.horologist.compose.ambient.AmbientState {
+    method public String getName();
+    property public String name;
+    field public static final com.google.android.horologist.compose.ambient.AmbientState.Inactive INSTANCE;
   }
 
   public static final class AmbientState.Interactive implements com.google.android.horologist.compose.ambient.AmbientState {
+    method public String getName();
+    property public String name;
     field public static final com.google.android.horologist.compose.ambient.AmbientState.Interactive INSTANCE;
-  }
-
-  public final class AmbientStateUpdate {
-    ctor public AmbientStateUpdate(com.google.android.horologist.compose.ambient.AmbientState ambientState, optional long changeTimeMillis);
-    method public com.google.android.horologist.compose.ambient.AmbientState component1();
-    method public long component2();
-    method public com.google.android.horologist.compose.ambient.AmbientStateUpdate copy(com.google.android.horologist.compose.ambient.AmbientState ambientState, long changeTimeMillis);
-    method public com.google.android.horologist.compose.ambient.AmbientState getAmbientState();
-    method public long getChangeTimeMillis();
-    property public final com.google.android.horologist.compose.ambient.AmbientState ambientState;
-    property public final long changeTimeMillis;
   }
 
 }

--- a/compose-layout/api/current.api
+++ b/compose-layout/api/current.api
@@ -8,16 +8,16 @@ package com.google.android.horologist.compose.ambient {
   }
 
   public final class AmbientAwareTimeKt {
-    method @RequiresApi(android.os.Build.VERSION_CODES.O) @androidx.compose.runtime.Composable public static void AmbientAwareTime(com.google.android.horologist.compose.ambient.AmbientState stateUpdate, optional long updatePeriodMillis, kotlin.jvm.functions.Function2<? super java.time.ZonedDateTime,? super java.lang.Boolean,kotlin.Unit> block);
+    method @androidx.compose.runtime.Composable public static void AmbientAwareTime(com.google.android.horologist.compose.ambient.AmbientState stateUpdate, optional long updatePeriodMillis, kotlin.jvm.functions.Function2<? super java.time.ZonedDateTime,? super java.lang.Boolean,kotlin.Unit> block);
   }
 
   @androidx.compose.runtime.Immutable public sealed interface AmbientState {
-    method public String getName();
+    method public String getDisplayName();
     method public default boolean isAmbient();
     method public default boolean isInteractive();
+    property public abstract String displayName;
     property public default boolean isAmbient;
     property public default boolean isInteractive;
-    property public abstract String name;
   }
 
   public static final class AmbientState.Ambient implements com.google.android.horologist.compose.ambient.AmbientState {
@@ -28,23 +28,23 @@ package com.google.android.horologist.compose.ambient {
     method public com.google.android.horologist.compose.ambient.AmbientState.Ambient copy(boolean burnInProtectionRequired, boolean deviceHasLowBitAmbient, long updateTimeMillis);
     method public boolean getBurnInProtectionRequired();
     method public boolean getDeviceHasLowBitAmbient();
-    method public String getName();
+    method public String getDisplayName();
     method public long getUpdateTimeMillis();
     property public final boolean burnInProtectionRequired;
     property public final boolean deviceHasLowBitAmbient;
-    property public String name;
+    property public String displayName;
     property public final long updateTimeMillis;
   }
 
   public static final class AmbientState.Inactive implements com.google.android.horologist.compose.ambient.AmbientState {
-    method public String getName();
-    property public String name;
+    method public String getDisplayName();
+    property public String displayName;
     field public static final com.google.android.horologist.compose.ambient.AmbientState.Inactive INSTANCE;
   }
 
   public static final class AmbientState.Interactive implements com.google.android.horologist.compose.ambient.AmbientState {
-    method public String getName();
-    property public String name;
+    method public String getDisplayName();
+    property public String displayName;
     field public static final com.google.android.horologist.compose.ambient.AmbientState.Interactive INSTANCE;
   }
 

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
@@ -21,7 +21,6 @@ import android.content.Context
 import android.content.ContextWrapper
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -98,6 +97,18 @@ fun AmbientAware(
     }
 }
 
+/**
+ * AmbientState represents the current state of an ambient effect.
+ * It defaults to [AmbientState.Inactive] if no state is provided.
+ *
+ * @sample
+ * ```kotlin
+ * val state = LocalAmbientState.current
+ * if (state is AmbientState.Active) {
+ *   // Perform actions based on the active state
+ * }
+ * ```
+ */
 val LocalAmbientState = compositionLocalOf<AmbientState> { AmbientState.Inactive }
 
 private fun Context.findActivityOrNull(): Activity? {

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
@@ -31,7 +31,7 @@ import androidx.wear.ambient.AmbientLifecycleObserver
 
 /**
  * Composable for general handling of changes and updates to ambient status. A new
- * [AmbientAwareState] is generated with any change of ambient state, as well as with any periodic
+ * [AmbientState] is generated with any change of ambient state, as well as with any periodic
  * update generated whilst the screen is in ambient mode.
  *
  * This composable changes the behavior of the activity, enabling Always-On. See:
@@ -58,12 +58,10 @@ fun AmbientAware(
 
     val observer = remember {
         if (activity != null) {
-            println("Creating observer")
             AmbientLifecycleObserver(
                 activity,
                 object : AmbientLifecycleObserver.AmbientLifecycleCallback {
                     override fun onEnterAmbient(ambientDetails: AmbientLifecycleObserver.AmbientDetails) {
-                        println("onEnterAmbient")
                         ambientState.value = AmbientState.Ambient(
                             burnInProtectionRequired = ambientDetails.burnInProtectionRequired,
                             deviceHasLowBitAmbient = ambientDetails.deviceHasLowBitAmbient,
@@ -71,12 +69,10 @@ fun AmbientAware(
                     }
 
                     override fun onExitAmbient() {
-                        println("onExitAmbient")
                         ambientState.value = AmbientState.Interactive
                     }
 
                     override fun onUpdateAmbient() {
-                        println("onUpdateAmbient")
                         val lastAmbientDetails =
                             (ambientState.value as? AmbientState.Ambient)
                         ambientState.value = AmbientState.Ambient(
@@ -89,7 +85,6 @@ fun AmbientAware(
                 ambientState.value =
                     if (observer.isAmbient) AmbientState.Ambient() else AmbientState.Interactive
 
-                println("addObserver")
                 lifecycle.addObserver(observer)
             }
         } else {
@@ -98,9 +93,6 @@ fun AmbientAware(
     }
 
     val value = ambientState.value
-    SideEffect {
-        println("Side Effect $value")
-    }
     CompositionLocalProvider(LocalAmbientState provides value) {
         content(value)
     }

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAwareTime.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAwareTime.kt
@@ -22,9 +22,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import java.time.ZonedDateTime
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
+import java.time.ZonedDateTime
 
 /**
  * An example of using [AmbientAware]: Provides the time, at the specified update frequency, whilst

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAwareTime.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAwareTime.kt
@@ -61,7 +61,7 @@ import java.time.ZonedDateTime
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun AmbientAwareTime(
-    stateUpdate: AmbientStateUpdate,
+    stateUpdate: AmbientState,
     updatePeriodMillis: Long = 1000,
     block: @Composable (dateTime: ZonedDateTime, isAmbient: Boolean) -> Unit,
 ) {
@@ -75,7 +75,7 @@ fun AmbientAwareTime(
     }
 
     LaunchedEffect(stateUpdate) {
-        if (stateUpdate.ambientState == AmbientState.Interactive) {
+        if (stateUpdate.isInteractive) {
             while (isActive) {
                 isAmbient = false
                 currentTime = ZonedDateTime.now()

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAwareTime.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAwareTime.kt
@@ -16,17 +16,15 @@
 
 package com.google.android.horologist.compose.ambient
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import java.time.ZonedDateTime
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
-import java.time.ZonedDateTime
 
 /**
  * An example of using [AmbientAware]: Provides the time, at the specified update frequency, whilst
@@ -58,7 +56,6 @@ import java.time.ZonedDateTime
  * @param updatePeriodMillis The update period, whilst in interactive mode
  * @param block The developer-supplied composable for rendering the date and time.
  */
-@RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun AmbientAwareTime(
     stateUpdate: AmbientState,

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientState.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientState.kt
@@ -17,6 +17,7 @@
 package com.google.android.horologist.compose.ambient
 
 import androidx.compose.runtime.Immutable
+import androidx.wear.ambient.AmbientLifecycleObserver
 
 /**
  * Represent Ambient as updates, with the state and time of change. This is necessary to ensure that
@@ -25,25 +26,52 @@ import androidx.compose.runtime.Immutable
  */
 @Immutable
 sealed interface AmbientState {
-    val name: String
+    val displayName: String
 
+    /**
+     * Represents that the state of the device is is interactive, and the app is open and being used.
+     *
+     * This object is used to track whether the application is currently
+     * being interacted with by the user.
+     */
+    data object Interactive : AmbientState {
+        override val displayName: String
+            get() = "Interactive"
+    }
+
+    /**
+     * Represents the state of a device, that the app is in ambient mode and not actively updating
+     * the display.
+     *
+     * This class holds information about the ambient display properties, such as
+     * whether burn-in protection is required, if the device has low bit ambient display,
+     * and the last time the ambient state was updated.
+     *
+     * @see [AmbientLifecycleObserver.AmbientDetails]
+     * @property burnInProtectionRequired Indicates if burn-in protection is necessary for the device.
+     * Defaults to false.
+     * @property deviceHasLowBitAmbient Specifies if the device has a low bit ambient display.
+     * Defaults to false.
+     * @property updateTimeMillis The timestamp in milliseconds when the ambient state was last updated.
+     * Defaults to the current system time.
+     */
     data class Ambient(
         val burnInProtectionRequired: Boolean = false,
         val deviceHasLowBitAmbient: Boolean = false,
         val updateTimeMillis: Long = System.currentTimeMillis(),
     ) :
         AmbientState {
-            override val name: String
+            override val displayName: String
                 get() = "Ambient"
         }
 
-    data object Interactive : AmbientState {
-        override val name: String
-            get() = "Interactive"
-    }
-
+    /**
+     * Represents the state of a device, that the app isn't currently monitoring the ambient state.
+     *
+     * @property displayName A user-friendly name for this state, displayed as "Inactive".
+     */
     data object Inactive : AmbientState {
-        override val name: String
+        override val displayName: String
             get() = "Inactive"
     }
 

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientState.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientState.kt
@@ -16,31 +16,40 @@
 
 package com.google.android.horologist.compose.ambient
 
-import androidx.wear.ambient.AmbientLifecycleObserver
+import androidx.compose.runtime.Immutable
 
 /**
  * Represent Ambient as updates, with the state and time of change. This is necessary to ensure that
  * when the system provides a (typically) 1min-frequency callback to onUpdateAmbient, the developer
  * may wish to update composables, but the state hasn't changed.
  */
-data class AmbientStateUpdate(
-    val ambientState: AmbientState,
-    val changeTimeMillis: Long = System.currentTimeMillis(),
-) {
-    override fun toString(): String {
-        return "${ambientState.javaClass.simpleName}[$changeTimeMillis]"
+@Immutable
+sealed interface AmbientState {
+    val name: String
+
+    data class Ambient(
+        val burnInProtectionRequired: Boolean = false,
+        val deviceHasLowBitAmbient: Boolean = false,
+        val updateTimeMillis: Long = System.currentTimeMillis(),
+    ) :
+        AmbientState {
+            override val name: String
+                get() = "Ambient"
+        }
+
+    data object Interactive : AmbientState {
+        override val name: String
+            get() = "Interactive"
+    }
+
+    data object Inactive : AmbientState {
+        override val name: String
+            get() = "Inactive"
     }
 
     val isInteractive: Boolean
-        get() = ambientState is AmbientState.Interactive
+        get() = !isAmbient
 
     val isAmbient: Boolean
-        get() = ambientState is AmbientState.Ambient
-}
-
-sealed interface AmbientState {
-    data class Ambient(val ambientDetails: AmbientLifecycleObserver.AmbientDetails? = null) :
-        AmbientState
-
-    data object Interactive : AmbientState
+        get() = this is Ambient
 }

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientStateUpdate.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientStateUpdate.kt
@@ -26,11 +26,21 @@ import androidx.wear.ambient.AmbientLifecycleObserver
 data class AmbientStateUpdate(
     val ambientState: AmbientState,
     val changeTimeMillis: Long = System.currentTimeMillis(),
-)
+) {
+    override fun toString(): String {
+        return "${ambientState.javaClass.simpleName}[$changeTimeMillis]"
+    }
+
+    val isInteractive: Boolean
+        get() = ambientState is AmbientState.Interactive
+
+    val isAmbient: Boolean
+        get() = ambientState is AmbientState.Ambient
+}
 
 sealed interface AmbientState {
     data class Ambient(val ambientDetails: AmbientLifecycleObserver.AmbientDetails? = null) :
         AmbientState
 
-    object Interactive : AmbientState
+    data object Interactive : AmbientState
 }

--- a/docs/compose-layout.md
+++ b/docs/compose-layout.md
@@ -151,46 +151,28 @@ Box(
 `AmbientAware` allows your UI to react to ambient mode changes. For more information on how Ambient
 mode and Always-on work on Wear OS, see the [developer guidance][always-on].
 
-You should place this composable high up in your design, as it alters the behavior of the Activity.
+You should place this composable high up in your screen, but within navigation routes so that 
+different screens can handle ambient mode differently.
 
 ```kotlin
 @Composable
-fun WearApp() {
-    AmbientAware { ambientStateUpdate ->
-        when (val state = ambientStateUpdate.ambientState) {
-            is AmbientState.Ambient -> {
-                val ambientDetails = state.ambientDetails
-                val burnInProtectionRequired = ambientDetails?.burnInProtectionRequired
-                val deviceHasLowBitAmbient = ambientDetails?.deviceHasLowBitAmbient
-                // Device is in ambient (low power) mode
-            }
-            is AmbientState.Interactive -> {
-                // Device is in interactive (high power) mode
-            }
+fun MyScreen() {
+    AmbientAware { ambientState ->
+        if (ambientState.isAmbient) {
+            val ambientDetails = state.ambientDetails
+            val burnInProtectionRequired = ambientDetails?.burnInProtectionRequired
+            val deviceHasLowBitAmbient = ambientDetails?.deviceHasLowBitAmbient
+            // Device is in ambient (low power) mode
+        } else {
+            // Device is in interactive (high power) mode
         }
     }
 }
 ```
 
-If you need some screens to use always-on, and others not to, then you can use
-the additional argument supplied to `AmbientAware` to indicate whether a
-recomposition should be triggered when the system goes into ambient mode (i.e.
-whether the composable wants to handle ambient mode or not).
-
 For example, in a workout app, it is desirable that the main  workout screen uses always-on, but the
 workout summary at the end does not. See the [`ExerciseClient`][exercise-client]
 guide and [samples][health-samples] for more information on building a workout app.
-
-```kotlin
-@Composable
-fun WearApp() {
-    // Hoist state here for your current screen logic
-    
-    AmbientAware(isAlwaysOnScreen = currentScreen.useAlwaysOn) { ambientStateUpdate ->
-        // App Content here
-    }
-}
-```
 
 ## Download
 

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -106,6 +106,17 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name="com.google.android.horologist.ambient.AmbientAwareActivity"
+            android:exported="true"
+            android:label="Ambient"
+            android:taskAffinity=".ambient">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
         <service
             android:name=".tiles.ExampleTileService"
             android:description="@string/tile_description"

--- a/sample/src/main/java/com/google/android/horologist/ambient/AmbientAwareActivity.kt
+++ b/sample/src/main/java/com/google/android/horologist/ambient/AmbientAwareActivity.kt
@@ -75,8 +75,6 @@ class AmbientAwareActivity : ComponentActivity() {
 fun AmbientAwareWearApp() {
     val navController = rememberSwipeDismissableNavController()
 
-    navController.cu
-
     AppScaffold {
         Box(modifier = Modifier.fillMaxSize()) {
             SwipeDismissableNavHost(navController, Home) {
@@ -165,7 +163,7 @@ fun PreparingScreen(modifier: Modifier = Modifier, onStart: () -> Unit, onSettin
                     color = Color.Blue,
                 )
                 Text(
-                    ambientState.name,
+                    ambientState.displayName,
                     color = Color.Blue,
                 )
                 Button(onClick = onStart, imageVector = Icons.Rounded.PlayArrow, contentDescription = "Start")
@@ -224,7 +222,7 @@ internal fun Modifier.ambientGray(ambientState: AmbientState): Modifier =
 @Composable
 fun AmbientAwareTimeText(ambientState: AmbientState) {
     TimeText(endCurvedContent = {
-        curvedText(ambientState.name, color = Color.LightGray)
+        curvedText(ambientState.displayName, color = Color.LightGray)
     })
 }
 

--- a/sample/src/main/java/com/google/android/horologist/ambient/AmbientAwareActivity.kt
+++ b/sample/src/main/java/com/google/android/horologist/ambient/AmbientAwareActivity.kt
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.ambient
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Cancel
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.toRect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ColorMatrix
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.withSaveLayer
+import androidx.wear.compose.material.Text
+import androidx.wear.compose.material.TimeText
+import androidx.wear.compose.material.curvedText
+import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
+import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
+import com.google.android.horologist.compose.ambient.AmbientAware
+import com.google.android.horologist.compose.ambient.AmbientState
+import com.google.android.horologist.compose.layout.AppScaffold
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScreenScaffold
+import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
+import com.google.android.horologist.compose.material.Button
+import com.google.android.horologist.compose.material.Chip
+import com.google.android.horologist.compose.material.Title
+import com.google.android.horologist.compose.material.ToggleChip
+import com.google.android.horologist.compose.material.ToggleChipToggleControl
+import com.google.android.horologist.compose.nav.SwipeDismissableNavHost
+import com.google.android.horologist.compose.nav.composable
+import kotlinx.serialization.Serializable
+
+class AmbientAwareActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            AmbientAwareWearApp()
+        }
+    }
+}
+
+@Composable
+fun AmbientAwareWearApp() {
+    val navController = rememberSwipeDismissableNavController()
+
+    AppScaffold {
+        Box(modifier = Modifier.fillMaxSize()) {
+            SwipeDismissableNavHost(navController, Home) {
+                composable<Home> {
+                    HomeScreen(onRun = { navController.navigate(Preparing) }, onSettings = { navController.navigate(Settings) })
+                }
+                composable<Preparing> {
+                    PreparingScreen(onStart = { navController.navigate(Exercise) }, onSettings = { navController.navigate(Settings) })
+                }
+                composable<Exercise> {
+                    ExerciseScreen(onStop = { navController.navigate(Home) }, onSettings = { navController.navigate(Settings) })
+                }
+                composable<Settings> {
+                    SettingsScreen()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun HomeScreen(modifier: Modifier = Modifier, onRun: () -> Unit, onSettings: () -> Unit) {
+    val columnState = rememberResponsiveColumnState()
+    ScreenScaffold(modifier = modifier, scrollState = columnState) {
+        ScalingLazyColumn(columnState = columnState) {
+            item {
+                Title("Home")
+            }
+            item {
+                Chip(
+                    label = "Run",
+                    onClick = onRun,
+                )
+            }
+            item {
+                Chip(
+                    label = "Settings",
+                    onClick = onSettings,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun ExerciseScreen(modifier: Modifier = Modifier, onStop: () -> Unit, onSettings: () -> Unit) {
+    AmbientAware { ambientState ->
+        if (ambientState.isInteractive) {
+            ScreenScaffold(modifier = modifier, timeText = {
+                if (ambientState.isInteractive) {
+                    AmbientAwareTimeText(ambientState)
+                }
+            }) {
+                Box(modifier = modifier.fillMaxSize()) {
+                    Column(
+                        modifier = Modifier.fillMaxSize(),
+                        verticalArrangement = Arrangement.Center,
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Text(
+                            "Exercise",
+                            color = Color.Green,
+                        )
+                        Button(onClick = onStop, imageVector = Icons.Rounded.Cancel, contentDescription = "Cancel")
+                        Button(onClick = onSettings, imageVector = Icons.Rounded.Settings, contentDescription = "Settings")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun PreparingScreen(modifier: Modifier = Modifier, onStart: () -> Unit, onSettings: () -> Unit) {
+    AmbientAware { ambientState ->
+        ScreenScaffold(modifier = modifier.ambientGray(ambientState), timeText = {
+            AmbientAwareTimeText(ambientState)
+        }) {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    "Preparing",
+                    color = Color.Blue,
+                )
+                Text(
+                    ambientState.name,
+                    color = Color.Blue,
+                )
+                Button(onClick = onStart, imageVector = Icons.Rounded.PlayArrow, contentDescription = "Start")
+                Button(onClick = onSettings, imageVector = Icons.Rounded.Settings, contentDescription = "Settings")
+            }
+        }
+    }
+}
+
+@Composable
+fun SettingsScreen(modifier: Modifier = Modifier) {
+    val columnState = rememberResponsiveColumnState()
+    ScreenScaffold(modifier = modifier, scrollState = columnState) {
+        ScalingLazyColumn(columnState = columnState) {
+            item {
+                Title("Settings")
+            }
+            items(5) {
+                val toggled = remember { mutableStateOf(false) }
+                ToggleChip(
+                    checked = false,
+                    label = "Item $it",
+                    onCheckedChanged = { toggled.value = !toggled.value },
+                    toggleControl = ToggleChipToggleControl.Switch,
+                )
+            }
+        }
+    }
+}
+
+private val grayscale = Paint().apply {
+    colorFilter = ColorFilter.colorMatrix(
+        ColorMatrix().apply {
+            setToSaturation(0f)
+        },
+    )
+    isAntiAlias = false
+}
+
+internal fun Modifier.ambientGray(ambientState: AmbientState): Modifier =
+    if (ambientState.isAmbient) {
+        graphicsLayer {
+            scaleX = 0.9f
+            scaleY = 0.9f
+        }.drawWithContent {
+            drawIntoCanvas {
+                it.withSaveLayer(size.toRect(), grayscale) {
+                    drawContent()
+                }
+            }
+        }
+    } else {
+        this
+    }
+
+@Composable
+fun AmbientAwareTimeText(ambientState: AmbientState) {
+    TimeText(endCurvedContent = {
+        curvedText(ambientState.name, color = Color.LightGray)
+    })
+}
+
+@Serializable
+object Home
+
+@Serializable
+object Preparing
+
+@Serializable
+object Exercise
+
+@Serializable
+object Settings
+
+@WearPreviewLargeRound
+@Composable
+fun WearAppPreview() {
+    AmbientAwareWearApp()
+}

--- a/sample/src/main/java/com/google/android/horologist/ambient/AmbientAwareActivity.kt
+++ b/sample/src/main/java/com/google/android/horologist/ambient/AmbientAwareActivity.kt
@@ -75,6 +75,8 @@ class AmbientAwareActivity : ComponentActivity() {
 fun AmbientAwareWearApp() {
     val navController = rememberSwipeDismissableNavController()
 
+    navController.cu
+
     AppScaffold {
         Box(modifier = Modifier.fillMaxSize()) {
             SwipeDismissableNavHost(navController, Home) {

--- a/sample/src/main/java/com/google/android/horologist/scratch/ScratchActivity.kt
+++ b/sample/src/main/java/com/google/android/horologist/scratch/ScratchActivity.kt
@@ -19,8 +19,33 @@ package com.google.android.horologist.scratch
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.State
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.toRect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ColorMatrix
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.withSaveLayer
+import androidx.wear.compose.material.Text
+import androidx.wear.compose.material.TimeText
+import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
+import com.google.android.horologist.compose.ambient.AmbientAware
+import com.google.android.horologist.compose.ambient.AmbientStateUpdate
+import com.google.android.horologist.compose.layout.AppScaffold
+import com.google.android.horologist.compose.layout.ScreenScaffold
+import com.google.android.horologist.compose.nav.SwipeDismissableNavHost
+import com.google.android.horologist.compose.nav.composable
+import kotlinx.serialization.Serializable
 
 class ScratchActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -34,7 +59,84 @@ class ScratchActivity : ComponentActivity() {
 
 @Composable
 fun WearApp() {
+    val navController = rememberSwipeDismissableNavController()
+    AmbientAware { update ->
+        AppScaffold(timeText = {
+            if (update.value.isInteractive) {
+                TimeText()
+            }
+        }) {
+            SideEffect {
+                println("App - Ambient state update: $update")
+            }
+
+            Box(modifier = Modifier.fillMaxSize()) {
+                SwipeDismissableNavHost(navController, Preparing) {
+                    composable<Preparing> {
+                        PreparingScreen(update, modifier = Modifier.ambientGray(update))
+                    }
+                    composable<Exercise> {
+                        ExerciseScreen(update, modifier = Modifier.ambientGray(update))
+                    }
+                }
+            }
+        }
+    }
 }
+
+private val grayscale = Paint().apply {
+    colorFilter = ColorFilter.colorMatrix(
+        ColorMatrix().apply {
+            setToSaturation(0.5f)
+        },
+    )
+    isAntiAlias = false
+}
+
+internal fun Modifier.ambientGray(ambientState: State<AmbientStateUpdate>): Modifier =
+    if (ambientState.value.isAmbient) {
+        graphicsLayer {
+            scaleX = 0.9f
+            scaleY = 0.9f
+        }.drawWithContent {
+            drawIntoCanvas {
+                it.withSaveLayer(size.toRect(), grayscale) {
+                    drawContent()
+                }
+            }
+        }
+    } else {
+        this
+    }
+
+@Composable
+fun ExerciseScreen(ambientState: State<AmbientStateUpdate>, modifier: Modifier = Modifier) {
+    ScreenScaffold {
+    }
+}
+
+@Composable
+fun PreparingScreen(update: State<AmbientStateUpdate>, modifier: Modifier = Modifier) {
+    SideEffect {
+        println("PreparingScreen - Ambient state update: $update")
+    }
+
+    ScreenScaffold {
+        Box(modifier = modifier.fillMaxSize()) {
+            Text(
+                "Preparing: ${update.value}",
+                color = Color.Blue,
+                modifier = Modifier.align(Alignment.Center),
+            )
+        }
+    }
+}
+
+@Serializable
+object Preparing
+
+@Serializable
+object Exercise
 
 @WearPreviewLargeRound
 @Composable

--- a/sample/src/main/java/com/google/android/horologist/scratch/ScratchActivity.kt
+++ b/sample/src/main/java/com/google/android/horologist/scratch/ScratchActivity.kt
@@ -19,33 +19,8 @@ package com.google.android.horologist.scratch
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.State
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.geometry.toRect
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.ColorMatrix
-import androidx.compose.ui.graphics.Paint
-import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.withSaveLayer
-import androidx.wear.compose.material.Text
-import androidx.wear.compose.material.TimeText
-import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
-import com.google.android.horologist.compose.ambient.AmbientAware
-import com.google.android.horologist.compose.ambient.AmbientStateUpdate
-import com.google.android.horologist.compose.layout.AppScaffold
-import com.google.android.horologist.compose.layout.ScreenScaffold
-import com.google.android.horologist.compose.nav.SwipeDismissableNavHost
-import com.google.android.horologist.compose.nav.composable
-import kotlinx.serialization.Serializable
 
 class ScratchActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -59,84 +34,7 @@ class ScratchActivity : ComponentActivity() {
 
 @Composable
 fun WearApp() {
-    val navController = rememberSwipeDismissableNavController()
-    AmbientAware { update ->
-        AppScaffold(timeText = {
-            if (update.value.isInteractive) {
-                TimeText()
-            }
-        }) {
-            SideEffect {
-                println("App - Ambient state update: $update")
-            }
-
-            Box(modifier = Modifier.fillMaxSize()) {
-                SwipeDismissableNavHost(navController, Preparing) {
-                    composable<Preparing> {
-                        PreparingScreen(update, modifier = Modifier.ambientGray(update))
-                    }
-                    composable<Exercise> {
-                        ExerciseScreen(update, modifier = Modifier.ambientGray(update))
-                    }
-                }
-            }
-        }
-    }
 }
-
-private val grayscale = Paint().apply {
-    colorFilter = ColorFilter.colorMatrix(
-        ColorMatrix().apply {
-            setToSaturation(0.5f)
-        },
-    )
-    isAntiAlias = false
-}
-
-internal fun Modifier.ambientGray(ambientState: State<AmbientStateUpdate>): Modifier =
-    if (ambientState.value.isAmbient) {
-        graphicsLayer {
-            scaleX = 0.9f
-            scaleY = 0.9f
-        }.drawWithContent {
-            drawIntoCanvas {
-                it.withSaveLayer(size.toRect(), grayscale) {
-                    drawContent()
-                }
-            }
-        }
-    } else {
-        this
-    }
-
-@Composable
-fun ExerciseScreen(ambientState: State<AmbientStateUpdate>, modifier: Modifier = Modifier) {
-    ScreenScaffold {
-    }
-}
-
-@Composable
-fun PreparingScreen(update: State<AmbientStateUpdate>, modifier: Modifier = Modifier) {
-    SideEffect {
-        println("PreparingScreen - Ambient state update: $update")
-    }
-
-    ScreenScaffold {
-        Box(modifier = modifier.fillMaxSize()) {
-            Text(
-                "Preparing: ${update.value}",
-                color = Color.Blue,
-                modifier = Modifier.align(Alignment.Center),
-            )
-        }
-    }
-}
-
-@Serializable
-object Preparing
-
-@Serializable
-object Exercise
 
 @WearPreviewLargeRound
 @Composable


### PR DESCRIPTION
#### WHAT

This change refactors the `AmbientAware` API to make it more intuitive and easier to use.

The following changes were made:

- The `AmbientAware` composable moves to the screen level
- The `AmbientStateUpdate` class was merged into `AmbientState`.
- The `AmbientState` sealed interface now has a data object `Interactive` and a data class `Ambient` to store AmbientDetails, as well as Inactive.

#### WHY


#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
