### PR TITLE
Update golden screenshots to match Pill shape design

### DIFF
--- a/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.screens_SignedInConfirmationDialogTest_signedInConfirmationDialog.png
+++ b/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.screens_SignedInConfirmationDialogTest_signedInConfirmationDialog.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b670044ec2c818f7850f6dc5fe7ce4581784a2b493b23665d7e6dbf650fdc948
-size 95140
+oid sha256:b663bae23e34582655a23f7955a46154cc3cd22a8fafc8e170314d74dc1196da
+size 95263

--- a/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.screens_SignedInConfirmationDialogTest_signedInConfirmationDialogNoEmail.png
+++ b/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.screens_SignedInConfirmationDialogTest_signedInConfirmationDialogNoEmail.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6c9fd1fccd965d7267cba76b61e82b6337b5c9c8a3be71a6d8c4a838828bcfa0
-size 89979
+oid sha256:374e18988199850a43ac7b98fa93c88aa6e585d07416d08712ecf79b00049265
+size 90145

--- a/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.screens_SignedInConfirmationDialogTest_signedInConfirmationDialogNoName.png
+++ b/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.screens_SignedInConfirmationDialogTest_signedInConfirmationDialogNoName.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8bc8c37cc6e4458677abf6a93cb6fd5193aeeb10ce2a44af513d4b8b02b84cbb
-size 91276
+oid sha256:92a63fded6074ec13f2df10442f3211825ba1cf5feabe3deafd564b9f944c807
+size 91396

--- a/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.screens_SignedInConfirmationDialogTest_signedInConfirmationNoAvatar.png
+++ b/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.screens_SignedInConfirmationDialogTest_signedInConfirmationNoAvatar.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a10a5c4095e8bca2b2d0cb296220250b9f799bcde43b9e61ae61182d548210c
-size 22477
+oid sha256:7521d4aacca56712f0fc95de3245a7f5295cce8c4c9fed72690b3422ff761b72
+size 22346

--- a/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.screens_SignedInConfirmationDialogTest_signedInConfirmationNoAvatarEmailName.png
+++ b/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.screens_SignedInConfirmationDialogTest_signedInConfirmationNoAvatarEmailName.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d4f46f510bf8e93c47d1b1db3e9b46125b0231fa481f34fa8cb20654b8d75e53
-size 12734
+oid sha256:5ee7026a156458dca4f500c5acf837b5b04e8733399b5455d8f455c561241db6
+size 12589

--- a/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.screens_SignedInConfirmationDialogTest_signedInLongEmailAndName.png
+++ b/auth/composables-material3/src/test/snapshots/images/com.google.android.horologist.auth.composables.material3.screens_SignedInConfirmationDialogTest_signedInLongEmailAndName.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5144c20f57b4c1d64f82c649f60b85e9942a45cd920652dbd4e491971f247f06
-size 97998
+oid sha256:124b789fd0397b8f12c72f585ea4ea9e99f09ce5c74ebce7098aa40ae9d2c4db
+size 98117


### PR DESCRIPTION
#### WHAT

Since the avatar shape in SignedInConfirmationDialog was updated to Pill, the golden screenshots need to be updated to match the new design.


#### WHY


#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
