### PR TITLE
Fix position and appearances of title and subtitle in ambient mode.

### DIFF
--- a/media/ui-material3/src/main/java/com/google/android/horologist/media/ui/material3/components/ambient/AmbientMediaInfoDisplay.kt
+++ b/media/ui-material3/src/main/java/com/google/android/horologist/media/ui/material3/components/ambient/AmbientMediaInfoDisplay.kt
@@ -19,6 +19,7 @@ package com.google.android.horologist.media.ui.material3.components.ambient
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.wear.compose.material3.ColorScheme
 import androidx.wear.compose.material3.MaterialTheme
 import com.google.android.horologist.media.ui.material3.components.display.TrackMediaDisplay
@@ -41,7 +42,15 @@ public fun AmbientMediaInfoDisplay(
     colorScheme: ColorScheme = MaterialTheme.colorScheme,
 ) {
     if (media is MediaUiModel.Ready) {
-        TrackMediaDisplay(media = media, modifier = modifier, colorScheme = colorScheme)
+        TrackMediaDisplay(
+            media = media,
+            modifier = modifier,
+            colorScheme = colorScheme,
+            titleOverflow = TextOverflow.Clip,
+            subtitleOverflow = TextOverflow.Clip,
+            titleSoftWrap = false,
+            subtitleSoftWrap = false,
+        )
     } else {
         AmbientMessageDisplay(
             message =

--- a/media/ui-material3/src/main/java/com/google/android/horologist/media/ui/material3/components/display/TextMediaDisplay.kt
+++ b/media/ui-material3/src/main/java/com/google/android/horologist/media/ui/material3/components/display/TextMediaDisplay.kt
@@ -26,10 +26,20 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material3.ColorScheme
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
@@ -48,16 +58,32 @@ public fun TextMediaDisplay(
     modifier: Modifier = Modifier,
     titleIcon: Paintable? = null,
     colorScheme: ColorScheme = MaterialTheme.colorScheme,
+    titleOverflow: TextOverflow = TextOverflow.Ellipsis,
+    subtitleOverflow: TextOverflow = TextOverflow.Ellipsis,
+    titleSoftWrap: Boolean = true,
+    subtitleSoftWrap: Boolean = true,
 ) {
+    val textMeasurer = rememberTextMeasurer()
+    var measuredTextWidth by remember { mutableStateOf(0.dp) }
+    with(LocalDensity.current) {
+        measuredTextWidth = textMeasurer.measure(
+            text = AnnotatedString(title),
+            style = MaterialTheme.typography.titleMedium,
+            constraints = Constraints(maxWidth = Int.MAX_VALUE),
+        ).size.width.toDp()
+    }
+    val screenWidthPx = LocalConfiguration.current.screenWidthDp.dp.value
+    val titleWidthRatio = if (titleIcon != null) 0.648f else 0.6672f
+    val subtitleWidthRatio = if (titleIcon != null) 0.71f else 0.75f
+    val shouldShowTitleSpacer = titleIcon != null || (measuredTextWidth.value > titleWidthRatio * screenWidthPx)
+
     Column(
         modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
         Row(
-            modifier =
-                Modifier.fillMaxWidth(titleIcon?.let { 0.648f } ?: 0.6672f)
-                    .height(TRACK_TITLE_HEIGHT),
+            modifier = Modifier.fillMaxWidth(titleWidthRatio).height(TRACK_TITLE_HEIGHT),
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -65,20 +91,21 @@ public fun TextMediaDisplay(
                 Box(modifier = Modifier.size(MEDIA_TITLE_ICON_SIZE)) {
                     MediaTitleIcon(paintableRes = it, tint = colorScheme.primary)
                 }
+            }
+            if (shouldShowTitleSpacer) {
                 Spacer(modifier = Modifier.width(MEDIA_TITLE_EDGE_GRADIENT_WIDTH))
             }
             Text(
                 text = title,
                 color = colorScheme.onSurface,
                 maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
+                overflow = titleOverflow,
+                softWrap = titleSoftWrap,
                 style = MaterialTheme.typography.titleMedium,
             )
         }
         Row(
-            modifier =
-                Modifier.fillMaxWidth(if (titleIcon != null) 0.71f else 0.75f)
-                    .height(TRACK_SUBTITLE_HEIGHT),
+            modifier = Modifier.fillMaxWidth(subtitleWidthRatio).height(TRACK_SUBTITLE_HEIGHT),
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -86,7 +113,8 @@ public fun TextMediaDisplay(
                 text = subtitle,
                 color = colorScheme.onSurface,
                 textAlign = TextAlign.Center,
-                overflow = TextOverflow.Ellipsis,
+                overflow = subtitleOverflow,
+                softWrap = subtitleSoftWrap,
                 maxLines = 1,
                 style = MaterialTheme.typography.bodyMedium,
             )

--- a/media/ui-material3/src/main/java/com/google/android/horologist/media/ui/material3/components/display/TrackMediaDisplay.kt
+++ b/media/ui-material3/src/main/java/com/google/android/horologist/media/ui/material3/components/display/TrackMediaDisplay.kt
@@ -18,6 +18,7 @@ package com.google.android.horologist.media.ui.material3.components.display
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.wear.compose.material3.ColorScheme
 import androidx.wear.compose.material3.MaterialTheme
 import com.google.android.horologist.media.ui.state.model.MediaUiModel
@@ -28,6 +29,10 @@ public fun TrackMediaDisplay(
     media: MediaUiModel.Ready,
     modifier: Modifier = Modifier,
     colorScheme: ColorScheme = MaterialTheme.colorScheme,
+    titleOverflow: TextOverflow = TextOverflow.Ellipsis,
+    subtitleOverflow: TextOverflow = TextOverflow.Ellipsis,
+    titleSoftWrap: Boolean = true,
+    subtitleSoftWrap: Boolean = true,
 ) {
     TextMediaDisplay(
         title = media.title,
@@ -35,5 +40,9 @@ public fun TrackMediaDisplay(
         titleIcon = media.titleIcon,
         modifier = modifier,
         colorScheme = colorScheme,
+        titleOverflow = titleOverflow,
+        subtitleOverflow = subtitleOverflow,
+        titleSoftWrap = titleSoftWrap,
+        subtitleSoftWrap = subtitleSoftWrap,
     )
 }


### PR DESCRIPTION
#### WHAT
Fix position and appearances of title and subtitle in ambient mode.

#### WHY
Position of title & subtitle currently does not match with interactive mode. Also, the ellipse towards end of the title & subtitle is not expected.

#### HOW
Modified the Text property and added spacer towards beginning of the title.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
