### PR TITLE
Handle hardware bitmaps in tile image resources

### DIFF
--- a/tiles/build.gradle.kts
+++ b/tiles/build.gradle.kts
@@ -94,6 +94,11 @@ dependencies {
   testImplementation(libs.androidx.concurrent.future.ktx)
   testImplementation(libs.androidx.lifecycle.testing)
   testImplementation(libs.androidx.wear.compose.material3)
+
+  androidTestImplementation(libs.androidx.test.ext)
+  androidTestImplementation(libs.androidx.test.runner)
+  androidTestImplementation(libs.junit)
+  androidTestImplementation(libs.truth)
   debugImplementation(libs.compose.ui.test.manifest)
 }
 

--- a/tiles/src/androidTest/java/com/google/android/horologist/tiles/ImagesTest.kt
+++ b/tiles/src/androidTest/java/com/google/android/horologist/tiles/ImagesTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.tiles
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.ImageDecoder
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SdkSuppress
+import androidx.wear.protolayout.ResourceBuilders
+import com.google.android.horologist.tiles.images.toImageResource
+import com.google.common.truth.Truth.assertThat
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@SdkSuppress(minSdkVersion = 28)
+class ImagesTest {
+    @Test
+    fun hardwareBitmapToImageResource() {
+        val softwareBitmap = Bitmap.createBitmap(
+            intArrayOf(Color.RED, Color.GREEN),
+            2,
+            1,
+            Bitmap.Config.ARGB_8888,
+        )
+        val encodedBitmap = ByteArrayOutputStream().also {
+            softwareBitmap.compress(Bitmap.CompressFormat.PNG, 100, it)
+        }.toByteArray()
+        val hardwareBitmap = ImageDecoder.decodeBitmap(
+            ImageDecoder.createSource(ByteBuffer.wrap(encodedBitmap)),
+        ) { decoder, _, _ ->
+            decoder.allocator = ImageDecoder.ALLOCATOR_HARDWARE
+        }
+        assertThat(hardwareBitmap.config).isEqualTo(Bitmap.Config.HARDWARE)
+        val expected = hardwareBitmap.copy(Bitmap.Config.ARGB_8888, false)
+            .toImageResource()
+            .inlineResource!!
+
+        val actual = hardwareBitmap.toImageResource().inlineResource!!
+
+        assertThat(actual.format).isEqualTo(ResourceBuilders.IMAGE_FORMAT_ARGB_8888)
+        assertThat(actual.widthPx).isEqualTo(2)
+        assertThat(actual.heightPx).isEqualTo(1)
+        assertThat(actual.data).isEqualTo(expected.data)
+    }
+}

--- a/tiles/src/main/java/com/google/android/horologist/tiles/images/Images.kt
+++ b/tiles/src/main/java/com/google/android/horologist/tiles/images/Images.kt
@@ -69,24 +69,29 @@ public suspend fun ImageLoader.loadImageResource(
  * Convert a bitmap to a ImageResource.
  *
  * Format will be one of IMAGE_FORMAT_ARGB_8888, IMAGE_FORMAT_RGB_565 or IMAGE_FORMAT_UNDEFINED,
- * based on the bitmap.
+ * based on the bitmap. Hardware bitmaps are copied to ARGB_8888 before conversion.
  */
 public fun Bitmap.toImageResource(): ImageResource {
-    val format = when (this.config) {
+    val pixelReadableBitmap = if (config == Bitmap.Config.HARDWARE) {
+        copy(Bitmap.Config.ARGB_8888, false)
+    } else {
+        this
+    }
+    val format = when (pixelReadableBitmap.config) {
         Bitmap.Config.ARGB_8888 -> IMAGE_FORMAT_ARGB_8888
         Bitmap.Config.RGB_565 -> IMAGE_FORMAT_RGB_565
         else -> IMAGE_FORMAT_UNDEFINED
     }
 
-    val byteBuffer = ByteBuffer.allocate(byteCount)
-    copyPixelsToBuffer(byteBuffer)
+    val byteBuffer = ByteBuffer.allocate(pixelReadableBitmap.byteCount)
+    pixelReadableBitmap.copyPixelsToBuffer(byteBuffer)
     val bytes: ByteArray = byteBuffer.array()
 
     return ImageResource.Builder().setInlineResource(
         ResourceBuilders.InlineImageResource.Builder()
             .setData(bytes)
-            .setWidthPx(width)
-            .setHeightPx(height)
+            .setWidthPx(pixelReadableBitmap.width)
+            .setHeightPx(pixelReadableBitmap.height)
             .setFormat(format)
             .build(),
     )


### PR DESCRIPTION
Fixes #2681.

Hardware-backed bitmaps do not permit direct pixel-buffer access. Copy them to ARGB_8888 before building the inline image resource, while preserving the existing path for software bitmaps.

The new instrumented regression test creates a genuine hardware bitmap with `ImageDecoder` and verifies its format, dimensions, and pixel data after conversion.

Tests:
- focused hardware-bitmap instrumentation test on an API 36 emulator
- Tiles unit tests
- debug and release compilation
- Metalava signature generation
- Tiles lint and ktfmt checks
