### PR TITLE
Bump deps, getting closer to stable release

### DIFF
--- a/compose-layout/api/current.api
+++ b/compose-layout/api/current.api
@@ -67,12 +67,14 @@ package com.google.android.horologist.compose.layout {
     method public com.google.android.horologist.compose.layout.ColumnItemType getButton();
     method public com.google.android.horologist.compose.layout.ColumnItemType getButtonRow();
     method public com.google.android.horologist.compose.layout.ColumnItemType getCard();
+    method public com.google.android.horologist.compose.layout.ColumnItemType getEdgeButtonPadding();
     method public com.google.android.horologist.compose.layout.ColumnItemType getIconButton();
     method public com.google.android.horologist.compose.layout.ColumnItemType getListHeader();
     property public final com.google.android.horologist.compose.layout.ColumnItemType BodyText;
     property public final com.google.android.horologist.compose.layout.ColumnItemType Button;
     property public final com.google.android.horologist.compose.layout.ColumnItemType ButtonRow;
     property public final com.google.android.horologist.compose.layout.ColumnItemType Card;
+    property public final com.google.android.horologist.compose.layout.ColumnItemType EdgeButtonPadding;
     property public final com.google.android.horologist.compose.layout.ColumnItemType IconButton;
     property public final com.google.android.horologist.compose.layout.ColumnItemType ListHeader;
   }

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/layout/TransformingLazyColumnDefaults.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/layout/TransformingLazyColumnDefaults.kt
@@ -93,5 +93,13 @@ public interface ColumnItemType {
 
         val ButtonRow: ColumnItemType
             get() = ItemType.MultiButton
+
+        val EdgeButtonPadding: ColumnItemType = object : ColumnItemType {
+            @Composable
+            override fun topPadding(horizontalPercent: Float): Dp = 0.dp
+
+            @Composable
+            override fun bottomPadding(horizontalPercent: Float): Dp = 0.dp
+        }
     }
 }

--- a/compose-layout/src/test/java/com/google/android/horologist/compose/layout/TransformingLazyColumnDefaultsTest.kt
+++ b/compose-layout/src/test/java/com/google/android/horologist/compose/layout/TransformingLazyColumnDefaultsTest.kt
@@ -23,8 +23,6 @@ import androidx.compose.material.icons.rounded.ArrowUpward
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumnState
 import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
@@ -44,6 +42,7 @@ import androidx.wear.compose.material3.TitleCard
 import androidx.wear.compose.material3.lazy.rememberTransformationSpec
 import androidx.wear.compose.material3.lazy.transformedHeight
 import androidx.wear.compose.material3.timeTextCurvedText
+import com.google.android.horologist.compose.layout.ColumnItemType.Companion.EdgeButtonPadding
 import com.google.android.horologist.screenshots.rng.WearDevice
 import com.google.android.horologist.screenshots.rng.WearScreenshotTest
 import kotlinx.coroutines.runBlocking
@@ -119,14 +118,6 @@ class TransformingLazyColumnDefaultsTest(override val device: WearDevice) : Wear
         }
 
         captureScreenshot("_end")
-    }
-
-    object EdgeButtonPadding : ColumnItemType {
-        @Composable
-        override fun topPadding(horizontalPercent: Float): Dp = 0.dp
-
-        @Composable
-        override fun bottomPadding(horizontalPercent: Float): Dp = 0.dp
     }
 
     @Test

--- a/compose-layout/src/test/java/com/google/android/horologist/compose/layout/TransformingLazyColumnDefaultsTest.kt
+++ b/compose-layout/src/test/java/com/google/android/horologist/compose/layout/TransformingLazyColumnDefaultsTest.kt
@@ -113,7 +113,9 @@ class TransformingLazyColumnDefaultsTest(override val device: WearDevice) : Wear
         composeRule.waitForIdle()
 
         runBlocking {
-            columnState.dispatchRawDelta(2000f)
+            columnState.scroll {
+                scrollBy(2000f)
+            }
         }
 
         captureScreenshot("_end")
@@ -185,7 +187,9 @@ class TransformingLazyColumnDefaultsTest(override val device: WearDevice) : Wear
         composeRule.waitForIdle()
 
         runBlocking {
-            columnState.dispatchRawDelta(2000f)
+            columnState.scroll {
+                scrollBy(2000f)
+            }
         }
 
         captureScreenshot("_end")
@@ -247,7 +251,9 @@ class TransformingLazyColumnDefaultsTest(override val device: WearDevice) : Wear
         composeRule.waitForIdle()
 
         runBlocking {
-            columnState.dispatchRawDelta(2000f)
+            columnState.scroll {
+                scrollBy(2000f)
+            }
         }
 
         captureScreenshot("_end")

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_ButtonAndEdgeButton[0]_ticwatch_pro_5_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_ButtonAndEdgeButton[0]_ticwatch_pro_5_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7b9f2808121979f95ed8e99e939a09fe48efc5d7e664cc52744a94e050520948
-size 25528
+oid sha256:19c88537ae5be9193e4fa14d2e7bd7f685a8dbd6b8e5961e977576da744cc0eb
+size 33500

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_ButtonAndEdgeButton[1]_galaxy_watch_5_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_ButtonAndEdgeButton[1]_galaxy_watch_5_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0923af5000de7725b58f2a86ade6bd7e98549311377db7d2ca497438d52a8d9e
-size 18978
+oid sha256:604f314a4f717c28bc3309a1993dc127eaac141320cff5538d3378a6c04a40ab
+size 26022

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_ButtonAndEdgeButton[2]_galaxy_watch_6_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_ButtonAndEdgeButton[2]_galaxy_watch_6_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a1a543e5abd2dc9bb6f4553fecb2a6f02791352db17d9f787424e1c12a6091ed
-size 23987
+oid sha256:5bbd15b783c6be6695c7d2c6127d61dc0d32f7630a5c244b09a148aac6bcd7be
+size 32190

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_ButtonAndEdgeButton[3]_pixel_watch_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_ButtonAndEdgeButton[3]_pixel_watch_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:42b533b0e948a7588b7b850633d347254689f2630c4eeb52f67643a63f0cb544
-size 20015
+oid sha256:4b017e0a41590f742f91ab4cfda368b3a6cce0e34c32fae5b42ca101c73103b8
+size 24074

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_ButtonAndEdgeButton[4]_small_round_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_ButtonAndEdgeButton[4]_small_round_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:42b533b0e948a7588b7b850633d347254689f2630c4eeb52f67643a63f0cb544
-size 20015
+oid sha256:4b017e0a41590f742f91ab4cfda368b3a6cce0e34c32fae5b42ca101c73103b8
+size 24074

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_ButtonAndEdgeButton[5]_large_round_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_ButtonAndEdgeButton[5]_large_round_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7c5ec370a5fe66636620be9b9ee91e4cb9c60aca39994cc55edd6abbdd3343fb
-size 24375
+oid sha256:78fd37faa1ad65cc10a8667035d192e5eb8bf01431690621ef1c31972e3cd30d
+size 32375

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_ButtonAndEdgeButton[6]_galaxy_watch_6_small_font_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_ButtonAndEdgeButton[6]_galaxy_watch_6_small_font_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:300989506eaa32cb518ab24ef5600910a7507acfdf5c5f5eb42babeb40cfd769
-size 23386
+oid sha256:82222a60d77e33dca55469b2b1e56c6b5da7b125305ccd911d7812f80edbb3e3
+size 31441

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_ButtonAndEdgeButton[7]_pixel_watch_large_font.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_ButtonAndEdgeButton[7]_pixel_watch_large_font.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b5f01257cd5720dde8a3fb81ad1227d675d2b14bdccd0530090185c67bbe397f
-size 23340
+oid sha256:32bda6ec33941164bc5bf1fd4fe329cca68fd2940a458d8ce040ee0190b92da8
+size 23263

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_ButtonAndEdgeButton[7]_pixel_watch_large_font.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_ButtonAndEdgeButton[7]_pixel_watch_large_font.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:32bda6ec33941164bc5bf1fd4fe329cca68fd2940a458d8ce040ee0190b92da8
-size 23263
+oid sha256:b5f01257cd5720dde8a3fb81ad1227d675d2b14bdccd0530090185c67bbe397f
+size 23340

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_ButtonAndEdgeButton[7]_pixel_watch_large_font_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_ButtonAndEdgeButton[7]_pixel_watch_large_font_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e95879978f8cbfa411c3cdb2ac42016a1bf4b86e3cc98f53b7db715ee04b374a
-size 23335
+oid sha256:8d24594268a6cf72775ddfeb70597da93a822d8cf3a9843d559f95e29114613f
+size 25520

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_IconButtonAndExtraSmallEdgeButton[0]_ticwatch_pro_5_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_IconButtonAndExtraSmallEdgeButton[0]_ticwatch_pro_5_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a56f810c9c778c64515d59b666b90a6cc4cf37fa6d1975b05cf3945622a929fa
-size 27797
+oid sha256:e522bf6896d3156b45cce3d983d72790bd6a3d808391209599424a3fa36c2f1c
+size 31359

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_IconButtonAndExtraSmallEdgeButton[1]_galaxy_watch_5_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_IconButtonAndExtraSmallEdgeButton[1]_galaxy_watch_5_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2929923dbf310481906d254026484f93b69d261bd06d14bc5c8ed3ea75a607a1
-size 23889
+oid sha256:1cd7b24bb1354ff1dd6f17b8db65d3a2c081cfaad4fea764a940d3df651313ac
+size 27057

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_IconButtonAndExtraSmallEdgeButton[2]_galaxy_watch_6_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_IconButtonAndExtraSmallEdgeButton[2]_galaxy_watch_6_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:37a319f53a833e14c7ba4f4f6328a5cf103decce04db890bf942879fe1f99fa8
-size 26999
+oid sha256:f534eca1adb7ecbd3b943020faaa4bf40a259672f292d96d6f15681b6510e574
+size 30476

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_IconButtonAndExtraSmallEdgeButton[3]_pixel_watch_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_IconButtonAndExtraSmallEdgeButton[3]_pixel_watch_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:97e7a4168925ddd29288ac1f02a8aea0f3c5496a07c5b4e3a87b086b25aecf33
-size 23249
+oid sha256:5c6fc939819d1e6d48f5bb81336a6bfae94afee67a4247e86ea7341ebe37b906
+size 26426

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_IconButtonAndExtraSmallEdgeButton[4]_small_round_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_IconButtonAndExtraSmallEdgeButton[4]_small_round_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:97e7a4168925ddd29288ac1f02a8aea0f3c5496a07c5b4e3a87b086b25aecf33
-size 23249
+oid sha256:5c6fc939819d1e6d48f5bb81336a6bfae94afee67a4247e86ea7341ebe37b906
+size 26426

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_IconButtonAndExtraSmallEdgeButton[5]_large_round_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_IconButtonAndExtraSmallEdgeButton[5]_large_round_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:74a3f72d0162dd0abcf9e02f9275274274ce11eddd191f14d122a222ebb6ba79
-size 27215
+oid sha256:401e12b915783c359f3dabf2be8870a74e8f269206f2a53bc89d1f908d76ce07
+size 30654

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_IconButtonAndExtraSmallEdgeButton[6]_galaxy_watch_6_small_font_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_IconButtonAndExtraSmallEdgeButton[6]_galaxy_watch_6_small_font_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4b0c16a8c5963dcd50d091b22ebfa9da2f275dff881a27b530b0b2b9bfe4d751
-size 26049
+oid sha256:cb6c893cdce20510c2bdf4f0a5d42e71560f120cd7b60d0d8a88eeb931d8938c
+size 29403

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_IconButtonAndExtraSmallEdgeButton[7]_pixel_watch_large_font.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_IconButtonAndExtraSmallEdgeButton[7]_pixel_watch_large_font.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:72a03e03fd01d73a57bce780d763112149e70ee0431a40a1f41ada3313499e82
-size 24243
+oid sha256:ba92014f65fb5dbd22bb56bfab0f78abd095b0bb9fd6b7245763111b260f847a
+size 24330

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_IconButtonAndExtraSmallEdgeButton[7]_pixel_watch_large_font.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_IconButtonAndExtraSmallEdgeButton[7]_pixel_watch_large_font.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ba92014f65fb5dbd22bb56bfab0f78abd095b0bb9fd6b7245763111b260f847a
-size 24330
+oid sha256:72a03e03fd01d73a57bce780d763112149e70ee0431a40a1f41ada3313499e82
+size 24243

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_IconButtonAndExtraSmallEdgeButton[7]_pixel_watch_large_font_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_IconButtonAndExtraSmallEdgeButton[7]_pixel_watch_large_font_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c3c9203a7cd9c6f9334a83e8ccf47a4b7667dbd426b7e99a4fa49c0e749a327b
-size 25016
+oid sha256:c66b0522a59377fcb44173fd7d85a3ceb651dd665a0730e8fe79f96719735bbc
+size 28303

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_TitleAndCard[0]_ticwatch_pro_5_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_TitleAndCard[0]_ticwatch_pro_5_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fc1c182772276b5c60e27181798affb47a790c4771682c8817698ba54bea15d1
-size 29777
+oid sha256:2162fe124307edc58e628e030fd25d53bf9c7bc8fcfe0c366ea5138052e8f143
+size 30739

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_TitleAndCard[1]_galaxy_watch_5_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_TitleAndCard[1]_galaxy_watch_5_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:74fac8a184eb3daf1ccc8b6155c7f7da02feeccc98ca78071e9fff24a343d98e
-size 25511
+oid sha256:f81d8e4515fce8f4159174ac171b94a3b650c1a1ff7fddd27cb5ca42b6f4f528
+size 26531

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_TitleAndCard[2]_galaxy_watch_6_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_TitleAndCard[2]_galaxy_watch_6_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:61bcddc4491bae50589882103e51bfebad22341b58e60f3e5f3114c074e6331a
-size 28799
+oid sha256:228c26773d36c90d54f748f48690dec79b3fd38e9ef8c4fafc0d779b6c16add5
+size 29204

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_TitleAndCard[3]_pixel_watch_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_TitleAndCard[3]_pixel_watch_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e021dfa9b6cf685bba33969a55060044056868df7991163e2bed1ade08c6b933
-size 25112
+oid sha256:da43058baafc807c4e1f2292a9bf49c6913e8531cfd01d302ac2d21c6fa86fb9
+size 26145

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_TitleAndCard[4]_small_round_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_TitleAndCard[4]_small_round_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e021dfa9b6cf685bba33969a55060044056868df7991163e2bed1ade08c6b933
-size 25112
+oid sha256:da43058baafc807c4e1f2292a9bf49c6913e8531cfd01d302ac2d21c6fa86fb9
+size 26145

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_TitleAndCard[5]_large_round_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_TitleAndCard[5]_large_round_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:43a1dd5cd02fc7d7537984c203975190914ecaa65f868f677ce6cf2504c16017
-size 28849
+oid sha256:e768388bae8af63687ea7e5f616fb33a6b4e9db06db538c998f82dbe46d6dfe8
+size 29427

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_TitleAndCard[6]_galaxy_watch_6_small_font_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_TitleAndCard[6]_galaxy_watch_6_small_font_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:72145844a066ecd3d152443d6c5a15531b4a6275109d0adc37755702b583fb42
-size 27637
+oid sha256:68fae0b48682a411edce09ce06994b01e09d586b2392deaf910ded8a979d276a
+size 28134

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_TitleAndCard[7]_pixel_watch_large_font.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_TitleAndCard[7]_pixel_watch_large_font.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:35e2977eac2151eab706bc81147ce9cf948fe751d725d35333636dc7efe57d8e
-size 22476
+oid sha256:1b3028a4ed2e952db1b8eeacddab5b1d34c9b6fb84428ebfcbba863128351f02
+size 22540

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_TitleAndCard[7]_pixel_watch_large_font.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_TitleAndCard[7]_pixel_watch_large_font.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1b3028a4ed2e952db1b8eeacddab5b1d34c9b6fb84428ebfcbba863128351f02
-size 22540
+oid sha256:35e2977eac2151eab706bc81147ce9cf948fe751d725d35333636dc7efe57d8e
+size 22476

--- a/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_TitleAndCard[7]_pixel_watch_large_font_end.png
+++ b/compose-layout/src/test/screenshots/TransformingLazyColumnDefaultsTest_TitleAndCard[7]_pixel_watch_large_font_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2ba0c5347c0b639d73a0d49f5141dc7ef03c53364d30ffc71eb3acd92c06d11c
-size 26098
+oid sha256:4ee3c347783ee44bf52832bc5d43d27cb7a23099e8449f635b646d0748300512
+size 28204

--- a/gradle.properties
+++ b/gradle.properties
@@ -47,7 +47,7 @@ kotlin.daemon.jvmargs=-Dfile.encoding=UTF-8 -XX:+UseG1GC -XX:SoftRefLRUPolicyMSP
 systemProp.org.gradle.internal.http.socketTimeout=120000
 
 GROUP=com.google.android.horologist
-VERSION_NAME=0.7.14-beta
+VERSION_NAME=0.7.15-beta
 
 POM_DESCRIPTION=Utilities for Wear OS
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,8 +5,7 @@ androidx-benchmark = "1.3.4"
 androidx-complications-data = "1.2.1"
 androidx-concurrent = "1.2.0"
 androidx-constraintlayout-compose = "1.1.1"
-# Stay on 1.1.4 due to https://github.com/google/horologist/issues/2598
-androidx-datastore = "1.1.4"
+androidx-datastore = "1.1.7"
 androidx-graphics = "1.0.1"
 androidx-health-services = "1.0.0"
 androidx-hilt = "1.2.0"
@@ -16,7 +15,7 @@ androidx-test-ext = "1.2.1"
 androidx-test-runner = "1.6.2"
 androidx-wear-watchface = "1.2.1"
 androidxActivity = "1.10.1"
-androidxComposeBom = "2025.05.00"
+androidxComposeBom = "2025.06.00"
 androidxCore = "1.16.0"
 androidxLifecycle = "2.9.1"
 androidxNavigation = "2.9.0"
@@ -68,7 +67,6 @@ runtimeTracing = "1.8.2"
 spotless = "7.0.4"
 tiles-tooling-preview = "1.5.0"
 truth = "1.4.4"
-wearComposeMaterial3 = "1.0.0-beta01"
 wearInput = "1.2.0-alpha02"
 wearToolingPreview = "1.0.0"
 wearcompose = "1.5.0-beta03"
@@ -134,7 +132,7 @@ androidx-test-runner = { group = "androidx.test", name = "runner", version.ref =
 androidx-test-uiautomator = "androidx.test.uiautomator:uiautomator:2.3.0"
 androidx-tracing-ktx = { module = "androidx.tracing:tracing-ktx", version.ref = "androidxTracing" }
 androidx-wear = { module = "androidx.wear:wear", version.ref = "androidxWear" }
-androidx-wear-compose-material3 = { module = "androidx.wear.compose:compose-material3", version.ref = "wearComposeMaterial3" }
+androidx-wear-compose-material3 = { module = "androidx.wear.compose:compose-material3", version.ref = "wearcompose" }
 androidx-wear-input = { group = "androidx.wear", name = "wear-input", version.ref = "wearInput" }
 androidx-wear-phone-interactions = { module = "androidx.wear:wear-phone-interactions", version.ref = "androidxPhoneInteractions" }
 androidx-wear-protolayout-material = { module = "androidx.wear.protolayout:protolayout-material", version.ref = "androidxprotolayout" }
@@ -201,7 +199,7 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerialization" }
 lottie-compose = "com.airbnb.android:lottie-compose:6.6.6"
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
-mikepenz-markdown = "com.mikepenz:multiplatform-markdown-renderer:0.32.0"
+mikepenz-markdown = "com.mikepenz:multiplatform-markdown-renderer:0.35.0"
 moshi-adapters = { module = "com.squareup.moshi:moshi-adapters", version.ref = "moshi" }
 moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
 moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -147,6 +147,8 @@ dependencies {
     implementation(libs.compose.ui.toolingpreview)
     implementation(libs.androidx.wear.tooling.preview)
 
+    implementation(libs.androidx.wear.compose.material3)
+
     implementation(libs.kotlinx.serialization.core)
     implementation(projects.media.audioUiModel)
     testImplementation(projects.media.audioUiModel)

--- a/sample/src/main/java/com/google/android/horologist/m3/ButtonAndEdgeButton.kt
+++ b/sample/src/main/java/com/google/android/horologist/m3/ButtonAndEdgeButton.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.m3
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ArrowUpward
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
+import androidx.wear.compose.material3.AppScaffold
+import androidx.wear.compose.material3.EdgeButton
+import androidx.wear.compose.material3.EdgeButtonSize
+import androidx.wear.compose.material3.Icon
+import androidx.wear.compose.material3.IconButton
+import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.SurfaceTransformation
+import androidx.wear.compose.material3.Text
+import androidx.wear.compose.material3.TitleCard
+import androidx.wear.compose.material3.lazy.rememberTransformationSpec
+import androidx.wear.compose.material3.lazy.transformedHeight
+import com.google.android.horologist.compose.layout.ColumnItemType
+import com.google.android.horologist.compose.layout.ColumnItemType.Companion.EdgeButtonPadding
+import com.google.android.horologist.compose.layout.rememberResponsiveColumnPadding
+
+@Composable
+fun M3TLCButtonAndEdgeButton() {
+    // Disable other screen scaffold
+    com.google.android.horologist.compose.layout.ScreenScaffold(
+        timeText = {},
+        positionIndicator = {},
+    ) {
+        AppScaffold {
+            val columnState = rememberTransformingLazyColumnState()
+            ScreenScaffold(
+                scrollState = columnState,
+                contentPadding = rememberResponsiveColumnPadding(
+                    first = ColumnItemType.IconButton,
+                    last = EdgeButtonPadding,
+                ),
+                edgeButton = {
+                    EdgeButton(onClick = { }, buttonSize = EdgeButtonSize.Large) {
+                        Text("To top")
+                    }
+                },
+            ) { contentPadding ->
+                val transformationSpec = rememberTransformationSpec()
+
+                TransformingLazyColumn(
+                    state = columnState,
+                    contentPadding = contentPadding,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .testTag("TransformingLazyColumn"),
+                ) {
+                    item {
+                        IconButton(onClick = {}) {
+                            Icon(
+                                imageVector = Icons.Rounded.ArrowUpward,
+                                contentDescription = null,
+                            )
+                        }
+                    }
+                    items(3) {
+                        TitleCard(
+                            onClick = { /* Do something */ },
+                            title = { Text("Title card") },
+                            time = { Text("now") },
+                            modifier = Modifier.transformedHeight(this, transformationSpec),
+                            transformation = SurfaceTransformation(transformationSpec),
+                        ) { Text("Card content") }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
@@ -55,6 +55,12 @@ fun MenuScreen(
             }
             item {
                 Chip(
+                    label = "Material3",
+                    onClick = { navigateToRoute(Screen.Material3.route) },
+                )
+            }
+            item {
+                Chip(
                     label = "Networks",
                     onClick = { navigateToRoute(Screen.Network.route) },
                 )

--- a/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/SampleWearApp.kt
@@ -35,6 +35,7 @@ import com.google.android.horologist.compose.layout.AppScaffold
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults.ItemType
 import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
+import com.google.android.horologist.m3.M3TLCButtonAndEdgeButton
 import com.google.android.horologist.materialcomponents.SampleAlertDialog
 import com.google.android.horologist.materialcomponents.SampleAnimatedComponents
 import com.google.android.horologist.materialcomponents.SampleButtonScreen
@@ -83,6 +84,11 @@ fun SampleWearApp() {
                 MenuScreen(
                     navigateToRoute = { route -> navController.navigate(route) },
                 )
+            }
+            composable(
+                Screen.Material3.route,
+            ) {
+                M3TLCButtonAndEdgeButton()
             }
             composable(
                 Screen.Network.route,

--- a/sample/src/main/java/com/google/android/horologist/sample/Screen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/Screen.kt
@@ -29,6 +29,7 @@ sealed class Screen(
     object TimeWithSecondsPicker : Screen("timeWithSecondsPicker")
     object TimeWithoutSecondsPicker : Screen("timeWithoutSecondsPicker")
     object Network : Screen("network")
+    object Material3 : Screen("material3")
 
     object MaterialAlertDialog : Screen("materialAlertDialog")
     object MaterialAnimatedComponents : Screen("materialAnimatedComponents")


### PR DESCRIPTION
#### WHAT

Wear Compose 1.5.0-beta03

Adds an M3 sample and reusable function for edge hugging button padding.

#### WHY

Update dependencies closer to stable versions

note: the tests seem to indicate issues that aren't visible in real usage. See b/422943945

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
