### PR TITLE
Fix: Handle missing AmbientLifecycleObserver in Robolectric

### DIFF
--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
@@ -64,7 +64,7 @@ fun AmbientAware(
 @Composable
 private fun rememberAmbientState(
     activity: Activity?,
-    lifecycle: Lifecycle
+    lifecycle: Lifecycle,
 ): State<AmbientState> {
     val ambientState = remember {
         mutableStateOf<AmbientState>(AmbientState.Inactive)
@@ -84,7 +84,7 @@ private fun rememberAmbientState(
 private fun createObserver(
     activity: Activity,
     ambientState: MutableState<AmbientState>,
-    lifecycle: Lifecycle
+    lifecycle: Lifecycle,
 ): AmbientLifecycleObserver? {
     return try {
         AmbientLifecycleObserver(


### PR DESCRIPTION
#### WHAT

Handles missing AmbientLifecycleObserver in Robolectric tests by catching NoClassDefFoundError and returning null instead of crashing. This allows ambient-aware composables to be tested in Robolectric without requiring a real device or emulator.

#### WHY


#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
