### PR TITLE
Fix recompositions issue in VolumeScreen.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/media/audio-ui-material3/build.gradle.kts
+++ b/media/audio-ui-material3/build.gradle.kts
@@ -110,6 +110,7 @@ dependencies {
     implementation(libs.lottie.compose)
 
     implementation(libs.compose.ui.toolingpreview)
+    implementation(libs.androidx.wear.tooling.preview)
     debugImplementation(libs.compose.ui.tooling)
     debugImplementation(projects.composeTools)
     debugImplementation(libs.compose.ui.test.manifest)

--- a/media/audio-ui-material3/src/main/java/com/google/android/horologist/audio/ui/material3/VolumeLevelIndicator.kt
+++ b/media/audio-ui-material3/src/main/java/com/google/android/horologist/audio/ui/material3/VolumeLevelIndicator.kt
@@ -61,7 +61,6 @@ public fun VolumeLevelIndicator(
                 value = false
             }
         }
-    val uiState = volumeUiState()
 
     AnimatedVisibility(
         visible = visible,
@@ -70,8 +69,8 @@ public fun VolumeLevelIndicator(
     ) {
         StepperLevelIndicator(
             modifier = modifier.fillMaxSize(),
-            value = { uiState.current.toFloat() },
-            valueRange = (uiState.min.toFloat())..(uiState.max.toFloat()),
+            value = { volumeUiState().current.toFloat() },
+            valueRange = (volumeUiState().min.toFloat())..(volumeUiState().max.toFloat()),
             colors =
                 LevelIndicatorDefaults.colors(
                     indicatorColor = colorScheme.secondaryDim,

--- a/media/audio-ui-material3/src/main/java/com/google/android/horologist/audio/ui/material3/VolumeScreen.kt
+++ b/media/audio-ui-material3/src/main/java/com/google/android/horologist/audio/ui/material3/VolumeScreen.kt
@@ -32,7 +32,9 @@ import androidx.compose.material.icons.automirrored.rounded.VolumeUp
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -42,6 +44,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.wear.compose.foundation.rotary.rotaryScrollable
@@ -53,6 +56,7 @@ import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Stepper
 import androidx.wear.compose.material3.StepperDefaults
 import androidx.wear.compose.material3.Text
+import androidx.wear.tooling.preview.devices.WearDevices
 import com.google.android.horologist.audio.AudioOutput
 import com.google.android.horologist.audio.ui.VolumeUiState
 import com.google.android.horologist.audio.ui.VolumeViewModel
@@ -61,6 +65,25 @@ import com.google.android.horologist.audio.ui.material3.components.DeviceButton
 import com.google.android.horologist.audio.ui.material3.components.toAudioOutputUi
 import com.google.android.horologist.audio.ui.model.R
 import kotlin.math.roundToInt
+
+@Preview(
+    device = WearDevices.LARGE_ROUND,
+    showSystemUi = true,
+    showBackground = true,
+)
+@Composable
+fun VolumeScreenPreview() {
+    var currentVolume by remember { mutableStateOf(5) }
+    val maxVolume = 10
+
+    VolumeScreen(
+        volume = { VolumeUiState(current = currentVolume, max = maxVolume) },
+        audioOutputUi = AudioOutput.BluetoothHeadset("id", "name").toAudioOutputUi(),
+        increaseVolume = { currentVolume++ },
+        decreaseVolume = { currentVolume-- },
+        onAudioOutputClick = { },
+    )
+}
 
 /**
  * Volume Screen with an [Stepper] and Increase/Decrease buttons for the Audio Stream Volume.

--- a/media/audio-ui-material3/src/main/java/com/google/android/horologist/audio/ui/material3/VolumeScreen.kt
+++ b/media/audio-ui-material3/src/main/java/com/google/android/horologist/audio/ui/material3/VolumeScreen.kt
@@ -69,7 +69,7 @@ import kotlin.math.roundToInt
 @Preview(
     device = WearDevices.LARGE_ROUND,
     showSystemUi = true,
-    showBackground = true
+    showBackground = true,
 )
 @Composable
 fun VolumeScreenPreview() {
@@ -81,7 +81,7 @@ fun VolumeScreenPreview() {
         audioOutputUi = AudioOutput.BluetoothHeadset("id", "name").toAudioOutputUi(),
         increaseVolume = { currentVolume++ },
         decreaseVolume = { currentVolume-- },
-        onAudioOutputClick = { }
+        onAudioOutputClick = { },
     )
 }
 

--- a/media/audio-ui-material3/src/main/java/com/google/android/horologist/audio/ui/material3/VolumeScreen.kt
+++ b/media/audio-ui-material3/src/main/java/com/google/android/horologist/audio/ui/material3/VolumeScreen.kt
@@ -72,7 +72,7 @@ import kotlin.math.roundToInt
     showBackground = true,
 )
 @Composable
-fun VolumeScreenPreview() {
+private fun VolumeScreenPreview() {
     var currentVolume by remember { mutableStateOf(5) }
     val maxVolume = 10
 


### PR DESCRIPTION
Changes in volumeUiState were triggering recompositions which resulted in missing animation transition of LevelIndicator.

#### WHAT
StepperLevelIndicator was not properly used, which was triggering extra recompositions . That resulted in transition animation not properly played.

#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
