### PR TITLE
Add an Unknown VolumeUiState

### DIFF
--- a/media/audio-ui-model/src/main/java/com/google/android/horologist/audio/ui/VolumeUiState.kt
+++ b/media/audio-ui-model/src/main/java/com/google/android/horologist/audio/ui/VolumeUiState.kt
@@ -30,4 +30,8 @@ public data class VolumeUiState(
 
     public val isMin: Boolean
         get() = current == min
+
+    companion object {
+        val UNKNOWN = VolumeUiState(current = -1, max = -1, min = -1)
+    }
 }

--- a/media/audio-ui-model/src/main/java/com/google/android/horologist/audio/ui/VolumeUiState.kt
+++ b/media/audio-ui-model/src/main/java/com/google/android/horologist/audio/ui/VolumeUiState.kt
@@ -31,7 +31,7 @@ public data class VolumeUiState(
     public val isMin: Boolean
         get() = current == min
 
-    companion object {
-        val Unknown = VolumeUiState(current = -1, max = -1, min = -1)
+    public companion object {
+        public val Unknown: VolumeUiState = VolumeUiState(current = -1, max = -1, min = -1)
     }
 }

--- a/media/audio-ui-model/src/main/java/com/google/android/horologist/audio/ui/VolumeUiState.kt
+++ b/media/audio-ui-model/src/main/java/com/google/android/horologist/audio/ui/VolumeUiState.kt
@@ -32,6 +32,6 @@ public data class VolumeUiState(
         get() = current == min
 
     companion object {
-        val UNKNOWN = VolumeUiState(current = -1, max = -1, min = -1)
+        val Unknown = VolumeUiState(current = -1, max = -1, min = -1)
     }
 }


### PR DESCRIPTION
#### WHAT
Add an UNKNOWN companion object for volume ui state.

#### WHY
So we can explicitly set an UNKNOWN one (different from default).

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
