### PR TITLE
Cleanup the coroutines code in CaptureComposable.kt

### DIFF
--- a/sample/src/main/java/com/google/android/horologist/sample/tiles/ComposableTileService.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/tiles/ComposableTileService.kt
@@ -22,9 +22,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material3.FilledIconButton
 import androidx.wear.compose.material3.Text
 import androidx.wear.protolayout.DimensionBuilders.dp
@@ -72,17 +73,22 @@ class ComposableTileService : SuspendingTileService() {
 
     override suspend fun resourcesRequest(requestParams: ResourcesRequest): Resources {
         // Add images to the Resources object, and return
+        val circleComposeBitmap = circleCompose()
         return Resources.Builder()
             .setVersion(requestParams.version)
-            .addIdToImageMapping(
-                ComposeId,
-                circleCompose().copy(Bitmap.Config.ARGB_8888, false).toImageResource(),
-            )
+            .apply {
+                if (circleComposeBitmap != null) {
+                    addIdToImageMapping(
+                        ComposeId,
+                        circleComposeBitmap.copy(Bitmap.Config.ARGB_8888, false).toImageResource(),
+                    )
+                }
+            }
             .build()
     }
 
-    private suspend fun circleCompose(): Bitmap =
-        renderer.renderComposableToBitmap(Size(200f, 200f)) {
+    private suspend fun circleCompose(): Bitmap? =
+        renderer.renderComposableToBitmap(DpSize(100.dp, 100.dp)) {
             Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 Canvas(modifier = Modifier.fillMaxSize()) {
                     drawCircle(Color.DarkGray)
@@ -91,5 +97,5 @@ class ComposableTileService : SuspendingTileService() {
                     Text("\uD83D\uDC6A")
                 }
             }
-        }.asAndroidBitmap()
+        }?.asAndroidBitmap()
 }

--- a/tiles/api/current.api
+++ b/tiles/api/current.api
@@ -86,12 +86,12 @@ package com.google.android.horologist.tiles.components {
 package com.google.android.horologist.tiles.composable {
 
   public interface ComposableBitmapRenderer {
-    method public suspend Object? renderComposableToBitmap(long canvasSize, kotlin.jvm.functions.Function0<kotlin.Unit> composableContent, kotlin.coroutines.Continuation<? super androidx.compose.ui.graphics.ImageBitmap>);
+    method public suspend Object? renderComposableToBitmap(long canvasSize, kotlin.jvm.functions.Function0<kotlin.Unit> composableContent, kotlin.coroutines.Continuation<? super androidx.compose.ui.graphics.ImageBitmap?>);
   }
 
   public final class ServiceComposableBitmapRenderer implements com.google.android.horologist.tiles.composable.ComposableBitmapRenderer {
     ctor public ServiceComposableBitmapRenderer(android.app.Application application);
-    method public suspend Object? renderComposableToBitmap(long canvasSize, kotlin.jvm.functions.Function0<kotlin.Unit> composableContent, kotlin.coroutines.Continuation<? super androidx.compose.ui.graphics.ImageBitmap>);
+    method public suspend Object? renderComposableToBitmap(long canvasSize, kotlin.jvm.functions.Function0<kotlin.Unit> composableContent, kotlin.coroutines.Continuation<? super androidx.compose.ui.graphics.ImageBitmap?>);
   }
 
 }

--- a/tiles/src/main/java/com/google/android/horologist/tiles/composable/CaptureComposable.kt
+++ b/tiles/src/main/java/com/google/android/horologist/tiles/composable/CaptureComposable.kt
@@ -17,30 +17,26 @@
 package com.google.android.horologist.tiles.composable
 
 import android.app.Application
+import android.app.Dialog
 import android.app.Presentation
 import android.content.Context
-import android.content.Context.DISPLAY_SERVICE
 import android.graphics.SurfaceTexture
 import android.hardware.display.DisplayManager
-import android.hardware.display.VirtualDisplay
 import android.view.Display
 import android.view.Surface
 import android.view.ViewGroup
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -50,7 +46,11 @@ import androidx.savedstate.SavedStateRegistry
 import androidx.savedstate.SavedStateRegistryController
 import androidx.savedstate.SavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
-import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 
 /**
  * A renderer that renders a composable to a bitmap.
@@ -58,9 +58,9 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 public interface ComposableBitmapRenderer {
 
     public suspend fun renderComposableToBitmap(
-        canvasSize: Size,
+        canvasSize: DpSize,
         composableContent: @Composable () -> Unit,
-    ): ImageBitmap
+    ): ImageBitmap?
 }
 
 /**
@@ -78,133 +78,147 @@ public interface ComposableBitmapRenderer {
 public class ServiceComposableBitmapRenderer(private val application: Application) :
     ComposableBitmapRenderer {
 
-        private suspend fun <T> useVirtualDisplay(callback: suspend (display: Display) -> T): T {
-            val texture = SurfaceTexture(false)
-            val surface = Surface(texture)
-            val virtualDisplay: VirtualDisplay? =
-                (application.getSystemService(DISPLAY_SERVICE) as DisplayManager).createVirtualDisplay(
-                    "virtualDisplay",
-                    1,
-                    1,
-                    72,
-                    surface,
-                    DisplayManager.VIRTUAL_DISPLAY_FLAG_OWN_CONTENT_ONLY,
-                )
+    private suspend fun <T> useVirtualDisplay(callback: suspend (display: Display) -> T): T? {
+        val texture = SurfaceTexture(false)
+        val surface = Surface(texture)
+        val virtualDisplay =
+            application.getSystemService(DisplayManager::class.java).createVirtualDisplay(
+                "virtualDisplay",
+                1,
+                1,
+                72,
+                surface,
+                DisplayManager.VIRTUAL_DISPLAY_FLAG_OWN_CONTENT_ONLY,
+            ) ?: return null
 
-            val result = callback(virtualDisplay!!.display)
-            virtualDisplay.release()
-            surface.release()
-            texture.release()
-            return result
-        }
+        val result = callback(virtualDisplay!!.display)
+        virtualDisplay.release()
+        surface.release()
+        texture.release()
+        return result
+    }
 
-        override suspend fun renderComposableToBitmap(
-            canvasSize: Size,
-            composableContent: @Composable () -> Unit,
-        ): ImageBitmap {
-            val bitmap = useVirtualDisplay { display ->
-                val outputDensity = Density(1f)
+    override suspend fun renderComposableToBitmap(
+        canvasSize: DpSize,
+        composableContent: @Composable () -> Unit,
+    ): ImageBitmap? {
+        val bitmap = useVirtualDisplay { display ->
+            val density = Density(application)
 
-                val logicalHeightDp = canvasSize.height.dp
-                val logicalWidthDp = canvasSize.width.dp
-
-                val captureDpSize = DpSize(width = logicalWidthDp, height = logicalHeightDp)
-
-                captureComposable(
-                    context = application,
-                    size = captureDpSize,
-                    density = outputDensity,
-                    display = display,
-                ) {
-                    composableContent()
-                }
-            }
-            return bitmap
-        }
-
-        private fun Size.roundedToIntSize(): IntSize =
-            IntSize(width.toInt(), height.toInt())
-
-        private class EmptySavedStateRegistryOwner : SavedStateRegistryOwner {
-            private val controller = SavedStateRegistryController.create(this).apply {
-                performRestore(null)
-            }
-
-            private val lifecycleOwner: LifecycleOwner = ProcessLifecycleOwner.get()
-
-            override val lifecycle: Lifecycle
-                get() =
-                    object : Lifecycle() {
-                        @Suppress("UNNECESSARY_SAFE_CALL")
-                        override fun addObserver(observer: LifecycleObserver) {
-                            lifecycleOwner?.lifecycle?.addObserver(observer)
-                        }
-
-                        @Suppress("UNNECESSARY_SAFE_CALL")
-                        override fun removeObserver(observer: LifecycleObserver) {
-                            lifecycleOwner?.lifecycle?.removeObserver(observer)
-                        }
-
-                        override val currentState = State.INITIALIZED
-                    }
-
-            override val savedStateRegistry: SavedStateRegistry
-                get() = controller.savedStateRegistry
-        }
-
-        /** Captures composable content, by default using a hidden window on the default display.
-         *
-         *  Be sure to invoke capture() within the composable content (e.g. in a LaunchedEffect) to perform the capture.
-         *  This gives some level of control over when the capture occurs, so it's possible to wait for async resources */
-        private suspend fun captureComposable(
-            context: Context,
-            size: DpSize,
-            density: Density = Density(density = 1f),
-            display: Display = (context.getSystemService(DISPLAY_SERVICE) as DisplayManager)
-                .getDisplay(Display.DEFAULT_DISPLAY),
-            content: @Composable () -> Unit,
-        ): ImageBitmap {
-            val presentation = Presentation(context.applicationContext, display).apply {
+            val presentation = Presentation(application, display).apply {
                 window?.decorView?.let { view ->
                     view.setViewTreeLifecycleOwner(ProcessLifecycleOwner.get())
                     view.setViewTreeSavedStateRegistryOwner(EmptySavedStateRegistryOwner())
-                    view.alpha =
-                        0f // If using default display, to ensure this does not appear on top of content.
                 }
             }
 
-            val composeView = ComposeView(context).apply {
-                val intSize = with(density) { size.toSize().roundedToIntSize() }
-                require(intSize.width > 0 && intSize.height > 0) { "pixel size must not have zero dimension" }
-
-                layoutParams = ViewGroup.LayoutParams(intSize.width, intSize.height)
-            }
-
-            presentation.setContentView(composeView, composeView.layoutParams)
-            presentation.show()
-
-            val androidBitmap = suspendCancellableCoroutine { continuation ->
-                composeView.setContent {
-                    val graphicsLayer = rememberGraphicsLayer()
-                    Box(
-                        modifier = Modifier
-                            .size(size)
-                            .drawWithContent {
-                                graphicsLayer.record {
-                                    this@drawWithContent.drawContent()
-                                }
-                                drawLayer(graphicsLayer)
-                            },
+            coroutineScope {
+                try {
+                    val result = captureComposable(
+                        context = application,
+                        size = canvasSize,
+                        density = density,
+                        presentation = presentation,
+                        coroutineScope = this,
                     ) {
-                        LaunchedEffect(Unit) {
-                            val composeImageBitmap = graphicsLayer.toImageBitmap()
-                            continuation.resumeWith(Result.success(composeImageBitmap))
-                        }
-                        content()
+                        composableContent()
                     }
+
+                    result.await()
+                } finally {
+                    presentation.dismiss()
                 }
             }
-            presentation.dismiss()
-            return androidBitmap
+        }
+        return bitmap
+    }
+
+    private fun Size.roundedToIntSize(): IntSize =
+        IntSize(width.toInt(), height.toInt())
+
+    private class EmptySavedStateRegistryOwner : SavedStateRegistryOwner {
+        private val controller = SavedStateRegistryController.create(this).apply {
+            performRestore(null)
+        }
+
+        private val lifecycleOwner: LifecycleOwner = ProcessLifecycleOwner.get()
+
+        override val lifecycle: Lifecycle
+            get() =
+                object : Lifecycle() {
+                    @Suppress("UNNECESSARY_SAFE_CALL")
+                    override fun addObserver(observer: LifecycleObserver) {
+                        lifecycleOwner?.lifecycle?.addObserver(observer)
+                    }
+
+                    @Suppress("UNNECESSARY_SAFE_CALL")
+                    override fun removeObserver(observer: LifecycleObserver) {
+                        lifecycleOwner?.lifecycle?.removeObserver(observer)
+                    }
+
+                    override val currentState = State.INITIALIZED
+                }
+
+        override val savedStateRegistry: SavedStateRegistry
+            get() = controller.savedStateRegistry
+    }
+
+    /** Captures composable content, by default using a hidden window on the default display.
+     *
+     *  Be sure to invoke capture() within the composable content (e.g. in a LaunchedEffect) to perform the capture.
+     *  This gives some level of control over when the capture occurs, so it's possible to wait for async resources */
+    private fun captureComposable(
+        context: Context,
+        size: DpSize,
+        density: Density = Density(density = 1f),
+        presentation: Dialog,
+        coroutineScope: CoroutineScope,
+        content: @Composable () -> Unit,
+    ): Deferred<ImageBitmap> {
+        val composeView = ComposeView(context).apply {
+            val intSize = with(density) { size.toSize().roundedToIntSize() }
+            require(intSize.width > 0 && intSize.height > 0) { "pixel size must not have zero dimension" }
+
+            layoutParams = ViewGroup.LayoutParams(intSize.width, intSize.height)
+        }
+
+        presentation.setContentView(composeView, composeView.layoutParams)
+        presentation.show()
+
+        val result = CompletableDeferred<ImageBitmap>()
+        composeView.setContent {
+            InnerComposable(
+                coroutineScope = coroutineScope,
+                content = content,
+                onResult = {
+                    result.complete(it)
+                },
+            )
+        }
+
+        return result
+    }
+
+    @Composable
+    private fun InnerComposable(
+        coroutineScope: CoroutineScope,
+        content: @Composable () -> Unit,
+        onResult: (ImageBitmap) -> Unit,
+    ) {
+        val graphicsLayer = rememberGraphicsLayer()
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .drawWithContent {
+                    graphicsLayer.record {
+                        this@drawWithContent.drawContent()
+                    }
+                    coroutineScope.launch {
+                        onResult(graphicsLayer.toImageBitmap())
+                    }
+                },
+        ) {
+            content()
         }
     }
+}

--- a/tiles/src/test/java/com/google/android/horologist/tiles/RobolectricComposableBitmapRenderer.kt
+++ b/tiles/src/test/java/com/google/android/horologist/tiles/RobolectricComposableBitmapRenderer.kt
@@ -20,10 +20,13 @@ import android.os.Looper.getMainLooper
 import android.view.View
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.unit.DpSize
 import androidx.concurrent.futures.await
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.view.captureToBitmapAsync
@@ -33,14 +36,18 @@ import org.robolectric.shadows.ShadowLooper
 
 class RobolectricComposableBitmapRenderer() : ComposableBitmapRenderer {
     override suspend fun renderComposableToBitmap(
-        canvasSize: Size,
+        canvasSize: DpSize,
         composableContent: @Composable () -> Unit,
     ): ImageBitmap {
         val scenario = ActivityScenario.launch(ComponentActivity::class.java)
 
         lateinit var content: View
         scenario.onActivity({ activity ->
-            activity.setContent { composableContent() }
+            activity.setContent {
+                Box(modifier = Modifier.size(canvasSize)) {
+                    composableContent()
+                }
+            }
             content = activity.findViewById(android.R.id.content)
         })
 

--- a/tiles/src/test/java/com/google/android/horologist/tiles/TileScreenshotTest.kt
+++ b/tiles/src/test/java/com/google/android/horologist/tiles/TileScreenshotTest.kt
@@ -63,7 +63,7 @@ class TileScreenshotTest : WearScreenshotTest() {
         "src/test/screenshots/" +
             "${javaClass.simpleName}_" +
             "${testInfo.methodName}_" +
-            "${super.device?.id ?: WearDevice.GenericLargeRound.id}" +
+                (super.device?.id ?: WearDevice.GenericLargeRound.id) +
             "$suffix.png"
 
     @Composable
@@ -116,7 +116,7 @@ class TileScreenshotTest : WearScreenshotTest() {
     fun composable() {
         val capture = RobolectricComposableBitmapRenderer()
         val bitmap = runBlocking {
-            capture.renderComposableToBitmap(DpSize(100.dp, 100.dp)) {
+            capture.renderComposableToBitmap(DpSize(400.dp, 300.dp)) {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     Canvas(modifier = Modifier.fillMaxSize()) {
                         drawCircle(androidx.compose.ui.graphics.Color.DarkGray)

--- a/tiles/src/test/java/com/google/android/horologist/tiles/TileScreenshotTest.kt
+++ b/tiles/src/test/java/com/google/android/horologist/tiles/TileScreenshotTest.kt
@@ -63,7 +63,7 @@ class TileScreenshotTest : WearScreenshotTest() {
         "src/test/screenshots/" +
             "${javaClass.simpleName}_" +
             "${testInfo.methodName}_" +
-                (super.device?.id ?: WearDevice.GenericLargeRound.id) +
+            (super.device?.id ?: WearDevice.GenericLargeRound.id) +
             "$suffix.png"
 
     @Composable

--- a/tiles/src/test/java/com/google/android/horologist/tiles/TileScreenshotTest.kt
+++ b/tiles/src/test/java/com/google/android/horologist/tiles/TileScreenshotTest.kt
@@ -33,6 +33,8 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material3.FilledIconButton
 import androidx.wear.compose.material3.Text
 import androidx.wear.protolayout.ColorBuilders.argb
@@ -115,7 +117,7 @@ class TileScreenshotTest : WearScreenshotTest() {
     fun composable() {
         val capture = RobolectricComposableBitmapRenderer()
         val bitmap = runBlocking {
-            capture.renderComposableToBitmap(Size(100f, 100f)) {
+            capture.renderComposableToBitmap(DpSize(100.dp, 100.dp)) {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     Canvas(modifier = Modifier.fillMaxSize()) {
                         drawCircle(androidx.compose.ui.graphics.Color.DarkGray)

--- a/tiles/src/test/java/com/google/android/horologist/tiles/TileScreenshotTest.kt
+++ b/tiles/src/test/java/com/google/android/horologist/tiles/TileScreenshotTest.kt
@@ -29,7 +29,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.ExperimentalTestApi

--- a/tiles/src/test/screenshots/TileScreenshotTest_composable_large_round.png
+++ b/tiles/src/test/screenshots/TileScreenshotTest_composable_large_round.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:81d9de31e3849ef8034377e56a50d88aa1bafc4bb866ce53d41cb3b681bc3f13
-size 19263
+oid sha256:63b7dfa727d5453a9ceaa9efe09b9342c61420240d0823c5128ff5800c266044
+size 17786

--- a/tiles/src/test/screenshots/TileScreenshotTest_composable_large_round.png
+++ b/tiles/src/test/screenshots/TileScreenshotTest_composable_large_round.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:63b7dfa727d5453a9ceaa9efe09b9342c61420240d0823c5128ff5800c266044
-size 17786
+oid sha256:97c02fba1808f9a7e5bb8b5e76fb9e99e3281a2d9e7ee213e776c8652d18b433
+size 19304

--- a/tiles/src/test/screenshots/TileScreenshotTest_composable_large_round.png
+++ b/tiles/src/test/screenshots/TileScreenshotTest_composable_large_round.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:97c02fba1808f9a7e5bb8b5e76fb9e99e3281a2d9e7ee213e776c8652d18b433
-size 19304
+oid sha256:81d9de31e3849ef8034377e56a50d88aa1bafc4bb866ce53d41cb3b681bc3f13
+size 19263


### PR DESCRIPTION
#### WHAT

Split out functions to separate layers of abstraction (Compose, Coroutines, Normal).

#### WHY

Got some warnings about mixing suspend and non suspend methods. False alarm due to nesting, but removing that confusion seems worthwhile. 

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
