### PR TITLE
Define media info display for ambient mode.

### DIFF
--- a/media/ui-material3/src/main/java/com/google/android/horologist/media/ui/material3/components/ambient/AmbientMediaInfoDisplay.kt
+++ b/media/ui-material3/src/main/java/com/google/android/horologist/media/ui/material3/components/ambient/AmbientMediaInfoDisplay.kt
@@ -1,0 +1,39 @@
+package com.google.android.horologist.media.ui.material3.components.ambient
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.wear.compose.material3.ColorScheme
+import androidx.wear.compose.material3.MaterialTheme
+import com.google.android.horologist.media.ui.material3.components.display.LoadingMediaDisplay
+import com.google.android.horologist.media.ui.material3.components.display.NothingPlayingDisplay
+import com.google.android.horologist.media.ui.material3.components.display.TextMediaDisplay
+import com.google.android.horologist.media.ui.state.model.MediaUiModel
+
+/**
+ * Ambient [MediaDisplay] implementation for [PlayerScreen] including player status.
+ *
+ * @param media The current media being played.
+ * @param loading Whether the player is currently loading.
+ * @param modifier Modifier for the display.
+ * @param colorScheme The color scheme to use for the display.
+ */
+@Composable
+public fun AmbientMediaInfoDisplay(
+  media: MediaUiModel?,
+  loading: Boolean,
+  modifier: Modifier = Modifier,
+  colorScheme: ColorScheme = MaterialTheme.colorScheme
+) {
+  if (loading) {
+    LoadingMediaDisplay(modifier, colorScheme = colorScheme)
+  } else if (media is MediaUiModel.Ready) {
+    TextMediaDisplay(
+      modifier = modifier,
+      title = media.title,
+      subtitle = media.subtitle,
+      titleIcon = media.titleIcon,
+    )
+  } else {
+    NothingPlayingDisplay(modifier)
+  }
+}


### PR DESCRIPTION
#### WHAT
Adding media info display that can be displayed in the ambient mode

#### WHY
Ambient mode requires the title text without marquee


#### HOW
Created a new composable

#### Checklist :clipboard:
- [ x] Add explicit visibility modifier and explicit return types for public declarations
- [x ] Run spotless check
- [ x] Run tests
- [ x] Update metalava's signature text files
