### PR TITLE
Reduce the opacity to 0.12f from the existing 0.16f for player settin…

### DIFF
--- a/media/audio-ui-material3/src/main/java/com/google/android/horologist/audio/ui/material3/components/actions/SettingsButton.kt
+++ b/media/audio-ui-material3/src/main/java/com/google/android/horologist/audio/ui/material3/components/actions/SettingsButton.kt
@@ -146,7 +146,7 @@ public object SettingsButtonDefaults {
         IconButtonDefaults.iconButtonColors(
             containerColor = colorScheme.onSurface.copy(alpha = 0.16f),
             contentColor = colorScheme.onSurface,
-            disabledContainerColor = colorScheme.onSurface.toDisabledColor(disabledAlpha = 0.16f),
+            disabledContainerColor = colorScheme.onSurface.toDisabledColor(DisabledContainerAlpha),
             disabledContentColor = colorScheme.onSurface.toDisabledColor(DisabledContentAlpha),
         )
 
@@ -183,7 +183,7 @@ public object SettingsButtonDefaults {
     ): BorderStroke = ButtonDefaults.outlinedButtonBorder(
         enabled = enabled,
         borderColor = colorScheme.onSurface.toDisabledColor(DisabledContentAlpha),
-        disabledBorderColor = colorScheme.onSurface.toDisabledColor(0.16f),
+        disabledBorderColor = colorScheme.onSurface.toDisabledColor(alpha = DisabledContainerAlpha),
     )
 }
 


### PR DESCRIPTION
…gs button

#### WHAT
Reduce the opacity to 0.12f from the existing 0.16f

#### WHY
Background of disabled buttons is currently not much different from active buttons

#### HOW
Changed the background opacity

#### Checklist :clipboard:
- [x ] Add explicit visibility modifier and explicit return types for public declarations
- [ x] Run spotless check
- [ x] Run tests
- [x ] Update metalava's signature text files
