### PR TITLE
docs: fix invalid image documentation links

### DIFF
--- a/images/base/README.md
+++ b/images/base/README.md
@@ -2,7 +2,7 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.android.horologist/horologist-images-base)](https://search.maven.org/search?q=g:com.google.android.horologist)
 
-For more information, visit the documentation: https://google.github.io/horologist/images/base
+For more information, visit the documentation: https://google.github.io/horologist/api/images/base
 
 ## Download
 

--- a/images/coil/README.md
+++ b/images/coil/README.md
@@ -2,7 +2,7 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.android.horologist/horologist-images-coil)](https://search.maven.org/search?q=g:com.google.android.horologist)
 
-For more information, visit the documentation: https://google.github.io/horologist/images/coil
+For more information, visit the documentation: https://google.github.io/horologist/api/images/coil
 
 ## Download
 


### PR DESCRIPTION
#### WHAT

Correct the documentation links in the Images Base and Images Coil READMEs.

#### WHY

The current links return 404 because the generated module API documentation is published below `/api`.

#### HOW

Point each README to its existing deployed Dokka page:

- `/api/images/base`
- `/api/images/coil`

Fixes #2067

#### Checklist :clipboard:

- [x] Add explicit visibility modifier and explicit return types for public declarations (N/A: documentation-only)
- [x] Run formatting check (`git diff --check`; no code or formatting changed)
- [x] Run tests (N/A: two external README URL substitutions)
- [x] Update metalava's signature text files (N/A: no API change)

#### Validation

- confirmed both old URLs return 404
- confirmed both replacement URLs return 200
- confirmed zero old URL occurrences and one occurrence of each replacement
- `git diff --check`

#### AI disclosure

This focused documentation correction was prepared and independently reviewed with AI assistance.
