### PR TITLE
FIX: Update catalog BASE_URL to fetch media

### DIFF
--- a/media/sample/src/main/java/com/google/android/horologist/mediasample/data/api/UampService.kt
+++ b/media/sample/src/main/java/com/google/android/horologist/mediasample/data/api/UampService.kt
@@ -25,6 +25,6 @@ interface UampService {
     suspend fun catalog(): CatalogApiModel
 
     companion object {
-        const val BASE_URL = "https://storage.googleapis.com/uamp/"
+        const val BASE_URL = "https://storage.googleapis.com/androiddevelopers/samples_assets/uamp/"
     }
 }


### PR DESCRIPTION
#### WHAT
Updated the `BASE_URL` in [UampService](https://github.com/google/horologist/blob/main/media/sample/src/main/java/com/google/android/horologist/mediasample/data/api/UampService.kt) to the current official storage path for the UAMP sample.

#### WHY
The previous URL (https://storage.googleapis.com/uamp/) was no longer serving the media catalog resulting in AccessDenied error. The new URL from [UAMP FAQs](https://github.com/android/uamp/blob/main/docs/FAQs.md?plain=1#L4C31-L4C113) works.

#### HOW
In [UampService](https://github.com/google/horologist/blob/main/media/sample/src/main/java/com/google/android/horologist/mediasample/data/api/UampService.kt), changed the `BASE_URL` constant:
• From: `https://storage.googleapis.com/uamp/`
• To: `https://storage.googleapis.com/androiddevelopers/samples_assets/uamp/`

#### Checklist :clipboard:
• [x] Verified that the media catalog ([catalog.json](https://storage.googleapis.com/androiddevelopers/samples_assets/uamp/catalog.json)) is successfully fetched on app launch.
• [x] Confirmed that media items appear in the UI and playback starts correctly.