### PR TITLE
Adopt @AnimatedPreview annotations across target modules

### DIFF
--- a/compose-material/build.gradle.kts
+++ b/compose-material/build.gradle.kts
@@ -94,6 +94,7 @@ dependencies {
 
   debugImplementation(libs.compose.material.iconsext)
   debugImplementation(libs.compose.ui.toolingpreview)
+  debugImplementation(libs.compose.preview.annotations)
   debugRuntimeOnly(libs.compose.ui.tooling)
   debugRuntimeOnly(libs.compose.ui.test.manifest)
 

--- a/compose-material/src/debug/java/com/google/android/horologist/compose/material/ChipIconWithProgressPreview.kt
+++ b/compose-material/src/debug/java/com/google/android/horologist/compose/material/ChipIconWithProgressPreview.kt
@@ -22,11 +22,20 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.google.android.horologist.images.base.paintable.ImageVectorPaintable
+import ee.schimke.composeai.preview.AnimatedPreview
 
 @Preview(name = "Standard", backgroundColor = 0xff000000, showBackground = true)
+@AnimatedPreview(durationMs = 1500, frameIntervalMs = 100, showCurves = false)
 @Composable
 fun ChipIconWithProgressPreview() {
   ChipIconWithProgress()
+}
+
+@Preview(name = "Standard with Icon", backgroundColor = 0xff000000, showBackground = true)
+@AnimatedPreview(durationMs = 1500, frameIntervalMs = 100, showCurves = false)
+@Composable
+fun ChipIconWithProgressWithIconPreview() {
+  ChipIconWithProgress(icon = ImageVectorPaintable(Icon32dp))
 }
 
 @Preview(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -190,6 +190,7 @@ compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-mani
 compose-ui-text = { group = "androidx.compose.ui", name = "ui-text" }
 compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 compose-ui-toolingpreview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+compose-preview-annotations = { module = "ee.schimke.composeai:preview-annotations", version.ref = "composeAiTools" }
 compose-ui-unit = { group = "androidx.compose.ui", name = "ui-unit" }
 compose-ui-util = { group = "androidx.compose.ui", name = "ui-util" }
 dagger-hiltandroid = { module = "com.google.dagger:hilt-android", version.ref = "googledagger" }

--- a/health/composables/build.gradle.kts
+++ b/health/composables/build.gradle.kts
@@ -86,6 +86,7 @@ dependencies {
   debugImplementation(projects.composeTools)
   debugImplementation(libs.compose.ui.tooling)
   implementation(libs.compose.ui.toolingpreview)
+  implementation(libs.compose.preview.annotations)
   releaseCompileOnly(projects.composeTools)
 
   testImplementation(projects.roboscreenshots)

--- a/health/composables/src/main/java/com/google/android/horologist/health/composables/ActiveDurationText.kt
+++ b/health/composables/src/main/java/com/google/android/horologist/health/composables/ActiveDurationText.kt
@@ -36,6 +36,7 @@ import androidx.wear.compose.material.LocalTextStyle
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.tools.WearPreview
+import ee.schimke.composeai.preview.AnimatedPreview
 import java.time.Duration
 import java.time.Instant
 import kotlinx.coroutines.delay
@@ -175,6 +176,7 @@ private fun calculateDurationSeconds(
 }
 
 @WearPreview
+@AnimatedPreview(durationMs = 2500, frameIntervalMs = 500, showCurves = false)
 @Composable
 internal fun ActiveDurationTextPreview() {
   var state by remember { mutableStateOf(ExerciseState.ACTIVE) }

--- a/media/audio-ui/build.gradle.kts
+++ b/media/audio-ui/build.gradle.kts
@@ -92,6 +92,7 @@ dependencies {
 
   implementation(libs.compose.ui.toolingpreview)
   debugImplementation(libs.compose.ui.tooling)
+  debugImplementation(libs.compose.preview.annotations)
   debugImplementation(projects.composeTools)
   debugImplementation(libs.compose.ui.test.manifest)
 

--- a/media/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/animated/AnimatedSetVolumeButtonPreview.kt
+++ b/media/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/animated/AnimatedSetVolumeButtonPreview.kt
@@ -16,18 +16,12 @@
 
 package com.google.android.horologist.audio.ui.components.animated
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Stepper
 import androidx.wear.compose.ui.tooling.preview.WearPreviewSmallRound
@@ -56,21 +50,14 @@ fun AnimatedSetVolumeButtonPreview() {
   }
 }
 
-@Preview(
-  name = "Animated Volume Button",
-  device = "id:wearos_small_round",
-  showBackground = true,
-  backgroundColor = 0xFF000000,
-)
+@Preview(name = "Animated Volume Button", showBackground = true, backgroundColor = 0xFF000000)
 @AnimatedPreview(durationMs = 1200, frameIntervalMs = 100, showCurves = false)
 @Composable
 fun AnimatedVolumeButtonMotionPreview() {
   MaterialTheme {
-    Box(modifier = Modifier.background(Color.Black).padding(8.dp)) {
-      AnimatedSetVolumeButton(
-        volumeUiState = VolumeUiState(current = 6, max = 10),
-        onVolumeClick = {},
-      )
-    }
+    AnimatedSetVolumeButton(
+      volumeUiState = VolumeUiState(current = 6, max = 10),
+      onVolumeClick = {},
+    )
   }
 }

--- a/media/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/animated/AnimatedSetVolumeButtonPreview.kt
+++ b/media/audio-ui/src/debug/java/com/google/android/horologist/audio/ui/components/animated/AnimatedSetVolumeButtonPreview.kt
@@ -16,18 +16,28 @@
 
 package com.google.android.horologist.audio.ui.components.animated
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Stepper
 import androidx.wear.compose.ui.tooling.preview.WearPreviewSmallRound
 import com.google.android.horologist.audio.ui.VolumeScreenDefaults.DecreaseIcon
 import com.google.android.horologist.audio.ui.VolumeScreenDefaults.IncreaseIcon
 import com.google.android.horologist.audio.ui.VolumeUiState
+import ee.schimke.composeai.preview.AnimatedPreview
 
 @WearPreviewSmallRound
+@AnimatedPreview(durationMs = 1200, frameIntervalMs = 100, showCurves = false)
 @Composable
 fun AnimatedSetVolumeButtonPreview() {
   var volumeUiState by remember { mutableStateOf(VolumeUiState(3, 5)) }
@@ -42,6 +52,25 @@ fun AnimatedSetVolumeButtonPreview() {
       decreaseIcon = { DecreaseIcon() },
     ) {
       AnimatedSetVolumeButton(onVolumeClick = {}, volumeUiState = volumeUiState)
+    }
+  }
+}
+
+@Preview(
+  name = "Animated Volume Button",
+  device = "id:wearos_small_round",
+  showBackground = true,
+  backgroundColor = 0xFF000000,
+)
+@AnimatedPreview(durationMs = 1200, frameIntervalMs = 100, showCurves = false)
+@Composable
+fun AnimatedVolumeButtonMotionPreview() {
+  MaterialTheme {
+    Box(modifier = Modifier.background(Color.Black).padding(8.dp)) {
+      AnimatedSetVolumeButton(
+        volumeUiState = VolumeUiState(current = 6, max = 10),
+        onVolumeClick = {},
+      )
     }
   }
 }

--- a/media/ui-material3/build.gradle.kts
+++ b/media/ui-material3/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
   alias(libs.plugins.roborazzi)
   kotlin("plugin.serialization")
   alias(libs.plugins.compose.compiler)
+  alias(libs.plugins.composeAiPreview)
 }
 
 android {
@@ -114,6 +115,7 @@ dependencies {
   debugImplementation(projects.logo)
 
   debugImplementation(libs.compose.ui.tooling)
+  debugImplementation(libs.compose.preview.annotations)
   debugImplementation(libs.compose.ui.test.manifest)
   debugImplementation(projects.media.audioUiMaterial3)
   debugImplementation(projects.composeTools)

--- a/media/ui-material3/src/debug/java/com/google/android/horologist/media/ui/material3/components/PlayPauseProgressButtonPreview.kt
+++ b/media/ui-material3/src/debug/java/com/google/android/horologist/media/ui/material3/components/PlayPauseProgressButtonPreview.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.media.ui.material3.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material3.MaterialTheme
+import com.google.android.horologist.media.ui.material3.components.animated.AnimatedPlayPauseProgressButton
+import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
+import ee.schimke.composeai.preview.AnimatedPreview
+import kotlin.time.Duration.Companion.seconds
+
+@Preview(
+  name = "Animated Play Pause Progress",
+  device = "id:wearos_large_round",
+  showBackground = true,
+  backgroundColor = 0xFF000000,
+)
+@AnimatedPreview(durationMs = 2000, frameIntervalMs = 100, showCurves = false)
+@Composable
+fun AnimatedPlayPauseProgressButtonPreview() {
+  MaterialTheme {
+    Box(modifier = Modifier.background(Color.Black).padding(8.dp)) {
+      PlayPauseProgressButton(
+        onPlayClick = {},
+        onPauseClick = {},
+        enabled = true,
+        playing = true,
+        trackPositionUiModel = TrackPositionUiModel.Actual(0.5f, 50.seconds, 100.seconds),
+      )
+    }
+  }
+}
+
+@Preview(
+  name = "Animated Play Pause Progress Loading",
+  device = "id:wearos_large_round",
+  showBackground = true,
+  backgroundColor = 0xFF000000,
+)
+@AnimatedPreview(durationMs = 2000, frameIntervalMs = 100, showCurves = false)
+@Composable
+fun AnimatedPlayPauseProgressButtonLoadingPreview() {
+  MaterialTheme {
+    Box(modifier = Modifier.background(Color.Black).padding(8.dp)) {
+      PlayPauseProgressButton(
+        onPlayClick = {},
+        onPauseClick = {},
+        enabled = true,
+        playing = true,
+        trackPositionUiModel = TrackPositionUiModel.Loading(showProgress = true),
+      )
+    }
+  }
+}
+
+@Preview(
+  name = "Animated Play Pause Morph",
+  device = "id:wearos_large_round",
+  showBackground = true,
+  backgroundColor = 0xFF000000,
+)
+@AnimatedPreview(durationMs = 2000, frameIntervalMs = 100, showCurves = false)
+@Composable
+fun AnimatedPlayPauseMorphPreview() {
+  MaterialTheme {
+    Box(modifier = Modifier.background(Color.Black).padding(8.dp)) {
+      AnimatedPlayPauseProgressButton(
+        onPlayClick = {},
+        onPauseClick = {},
+        enabled = true,
+        playing = true,
+        trackPositionUiModel = TrackPositionUiModel.Actual(0.5f, 50.seconds, 100.seconds),
+      )
+    }
+  }
+}

--- a/media/ui-material3/src/debug/java/com/google/android/horologist/media/ui/material3/components/PlayPauseProgressButtonPreview.kt
+++ b/media/ui-material3/src/debug/java/com/google/android/horologist/media/ui/material3/components/PlayPauseProgressButtonPreview.kt
@@ -16,12 +16,9 @@
 
 package com.google.android.horologist.media.ui.material3.components
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material3.MaterialTheme
@@ -30,31 +27,24 @@ import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
 import ee.schimke.composeai.preview.AnimatedPreview
 import kotlin.time.Duration.Companion.seconds
 
-@Preview(
-  name = "Animated Play Pause Progress",
-  device = "id:wearos_large_round",
-  showBackground = true,
-  backgroundColor = 0xFF000000,
-)
+@Preview(name = "Animated Play Pause Progress", showBackground = true, backgroundColor = 0xFF000000)
 @AnimatedPreview(durationMs = 2000, frameIntervalMs = 100, showCurves = false)
 @Composable
 fun AnimatedPlayPauseProgressButtonPreview() {
   MaterialTheme {
-    Box(modifier = Modifier.background(Color.Black).padding(8.dp)) {
-      PlayPauseProgressButton(
-        onPlayClick = {},
-        onPauseClick = {},
-        enabled = true,
-        playing = true,
-        trackPositionUiModel = TrackPositionUiModel.Actual(0.5f, 50.seconds, 100.seconds),
-      )
-    }
+    PlayPauseProgressButton(
+      onPlayClick = {},
+      onPauseClick = {},
+      enabled = true,
+      playing = true,
+      trackPositionUiModel = TrackPositionUiModel.Actual(0.5f, 50.seconds, 100.seconds),
+      modifier = Modifier.size(72.dp),
+    )
   }
 }
 
 @Preview(
   name = "Animated Play Pause Progress Loading",
-  device = "id:wearos_large_round",
   showBackground = true,
   backgroundColor = 0xFF000000,
 )
@@ -62,36 +52,29 @@ fun AnimatedPlayPauseProgressButtonPreview() {
 @Composable
 fun AnimatedPlayPauseProgressButtonLoadingPreview() {
   MaterialTheme {
-    Box(modifier = Modifier.background(Color.Black).padding(8.dp)) {
-      PlayPauseProgressButton(
-        onPlayClick = {},
-        onPauseClick = {},
-        enabled = true,
-        playing = true,
-        trackPositionUiModel = TrackPositionUiModel.Loading(showProgress = true),
-      )
-    }
+    PlayPauseProgressButton(
+      onPlayClick = {},
+      onPauseClick = {},
+      enabled = true,
+      playing = true,
+      trackPositionUiModel = TrackPositionUiModel.Loading(showProgress = true),
+      modifier = Modifier.size(72.dp),
+    )
   }
 }
 
-@Preview(
-  name = "Animated Play Pause Morph",
-  device = "id:wearos_large_round",
-  showBackground = true,
-  backgroundColor = 0xFF000000,
-)
+@Preview(name = "Animated Play Pause Morph", showBackground = true, backgroundColor = 0xFF000000)
 @AnimatedPreview(durationMs = 2000, frameIntervalMs = 100, showCurves = false)
 @Composable
 fun AnimatedPlayPauseMorphPreview() {
   MaterialTheme {
-    Box(modifier = Modifier.background(Color.Black).padding(8.dp)) {
-      AnimatedPlayPauseProgressButton(
-        onPlayClick = {},
-        onPauseClick = {},
-        enabled = true,
-        playing = true,
-        trackPositionUiModel = TrackPositionUiModel.Actual(0.5f, 50.seconds, 100.seconds),
-      )
-    }
+    AnimatedPlayPauseProgressButton(
+      onPlayClick = {},
+      onPauseClick = {},
+      enabled = true,
+      playing = true,
+      trackPositionUiModel = TrackPositionUiModel.Actual(0.5f, 50.seconds, 100.seconds),
+      modifier = Modifier.size(72.dp),
+    )
   }
 }

--- a/media/ui/build.gradle.kts
+++ b/media/ui/build.gradle.kts
@@ -112,6 +112,7 @@ dependencies {
   debugImplementation(projects.logo)
 
   debugImplementation(libs.compose.ui.tooling)
+  debugImplementation(libs.compose.preview.annotations)
   debugImplementation(libs.compose.ui.test.manifest)
   debugImplementation(projects.media.audioUi)
   debugImplementation(projects.composeTools)

--- a/media/ui/src/debug/java/com/google/android/horologist/media/ui/components/PlayPauseProgressButtonPreview.kt
+++ b/media/ui/src/debug/java/com/google/android/horologist/media/ui/components/PlayPauseProgressButtonPreview.kt
@@ -18,11 +18,16 @@ package com.google.android.horologist.media.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.MaterialTheme
+import com.google.android.horologist.media.ui.components.animated.AnimatedPlayPauseProgressButton
 import com.google.android.horologist.media.ui.state.model.TrackPositionUiModel
+import ee.schimke.composeai.preview.AnimatedPreview
 import kotlin.time.Duration.Companion.seconds
 
 @Preview("Enabled - Playing - Progress 0%", backgroundColor = 0xff000000, showBackground = true)
@@ -82,6 +87,7 @@ fun PlayPauseProgressButtonPreview100() {
 }
 
 @Preview("Loading", backgroundColor = 0xff000000, showBackground = true)
+@AnimatedPreview(durationMs = 2000, frameIntervalMs = 100, showCurves = false)
 @Composable
 fun PlayPauseProgressButtonLoadingPreview() {
   PlayPauseProgressButton(
@@ -91,6 +97,50 @@ fun PlayPauseProgressButtonLoadingPreview() {
     playing = true,
     trackPositionUiModel = TrackPositionUiModel.Loading(showProgress = true),
   )
+}
+
+@Preview(
+  name = "Animated Play Pause Progress",
+  device = "id:wearos_large_round",
+  showBackground = true,
+  backgroundColor = 0xFF000000,
+)
+@AnimatedPreview(durationMs = 2000, frameIntervalMs = 100, showCurves = false)
+@Composable
+fun AnimatedPlayPauseProgressButtonPreview() {
+  MaterialTheme {
+    Box(modifier = Modifier.background(Color.Black).padding(8.dp)) {
+      PlayPauseProgressButton(
+        onPlayClick = {},
+        onPauseClick = {},
+        enabled = true,
+        playing = true,
+        trackPositionUiModel = TrackPositionUiModel.Actual(0.5f, 50.seconds, 100.seconds),
+      )
+    }
+  }
+}
+
+@Preview(
+  name = "Animated Play Pause Progress Morph",
+  device = "id:wearos_large_round",
+  showBackground = true,
+  backgroundColor = 0xFF000000,
+)
+@AnimatedPreview(durationMs = 2000, frameIntervalMs = 100, showCurves = false)
+@Composable
+fun AnimatedPlayPauseProgressButtonMorphPreview() {
+  MaterialTheme {
+    Box(modifier = Modifier.background(Color.Black).padding(8.dp)) {
+      AnimatedPlayPauseProgressButton(
+        onPlayClick = {},
+        onPauseClick = {},
+        enabled = true,
+        playing = true,
+        trackPositionUiModel = TrackPositionUiModel.Actual(0.5f, 50.seconds, 100.seconds),
+      )
+    }
+  }
 }
 
 @Preview("On Background - Progress 50%", backgroundColor = 0xff000000, showBackground = true)

--- a/media/ui/src/debug/java/com/google/android/horologist/media/ui/components/PlayPauseProgressButtonPreview.kt
+++ b/media/ui/src/debug/java/com/google/android/horologist/media/ui/components/PlayPauseProgressButtonPreview.kt
@@ -18,7 +18,7 @@ package com.google.android.horologist.media.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -96,50 +96,43 @@ fun PlayPauseProgressButtonLoadingPreview() {
     enabled = true,
     playing = true,
     trackPositionUiModel = TrackPositionUiModel.Loading(showProgress = true),
+    modifier = Modifier.size(60.dp),
   )
 }
 
-@Preview(
-  name = "Animated Play Pause Progress",
-  device = "id:wearos_large_round",
-  showBackground = true,
-  backgroundColor = 0xFF000000,
-)
+@Preview(name = "Animated Play Pause Progress", backgroundColor = 0xff000000, showBackground = true)
 @AnimatedPreview(durationMs = 2000, frameIntervalMs = 100, showCurves = false)
 @Composable
 fun AnimatedPlayPauseProgressButtonPreview() {
   MaterialTheme {
-    Box(modifier = Modifier.background(Color.Black).padding(8.dp)) {
-      PlayPauseProgressButton(
-        onPlayClick = {},
-        onPauseClick = {},
-        enabled = true,
-        playing = true,
-        trackPositionUiModel = TrackPositionUiModel.Actual(0.5f, 50.seconds, 100.seconds),
-      )
-    }
+    PlayPauseProgressButton(
+      onPlayClick = {},
+      onPauseClick = {},
+      enabled = true,
+      playing = true,
+      trackPositionUiModel = TrackPositionUiModel.Actual(0.5f, 50.seconds, 100.seconds),
+      modifier = Modifier.size(60.dp),
+    )
   }
 }
 
 @Preview(
   name = "Animated Play Pause Progress Morph",
-  device = "id:wearos_large_round",
+  backgroundColor = 0xff000000,
   showBackground = true,
-  backgroundColor = 0xFF000000,
 )
 @AnimatedPreview(durationMs = 2000, frameIntervalMs = 100, showCurves = false)
 @Composable
 fun AnimatedPlayPauseProgressButtonMorphPreview() {
   MaterialTheme {
-    Box(modifier = Modifier.background(Color.Black).padding(8.dp)) {
-      AnimatedPlayPauseProgressButton(
-        onPlayClick = {},
-        onPauseClick = {},
-        enabled = true,
-        playing = true,
-        trackPositionUiModel = TrackPositionUiModel.Actual(0.5f, 50.seconds, 100.seconds),
-      )
-    }
+    AnimatedPlayPauseProgressButton(
+      onPlayClick = {},
+      onPauseClick = {},
+      enabled = true,
+      playing = true,
+      trackPositionUiModel = TrackPositionUiModel.Actual(0.5f, 50.seconds, 100.seconds),
+      modifier = Modifier.size(60.dp),
+    )
   }
 }
 

--- a/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenPreview.kt
+++ b/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/PlaylistDownloadScreenPreview.kt
@@ -24,8 +24,10 @@ import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import com.google.android.horologist.images.base.util.rememberVectorPainter
 import com.google.android.horologist.media.ui.state.model.DownloadMediaUiModel
 import com.google.android.horologist.media.ui.state.model.PlaylistUiModel
+import ee.schimke.composeai.preview.AnimatedPreview
 
 @WearPreviewDevices
+@AnimatedPreview(durationMs = 2000, frameIntervalMs = 100, showCurves = false)
 @Composable
 fun PlaylistDownloadScreenPreviewLoading() {
   PlaylistDownloadScreen(
@@ -62,6 +64,7 @@ fun PlaylistDownloadScreenPreviewLoadedNoneDownloaded() {
 }
 
 @WearPreviewDevices
+@AnimatedPreview(durationMs = 2000, frameIntervalMs = 100, showCurves = false)
 @Composable
 fun PlaylistDownloadScreenPreviewLoadedNoneDownloadedDownloading() {
   PlaylistDownloadScreen(

--- a/remotecompose/lottie/build.gradle.kts
+++ b/remotecompose/lottie/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
   alias(libs.plugins.metalavaGradle)
   alias(libs.plugins.kotlinx.serialization)
   alias(libs.plugins.roborazzi)
+  alias(libs.plugins.composeAiPreview)
 }
 
 android {
@@ -55,6 +56,8 @@ dependencies {
   debugImplementation(libs.androidx.compose.remote.player.core)
   debugImplementation(libs.androidx.compose.remote.player.compose)
   debugImplementation(libs.androidx.compose.remote.player.view)
+  debugImplementation(libs.compose.ui.toolingpreview)
+  debugImplementation(libs.compose.preview.annotations)
 
   testImplementation(libs.junit)
   testImplementation(libs.truth)

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
   alias(libs.plugins.roborazzi)
   kotlin("plugin.serialization")
   alias(libs.plugins.compose.compiler)
+  alias(libs.plugins.composeAiPreview)
 }
 
 android {
@@ -128,6 +129,7 @@ dependencies {
   implementation(libs.okhttp.coroutines)
 
   implementation(libs.compose.ui.toolingpreview)
+  implementation(libs.compose.preview.annotations)
   implementation(libs.androidx.wear.tooling.preview)
 
   implementation(libs.androidx.wear.compose.material3)

--- a/sample/src/main/java/com/google/android/horologist/lottie/GeometryPreview.kt
+++ b/sample/src/main/java/com/google/android/horologist/lottie/GeometryPreview.kt
@@ -25,8 +25,10 @@ import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import com.google.android.horologist.remotecompose.lottie.LottiePreview
 import com.google.android.horologist.remotecompose.lottie.SlotMap
 import com.google.android.horologist.sample.R
+import ee.schimke.composeai.preview.AnimatedPreview
 
 @WearPreviewDevices
+@AnimatedPreview(durationMs = 3000, frameIntervalMs = 100, showCurves = false)
 @Composable
 fun GeometryPreview() {
   LottiePreview(animationResId = R.raw.geometry)
@@ -34,6 +36,7 @@ fun GeometryPreview() {
 
 @SuppressLint("RestrictedApi")
 @WearPreviewDevices
+@AnimatedPreview(durationMs = 3000, frameIntervalMs = 100, showCurves = false)
 @Composable
 fun TintGeometryPreview() {
   LottiePreview(


### PR DESCRIPTION
#### WHAT

Adopt the @AnimatedPreview annotation from ee.schimke.composeai:preview-annotations to render animated GIF preview artifacts for progress and motion composables:
- PlayPauseProgressButton in media:ui and media:ui-material3
- AnimatedSetVolumeButton in media:audio-ui
- ChipIconWithProgress in compose-material
- PlaylistDownloadScreen in media:ui
- ActiveDurationText in health:composables
- GeometryPreview in sample

#### WHY


#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
