### PR TITLE
Moves modifier to the scaffold instead of the pager component.

### DIFF
--- a/compose-layout/api/current.api
+++ b/compose-layout/api/current.api
@@ -249,7 +249,7 @@ package com.google.android.horologist.compose.pager {
   }
 
   public final class PagerScreenKt {
-    method @androidx.compose.runtime.Composable public static void PagerScreen(androidx.wear.compose.foundation.pager.PagerState state, optional androidx.compose.ui.Modifier modifier, optional int beyondViewportPageCount, optional boolean userScrollEnabled, optional boolean reverseLayout, optional kotlin.jvm.functions.Function1<? super java.lang.Integer,?>? key, optional androidx.compose.ui.input.nestedscroll.NestedScrollConnection pageNestedScrollConnection, kotlin.jvm.functions.Function1<? super java.lang.Integer,kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable public static void PagerScreen(androidx.wear.compose.foundation.pager.PagerState state, optional androidx.compose.ui.Modifier modifier, optional int beyondViewportPageCount, optional boolean userScrollEnabled, optional boolean reverseLayout, optional kotlin.jvm.functions.Function1<? super java.lang.Integer,?>? key, kotlin.jvm.functions.Function1<? super java.lang.Integer,kotlin.Unit> content);
   }
 
   public final class VerticalPageIndicatorKt {

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/pager/PagerScreen.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/pager/PagerScreen.kt
@@ -19,10 +19,8 @@
 package com.google.android.horologist.compose.pager
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.pager.PagerDefaults
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -31,7 +29,6 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
 import androidx.wear.compose.foundation.HierarchicalFocusCoordinator

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/pager/PagerScreen.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/pager/PagerScreen.kt
@@ -55,18 +55,13 @@ public fun PagerScreen(
     userScrollEnabled: Boolean = true,
     reverseLayout: Boolean = false,
     key: ((index: Int) -> Any)? = null,
-    pageNestedScrollConnection: NestedScrollConnection = PagerDefaults.pageNestedScrollConnection(
-        state,
-        Orientation.Horizontal,
-    ),
     content: @Composable (Int) -> Unit,
 ) {
     PagerScaffold(
-        modifier = Modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize(),
         pagerState = state,
     ) {
         HorizontalPager(
-            modifier = modifier,
             state = state,
             beyondViewportPageCount = beyondViewportPageCount,
             userScrollEnabled = userScrollEnabled,


### PR DESCRIPTION
#### WHAT

Also the `pageNestedScrollConnection` parameter was redundant and has been removed from `PagerScreen`.

#### WHY


#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
