### PR TITLE
Adopt @ScrollingPreview for scrollable list screens

### DIFF
--- a/compose-layout/src/main/java/com/google/android/horologist/compose/layout/ScreenScaffold.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/layout/ScreenScaffold.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalScrollCaptureInProgress
 import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
 import androidx.wear.compose.foundation.LocalScreenIsActive
 import androidx.wear.compose.foundation.lazy.ScalingLazyListState
@@ -79,14 +80,16 @@ fun ScreenScaffold(
         {
           if (positionIndicator != null) {
             positionIndicator()
-          } else if (scrollState is ScalingLazyColumnState) {
-            PositionIndicator(scalingLazyListState = scrollState.state)
-          } else if (scrollState is ScalingLazyListState) {
-            PositionIndicator(scalingLazyListState = scrollState)
-          } else if (scrollState is LazyListState) {
-            PositionIndicator(scrollState)
-          } else if (scrollState is ScrollState) {
-            PositionIndicator(scrollState)
+          } else if (!LocalScrollCaptureInProgress.current) {
+            if (scrollState is ScalingLazyColumnState) {
+              PositionIndicator(scalingLazyListState = scrollState.state)
+            } else if (scrollState is ScalingLazyListState) {
+              PositionIndicator(scalingLazyListState = scrollState)
+            } else if (scrollState is LazyListState) {
+              PositionIndicator(scrollState)
+            } else if (scrollState is ScrollState) {
+              PositionIndicator(scrollState)
+            }
           }
         }
       },

--- a/compose-tools/build.gradle.kts
+++ b/compose-tools/build.gradle.kts
@@ -61,6 +61,7 @@ metalava { filename.set("api/current.api") }
 
 dependencies {
   api(projects.annotations)
+  api(libs.compose.ai.preview.annotations)
 
   implementation(libs.kotlin.reflect)
   implementation(projects.tiles)

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodesActionsScreen.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodesActionsScreen.kt
@@ -42,6 +42,8 @@ import com.google.android.horologist.compose.material.Chip
 import com.google.android.horologist.compose.material.CompactChip
 import com.google.android.horologist.datalayer.sample.R
 import com.google.android.horologist.images.base.paintable.ImageVectorPaintable
+import ee.schimke.composeai.preview.ScrollMode
+import ee.schimke.composeai.preview.ScrollingPreview
 
 @Composable
 fun NodesActionsScreen(
@@ -130,6 +132,7 @@ fun NodesActionsScreen(
 }
 
 @WearPreviewDevices
+@ScrollingPreview(modes = [ScrollMode.END])
 @Composable
 fun NodesActionsScreenPreviewLoaded() {
   NodesActionsScreen(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -170,6 +170,7 @@ coil-test = { module = "io.coil-kt:coil-test", version.ref = "io-coil-kt" }
 com-squareup-okhttp3-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "com-squareup-okhttp3" }
 com-squareup-okhttp3-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "com-squareup-okhttp3" }
 com-squareup-okhttp3-okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "com-squareup-okhttp3" }
+compose-ai-preview-annotations = { module = "ee.schimke.composeai:preview-annotations", version.ref = "composeAiTools" }
 compose-animation-animationgraphics = { group = "androidx.compose.animation", name = "animation-graphics" }
 compose-animation-core = { group = "androidx.compose.animation", name = "animation-core", version.ref = "compose-animation" }
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }

--- a/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreenPreview.kt
+++ b/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreenPreview.kt
@@ -34,8 +34,11 @@ import com.google.android.horologist.composables.Section
 import com.google.android.horologist.compose.material.Chip
 import com.google.android.horologist.images.base.paintable.ImageVectorPaintable.Companion.asPaintable
 import com.google.android.horologist.media.ui.R
+import ee.schimke.composeai.preview.ScrollMode
+import ee.schimke.composeai.preview.ScrollingPreview
 
 @WearPreviewDevices
+@ScrollingPreview(modes = [ScrollMode.LONG])
 @Composable
 fun BrowseScreenPreview() {
   BrowseScreenPreviewSample(

--- a/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreenPreview.kt
+++ b/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/playlists/PlaylistsScreenPreview.kt
@@ -16,14 +16,47 @@
 
 package com.google.android.horologist.media.ui.screens.playlists
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.FeaturedPlayList
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.TimeText
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
+import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
+import com.google.android.horologist.compose.layout.AppScaffold
 import com.google.android.horologist.compose.material.Chip
 import com.google.android.horologist.images.base.util.rememberVectorPainter
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
+import ee.schimke.composeai.preview.ScrollMode
+import ee.schimke.composeai.preview.ScrollingPreview
+
+@WearPreviewLargeRound
+@ScrollingPreview(modes = [ScrollMode.LONG, ScrollMode.END])
+@Composable
+fun PlaylistsScreenLongPreview() {
+  MaterialTheme {
+    AppScaffold(
+      modifier = Modifier.fillMaxSize().background(Color.Black),
+      timeText = { TimeText() },
+    ) {
+      PlaylistsScreen(
+        playlistsScreenState =
+          PlaylistsScreenState.Loaded(
+            buildList {
+              repeat(10) { index ->
+                add(PlaylistUiModel(id = "$index", title = "Playlist #$index"))
+              }
+            }
+          ),
+        onPlaylistItemClick = {},
+      )
+    }
+  }
+}
 
 @WearPreviewDevices
 @Composable

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
   alias(libs.plugins.roborazzi)
   kotlin("plugin.serialization")
   alias(libs.plugins.compose.compiler)
+  alias(libs.plugins.composeAiPreview)
 }
 
 android {

--- a/sample/src/main/java/com/google/android/horologist/materialcomponents/SampleCardScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/materialcomponents/SampleCardScreen.kt
@@ -31,8 +31,11 @@ import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults.It
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
 import com.google.android.horologist.compose.material.Card
+import ee.schimke.composeai.preview.ScrollMode
+import ee.schimke.composeai.preview.ScrollingPreview
 
 @WearPreviewDevices
+@ScrollingPreview(modes = [ScrollMode.LONG])
 @Composable
 fun SampleCardScreenPreview() {
   val state = rememberResponsiveColumnState(first = ItemType.Card, last = ItemType.Card)

--- a/sample/src/main/java/com/google/android/horologist/materialcomponents/SampleCardScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/materialcomponents/SampleCardScreen.kt
@@ -25,22 +25,9 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
-import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
-import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults.ItemType
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
-import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
 import com.google.android.horologist.compose.material.Card
-import ee.schimke.composeai.preview.ScrollMode
-import ee.schimke.composeai.preview.ScrollingPreview
-
-@WearPreviewDevices
-@ScrollingPreview(modes = [ScrollMode.LONG])
-@Composable
-fun SampleCardScreenPreview() {
-  val state = rememberResponsiveColumnState(first = ItemType.Card, last = ItemType.Card)
-  SampleCardScreen(columnState = state)
-}
 
 @Composable
 internal fun SampleCardScreen(modifier: Modifier = Modifier, columnState: ScalingLazyColumnState) {

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/SectionedListMenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/SectionedListMenuScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
 import com.google.android.horologist.composables.SectionedList
+import com.google.android.horologist.compose.layout.AppScaffold
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
@@ -79,5 +80,7 @@ fun SectionedListMenuScreen(
 @ScrollingPreview(modes = [ScrollMode.LONG])
 @Composable
 fun Preview() {
-  SectionedListMenuScreen(navigateToRoute = {}, columnState = rememberResponsiveColumnState())
+  AppScaffold {
+    SectionedListMenuScreen(navigateToRoute = {}, columnState = rememberResponsiveColumnState())
+  }
 }

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/SectionedListMenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/SectionedListMenuScreen.kt
@@ -33,6 +33,8 @@ import com.google.android.horologist.compose.material.Title
 import com.google.android.horologist.images.base.paintable.ImageVectorPaintable.Companion.asPaintable
 import com.google.android.horologist.sample.R
 import com.google.android.horologist.sample.Screen
+import ee.schimke.composeai.preview.ScrollMode
+import ee.schimke.composeai.preview.ScrollingPreview
 
 @Composable
 fun SectionedListMenuScreen(
@@ -73,8 +75,9 @@ fun SectionedListMenuScreen(
   }
 }
 
-@Composable
 @WearPreviewLargeRound
+@ScrollingPreview(modes = [ScrollMode.LONG])
+@Composable
 fun Preview() {
   SectionedListMenuScreen(navigateToRoute = {}, columnState = rememberResponsiveColumnState())
 }

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/expandable/SectionedListExpandableScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/expandable/SectionedListExpandableScreen.kt
@@ -52,6 +52,8 @@ import com.google.android.horologist.compose.material.Chip
 import com.google.android.horologist.compose.material.Title
 import com.google.android.horologist.compose.material.util.DECORATIVE_ELEMENT_CONTENT_DESCRIPTION
 import com.google.android.horologist.sample.R
+import ee.schimke.composeai.preview.ScrollMode
+import ee.schimke.composeai.preview.ScrollingPreview
 
 private val todayTasks =
   listOf(
@@ -176,6 +178,7 @@ private fun SectionHeader(text: String, expanded: Boolean, onClick: () -> Unit) 
 }
 
 @WearPreviewDevices
+@ScrollingPreview(modes = [ScrollMode.LONG])
 @Composable
 fun SectionedListExpandableScreenPreview() {
   SectionedListExpandableScreen(columnState = rememberResponsiveColumnState())

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/expandable/SectionedListExpandableScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/expandable/SectionedListExpandableScreen.kt
@@ -46,6 +46,7 @@ import com.google.android.horologist.composables.Section
 import com.google.android.horologist.composables.SectionContentScope
 import com.google.android.horologist.composables.SectionedList
 import com.google.android.horologist.composables.SectionedListScope
+import com.google.android.horologist.compose.layout.AppScaffold
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
 import com.google.android.horologist.compose.material.Chip
@@ -181,5 +182,5 @@ private fun SectionHeader(text: String, expanded: Boolean, onClick: () -> Unit) 
 @ScrollingPreview(modes = [ScrollMode.LONG])
 @Composable
 fun SectionedListExpandableScreenPreview() {
-  SectionedListExpandableScreen(columnState = rememberResponsiveColumnState())
+  AppScaffold { SectionedListExpandableScreen(columnState = rememberResponsiveColumnState()) }
 }

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/stateful/SectionedListStatefulScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/stateful/SectionedListStatefulScreen.kt
@@ -52,6 +52,7 @@ import com.google.android.horologist.composables.PlaceholderChip
 import com.google.android.horologist.composables.Section
 import com.google.android.horologist.composables.SectionedList
 import com.google.android.horologist.composables.SectionedListScope
+import com.google.android.horologist.compose.layout.AppScaffold
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
 import com.google.android.horologist.compose.material.Chip
@@ -232,5 +233,5 @@ private fun FailedView(onClick: () -> Unit) {
 @ScrollingPreview(modes = [ScrollMode.LONG])
 @Composable
 fun SectionedListStatefulScreenPreview() {
-  SectionedListStatefulScreen(columnState = rememberResponsiveColumnState())
+  AppScaffold { SectionedListStatefulScreen(columnState = rememberResponsiveColumnState()) }
 }

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/stateful/SectionedListStatefulScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/stateful/SectionedListStatefulScreen.kt
@@ -63,6 +63,8 @@ import com.google.android.horologist.sectionedlist.stateful.SectionedListStatefu
 import com.google.android.horologist.sectionedlist.stateful.SectionedListStatefulScreenViewModel.RecommendationSectionState
 import com.google.android.horologist.sectionedlist.stateful.SectionedListStatefulScreenViewModel.Trending
 import com.google.android.horologist.sectionedlist.stateful.SectionedListStatefulScreenViewModel.TrendingSectionState
+import ee.schimke.composeai.preview.ScrollMode
+import ee.schimke.composeai.preview.ScrollingPreview
 
 @Composable
 fun SectionedListStatefulScreen(
@@ -227,6 +229,7 @@ private fun FailedView(onClick: () -> Unit) {
 }
 
 @WearPreviewDevices
+@ScrollingPreview(modes = [ScrollMode.LONG])
 @Composable
 fun SectionedListStatefulScreenPreview() {
   SectionedListStatefulScreen(columnState = rememberResponsiveColumnState())

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/stateless/SectionedListStatelessScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/stateless/SectionedListStatelessScreen.kt
@@ -33,6 +33,7 @@ import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import com.google.android.horologist.composables.SectionedList
 import com.google.android.horologist.composables.SectionedListScope
+import com.google.android.horologist.compose.layout.AppScaffold
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
 import com.google.android.horologist.compose.material.Chip
@@ -166,5 +167,5 @@ private fun SectionedListScope.bottomMenuSection() {
 @ScrollingPreview(modes = [ScrollMode.LONG])
 @Composable
 fun SectionedListStatelessScreenPreview() {
-  SectionedListStatelessScreen(columnState = rememberResponsiveColumnState())
+  AppScaffold { SectionedListStatelessScreen(columnState = rememberResponsiveColumnState()) }
 }

--- a/sample/src/main/java/com/google/android/horologist/sectionedlist/stateless/SectionedListStatelessScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sectionedlist/stateless/SectionedListStatelessScreen.kt
@@ -39,6 +39,8 @@ import com.google.android.horologist.compose.material.Chip
 import com.google.android.horologist.compose.material.Title
 import com.google.android.horologist.images.base.paintable.ImageVectorPaintable.Companion.asPaintable
 import com.google.android.horologist.sample.R
+import ee.schimke.composeai.preview.ScrollMode
+import ee.schimke.composeai.preview.ScrollingPreview
 
 @Composable
 fun SectionedListStatelessScreen(
@@ -161,6 +163,7 @@ private fun SectionedListScope.bottomMenuSection() {
 }
 
 @WearPreviewDevices
+@ScrollingPreview(modes = [ScrollMode.LONG])
 @Composable
 fun SectionedListStatelessScreenPreview() {
   SectionedListStatelessScreen(columnState = rememberResponsiveColumnState())


### PR DESCRIPTION
#### WHAT

- Add @ScrollingPreview(modes = [ScrollMode.LONG, ScrollMode.END]) to PlaylistsScreen preview
- Add @ScrollingPreview(modes = [ScrollMode.LONG]) to BrowseScreen preview
- Add @ScrollingPreview(modes = [ScrollMode.LONG]) to SectionedList expandable, stateful, and stateless screen previews
- Add @ScrollingPreview(modes = [ScrollMode.LONG]) to SampleCardScreen preview
- Add @ScrollingPreview(modes = [ScrollMode.END]) to NodesActionsScreen preview
- Expose preview-annotations in compose-tools and apply composeAiPreview plugin to sample


#### WHY


#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
