### PR TITLE
Handle font changes in Pickers without truncation

### DIFF
--- a/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
@@ -161,7 +161,7 @@ public fun TimePicker(
 
         (0..9).maxOf { mm.getBoundingBox(it).width }
     }
-    val pickerWidth = with(LocalDensity.current) { (digitWidth * 2).toDp() + 6.dp }
+    val pickerWidth = with(LocalDensity.current) { (digitWidth * 2).toDp() - 6.dp }
 
     val optionColor = MaterialTheme.colors.secondary
     val pickerOption = pickerTextOption(textStyle, { "%02d".format(it) })

--- a/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
@@ -153,6 +153,7 @@ public fun TimePicker(
     val digitWidth = remember(
         density.density,
         LocalConfiguration.current.screenWidthDp,
+        textStyle,
     ) {
         val mm = measurer.measure(
             "0123456789",

--- a/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
@@ -67,6 +67,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -161,7 +162,7 @@ public fun TimePicker(
 
         (0..9).maxOf { mm.getBoundingBox(it).width }
     }
-    val pickerWidth = with(LocalDensity.current) { (digitWidth * 2).toDp() - 6.dp }
+    val pickerWidth = with(LocalDensity.current) { (digitWidth * 2).toDp() + 6.dp }
 
     val optionColor = MaterialTheme.colors.secondary
     val pickerOption = pickerTextOption(textStyle, { "%02d".format(it) })
@@ -628,10 +629,14 @@ internal fun pickerTextOption(
     indexToText: (Int) -> String,
     isValid: (Int) -> Boolean = { true },
 ): (@Composable PickerScope.(optionIndex: Int, pickerSelected: Boolean) -> Unit) = { value: Int, pickerSelected: Boolean ->
+
     Box(modifier = Modifier.fillMaxSize()) {
         Text(
             text = indexToText(value),
             maxLines = 1,
+            overflow = TextOverflow.Visible,
+            // Softwrap ensures the Visible works b/283157037
+            softWrap = false,
             style = textStyle,
             color = if (!isValid(value)) {
                 Color(0xFF757575)

--- a/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
+++ b/composables/src/main/java/com/google/android/horologist/composables/TimePicker.kt
@@ -635,7 +635,6 @@ internal fun pickerTextOption(
             text = indexToText(value),
             maxLines = 1,
             overflow = TextOverflow.Visible,
-            // Softwrap ensures the Visible works b/283157037
             softWrap = false,
             style = textStyle,
             color = if (!isValid(value)) {

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/TimePicker12hTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/TimePicker12hTest.kt
@@ -35,6 +35,16 @@ class TimePicker12hTest : WearLegacyScreenTest() {
     }
 
     @Test
+    fun midnight() {
+        runTest {
+            TimePickerWith12HourClock(
+                time = LocalTime.of(0, 0, 0),
+                onTimeConfirm = {},
+            )
+        }
+    }
+
+    @Test
     @Config(
         fontScale = 1.24f,
     )

--- a/composables/src/test/kotlin/com/google/android/horologist/composables/TimePickerTest.kt
+++ b/composables/src/test/kotlin/com/google/android/horologist/composables/TimePickerTest.kt
@@ -37,6 +37,17 @@ class TimePickerTest : WearLegacyScreenTest() {
     }
 
     @Test
+    fun midnight() {
+        runTest {
+            TimePicker(
+                time = LocalTime.of(0, 0, 0),
+                onTimeConfirm = {},
+                showSeconds = false,
+            )
+        }
+    }
+
+    @Test
     @Config(
         fontScale = 1.24f,
     )

--- a/composables/src/test/snapshots/images/com.google.android.horologist.composables_TimePicker12hTest_midnight.png
+++ b/composables/src/test/snapshots/images/com.google.android.horologist.composables_TimePicker12hTest_midnight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b0ed64c5d5d76425216fddc1b8e8844814fdf9e38636ccf8d04f4d96331045b
+size 20017

--- a/composables/src/test/snapshots/images/com.google.android.horologist.composables_TimePickerTest_midnight.png
+++ b/composables/src/test/snapshots/images/com.google.android.horologist.composables_TimePickerTest_midnight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38ab92d84d3971b3a11d1931ac21537db43853ac0f8cb5b6d9d972369a8e77d8
+size 19089


### PR DESCRIPTION
#### WHAT

Handle font changes in Pickers without truncation

#### WHY

Different font widths can cause the picker items to be truncated

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
