### PR TITLE
Exclude lint configurations from protobuf-java

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,15 +99,18 @@ allprojects {
     }
 
     configurations.all {
-        exclude(group = "com.google.protobuf", module = "protobuf-java")
-        resolutionStrategy {
-            dependencySubstitution {
-                substitute(module("com.google.protobuf:protobuf-java")).using(module("com.google.protobuf:protobuf-javalite:4.34.1"))
+        val isLint = name.contains("lint", ignoreCase = true)
+        if (!isLint) {
+            exclude(group = "com.google.protobuf", module = "protobuf-java")
+            resolutionStrategy {
+                dependencySubstitution {
+                    substitute(module("com.google.protobuf:protobuf-java")).using(module("com.google.protobuf:protobuf-javalite:4.34.1"))
+                }
+                force("io.grpc:grpc-stub:1.80.0")
+                force("io.grpc:grpc-protobuf-lite:1.80.0")
+                force("io.grpc:grpc-android:1.80.0")
+                force("io.grpc:grpc-binder:1.80.0")
             }
-            force("io.grpc:grpc-stub:1.80.0")
-            force("io.grpc:grpc-protobuf-lite:1.80.0")
-            force("io.grpc:grpc-android:1.80.0")
-            force("io.grpc:grpc-binder:1.80.0")
         }
     }
 


### PR DESCRIPTION


#### WHAT

use substitution to prevent lint crashes

Lint runs on the host JVM and requires the full protobuf-java library. Forcing protobuf-javalite on lint configurations causes NoClassDefFoundError for ProtocolMessageEnum during lint analysis.


#### WHY


#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
