### PR TITLE
Remove play URL metadata mirroring and secure media callback interfaces

### DIFF
--- a/media/backend-media3/src/main/java/com/google/android/horologist/media3/service/SuspendingMediaLibrarySessionCallback.kt
+++ b/media/backend-media3/src/main/java/com/google/android/horologist/media3/service/SuspendingMediaLibrarySessionCallback.kt
@@ -104,23 +104,18 @@ public abstract class SuspendingMediaLibrarySessionCallback(
         }
 
         /**
-         * default implementation of onAddMediaItems that sets the URI from the requestMetadata
-         * if present.
+         * Subclasses MUST override this to resolve [MediaItem.mediaId] against their own
+         * catalog. Controller-supplied URIs (e.g. [MediaItem.RequestMetadata.mediaUri]) come
+         * from an untrusted process and MUST NOT be used as the playable URI without
+         * validation. The default implementation rejects all items.
          */
         protected open suspend fun onAddMediaItemsInternal(
             mediaSession: MediaSession,
             controller: MediaSession.ControllerInfo,
             mediaItems: MutableList<MediaItem>,
         ): MutableList<MediaItem> {
-            return mediaItems.map {
-                if (it.requestMetadata.mediaUri != null) {
-                    it.buildUpon()
-                        .setUri(it.requestMetadata.mediaUri)
-                        .build()
-                } else {
-                    it
-                }
-            }.toMutableList()
+            // Secure default: do not trust controller URIs. Subclasses must resolve mediaId.
+            return mediaItems
         }
 
         @SuppressLint("UnsafeOptInUsageError")

--- a/media/data/src/main/java/com/google/android/horologist/media/data/mapper/MediaItemMapper.kt
+++ b/media/data/src/main/java/com/google/android/horologist/media/data/mapper/MediaItemMapper.kt
@@ -49,9 +49,6 @@ public class MediaItemMapper(
             .setArtist(mediaItem.artist)
             .setArtworkUri(artworkUri)
 
-        requestMetadataBuilder
-            .setMediaUri(parsedUri)
-
         mediaItemExtrasMapper.map(
             mediaItem,
             mediaItemBuilder,

--- a/media/data/src/test/java/com/google/android/horologist/media/data/mapper/MediaItemMapperTest.kt
+++ b/media/data/src/test/java/com/google/android/horologist/media/data/mapper/MediaItemMapperTest.kt
@@ -62,7 +62,7 @@ class MediaItemMapperTest {
         // then
         assertThat(result.mediaId).isEqualTo(id)
         assertThat(result.localConfiguration!!.uri).isEqualTo((Uri.parse(uri)))
-        assertThat(result.requestMetadata.mediaUri).isEqualTo((Uri.parse(uri)))
+        assertThat(result.requestMetadata.mediaUri).isNull()
         assertThat(result.mediaMetadata.displayTitle).isEqualTo(title)
         assertThat(result.mediaMetadata.title).isEqualTo(title)
         assertThat(result.mediaMetadata.artist).isEqualTo(artist)
@@ -90,7 +90,7 @@ class MediaItemMapperTest {
         // then
         assertThat(result.mediaId).isEqualTo(id)
         assertThat(result.localConfiguration!!.uri).isEqualTo((Uri.parse(uri)))
-        assertThat(result.requestMetadata.mediaUri).isEqualTo((Uri.parse(uri)))
+        assertThat(result.requestMetadata.mediaUri).isNull()
         assertThat(result.mediaMetadata.displayTitle).isEqualTo(title)
         assertThat(result.mediaMetadata.title).isEqualTo(title)
         assertThat(result.mediaMetadata.artist).isEqualTo(artist)


### PR DESCRIPTION
#### WHAT

Remove play URL metadata mirroring and secure media callback interfaces

#### WHY

Apps should be more explicit about which items to add.
Also avoid exposing internal urls.

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
