### PR TITLE
Increase text contrast

### DIFF
--- a/media/sample/src/main/java/com/google/android/horologist/mediasample/ui/settings/UampSettingsScreen.kt
+++ b/media/sample/src/main/java/com/google/android/horologist/mediasample/ui/settings/UampSettingsScreen.kt
@@ -85,6 +85,7 @@ fun UampSettingsScreen(
                             navController.navigate(GoogleSignInScreen)
                         },
                         enabled = !screenState.guestMode,
+                        colors = ChipDefaults.secondaryChipColors()
                     )
                 } else {
                     Chip(
@@ -95,6 +96,7 @@ fun UampSettingsScreen(
                                 popUpTo<NavigationScreen.Player>()
                             }
                         },
+                        colors = ChipDefaults.secondaryChipColors()
                     )
                 }
             }

--- a/media/sample/src/main/java/com/google/android/horologist/mediasample/ui/settings/UampSettingsScreen.kt
+++ b/media/sample/src/main/java/com/google/android/horologist/mediasample/ui/settings/UampSettingsScreen.kt
@@ -85,7 +85,7 @@ fun UampSettingsScreen(
                             navController.navigate(GoogleSignInScreen)
                         },
                         enabled = !screenState.guestMode,
-                        colors = ChipDefaults.secondaryChipColors()
+                        colors = ChipDefaults.secondaryChipColors(),
                     )
                 } else {
                     Chip(
@@ -96,7 +96,7 @@ fun UampSettingsScreen(
                                 popUpTo<NavigationScreen.Player>()
                             }
                         },
-                        colors = ChipDefaults.secondaryChipColors()
+                        colors = ChipDefaults.secondaryChipColors(),
                     )
                 }
             }


### PR DESCRIPTION
#### WHAT

Increase the contrast of the "sign-in" button.

#### WHY

Before:

<img width="384" height="384" alt="image" src="https://github.com/user-attachments/assets/f73b4d79-4cc7-4d32-b5d3-864098093df5" />

After:

<img width="384" height="384" alt="image" src="https://github.com/user-attachments/assets/27ceacb7-a1d2-4b76-9f76-3aba33f58e79" />

#### HOW

Explicitly specify `secondaryChipColors()`. Might also be a good idea to convert the Chip() to ActionSetting() for consistency too but going with the less invasive change.

#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
