### PR TITLE
Enforce package signature verification for AI gRPC Binder services

### DIFF
--- a/ai/sample/core/src/main/java/com/google/android/horologist/ai/core/AiGrpcClientLookup.kt
+++ b/ai/sample/core/src/main/java/com/google/android/horologist/ai/core/AiGrpcClientLookup.kt
@@ -23,10 +23,16 @@ import io.grpc.binder.BinderChannelBuilder
 import io.grpc.binder.UntrustedSecurityPolicies
 
 object AiGrpcClientLookup {
+    @android.annotation.SuppressLint("PackageManagerGetSignatures")
     fun lookupInferenceService(
         context: Context,
         packageName: String,
     ): InferenceServiceGrpcKt.InferenceServiceCoroutineStub {
+        val mySignature = context.packageManager.getPackageInfo(
+            context.packageName,
+            android.content.pm.PackageManager.GET_SIGNATURES,
+        ).signatures!![0]
+
         val channel = BinderChannelBuilder.forAddress(
             AndroidComponentAddress.forBindIntent(
                 Intent().apply {
@@ -36,7 +42,13 @@ object AiGrpcClientLookup {
             ),
             context,
         )
-            .securityPolicy(UntrustedSecurityPolicies.untrustedPublic())
+            .securityPolicy(
+                io.grpc.binder.SecurityPolicies.hasSignature(
+                    context.packageManager,
+                    packageName,
+                    mySignature,
+                ),
+            )
             .build()
 
         return InferenceServiceGrpcKt.InferenceServiceCoroutineStub(channel)

--- a/ai/sample/core/src/main/java/com/google/android/horologist/ai/core/BindableAiGrpcService.kt
+++ b/ai/sample/core/src/main/java/com/google/android/horologist/ai/core/BindableAiGrpcService.kt
@@ -35,7 +35,18 @@ abstract class BindableAiGrpcService : LifecycleService() {
     private lateinit var server: Server
     private val binderReceiver = IBinderReceiver()
 
-    open val securityPolicy: SecurityPolicy = UntrustedSecurityPolicies.untrustedPublic()
+    @get:android.annotation.SuppressLint("PackageManagerGetSignatures")
+    open val securityPolicy: SecurityPolicy by lazy {
+        val mySignature = packageManager.getPackageInfo(
+            packageName,
+            android.content.pm.PackageManager.GET_SIGNATURES,
+        ).signatures!![0]
+        io.grpc.binder.SecurityPolicies.hasSignature(
+            packageManager,
+            packageName,
+            mySignature,
+        )
+    }
 
     abstract val bindableService: BindableService
 

--- a/ai/sample/core/src/main/java/com/google/android/horologist/ai/core/binder/BinderInferenceServiceRegistry.kt
+++ b/ai/sample/core/src/main/java/com/google/android/horologist/ai/core/binder/BinderInferenceServiceRegistry.kt
@@ -33,9 +33,15 @@ class BinderInferenceServiceRegistry(
         return flow {
             val intent = Intent("InferenceService")
             val services = context.packageManager.queryIntentServices(intent, 0)
+            val verifiedServices = services.filter {
+                context.packageManager.checkSignatures(
+                    context.packageName,
+                    it.serviceInfo.packageName,
+                ) == android.content.pm.PackageManager.SIGNATURE_MATCH
+            }
 
             emit(
-                services.map {
+                verifiedServices.map {
                     BinderInferenceService(
                         AiGrpcClientLookup.lookupInferenceService(
                             context,


### PR DESCRIPTION
#### WHAT

Enforce package signature verification for AI gRPC Binder services

#### WHY

Avoid processing requests for apps with different signing keys

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
