### PR TITLE
Fix publish-docs workflow permissions

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   deploy_docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       TERM: dumb
 


### PR DESCRIPTION
The `deploy_docs` job in `.github/workflows/publish-docs.yml` failed with a 403 error when attempting to push the built documentation to the `gh-pages` branch. This is because the default `GITHUB_TOKEN` permissions are often restricted to read-only.

This commit adds `permissions: contents: write` to the job, explicitly granting the necessary permissions to push changes to the repository.

---
*PR created automatically by Jules for task [17959891313383152011](https://jules.google.com/task/17959891313383152011) started by @luizgrp*