### PR TITLE
Use combinedClickable as basis of UnboundedRippleButton

### DIFF
--- a/composables/api/current.api
+++ b/composables/api/current.api
@@ -161,7 +161,7 @@ package com.google.android.horologist.composables {
   }
 
   public final class UnboundedRippleButtonKt {
-    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void UnboundedRippleButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional float rippleRadius, optional boolean enabled, optional androidx.wear.compose.material.ButtonColors colors, optional androidx.compose.foundation.interaction.MutableInteractionSource interactionSource, optional androidx.compose.ui.graphics.Shape shape, optional androidx.wear.compose.material.ButtonBorder border, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.BoxScope,kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable @com.google.android.horologist.annotations.ExperimentalHorologistApi public static void UnboundedRippleButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional float rippleRadius, optional boolean enabled, optional androidx.wear.compose.material.ButtonColors colors, optional androidx.compose.foundation.interaction.MutableInteractionSource interactionSource, optional androidx.compose.ui.graphics.Shape shape, optional androidx.wear.compose.material.ButtonBorder border, optional kotlin.jvm.functions.Function0<kotlin.Unit> onLongClick, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.BoxScope,kotlin.Unit> content);
   }
 
 }

--- a/composables/src/main/java/com/google/android/horologist/composables/UnboundedRippleButton.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/UnboundedRippleButton.kt
@@ -18,7 +18,7 @@ package com.google.android.horologist.composables
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -60,6 +60,7 @@ public fun UnboundedRippleButton(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     shape: Shape = CircleShape,
     border: ButtonBorder = ButtonDefaults.buttonBorder(),
+    onLongClick: (() -> Unit)? = null,
     content: @Composable BoxScope.() -> Unit,
 ) {
     val borderStroke = border.borderStroke(enabled = enabled).value
@@ -78,7 +79,7 @@ public fun UnboundedRippleButton(
                     Modifier
                 },
             )
-            .clickable(
+            .combinedClickable(
                 interactionSource = interactionSource,
                 indication = ripple(
                     bounded = false,
@@ -87,6 +88,7 @@ public fun UnboundedRippleButton(
                 onClick = {
                     onClick()
                 },
+                onLongClick = onLongClick,
                 role = Role.Button,
                 enabled = enabled,
             )


### PR DESCRIPTION
#### WHAT
Allow users of user of UnboundedRippleButton to use features like long press.

#### WHY
Long press is useful for UI interactions, e.g. [for a button that skips forward 30 seconds upon clicking, and skips to the end when held](https://github.com/Automattic/pocket-casts-android/issues/3634).

#### HOW
Use `combinedClickable` instead of `clickable`.

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
