### PR TITLE
Reorder modifier parameter to be first optional in LottieAnimation

### DIFF
--- a/remotecompose/lottie/api/current.api
+++ b/remotecompose/lottie/api/current.api
@@ -2,7 +2,7 @@
 package com.google.android.horologist.remotecompose.lottie {
 
   public final class LottieAnimationKt {
-    method @KotlinOnly @androidx.compose.remote.creation.compose.layout.RemoteComposable @androidx.compose.runtime.Composable public static void LottieAnimation(com.google.android.horologist.remotecompose.lottie.format.Animation animation, optional com.google.android.horologist.remotecompose.lottie.format.GraphicElement.Transform? transform, optional com.google.android.horologist.remotecompose.lottie.renderer.SlotMap slotMap, optional androidx.compose.remote.creation.compose.modifier.RemoteModifier modifier);
+    method @KotlinOnly @androidx.compose.remote.creation.compose.layout.RemoteComposable @androidx.compose.runtime.Composable public static void LottieAnimation(com.google.android.horologist.remotecompose.lottie.format.Animation animation, optional androidx.compose.remote.creation.compose.modifier.RemoteModifier modifier, optional com.google.android.horologist.remotecompose.lottie.format.GraphicElement.Transform? transform, optional com.google.android.horologist.remotecompose.lottie.renderer.SlotMap slotMap);
     method @InaccessibleFromKotlin public static androidx.compose.runtime.ProvidableCompositionLocal<com.google.android.horologist.remotecompose.lottie.LottieSettings> getLocalAnimationSettings();
     property public static androidx.compose.runtime.ProvidableCompositionLocal<com.google.android.horologist.remotecompose.lottie.LottieSettings> LocalAnimationSettings;
   }

--- a/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/LottieAnimation.kt
+++ b/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/LottieAnimation.kt
@@ -51,18 +51,18 @@ val LocalAnimationSettings =
  * A RemoteComposable that renders a Lottie animation to a RemoteCompose document.
  *
  * @param animation The Lottie animation to render.
+ * @param modifier The modifier to apply to the Lottie layout.
  * @param transform Optional additional transform to apply to the requested shape.
  * @param slotMap Mapping of slot IDs to values for dynamic theming.
- * @param modifier The modifier to apply to the Lottie layout.
  */
 @SuppressLint("RestrictedApi")
 @Composable
 @RemoteComposable
-fun LottieAnimation(
+public fun LottieAnimation(
   animation: Animation,
+  modifier: RemoteModifier = RemoteModifier,
   transform: Transform? = null,
   slotMap: SlotMap = SlotMap(emptyMap()),
-  modifier: RemoteModifier = RemoteModifier,
 ) {
   val totalFrames = animation.endFrame - animation.startFrame
   val currentFrame =

--- a/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/renderer/Layer.kt
+++ b/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/renderer/Layer.kt
@@ -17,7 +17,6 @@
 package com.google.android.horologist.remotecompose.lottie.renderer
 
 import androidx.compose.remote.creation.compose.layout.RemoteComposable
-import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.runtime.Composable
 import com.google.android.horologist.remotecompose.lottie.format.GraphicElement.Transform
 import com.google.android.horologist.remotecompose.lottie.format.Layer
@@ -30,7 +29,6 @@ internal fun Layer(
   layer: Layer,
   parentTransforms: Map<Int, Transform>,
   transform: Transform?,
-  modifier: RemoteModifier = RemoteModifier,
 ) {
   val transformStack =
     if (layer.parent == null || !parentTransforms.containsKey(layer.parent)) {
@@ -58,7 +56,6 @@ internal fun Layer(
 internal fun ShapeLayer(
   layer: Layer.ShapeLayer,
   transformStack: List<Transform?>? = null,
-  modifier: RemoteModifier = RemoteModifier,
 ) {
   if (layer.hidden == true) {
     return


### PR DESCRIPTION
Move `modifier` to be the first optional parameter in `LottieAnimation` to follow Compose API guidelines.

Summary of changes:
- Reorder `modifier: RemoteModifier` parameter in `LottieAnimation` to immediately follow required `animation` parameter.
- Update KDoc parameter order in `LottieAnimation.kt`.
- Remove unused `modifier` parameter from internal in `renderer/Layer.kt`.
- Update Metalava API signature (`api/current.api`).

Related to: https://github.com/google/horologist/pull/2744#discussion_r3615587484