### PR TITLE
Refactor: Move `isLowRes` to a default parameter

### DIFF
--- a/compose-layout/api/current.api
+++ b/compose-layout/api/current.api
@@ -293,7 +293,7 @@ package com.google.android.horologist.compose.paging {
 package com.google.android.horologist.compose.rotaryinput {
 
   public final class AccumulatedRotaryInputModifierKt {
-    method @androidx.compose.runtime.Composable public static androidx.wear.compose.foundation.rotary.RotaryScrollableBehavior accumulatedBehavior(optional long eventAccumulationThresholdMs, optional float minValueChangeDistancePx, optional long rateLimitCoolDownMs, kotlin.jvm.functions.Function1<? super java.lang.Float,kotlin.Unit> onValueChange);
+    method @androidx.compose.runtime.Composable public static androidx.wear.compose.foundation.rotary.RotaryScrollableBehavior accumulatedBehavior(optional long eventAccumulationThresholdMs, optional float minValueChangeDistancePx, optional long rateLimitCoolDownMs, optional boolean isLowRes, kotlin.jvm.functions.Function1<? super java.lang.Float,kotlin.Unit> onValueChange);
   }
 
   @Deprecated public final class DefaultRotaryHapticHandler implements com.google.android.horologist.compose.rotaryinput.RotaryHapticHandler {

--- a/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/AccumulatedRotaryInputModifier.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/rotaryinput/AccumulatedRotaryInputModifier.kt
@@ -31,9 +31,9 @@ fun accumulatedBehavior(
     eventAccumulationThresholdMs: Long = RotaryInputConfigDefaults.DEFAULT_EVENT_ACCUMULATION_THRESHOLD_MS,
     minValueChangeDistancePx: Float = RotaryInputConfigDefaults.DEFAULT_MIN_VALUE_CHANGE_DISTANCE_PX,
     rateLimitCoolDownMs: Long = RotaryInputConfigDefaults.DEFAULT_RATE_LIMIT_COOL_DOWN_MS,
+    isLowRes: Boolean = isLowResInput(),
     onValueChange: (change: Float) -> Unit,
 ): RotaryScrollableBehavior {
-    val isLowRes = isLowResInput()
     val onValueChangeState = rememberUpdatedState(newValue = onValueChange)
 
     return remember {


### PR DESCRIPTION
#### WHAT

Moves `isLowRes` to be a default parameter in the `accumulatedRotaryInput` function. This avoids capturing `isLowRes` in the remembered state, making the implementation cleaner.

#### WHY

allow overriding in tests

#### HOW


#### Checklist :clipboard:
- [x] Add explicit visibility modifier and explicit return types for public declarations
- [x] Run spotless check
- [x] Run tests
- [ ] Update metalava's signature text files
