### PR TITLE
Update SignInPromptScreen to compose-material3

### DIFF
--- a/auth/composables-material3/api/current.api
+++ b/auth/composables-material3/api/current.api
@@ -1,4 +1,16 @@
 // Signature format: 4.0
+package com.google.android.horologist.auth.composables.material3.buttons {
+
+  public final class GuestModeButtonKt {
+    method @androidx.compose.runtime.Composable public static void GuestModeButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional String label, optional androidx.wear.compose.material3.ButtonColors colors, optional boolean enabled);
+  }
+
+  public final class SignInButtonKt {
+    method @androidx.compose.runtime.Composable public static void SignInButton(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional String label, optional androidx.wear.compose.material3.ButtonColors colors, optional boolean enabled);
+  }
+
+}
+
 package com.google.android.horologist.auth.composables.material3.models {
 
   public final class AccountUiModel {

--- a/auth/composables-material3/src/debug/java/com/google/android/horologist/auth/composables/material3/buttons/GuestModeButtonPreview.kt
+++ b/auth/composables-material3/src/debug/java/com/google/android/horologist/auth/composables/material3/buttons/GuestModeButtonPreview.kt
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.auth.composables.material3.theme
+package com.google.android.horologist.auth.composables.material3.buttons
 
-import androidx.compose.ui.graphics.Color
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
 
-internal val horologist_primary: Color = Color(0xFFD3E3FD)
-internal val horologist_on_primary: Color = Color(0xFF001944)
-internal val horologist_primary_container: Color = Color(0xFF04409F)
-internal val horologist_on_primary_container: Color = Color(0xFFD3E3FD)
-internal val horologist_on_background: Color = Color(0xFFFFFFFF)
-internal val horologist_surface_container: Color = Color(0xFF29303D)
-internal val horologist_on_surface: Color = Color(0xFFEBF1FF)
+@Preview(
+    backgroundColor = 0xff000000,
+    showBackground = true,
+)
+@Composable
+fun GuestModeButtonPreview() {
+    GuestModeButton(onClick = { })
+}

--- a/auth/composables-material3/src/debug/java/com/google/android/horologist/auth/composables/material3/buttons/SignInButtonPreview.kt
+++ b/auth/composables-material3/src/debug/java/com/google/android/horologist/auth/composables/material3/buttons/SignInButtonPreview.kt
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-package com.google.android.horologist.auth.composables.material3.theme
+package com.google.android.horologist.auth.composables.material3.buttons
 
-import androidx.compose.ui.graphics.Color
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
 
-internal val horologist_primary: Color = Color(0xFFD3E3FD)
-internal val horologist_on_primary: Color = Color(0xFF001944)
-internal val horologist_primary_container: Color = Color(0xFF04409F)
-internal val horologist_on_primary_container: Color = Color(0xFFD3E3FD)
-internal val horologist_on_background: Color = Color(0xFFFFFFFF)
-internal val horologist_surface_container: Color = Color(0xFF29303D)
-internal val horologist_on_surface: Color = Color(0xFFEBF1FF)
+@Preview(
+    backgroundColor = 0xff000000,
+    showBackground = true,
+)
+@Composable
+fun SignInButtonPreview() {
+    SignInButton(onClick = { })
+}

--- a/auth/composables-material3/src/main/java/com/google/android/horologist/auth/composables/material3/buttons/GuestModeButton.kt
+++ b/auth/composables-material3/src/main/java/com/google/android/horologist/auth/composables/material3/buttons/GuestModeButton.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.composables.material3.buttons
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.wear.compose.material3.Button
+import androidx.wear.compose.material3.ButtonColors
+import androidx.wear.compose.material3.ButtonDefaults
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import com.google.android.horologist.auth.composables.material3.R
+
+/**
+ * An opinionated [Button] to represent the "Guest mode" action.
+ *
+ * <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables-material3/guest_mode_button.png" height="120" width="120" >
+ *
+ * @sample com.google.android.horologist.auth.sample.screens.googlesignin.prompt.GoogleSignInPromptSampleScreen
+ */
+@Composable
+public fun GuestModeButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    label: String = stringResource(id = R.string.horologist_guest_mode_chip_label),
+    colors: ButtonColors = ButtonDefaults.filledTonalButtonColors(),
+    enabled: Boolean = true,
+) {
+    Button(
+        label = {
+            Text(
+                label,
+                style = MaterialTheme.typography.titleMedium,
+                textAlign = TextAlign.Start,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
+        colors = colors,
+        enabled = enabled,
+    )
+}

--- a/auth/composables-material3/src/main/java/com/google/android/horologist/auth/composables/material3/buttons/SignInButton.kt
+++ b/auth/composables-material3/src/main/java/com/google/android/horologist/auth/composables/material3/buttons/SignInButton.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.composables.material3.buttons
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AccountCircle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.wear.compose.material3.Button
+import androidx.wear.compose.material3.ButtonColors
+import androidx.wear.compose.material3.ButtonDefaults
+import androidx.wear.compose.material3.ButtonDefaults.ButtonHorizontalPadding
+import androidx.wear.compose.material3.ButtonDefaults.ButtonVerticalPadding
+import androidx.wear.compose.material3.Icon
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import com.google.android.horologist.auth.composables.material3.R
+
+/**
+ * An opinionated [Button] to represent the "Sign in" action.
+ *
+ * <img src="https://media.githubusercontent.com/media/google/horologist/main/docs/auth-composables-material3/sign_in_button.png" height="120" width="120" >
+ *
+ * @sample com.google.android.horologist.auth.sample.screens.googlesignin.prompt.GoogleSignInPromptSampleScreen
+ */
+@Composable
+public fun SignInButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    label: String = stringResource(id = R.string.horologist_sign_in_chip_label),
+    colors: ButtonColors = ButtonDefaults.filledTonalButtonColors(),
+    enabled: Boolean = true,
+) {
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        label = {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.titleMedium,
+            )
+        },
+        icon = {
+            Icon(
+                imageVector = Icons.Outlined.AccountCircle,
+                contentDescription = null,
+                modifier = Modifier.size(ButtonDefaults.IconSize),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+        },
+        colors = colors,
+        contentPadding = PaddingValues(
+            start = ButtonHorizontalPadding,
+            top = ButtonVerticalPadding,
+            end = ButtonHorizontalPadding,
+            bottom = ButtonVerticalPadding,
+        ),
+        modifier = modifier.fillMaxWidth(),
+    )
+}

--- a/auth/composables-material3/src/main/java/com/google/android/horologist/auth/composables/material3/theme/Theme.kt
+++ b/auth/composables-material3/src/main/java/com/google/android/horologist/auth/composables/material3/theme/Theme.kt
@@ -28,6 +28,8 @@ internal fun HorologistMaterialTheme(content: @Composable () -> Unit) {
             primaryContainer = horologist_primary_container,
             onPrimaryContainer = horologist_on_primary_container,
             onBackground = horologist_on_background,
+            surfaceContainer = horologist_surface_container,
+            onSurface = horologist_on_surface,
         ),
         content = content,
     )

--- a/auth/composables-material3/src/test/java/com/google/android/horologist/auth/composables/material3/buttons/GuestModeButtonTest.kt
+++ b/auth/composables-material3/src/test/java/com/google/android/horologist/auth/composables/material3/buttons/GuestModeButtonTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.composables.material3.buttons
+
+import androidx.wear.compose.material3.ButtonDefaults
+import com.google.android.horologist.auth.composables.material3.theme.HorologistMaterialTheme
+import com.google.android.horologist.screenshots.rng.WearLegacyComponentTest
+import org.junit.Test
+
+class GuestModeButtonTest : WearLegacyComponentTest() {
+
+    @Test
+    fun default() {
+        runComponentTest {
+            HorologistMaterialTheme {
+                GuestModeButton(onClick = {})
+            }
+        }
+    }
+
+    @Test
+    fun disabled() {
+        runComponentTest {
+            HorologistMaterialTheme {
+                GuestModeButton(
+                    onClick = {},
+                    enabled = false,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun withVariantButtonStyle() {
+        runComponentTest {
+            GuestModeButton(
+                onClick = {},
+                colors = ButtonDefaults.filledVariantButtonColors(),
+            )
+        }
+    }
+
+    @Test
+    fun withVariantButtonStyleDisabled() {
+        runComponentTest {
+            HorologistMaterialTheme {
+                GuestModeButton(
+                    onClick = {},
+                    colors = ButtonDefaults.filledVariantButtonColors(),
+                    enabled = false,
+                )
+            }
+        }
+    }
+}

--- a/auth/composables-material3/src/test/java/com/google/android/horologist/auth/composables/material3/buttons/SignInButtonTest.kt
+++ b/auth/composables-material3/src/test/java/com/google/android/horologist/auth/composables/material3/buttons/SignInButtonTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.auth.composables.material3.buttons
+
+import androidx.wear.compose.material3.ButtonDefaults
+import com.google.android.horologist.auth.composables.material3.theme.HorologistMaterialTheme
+import com.google.android.horologist.screenshots.rng.WearLegacyComponentTest
+import org.junit.Test
+
+class SignInButtonTest : WearLegacyComponentTest() {
+
+    @Test
+    fun default() {
+        runComponentTest {
+            HorologistMaterialTheme {
+                SignInButton(onClick = {})
+            }
+        }
+    }
+
+    @Test
+    fun disabled() {
+        runComponentTest {
+            HorologistMaterialTheme {
+                SignInButton(
+                    onClick = {},
+                    enabled = false,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun withVariantButtonStyle() {
+        runComponentTest {
+            HorologistMaterialTheme {
+                SignInButton(
+                    onClick = {},
+                    colors = ButtonDefaults.filledVariantButtonColors(),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun withVariantButtonStyleDisabled() {
+        runComponentTest {
+            HorologistMaterialTheme {
+                SignInButton(
+                    onClick = {},
+                    colors = ButtonDefaults.filledVariantButtonColors(),
+                    enabled = false,
+                )
+            }
+        }
+    }
+}

--- a/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.buttons_GuestModeButtonTest_default.png
+++ b/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.buttons_GuestModeButtonTest_default.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bba2e0b44d6d6ccaaee883859a8a6a61d9bf24b96a2f113854d4d4ab8d9e4df4
+size 6400

--- a/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.buttons_GuestModeButtonTest_disabled.png
+++ b/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.buttons_GuestModeButtonTest_disabled.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8abc3937a78dad209bae9637ff31e021f9ec87c521512165a77c89fa8a2d2a08
+size 5851

--- a/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.buttons_GuestModeButtonTest_withVariantButtonStyle.png
+++ b/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.buttons_GuestModeButtonTest_withVariantButtonStyle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3c3b56b1985d2d881f5de9767132cf0f95d7f8c3cd291ead75fe5072ef1b4ed
+size 6399

--- a/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.buttons_GuestModeButtonTest_withVariantButtonStyleDisabled.png
+++ b/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.buttons_GuestModeButtonTest_withVariantButtonStyleDisabled.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8abc3937a78dad209bae9637ff31e021f9ec87c521512165a77c89fa8a2d2a08
+size 5851

--- a/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.buttons_SignInButtonTest_default.png
+++ b/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.buttons_SignInButtonTest_default.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a1917ccd6b5be3e9576a5435c95ce2a7fb0a088eadc716da31cd349aa750cc1
+size 5700

--- a/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.buttons_SignInButtonTest_disabled.png
+++ b/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.buttons_SignInButtonTest_disabled.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb580e59ab66c459b837c0b67c281bf8deb2f6f7b4bf3837b8add402f9d02bea
+size 5622

--- a/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.buttons_SignInButtonTest_withVariantButtonStyle.png
+++ b/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.buttons_SignInButtonTest_withVariantButtonStyle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ad201c8a3aab0aeff132f2ad2746ac77ada8dcc97ef96fd06c95c62bd23d7f3
+size 5461

--- a/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.buttons_SignInButtonTest_withVariantButtonStyleDisabled.png
+++ b/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.buttons_SignInButtonTest_withVariantButtonStyleDisabled.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb580e59ab66c459b837c0b67c281bf8deb2f6f7b4bf3837b8add402f9d02bea
+size 5622

--- a/auth/sample/wear/build.gradle.kts
+++ b/auth/sample/wear/build.gradle.kts
@@ -92,7 +92,7 @@ dependencies {
     api(projects.annotations)
 
     implementation(platform(libs.compose.bom))
-    implementation(projects.auth.composables)
+    implementation(projects.auth.composablesMaterial3)
     implementation(projects.auth.data)
     implementation(projects.auth.sample.shared)
     implementation(projects.auth.ui)

--- a/auth/sample/wear/src/main/java/com/google/android/horologist/auth/sample/screens/googlesignin/prompt/GoogleSignInPromptSampleScreen.kt
+++ b/auth/sample/wear/src/main/java/com/google/android/horologist/auth/sample/screens/googlesignin/prompt/GoogleSignInPromptSampleScreen.kt
@@ -27,12 +27,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
-import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
-import com.google.android.horologist.auth.composables.chips.GuestModeChip
-import com.google.android.horologist.auth.composables.chips.SignInChip
+import com.google.android.horologist.auth.composables.material3.buttons.GuestModeButton
+import com.google.android.horologist.auth.composables.material3.buttons.SignInButton
 import com.google.android.horologist.auth.sample.R
 import com.google.android.horologist.auth.sample.Screen
 import com.google.android.horologist.auth.ui.common.screens.prompt.SignInPromptScreen
@@ -55,19 +54,17 @@ fun GoogleSignInPromptSampleScreen(
         viewModel = viewModel,
     ) {
         item {
-            SignInChip(
+            SignInButton(
                 onClick = {
                     navController.navigate(Screen.GoogleSignInScreen.route) {
                         popUpTo(Screen.MainScreen.route)
                     }
                 },
-                colors = ChipDefaults.secondaryChipColors(),
             )
         }
         item {
-            GuestModeChip(
+            GuestModeButton(
                 onClick = navController::popBackStack,
-                colors = ChipDefaults.secondaryChipColors(),
             )
         }
     }

--- a/auth/ui/build.gradle.kts
+++ b/auth/ui/build.gradle.kts
@@ -96,6 +96,7 @@ metalava {
 dependencies {
 
     api(projects.auth.composables)
+    api(projects.auth.composablesMaterial3)
     api(projects.auth.data)
     api(projects.composeLayout)
 
@@ -115,6 +116,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodelktx)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.wear.compose.material3)
     implementation(libs.androidx.wear.phone.interactions)
     implementation(libs.compose.foundation.foundation.layout)
     implementation(libs.compose.ui.text)

--- a/auth/ui/src/debug/java/com/google/android/horologist/auth/composables/screens/SignInPromptScreenPreview.kt
+++ b/auth/ui/src/debug/java/com/google/android/horologist/auth/composables/screens/SignInPromptScreenPreview.kt
@@ -19,11 +19,11 @@ package com.google.android.horologist.auth.composables.screens
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
-import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Text
+import androidx.wear.compose.material3.ButtonDefaults
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
-import com.google.android.horologist.auth.composables.chips.GuestModeChip
-import com.google.android.horologist.auth.composables.chips.SignInChip
+import com.google.android.horologist.auth.composables.material3.buttons.GuestModeButton
+import com.google.android.horologist.auth.composables.material3.buttons.SignInButton
 import com.google.android.horologist.auth.ui.common.screens.prompt.SignInPromptScreen
 import com.google.android.horologist.auth.ui.common.screens.prompt.SignInPromptScreenState
 
@@ -38,15 +38,15 @@ fun SignInPromptScreenPreviewSignedOut() {
         onAlreadySignedIn = { },
     ) {
         item {
-            SignInChip(
+            SignInButton(
                 onClick = { },
-                colors = ChipDefaults.secondaryChipColors(),
+                colors = ButtonDefaults.filledTonalButtonColors(),
             )
         }
         item {
-            GuestModeChip(
+            GuestModeButton(
                 onClick = { },
-                colors = ChipDefaults.secondaryChipColors(),
+                colors = ButtonDefaults.filledTonalButtonColors(),
             )
         }
     }
@@ -63,15 +63,15 @@ fun SignInPromptScreenPreviewLoading() {
         onAlreadySignedIn = { },
     ) {
         item {
-            SignInChip(
+            SignInButton(
                 onClick = { },
-                colors = ChipDefaults.secondaryChipColors(),
+                colors = ButtonDefaults.filledTonalButtonColors(),
             )
         }
         item {
-            GuestModeChip(
+            GuestModeButton(
                 onClick = { },
-                colors = ChipDefaults.secondaryChipColors(),
+                colors = ButtonDefaults.filledTonalButtonColors(),
             )
         }
     }
@@ -93,15 +93,15 @@ fun SignInPromptScreenPreviewCustomLoading() {
         },
     ) {
         item {
-            SignInChip(
+            SignInButton(
                 onClick = { },
-                colors = ChipDefaults.secondaryChipColors(),
+                colors = ButtonDefaults.filledTonalButtonColors(),
             )
         }
         item {
-            GuestModeChip(
+            GuestModeButton(
                 onClick = { },
-                colors = ChipDefaults.secondaryChipColors(),
+                colors = ButtonDefaults.filledTonalButtonColors(),
             )
         }
     }

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptScreen.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptScreen.kt
@@ -24,11 +24,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.wear.compose.foundation.lazy.ScalingLazyListScope
-import com.google.android.horologist.auth.composables.R
-import com.google.android.horologist.auth.composables.model.AccountUiModel
+import androidx.wear.compose.material3.AlertDialogContent
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import com.google.android.horologist.auth.composables.material3.R
+import com.google.android.horologist.auth.composables.material3.models.AccountUiModel
 import com.google.android.horologist.auth.composables.screens.SignInPlaceholderScreen
 import com.google.android.horologist.compose.layout.ScreenScaffold
-import com.google.android.horologist.compose.material.AlertContent
 
 /**
  * A screen to prompt users to sign in.
@@ -103,9 +105,19 @@ public fun SignInPromptScreen(
             }
 
             SignInPromptScreenState.SignedOut -> {
-                AlertContent(
-                    title = title,
-                    message = message,
+                AlertDialogContent(
+                    title = @Composable {
+                        Text(
+                            text = title,
+                            style = MaterialTheme.typography.titleLarge,
+                        )
+                    },
+                    text = @Composable {
+                        Text(
+                            text = message,
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    },
                     content = content,
                     modifier = modifier,
                 )

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptViewModel.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptViewModel.kt
@@ -18,7 +18,7 @@ package com.google.android.horologist.auth.ui.common.screens.prompt
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.android.horologist.auth.composables.model.AccountUiModel
+import com.google.android.horologist.auth.composables.material3.models.AccountUiModel
 import com.google.android.horologist.auth.data.common.repository.AuthUserRepository
 import com.google.android.horologist.auth.ui.ext.compareAndSet
 import com.google.android.horologist.auth.ui.mapper.AccountUiModelMapper

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInDefaultScreen.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInDefaultScreen.kt
@@ -21,9 +21,9 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.google.android.horologist.auth.composables.dialogs.SignedInConfirmationDialog
-import com.google.android.horologist.auth.composables.model.AccountUiModel
-import com.google.android.horologist.auth.composables.screens.SelectAccountScreen
+import com.google.android.horologist.auth.composables.material3.models.AccountUiModel
+import com.google.android.horologist.auth.composables.material3.screens.SelectAccountScreen
+import com.google.android.horologist.auth.composables.material3.screens.SignedInConfirmationScreen
 
 /**
  * An opinionated implementation of [StreamlineSignInScreen] that:
@@ -60,7 +60,7 @@ public fun StreamlineSignInDefaultScreen(
 
         is StreamlineSignInDefaultScreenState.SignedIn -> {
             val account = (state as StreamlineSignInDefaultScreenState.SignedIn).account
-            SignedInConfirmationDialog(
+            SignedInConfirmationScreen(
                 onDismissOrTimeout = { onSignedInConfirmationDialogDismissOrTimeout(account) },
                 modifier = modifier,
                 accountUiModel = account,

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInDefaultViewModel.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInDefaultViewModel.kt
@@ -18,7 +18,7 @@ package com.google.android.horologist.auth.ui.common.screens.streamline
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.android.horologist.auth.composables.model.AccountUiModel
+import com.google.android.horologist.auth.composables.material3.models.AccountUiModel
 import com.google.android.horologist.auth.data.common.repository.AuthUserRepository
 import com.google.android.horologist.auth.ui.ext.compareAndSet
 import com.google.android.horologist.auth.ui.mapper.AccountUiModelMapper

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInScreen.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInScreen.kt
@@ -21,8 +21,7 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.google.android.horologist.auth.composables.dialogs.SignedInConfirmationDialog
-import com.google.android.horologist.auth.composables.model.AccountUiModel
+import com.google.android.horologist.auth.composables.material3.models.AccountUiModel
 
 /**
  * A composable to streamline the sign in process.

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInViewModel.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInViewModel.kt
@@ -18,7 +18,7 @@ package com.google.android.horologist.auth.ui.common.screens.streamline
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.android.horologist.auth.composables.model.AccountUiModel
+import com.google.android.horologist.auth.composables.material3.models.AccountUiModel
 import com.google.android.horologist.auth.data.common.repository.AuthUserRepository
 import com.google.android.horologist.auth.ui.ext.compareAndSet
 import com.google.android.horologist.auth.ui.mapper.AccountUiModelMapper

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/mapper/AccountUiModelMapper.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/mapper/AccountUiModelMapper.kt
@@ -19,7 +19,7 @@
 package com.google.android.horologist.auth.ui.googlesignin.mapper
 
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
-import com.google.android.horologist.auth.composables.model.AccountUiModel
+import com.google.android.horologist.auth.composables.material3.models.AccountUiModel
 import com.google.android.horologist.images.coil.CoilPaintable
 
 /**
@@ -33,9 +33,10 @@ public object AccountUiModelMapper {
     public fun map(
         account: GoogleSignInAccount,
         defaultEmail: String = "",
+        defaultName: String = "",
     ): AccountUiModel = AccountUiModel(
         email = account.email ?: defaultEmail,
-        name = account.displayName,
+        name = account.displayName ?: defaultName,
         avatar = account.photoUrl?.let { CoilPaintable(it) },
     )
 }

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInScreen.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInScreen.kt
@@ -39,7 +39,7 @@ import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.google.android.gms.auth.api.signin.GoogleSignInStatusCodes
 import com.google.android.gms.auth.api.signin.GoogleSignInStatusCodes.SIGN_IN_CANCELLED
 import com.google.android.gms.common.api.ApiException
-import com.google.android.horologist.auth.composables.dialogs.SignedInConfirmationDialog
+import com.google.android.horologist.auth.composables.material3.screens.SignedInConfirmationScreen
 import com.google.android.horologist.auth.composables.screens.AuthErrorScreen
 import com.google.android.horologist.auth.composables.screens.SignInPlaceholderScreen
 import com.google.android.horologist.auth.ui.common.logging.TAG
@@ -151,7 +151,7 @@ public fun GoogleSignInScreen(
         },
         viewModel = viewModel,
     ) { successState ->
-        SignedInConfirmationDialog(
+        SignedInConfirmationScreen(
             onDismissOrTimeout = { onAuthSucceed() },
             modifier = modifier,
             accountUiModel = successState.accountUiModel,

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInViewModel.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/googlesignin/signin/GoogleSignInViewModel.kt
@@ -22,7 +22,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
-import com.google.android.horologist.auth.composables.model.AccountUiModel
+import com.google.android.horologist.auth.composables.material3.models.AccountUiModel
 import com.google.android.horologist.auth.data.googlesignin.GoogleSignInEventListener
 import com.google.android.horologist.auth.data.googlesignin.GoogleSignInEventListenerNoOpImpl
 import com.google.android.horologist.auth.ui.googlesignin.mapper.AccountUiModelMapper

--- a/auth/ui/src/main/java/com/google/android/horologist/auth/ui/mapper/AccountUiModelMapper.kt
+++ b/auth/ui/src/main/java/com/google/android/horologist/auth/ui/mapper/AccountUiModelMapper.kt
@@ -16,7 +16,7 @@
 
 package com.google.android.horologist.auth.ui.mapper
 
-import com.google.android.horologist.auth.composables.model.AccountUiModel
+import com.google.android.horologist.auth.composables.material3.models.AccountUiModel
 import com.google.android.horologist.auth.data.common.model.AuthUser
 import com.google.android.horologist.images.coil.CoilPaintable
 
@@ -28,9 +28,9 @@ public object AccountUiModelMapper {
     /**
      * Maps from a [AuthUser].
      */
-    public fun map(authUser: AuthUser, defaultEmail: String = ""): AccountUiModel = AccountUiModel(
+    public fun map(authUser: AuthUser, defaultEmail: String = "", defaultName: String = ""): AccountUiModel = AccountUiModel(
         email = authUser.email ?: defaultEmail,
-        name = authUser.displayName,
+        name = authUser.displayName ?: defaultName,
         avatar = authUser.avatarUri?.let { CoilPaintable(it) },
     )
 }

--- a/auth/ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptScreenTest.kt
+++ b/auth/ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptScreenTest.kt
@@ -21,11 +21,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.wear.compose.foundation.lazy.ScalingLazyListScope
-import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Text
-import com.google.android.horologist.auth.composables.chips.GuestModeChip
-import com.google.android.horologist.auth.composables.chips.SignInChip
-import com.google.android.horologist.auth.composables.model.AccountUiModel
+import com.google.android.horologist.auth.composables.material3.buttons.GuestModeButton
+import com.google.android.horologist.auth.composables.material3.buttons.SignInButton
+import com.google.android.horologist.auth.composables.material3.models.AccountUiModel
 import com.google.android.horologist.screenshots.rng.WearLegacyScreenTest
 import org.junit.Test
 
@@ -85,7 +84,12 @@ class SignInPromptScreenTest : WearLegacyScreenTest() {
     fun signedIn() {
         runTest {
             SignInPromptScreen(
-                state = SignInPromptScreenState.SignedIn(AccountUiModel("user@example.com")),
+                state = SignInPromptScreenState.SignedIn(
+                    AccountUiModel(
+                        "user@example.com",
+                        "John Doe",
+                    ),
+                ),
                 title = "Sign in",
                 message = "Send messages and create chat groups with your friends",
                 onIdleStateObserved = { },
@@ -132,17 +136,7 @@ class SignInPromptScreenTest : WearLegacyScreenTest() {
     }
 
     private fun ScalingLazyListScope.testContent() {
-        item {
-            SignInChip(
-                onClick = { },
-                colors = ChipDefaults.secondaryChipColors(),
-            )
-        }
-        item {
-            GuestModeChip(
-                onClick = { },
-                colors = ChipDefaults.secondaryChipColors(),
-            )
-        }
+        item { SignInButton(onClick = { }) }
+        item { GuestModeButton(onClick = { }) }
     }
 }

--- a/auth/ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptViewModelTest.kt
+++ b/auth/ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/prompt/SignInPromptViewModelTest.kt
@@ -19,7 +19,7 @@
 package com.google.android.horologist.auth.ui.common.screens.prompt
 
 import app.cash.turbine.test
-import com.google.android.horologist.auth.composables.model.AccountUiModel
+import com.google.android.horologist.auth.composables.material3.models.AccountUiModel
 import com.google.android.horologist.auth.data.common.model.AuthUser
 import com.google.android.horologist.test.toolbox.rules.MainDispatcherRule
 import com.google.android.horologist.test.toolbox.testdoubles.AuthUserRepositoryStub
@@ -101,14 +101,25 @@ class SignInPromptViewModelTest {
     fun givenUserAuthenticated_whenOnIdleStateObserved_thenStateIsSignedIn() = runTest {
         // given
         val email = "user@example.com"
-        fakeAuthUserRepository.authUser = AuthUser(email = email)
+        val name = "Name"
+        fakeAuthUserRepository.authUser = AuthUser(
+            email = email,
+            displayName = name,
+        )
 
         // when
         sut.onIdleStateObserved()
 
         // then
         sut.uiState.test {
-            assertThat(awaitItem()).isEqualTo(SignInPromptScreenState.SignedIn(AccountUiModel(email = email)))
+            assertThat(awaitItem()).isEqualTo(
+                SignInPromptScreenState.SignedIn(
+                    AccountUiModel(
+                        email = email,
+                        name = name,
+                    ),
+                ),
+            )
         }
     }
 }

--- a/auth/ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInDefaultViewModelTest.kt
+++ b/auth/ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInDefaultViewModelTest.kt
@@ -19,7 +19,7 @@
 package com.google.android.horologist.auth.ui.common.screens.streamline
 
 import app.cash.turbine.test
-import com.google.android.horologist.auth.composables.model.AccountUiModel
+import com.google.android.horologist.auth.composables.material3.models.AccountUiModel
 import com.google.android.horologist.auth.data.common.model.AuthUser
 import com.google.android.horologist.test.toolbox.rules.MainDispatcherRule
 import com.google.android.horologist.test.toolbox.testdoubles.AuthUserRepositoryStub
@@ -101,7 +101,8 @@ class StreamlineSignInDefaultViewModelTest {
     fun givenSingleAccountAvailable_whenOnIdleStateObserved_thenStateIsSingleAccountAvailable() = runTest {
         // given
         val email = "user@example.com"
-        fakeAuthUserRepository.authUserList = listOf(AuthUser(email = email))
+        val name = "Name"
+        fakeAuthUserRepository.authUserList = listOf(AuthUser(email = email, displayName = name))
 
         // when
         sut.onIdleStateObserved()
@@ -109,7 +110,12 @@ class StreamlineSignInDefaultViewModelTest {
         // then
         sut.uiState.test {
             assertThat(awaitItem()).isEqualTo(
-                StreamlineSignInDefaultScreenState.SignedIn(AccountUiModel(email = email)),
+                StreamlineSignInDefaultScreenState.SignedIn(
+                    AccountUiModel(
+                        email = email,
+                        name = name,
+                    ),
+                ),
             )
         }
     }
@@ -117,7 +123,7 @@ class StreamlineSignInDefaultViewModelTest {
     @Test
     fun whenOnAccountSelected_thenStateIsSignedIn() = runTest {
         // given
-        val account = AccountUiModel(email = "email@example.com")
+        val account = AccountUiModel(email = "email@example.com", name = "Name")
 
         // when
         sut.onAccountSelected(account)

--- a/auth/ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInViewModelTest.kt
+++ b/auth/ui/src/test/java/com/google/android/horologist/auth/ui/common/screens/streamline/StreamlineSignInViewModelTest.kt
@@ -19,7 +19,7 @@
 package com.google.android.horologist.auth.ui.common.screens.streamline
 
 import app.cash.turbine.test
-import com.google.android.horologist.auth.composables.model.AccountUiModel
+import com.google.android.horologist.auth.composables.material3.models.AccountUiModel
 import com.google.android.horologist.auth.data.common.model.AuthUser
 import com.google.android.horologist.test.toolbox.rules.MainDispatcherRule
 import com.google.android.horologist.test.toolbox.testdoubles.AuthUserRepositoryStub
@@ -101,7 +101,8 @@ class StreamlineSignInViewModelTest {
     fun givenSingleAccountAvailable_whenOnIdleStateObserved_thenStateIsSingleAccountAvailable() = runTest {
         // given
         val email = "user@example.com"
-        fakeAuthUserRepository.authUserList = listOf(AuthUser(email = email))
+        val name = "Name"
+        fakeAuthUserRepository.authUserList = listOf(AuthUser(email = email, displayName = name))
 
         // when
         sut.onIdleStateObserved()
@@ -109,7 +110,12 @@ class StreamlineSignInViewModelTest {
         // then
         sut.uiState.test {
             assertThat(awaitItem()).isEqualTo(
-                StreamlineSignInScreenState.SingleAccountAvailable(AccountUiModel(email = email)),
+                StreamlineSignInScreenState.SingleAccountAvailable(
+                    AccountUiModel(
+                        email = email,
+                        name = name,
+                    ),
+                ),
             )
         }
     }
@@ -119,8 +125,13 @@ class StreamlineSignInViewModelTest {
         // given
         val email1 = "user1@example.com"
         val email2 = "user2@example.com"
+        val name1 = "Name1"
+        val name2 = "Name2"
         fakeAuthUserRepository.authUserList =
-            listOf(AuthUser(email = email1), AuthUser(email = email2))
+            listOf(
+                AuthUser(email = email1, displayName = name1),
+                AuthUser(email = email2, displayName = name2),
+            )
 
         // when
         sut.onIdleStateObserved()
@@ -129,7 +140,10 @@ class StreamlineSignInViewModelTest {
         sut.uiState.test {
             assertThat(awaitItem()).isEqualTo(
                 StreamlineSignInScreenState.MultipleAccountsAvailable(
-                    listOf(AccountUiModel(email = email1), AccountUiModel(email = email2)),
+                    listOf(
+                        AccountUiModel(email = email1, name = name1),
+                        AccountUiModel(email = email2, name = name2),
+                    ),
                 ),
             )
         }

--- a/auth/ui/src/test/snapshots/images/com.google.android.horologist.auth.ui.common.screens.prompt_SignInPromptScreenTest_signedOut.png
+++ b/auth/ui/src/test/snapshots/images/com.google.android.horologist.auth.ui.common.screens.prompt_SignInPromptScreenTest_signedOut.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f5c8f88f52ba1717ad431ef3353406b1dc8b4f214693214e6129daf269adf1dd
-size 27908
+oid sha256:d55bad96b393abd72074e845b98157f0f77156023adabc61a81d71fafb335e68
+size 29738

--- a/auth/ui/src/test/snapshots/images/com.google.android.horologist.auth.ui.common.screens.prompt_SignInPromptScreenTest_signedOutTruncation.png
+++ b/auth/ui/src/test/snapshots/images/com.google.android.horologist.auth.ui.common.screens.prompt_SignInPromptScreenTest_signedOutTruncation.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d7eafdd2b3811a0bebc1ee96a9673ee69c779e02835c18bc06237b90636427d
-size 57484
+oid sha256:07e294afb0da1493f675e45d8b35138061c761471f38d2708f8bdbb54608120e
+size 39626

--- a/docs/auth-composables-material3.md
+++ b/docs/auth-composables-material3.md
@@ -1,0 +1,14 @@
+# Auth Composables Material 3
+
+This library contains a set of Material 3 composables screens and components related to authentication.
+
+The previews of the composables can be found in the `debug` folder of the module source code.
+
+This library is not dependent on any specific authentication implementation as
+per [architecture overview](auth-overview.md#architecture-overview).
+
+## Buttons
+
+- [GuestModeButton](https://google.github.io/horologist/api/auth/composables/material3/com.google.android.horologist.auth.composables.material3.buttons/-guest-mode-buttons.html)
+
+- [SignInButton](https://google.github.io/horologist/api/auth/composables/material3/com.google.android.horologist.auth.composables.material3.buttons/-sign-in-buttons.html)

--- a/docs/auth-composables-material3/guest_mode_button.png
+++ b/docs/auth-composables-material3/guest_mode_button.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b997abc7de9791632d92282100f3319a894c359bc3e4ab26225a6faf5aecab13
+size 12588

--- a/docs/auth-composables-material3/sign_in_button.png
+++ b/docs/auth-composables-material3/sign_in_button.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:491265c93484e9986b3eb61ae17e6d47799644238484c38021a2e140c0ff2e25
+size 11893


### PR DESCRIPTION
#### WHAT
Update SignInPromptScreen to compose-material3
<img width="454" height="454" alt="Screenshot_20250821_123555" src="https://github.com/user-attachments/assets/a0c42ad4-9d69-4dfa-a684-2020d546321c" />


#### WHY


#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [x] Update metalava's signature text files
