### PR TITLE
Modify MediaUiModel and AudioOutput to support remote media output an…

### DIFF
--- a/media/audio/api/current.api
+++ b/media/audio/api/current.api
@@ -3,16 +3,19 @@ package com.google.android.horologist.audio {
 
   public interface AudioOutput {
     method public String getId();
+    method public default Integer? getMediaRouteType();
     method public String getName();
     method public default String getType();
     method public boolean isPlayable();
     property public abstract String id;
     property public abstract boolean isPlayable;
+    property public default Integer? mediaRouteType;
     property public abstract String name;
     property public default String type;
     field public static final com.google.android.horologist.audio.AudioOutput.Companion Companion;
     field public static final String TYPE_HEADPHONES = "headphones";
     field public static final String TYPE_NONE = "none";
+    field public static final String TYPE_REMOTE = "remote";
     field public static final String TYPE_WATCH = "watch";
   }
 
@@ -34,6 +37,7 @@ package com.google.android.horologist.audio {
   public static final class AudioOutput.Companion {
     field public static final String TYPE_HEADPHONES = "headphones";
     field public static final String TYPE_NONE = "none";
+    field public static final String TYPE_REMOTE = "remote";
     field public static final String TYPE_WATCH = "watch";
   }
 
@@ -46,6 +50,24 @@ package com.google.android.horologist.audio {
     property public String name;
     property public String type;
     field public static final com.google.android.horologist.audio.AudioOutput.None INSTANCE;
+  }
+
+  public static final class AudioOutput.Remote implements com.google.android.horologist.audio.AudioOutput {
+    ctor public AudioOutput.Remote(String id, String name, int mediaRouteType, optional boolean isPlayable);
+    method public String component1();
+    method public String component2();
+    method public int component3();
+    method public boolean component4();
+    method public com.google.android.horologist.audio.AudioOutput.Remote copy(String id, String name, int mediaRouteType, boolean isPlayable);
+    method public String getId();
+    method public int getMediaRouteType();
+    method public String getName();
+    method public boolean isPlayable();
+    property public String id;
+    property public boolean isPlayable;
+    property public int mediaRouteType;
+    property public String name;
+    property public String type;
   }
 
   public static final class AudioOutput.Unknown implements com.google.android.horologist.audio.AudioOutput {

--- a/media/audio/src/main/java/com/google/android/horologist/audio/AudioOutput.kt
+++ b/media/audio/src/main/java/com/google/android/horologist/audio/AudioOutput.kt
@@ -16,6 +16,8 @@
 
 package com.google.android.horologist.audio
 
+import android.media.MediaRoute2Info
+
 /**
  * A device capable of playing audio.
  *
@@ -33,12 +35,19 @@ public interface AudioOutput {
     public val name: String
 
     /**
+     * Whether the audio output has ability to play media.
+     */
+    public val isPlayable: Boolean
+
+    /**
      * Optional type of output which may be associated with an icon or displayed name.
      */
     public val type: String
         get() = ""
 
-    public val isPlayable: Boolean
+    /** Optional [MediaRoute2Info.getType] associated. */
+    public val mediaRouteType: Int?
+        get() = null
 
     /**
      * No current device.
@@ -73,6 +82,18 @@ public interface AudioOutput {
     }
 
     /**
+     * The media output connected to the paired phone on which media is currently playing.
+     */
+    public data class Remote(
+        override val id: String,
+        override val name: String,
+        override val mediaRouteType: Int,
+        override val isPlayable: Boolean = true,
+    ) : AudioOutput {
+        override val type: String = TYPE_REMOTE
+    }
+
+    /**
      * An unknown audio output device
      */
     public data class Unknown(
@@ -84,6 +105,7 @@ public interface AudioOutput {
     public companion object {
         public const val TYPE_WATCH: String = "watch"
         public const val TYPE_HEADPHONES: String = "headphones"
+        public const val TYPE_REMOTE: String = "remote"
         public const val TYPE_NONE: String = "none"
     }
 }

--- a/media/ui-model/api/current.api
+++ b/media/ui-model/api/current.api
@@ -270,26 +270,32 @@ package com.google.android.horologist.media.ui.state.model {
   }
 
   public static final class MediaUiModel.Ready extends com.google.android.horologist.media.ui.state.model.MediaUiModel {
-    ctor public MediaUiModel.Ready(String id, String title, optional String subtitle, optional String? clientPackageName, optional com.google.android.horologist.images.base.paintable.Paintable? artwork, optional androidx.compose.ui.graphics.Color? artworkColor, optional com.google.android.horologist.images.base.paintable.Paintable? titleIcon);
+    ctor public MediaUiModel.Ready(String id, String title, optional String subtitle, optional String? clientPackageName, optional com.google.android.horologist.images.base.paintable.Paintable? artwork, optional androidx.compose.ui.graphics.Color? artworkColor, optional androidx.compose.ui.graphics.Color? artworkColorSeed, optional com.google.android.horologist.images.base.paintable.Paintable? titleIcon, optional com.google.android.horologist.audio.AudioOutput? selectedAudioOutput);
     method public String component1();
     method public String component2();
     method public String component3();
     method public String? component4();
     method public com.google.android.horologist.images.base.paintable.Paintable? component5();
     method public androidx.compose.ui.graphics.Color? component6-QN2ZGVo();
-    method public com.google.android.horologist.images.base.paintable.Paintable? component7();
-    method public com.google.android.horologist.media.ui.state.model.MediaUiModel.Ready copy-lMAxDYE(String id, String title, String subtitle, String? clientPackageName, com.google.android.horologist.images.base.paintable.Paintable? artwork, androidx.compose.ui.graphics.Color? artworkColor, com.google.android.horologist.images.base.paintable.Paintable? titleIcon);
+    method public androidx.compose.ui.graphics.Color? component7-QN2ZGVo();
+    method public com.google.android.horologist.images.base.paintable.Paintable? component8();
+    method public com.google.android.horologist.audio.AudioOutput? component9();
+    method public com.google.android.horologist.media.ui.state.model.MediaUiModel.Ready copy-pnjrP7c(String id, String title, String subtitle, String? clientPackageName, com.google.android.horologist.images.base.paintable.Paintable? artwork, androidx.compose.ui.graphics.Color? artworkColor, androidx.compose.ui.graphics.Color? artworkColorSeed, com.google.android.horologist.images.base.paintable.Paintable? titleIcon, com.google.android.horologist.audio.AudioOutput? selectedAudioOutput);
     method public com.google.android.horologist.images.base.paintable.Paintable? getArtwork();
     method public androidx.compose.ui.graphics.Color? getArtworkColor();
+    method public androidx.compose.ui.graphics.Color? getArtworkColorSeed();
     method public String? getClientPackageName();
     method public String getId();
+    method public com.google.android.horologist.audio.AudioOutput? getSelectedAudioOutput();
     method public String getSubtitle();
     method public String getTitle();
     method public com.google.android.horologist.images.base.paintable.Paintable? getTitleIcon();
     property public final com.google.android.horologist.images.base.paintable.Paintable? artwork;
     property public final androidx.compose.ui.graphics.Color? artworkColor;
+    property public final androidx.compose.ui.graphics.Color? artworkColorSeed;
     property public final String? clientPackageName;
     property public final String id;
+    property public final com.google.android.horologist.audio.AudioOutput? selectedAudioOutput;
     property public final String subtitle;
     property public final String title;
     property public final com.google.android.horologist.images.base.paintable.Paintable? titleIcon;

--- a/media/ui-model/build.gradle.kts
+++ b/media/ui-model/build.gradle.kts
@@ -105,7 +105,7 @@ dependencies {
     api(libs.wearcompose.material)
     implementation(projects.images.coil)
     implementation(libs.androidx.lifecycle.viewmodelktx)
-  implementation(project(":media:audio"))
+    implementation(project(":media:audio"))
 
     testImplementation(libs.androidx.test.ext.ktx)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/media/ui-model/build.gradle.kts
+++ b/media/ui-model/build.gradle.kts
@@ -105,6 +105,7 @@ dependencies {
     api(libs.wearcompose.material)
     implementation(projects.images.coil)
     implementation(libs.androidx.lifecycle.viewmodelktx)
+  implementation(project(":media:audio"))
 
     testImplementation(libs.androidx.test.ext.ktx)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/media/ui-model/src/main/java/com/google/android/horologist/media/ui/state/model/MediaUiModel.kt
+++ b/media/ui-model/src/main/java/com/google/android/horologist/media/ui/state/model/MediaUiModel.kt
@@ -18,10 +18,26 @@ package com.google.android.horologist.media.ui.state.model
 
 import androidx.compose.ui.graphics.Color
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.audio.AudioOutput
 import com.google.android.horologist.images.base.paintable.Paintable
 
 @ExperimentalHorologistApi
+/** A sealed class representing the UI state of a media item. */
 public sealed class MediaUiModel {
+
+    /**
+     * Represents the UI state when media data is available.
+     *
+     * @param id The unique identifier of the media item.
+     * @param title The title of the media item.
+     * @param subtitle The subtitle of the media item (optional).
+     * @param artwork The artwork to display for the media item (optional).
+     * @param artworkColor The primary color to use for the artwork background (optional).
+     * @param artworkColorSeed The seed color to use for generating the artwork color pallet
+     *   (optional).
+     * @param titleIcon An icon to display next to the title (optional).
+     * @param selectedAudioOutput The audio output on which the media is currently playing (optional).
+     */
     public data class Ready(
         val id: String,
         val title: String,
@@ -29,7 +45,9 @@ public sealed class MediaUiModel {
         val clientPackageName: String? = null,
         val artwork: Paintable? = null,
         val artworkColor: Color? = null,
+        val artworkColorSeed: Color? = null,
         val titleIcon: Paintable? = null,
+        val selectedAudioOutput: AudioOutput? = null,
     ) : MediaUiModel()
     public object Loading : MediaUiModel()
 }

--- a/media/ui-model/src/main/java/com/google/android/horologist/media/ui/state/model/MediaUiModel.kt
+++ b/media/ui-model/src/main/java/com/google/android/horologist/media/ui/state/model/MediaUiModel.kt
@@ -33,7 +33,7 @@ public sealed class MediaUiModel {
      * @param subtitle The subtitle of the media item (optional).
      * @param artwork The artwork to display for the media item (optional).
      * @param artworkColor The primary color to use for the artwork background (optional).
-     * @param artworkColorSeed The seed color to use for generating the artwork color pallet
+     * @param artworkColorSeed The seed color to use for generating the artwork color palette
      *   (optional).
      * @param titleIcon An icon to display next to the title (optional).
      * @param selectedAudioOutput The audio output on which the media is currently playing (optional).


### PR DESCRIPTION
Modify MediaUiModel and AudioOutput to support remote media output and artwork seed color.

#### WHAT
The `MediaUiModel` data class now includes properties for the currently selected media output and artwork color seed. The `AudioOutput` interface now uses the Android Media Router type for the represented media route. An AudioOutput implementation for remote media output has also been added.


#### WHY
The `MediaUiModel`'s added properties will help build the related UI. The provision for `MediaRoute2Info.getType` in the AudioOutput will aid in recognizing the different types of media output supported by the Android Media Router.

#### HOW
The modifications are directly made in the MediaUiModel and AudioOutput classes.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
