### PR TITLE
Update oss-licenses-android to v0.7.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,6 @@ import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 import com.vanniktech.maven.publish.JavaLibrary
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.SonatypeHost
-import java.net.URI
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.net.URL
 import java.util.Properties
@@ -100,12 +99,6 @@ allprojects {
         val composeSnapshot = rootProject.libs.versions.composesnapshot.get()
         if (composeSnapshot.length > 1) {
             maven(url = uri("https://androidx.dev/snapshots/builds/$composeSnapshot/artifacts/repository/"))
-        }
-        maven {
-            url = URI("https://jitpack.io")
-            content {
-                includeGroup("com.github.droibit.oss-licenses-android")
-            }
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ com-squareup-okhttp3 = "5.0.0-alpha.14"
 com-squareup-retrofit2 = "2.11.0"
 compose-material3 = "1.3.1"
 ossLicensesPlugin = "0.10.6"
-osslicenses = "0.5.0"
+osslicenses = "0.7.0"
 playServicesOssLicenses = "17.1.0"
 wearComposeMaterial3 = "1.0.0-alpha32"
 composesnapshot = "-"
@@ -202,8 +202,7 @@ moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", ver
 okhttp-coroutines = { module = "com.squareup.okhttp3:okhttp-coroutines", version.ref = "com-squareup-okhttp3" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 oss-licenses-plugin = { module = "com.google.android.gms:oss-licenses-plugin", version.ref = "ossLicensesPlugin" }
-osslicenses-parser = { module = "com.github.droibit.oss-licenses-android:parser", version.ref = "osslicenses" }
-osslicenses-wear-compose = { module = "com.github.droibit.oss-licenses-android:ui-wear-compose", version.ref = "osslicenses" }
+osslicenses-wear-compose-material = { module = "io.github.droibit.oss-licenses-android:ui-wear-compose-material", version.ref = "osslicenses" }
 play-services-oss-licenses = { module = "com.google.android.gms:play-services-oss-licenses", version.ref = "playServicesOssLicenses" }
 playservices-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "playServicesAuth" }
 playservices-base = "com.google.android.gms:play-services-base:18.5.0"

--- a/media/sample/build.gradle.kts
+++ b/media/sample/build.gradle.kts
@@ -248,8 +248,7 @@ dependencies {
     implementation(libs.playservices.auth)
     implementation(libs.kotlinx.coroutines.playservices)
 
-    implementation(libs.osslicenses.parser)
-    implementation(libs.osslicenses.wear.compose)
+    implementation(libs.osslicenses.wear.compose.material)
 
     add("benchmarkImplementation", libs.androidx.runtime.tracing)
 

--- a/media/sample/src/main/AndroidManifest.xml
+++ b/media/sample/src/main/AndroidManifest.xml
@@ -135,9 +135,7 @@
 
         <activity
             android:name="com.github.droibit.oss_licenses.ui.wear.compose.material.WearableOssLicensesActivity"
-            android:label="@string/show_licenses"
-            tools:node="merge">
-        </activity>
+            android:label="@string/show_licenses" />
     </application>
 
     <uses-sdk

--- a/media/sample/src/main/AndroidManifest.xml
+++ b/media/sample/src/main/AndroidManifest.xml
@@ -132,10 +132,6 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </service>
-
-        <activity
-            android:name="com.github.droibit.oss_licenses.ui.wear.compose.material.WearableOssLicensesActivity"
-            android:label="@string/show_licenses" />
     </application>
 
     <uses-sdk

--- a/media/sample/src/main/AndroidManifest.xml
+++ b/media/sample/src/main/AndroidManifest.xml
@@ -134,16 +134,9 @@
         </service>
 
         <activity
-            android:name="com.github.droibit.oss_licenses.ui.wear.compose.WearableOssLicensesActivity"
-            android:exported="true"
+            android:name="com.github.droibit.oss_licenses.ui.wear.compose.material.WearableOssLicensesActivity"
             android:label="@string/show_licenses"
-            android:taskAffinity=".licenses"
-            android:theme="@android:style/Theme.DeviceDefault"
-            tools:node="replace">
-            <intent-filter>
-                <action android:name="com.google.wear.ACTION_SHOW_LICENSE" />
-                <category android:name="android.intent.category.DEFAULT" />
-            </intent-filter>
+            tools:node="merge">
         </activity>
     </application>
 


### PR DESCRIPTION
#### WHAT

Updated the dependency oss-licenses-android to the latest version [v0.7.0](https://github.com/droibit/oss-licenses-android/releases/tag/0.7.0).

This update includes switching the library distribution from JitPack to Maven Central, which resolves the following issue:
- https://github.com/droibit/oss-licenses-android/issues/128

#### WHY

Due to the above changes, the groupId in the artifacts has been changed, so I manually updated the dependencies to reflect this change.

#### HOW

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
