### PR TITLE
Shard Roborazzi screenshot tests across 6 matrix shards

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,12 +51,18 @@ jobs:
             **/build/reports/*
             **/out/*
 
-  screenshot1:
+  screenshots:
     # Skip build if head commit contains 'skip ci'
     if: "!contains(github.event.head_commit.message, 'skip ci')"
 
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5]
+        totalShards: [6]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -75,52 +81,14 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
 
-      - name: Unit Tests
-        run: ./gradlew verifyRoborazziDebug -x composables:verifyRoborazziDebug -x sample:verifyRoborazziDebug
+      - name: Screenshot Tests (Shard ${{ matrix.shard }}/${{ matrix.totalShards }})
+        run: ./gradlew verifyRoborazziDebug -PshardIndex=${{ matrix.shard }} -PtotalShards=${{ matrix.totalShards }}
 
-      - name: screenshot-test-results-1
+      - name: screenshot-test-results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: screenshot-results-1
-          path: |
-            **/build/test-results/*
-            **/build/reports/*
-            **/build/outputs/roborazzi/*
-            **/out/*
-
-  screenshot2:
-    # Skip build if head commit contains 'skip ci'
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
-
-    runs-on: ubuntu-latest
-    timeout-minutes: 40
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          lfs: 'true'
-
-      - name: Copy CI gradle.properties
-        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
-
-      - name: set up JDK
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
-        with:
-          distribution: 'zulu'
-          java-version: 21
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
-
-      - name: Unit Tests 2
-        run: ./gradlew composables:verifyRoborazziDebug sample:verifyRoborazziDebug
-
-      - name: screenshot-test-results-2
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: screenshot-results-2
+          name: screenshot-results-${{ matrix.shard }}
           path: |
             **/build/test-results/*
             **/build/reports/*

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -179,6 +179,24 @@ subprojects {
     }
   }
 
+  tasks.withType<Test>().configureEach {
+    val shardIndex =
+      (project.findProperty("shardIndex") as? String)
+        ?: (project.findProperty("test.shardIndex") as? String)
+        ?: System.getProperty("test.shardIndex")
+    val totalShards =
+      (project.findProperty("totalShards") as? String)
+        ?: (project.findProperty("test.totalShards") as? String)
+        ?: System.getProperty("test.totalShards")
+
+    if (shardIndex != null) {
+      systemProperty("test.shardIndex", shardIndex)
+    }
+    if (totalShards != null) {
+      systemProperty("test.totalShards", totalShards)
+    }
+  }
+
   // Must be afterEvaluate or else com.vanniktech.maven.publish will overwrite our
   // dokka and version configuration.
   afterEvaluate {

--- a/roboscreenshots/api/current.api
+++ b/roboscreenshots/api/current.api
@@ -131,6 +131,7 @@ package com.google.android.horologist.screenshots.rng {
     method @InaccessibleFromKotlin @org.junit.Rule public final androidx.compose.ui.test.junit4.ComposeContentTestRule getComposeRule();
     method @InaccessibleFromKotlin public com.google.android.horologist.screenshots.rng.WearDevice? getDevice();
     method @InaccessibleFromKotlin public coil.test.FakeImageLoaderEngine? getImageLoader();
+    method @InaccessibleFromKotlin @org.junit.Rule public final org.junit.rules.TestRule getShardRule();
     method @InaccessibleFromKotlin @org.junit.Rule public final org.junit.rules.TestName getTestInfo();
     method @InaccessibleFromKotlin public float getTolerance();
     method public com.github.takahirom.roborazzi.RoborazziOptions roborazziOptions(optional boolean applyDeviceCrop);
@@ -139,6 +140,7 @@ package com.google.android.horologist.screenshots.rng {
     property @org.junit.Rule public final androidx.compose.ui.test.junit4.ComposeContentTestRule composeRule;
     property public com.google.android.horologist.screenshots.rng.WearDevice? device;
     property public coil.test.FakeImageLoaderEngine? imageLoader;
+    property @org.junit.Rule public final org.junit.rules.TestRule shardRule;
     property @org.junit.Rule public final org.junit.rules.TestName testInfo;
     property public float tolerance;
     field public static final com.google.android.horologist.screenshots.rng.WearScreenshotTest.Companion Companion;

--- a/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/rng/WearScreenshotTest.kt
+++ b/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/rng/WearScreenshotTest.kt
@@ -44,10 +44,13 @@ import com.github.takahirom.roborazzi.captureScreenRoboImage
 import com.google.android.horologist.compose.layout.AppScaffold
 import com.google.android.horologist.compose.layout.ResponsiveTimeText
 import com.google.android.horologist.screenshots.FixedTimeSource
+import org.junit.Assume
 import org.junit.Rule
 import org.junit.experimental.categories.Category
 import org.junit.rules.TestName
+import org.junit.rules.TestRule
 import org.junit.runner.RunWith
+import org.junit.runners.model.Statement
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
@@ -61,6 +64,25 @@ public abstract class WearScreenshotTest {
   @get:Rule public val composeRule: ComposeContentTestRule = createComposeRule()
 
   @get:Rule public val testInfo: TestName = TestName()
+
+  @get:Rule
+  public val shardRule: TestRule = TestRule { base, description ->
+    object : Statement() {
+      override fun evaluate() {
+        val shardIndex = System.getProperty("test.shardIndex")?.toIntOrNull()
+        val totalShards = System.getProperty("test.totalShards")?.toIntOrNull()
+        if (shardIndex != null && totalShards != null && totalShards > 1) {
+          val className = description.className ?: this@WearScreenshotTest.javaClass.name
+          val assignedShard = Math.floorMod(className.hashCode(), totalShards)
+          Assume.assumeTrue(
+            "Skipping $className for shard $shardIndex of $totalShards (assigned to $assignedShard)",
+            assignedShard == shardIndex,
+          )
+        }
+        base.evaluate()
+      }
+    }
+  }
 
   public open val device: WearDevice? = null
 


### PR DESCRIPTION
#### WHAT

- Add shardRule (TestRule) in WearScreenshotTest to filter test classes by hashCode
- Configure Test tasks in build.gradle.kts to forward shardIndex and totalShards
- Replace static screenshot1/screenshot2 jobs in build.yml with a 6-shard matrix
- Update roboscreenshots API signature

#### WHY

Current 2 shards were getting lopsided. 

#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
