### PR TITLE
Modify VolumeUiState.Unknown to avoid rendering crashes.

### DIFF
--- a/media/audio-ui-model/src/main/java/com/google/android/horologist/audio/ui/VolumeUiState.kt
+++ b/media/audio-ui-model/src/main/java/com/google/android/horologist/audio/ui/VolumeUiState.kt
@@ -24,6 +24,7 @@ public data class VolumeUiState(
     val max: Int = 1,
     val min: Int = 0,
 ) {
+    private var unknown = false
 
     public val isMax: Boolean
         get() = current >= max
@@ -32,6 +33,14 @@ public data class VolumeUiState(
         get() = current == min
 
     public companion object {
-        public val Unknown: VolumeUiState = VolumeUiState(current = -1, max = -1, min = -1)
+        /** Represents an unknown [VolumeUiState].
+         *
+         * Since this is not a type but an instance of [VolumeUiState] the members are intentionally
+         * as they are are, current=0, max=1, min=0, in case this is accidentally interpreted as
+         * a known volume. This will prevent potential issues such as division by zero, negativeranges etc.
+         */
+        public val Unknown: VolumeUiState = VolumeUiState(current = 0, max = 1, min = 0)
+          .also { it.unknown = true } // Set unknown here to guarantee equality check to be correct
     }
 }
+


### PR DESCRIPTION
VolumUiState.Unknown was added in https://github.com/google/horologist/pull/2512 without modifying the code reading it. RotaryVolumeControls has since been updated, but it still means that if it's used with any composable but RotaryVolumeControls it will crash when rendering those composables.

Since the value is already introduced and is used this PR changes the object to avoid these crashes. Changing Unknown to current=0, max=1, min=0 avoids the crashes, but in the unusual event that an app would offer this odd binary volume control it would mean that it would be interpreted as Unknown. To support this corner case, as well as the concept of Unknown this PR also adds a private boolean, unknown, that's only set by the Unknown instance. The unusual .also{} mechanism is to avoid exposing this boolean in the constructor.

This PR avoids any possible crashes if VolumeUiState is used incorrectly, but the composables using VolumeUiState should most likely be updated to handle Unknown too, now that it is introduced. Possibly VolumeUiState should be changed to a sealed interface with actual volume and Unknown as separate sub-classes, but that's a way larger change and out of scope for this de-risking PR.

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
