### PR TITLE
Fix start destination

### DIFF
--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/navigation/MediaPlayerScaffold.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/navigation/MediaPlayerScaffold.kt
@@ -85,7 +85,7 @@ public fun MediaPlayerScaffold(
         timeText = { timeText() },
     ) {
         SwipeDismissableNavHost(
-            startDestination = NavigationScreens.Player.navRoute,
+            startDestination = NavigationScreens.Player.playerDestination(),
             navController = navController,
             modifier = modifier.background(Color.Transparent),
             state = navHostState,


### PR DESCRIPTION
#### WHAT

Fix start destination of SwipeDismissableNavHost to Player destination

navigation got stricter, so fix the destination which should never have been the route pattern.

#### WHY

fixes #2541

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
