### PR TITLE
Add missing Compose previews for AI UI, Material, and Layout components

### DIFF
--- a/ai/ui/src/debug/kotlin/com/google/android/horologist/ai/ui/components/ResponsePreview.kt
+++ b/ai/ui/src/debug/kotlin/com/google/android/horologist/ai/ui/components/ResponsePreview.kt
@@ -16,6 +16,17 @@
 
 package com.google.android.horologist.ai.ui.components
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
+import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
+import com.google.android.horologist.ai.ui.model.FailedResponseUiModel
+import com.google.android.horologist.ai.ui.model.InProgressResponseUiModel
+import com.google.android.horologist.ai.ui.model.TextResponseUiModel
+
 @WearPreviewLargeRound
 @Composable
 internal fun TextResponseCardPreview() {

--- a/ai/ui/src/debug/kotlin/com/google/android/horologist/ai/ui/components/TextPromptDisplayPreview.kt
+++ b/ai/ui/src/debug/kotlin/com/google/android/horologist/ai/ui/components/TextPromptDisplayPreview.kt
@@ -16,6 +16,14 @@
 
 package com.google.android.horologist.ai.ui.components
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
+import com.google.android.horologist.ai.ui.model.TextPromptUiModel
+
 @WearPreviewLargeRound
 @Composable
 internal fun TextPromptDisplayPreview() {

--- a/ai/ui/src/debug/kotlin/com/google/android/horologist/ai/ui/screens/PromptScreenPreview.kt
+++ b/ai/ui/src/debug/kotlin/com/google/android/horologist/ai/ui/screens/PromptScreenPreview.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.ai.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.wear.compose.material3.AppScaffold
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.TimeText
+import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
+import com.google.android.horologist.ai.ui.model.FailedResponseUiModel
+import com.google.android.horologist.ai.ui.model.ModelInstanceUiModel
+import com.google.android.horologist.ai.ui.model.TextPromptUiModel
+import com.google.android.horologist.ai.ui.model.TextResponseUiModel
+
+@WearPreviewDevices
+@Composable
+fun PromptScreenSuccessPreview() {
+  MaterialTheme {
+    AppScaffold(
+      modifier = Modifier.fillMaxSize().background(Color.Black),
+      timeText = { TimeText() },
+    ) {
+      PromptScreen(
+        uiState =
+          PromptUiState(
+            modelInfo = ModelInstanceUiModel("nano", "Gemini Nano"),
+            messages =
+              listOf(
+                TextPromptUiModel("Summarize my daily meetings"),
+                TextResponseUiModel(
+                  "You have 3 meetings today:\n1. 10:00 AM - Sprint Planning\n2. 2:00 PM - Design Review\n3. 4:30 PM - 1:1 with Manager"
+                ),
+              ),
+          ),
+        promptEntry = {},
+      )
+    }
+  }
+}
+
+@WearPreviewDevices
+@Composable
+fun PromptScreenStreamingPreview() {
+  MaterialTheme {
+    AppScaffold(
+      modifier = Modifier.fillMaxSize().background(Color.Black),
+      timeText = { TimeText() },
+    ) {
+      PromptScreen(
+        uiState =
+          PromptUiState(
+            modelInfo = ModelInstanceUiModel("nano", "Gemini Nano"),
+            messages = listOf(TextPromptUiModel("Summarize my daily meetings")),
+            pending = true,
+          ),
+        promptEntry = {},
+      )
+    }
+  }
+}
+
+@WearPreviewDevices
+@Composable
+fun PromptScreenErrorPreview() {
+  MaterialTheme {
+    AppScaffold(
+      modifier = Modifier.fillMaxSize().background(Color.Black),
+      timeText = { TimeText() },
+    ) {
+      PromptScreen(
+        uiState =
+          PromptUiState(
+            modelInfo = ModelInstanceUiModel("nano", "Gemini Nano"),
+            messages =
+              listOf(
+                TextPromptUiModel("Summarize my daily meetings"),
+                FailedResponseUiModel(
+                  message = "Network connection lost. Please check Bluetooth or Wi-Fi."
+                ),
+              ),
+          ),
+        promptEntry = {},
+      )
+    }
+  }
+}
+
+@WearPreviewDevices
+@Composable
+fun PromptScreenMultiTurnPreview() {
+  MaterialTheme {
+    AppScaffold(
+      modifier = Modifier.fillMaxSize().background(Color.Black),
+      timeText = { TimeText() },
+    ) {
+      PromptScreen(
+        uiState =
+          PromptUiState(
+            modelInfo = ModelInstanceUiModel("nano", "Gemini Nano"),
+            messages =
+              listOf(
+                TextPromptUiModel("Summarize my daily meetings"),
+                TextResponseUiModel(
+                  "You have 3 meetings today:\n1. 10:00 AM - Sprint Planning\n2. 2:00 PM - Design Review\n3. 4:30 PM - 1:1 with Manager"
+                ),
+                TextPromptUiModel("When is the design review?"),
+                TextResponseUiModel("The Design Review is at 2:00 PM."),
+              ),
+          ),
+        promptEntry = {},
+      )
+    }
+  }
+}

--- a/compose-layout/src/debug/java/com/google/android/horologist/compose/pager/PagerScreenPreview.kt
+++ b/compose-layout/src/debug/java/com/google/android/horologist/compose/pager/PagerScreenPreview.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.compose.pager
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.wear.compose.foundation.pager.rememberPagerState
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
+import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
+
+@WearPreviewDevices
+@Composable
+fun PagerScreenPreview() {
+  MaterialTheme {
+    val pagerState = rememberPagerState { 3 }
+    PagerScreen(state = pagerState) { page ->
+      Box(
+        modifier = Modifier.fillMaxSize().background(Color.DarkGray),
+        contentAlignment = Alignment.Center,
+      ) {
+        Text("Page $page / 3")
+      }
+    }
+  }
+}

--- a/compose-material/src/debug/java/com/google/android/horologist/compose/material/AlertDialogPreview.kt
+++ b/compose-material/src/debug/java/com/google/android/horologist/compose/material/AlertDialogPreview.kt
@@ -16,7 +16,10 @@
 
 package com.google.android.horologist.compose.material
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.runtime.Composable
+import androidx.wear.compose.material.Icon
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 
 @WearPreviewDevices
@@ -44,6 +47,20 @@ fun AlertDialogWithLongBodyPreview() {
         "irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla " +
         "pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia " +
         "deserunt mollit anim id est laborum.",
+    onCancel = {},
+    onOk = {},
+    okButtonContentDescription = "Ok",
+    cancelButtonContentDescription = "Cancel",
+  )
+}
+
+@WearPreviewDevices
+@Composable
+fun AlertDialogWithIconPreview() {
+  AlertContent(
+    icon = { Icon(imageVector = Icons.Default.Warning, contentDescription = "Warning") },
+    title = "Warning",
+    message = "Are you sure you want to proceed?",
     onCancel = {},
     onOk = {},
     okButtonContentDescription = "Ok",

--- a/compose-material/src/debug/java/com/google/android/horologist/compose/material/ConfirmationPreview.kt
+++ b/compose-material/src/debug/java/com/google/android/horologist/compose/material/ConfirmationPreview.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.compose.material
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.runtime.Composable
+import androidx.wear.compose.material.Icon
+import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
+
+@WearPreviewDevices
+@Composable
+fun ConfirmationPreview() {
+  ConfirmationContent(
+    icon = { Icon(imageVector = Icons.Default.Check, contentDescription = "Checkmark") },
+    title = "Saved",
+  )
+}
+
+@WearPreviewDevices
+@Composable
+fun ConfirmationLongTitlePreview() {
+  ConfirmationContent(
+    icon = { Icon(imageVector = Icons.Default.Check, contentDescription = "Checkmark") },
+    title = "Your changes have been successfully saved",
+  )
+}

--- a/compose-material/src/debug/java/com/google/android/horologist/compose/material/StepperPreview.kt
+++ b/compose-material/src/debug/java/com/google/android/horologist/compose/material/StepperPreview.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.compose.material
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
+import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
+
+@WearPreviewLargeRound
+@Composable
+fun StepperPreview() {
+  MaterialTheme {
+    Box(
+      modifier = Modifier.fillMaxSize().background(Color.Black),
+      contentAlignment = Alignment.Center,
+    ) {
+      Stepper(value = 5, onValueChange = {}, valueProgression = 0..10) { Text("Value: 5") }
+    }
+  }
+}
+
+@WearPreviewLargeRound
+@Composable
+fun StepperFloatPreview() {
+  MaterialTheme {
+    Box(
+      modifier = Modifier.fillMaxSize().background(Color.Black),
+      contentAlignment = Alignment.Center,
+    ) {
+      Stepper(value = 2.5f, onValueChange = {}, steps = 5, valueRange = 0f..5f) {
+        Text("Value: 2.5")
+      }
+    }
+  }
+}


### PR DESCRIPTION

#### WHAT

- Fix ai:ui debug source path so previews are properly discovered
- Add PromptScreen previews covering success, streaming, error, and multi-turn states
- Add previews for Stepper, Confirmation, and AlertDialog with icon in compose-material
- Add PagerScreen preview in compose-layout


#### WHY


#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
