### PR TITLE
 Add lifecycle parameter to AmbientAware

### DIFF
--- a/compose-layout/api/current.api
+++ b/compose-layout/api/current.api
@@ -2,7 +2,7 @@
 package com.google.android.horologist.compose.ambient {
 
   public final class AmbientAwareKt {
-    method @androidx.compose.runtime.Composable public static void AmbientAware(kotlin.jvm.functions.Function1<? super com.google.android.horologist.compose.ambient.AmbientState,kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable public static void AmbientAware(optional androidx.lifecycle.Lifecycle lifecycle, kotlin.jvm.functions.Function1<? super com.google.android.horologist.compose.ambient.AmbientState,kotlin.Unit> content);
     method public static androidx.compose.runtime.ProvidableCompositionLocal<com.google.android.horologist.compose.ambient.AmbientState> getLocalAmbientState();
     property public static final androidx.compose.runtime.ProvidableCompositionLocal<com.google.android.horologist.compose.ambient.AmbientState> LocalAmbientState;
   }

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
@@ -28,7 +28,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.wear.ambient.AmbientLifecycleObserver
 

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/ambient/AmbientAware.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.wear.ambient.AmbientLifecycleObserver
 
@@ -42,17 +43,18 @@ import androidx.wear.ambient.AmbientLifecycleObserver
  *
  * It should be used within each individual screen inside nav routes.
  *
+ * @param lifecycle The [Lifecycle] of the activity or current owner such as NavBackStackEntry.
  * @param content Lambda that will be used for building the UI, which is passed the current ambient
  * state.
  */
 @Composable
 fun AmbientAware(
+    lifecycle: Lifecycle = LocalLifecycleOwner.current.lifecycle,
     content: @Composable (AmbientState) -> Unit,
 ) {
     // Using AmbientAware correctly relies on there being an Activity context. If there isn't, then
     // gracefully allow the composition of [block], but no ambient-mode functionality is enabled.
     val activity = LocalContext.current.findActivityOrNull()
-    val lifecycle = LocalLifecycleOwner.current.lifecycle
 
     val ambientState = rememberAmbientState(activity, lifecycle)
 


### PR DESCRIPTION
#### WHAT

This change adds an optional `lifecycle` parameter to the `AmbientAware` composable function, allowing developers to specify a custom lifecycle instead of relying on the `LocalLifecycleOwner`.

This provides more flexibility when using `AmbientAware` in different contexts, such as within individual screens in navigation routes. If not specified, it defaults to the current `LocalLifecycleOwner`'s lifecycle.


#### WHY


#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
