### PR TITLE
Add WearPreviewScreenScaffold, PinnedTimeSource, and phone landscape …

### DIFF
--- a/compose-tools/api/current.api
+++ b/compose-tools/api/current.api
@@ -41,6 +41,17 @@ package com.google.android.horologist.compose.tools {
     property public static com.google.android.horologist.compose.tools.Device SamsungGalaxyWatch6Large;
   }
 
+  public final class FixedTimeSource implements androidx.wear.compose.material.TimeSource {
+    ctor public FixedTimeSource();
+    ctor public FixedTimeSource(optional String time);
+    property public String currentTime;
+  }
+
+  public final class PinnedTimeSource implements androidx.wear.compose.material.TimeSource {
+    property public String currentTime;
+    field public static final com.google.android.horologist.compose.tools.PinnedTimeSource INSTANCE;
+  }
+
   public final class ThemeColors {
     ctor public ThemeColors();
     ctor @KotlinOnly public ThemeColors(optional androidx.compose.ui.graphics.Color primary, optional androidx.compose.ui.graphics.Color primaryVariant, optional androidx.compose.ui.graphics.Color secondary, optional androidx.compose.ui.graphics.Color secondaryVariant, optional androidx.compose.ui.graphics.Color background, optional androidx.compose.ui.graphics.Color surface, optional androidx.compose.ui.graphics.Color error, optional androidx.compose.ui.graphics.Color onPrimary, optional androidx.compose.ui.graphics.Color onSecondary, optional androidx.compose.ui.graphics.Color onBackground, optional androidx.compose.ui.graphics.Color onSurface, optional androidx.compose.ui.graphics.Color onSurfaceVariant, optional androidx.compose.ui.graphics.Color onError);
@@ -109,6 +120,10 @@ package com.google.android.horologist.compose.tools {
   }
 
   @androidx.compose.ui.tooling.preview.Preview(backgroundColor=4278190080L, showBackground=true) public @interface WearPreview {
+  }
+
+  public final class WearPreviewScreenScaffoldKt {
+    method @KotlinOnly @androidx.compose.runtime.Composable public static void WearPreviewScreenScaffold(optional androidx.compose.ui.Modifier modifier, optional androidx.wear.compose.foundation.lazy.ScalingLazyListState? scrollState, optional kotlin.jvm.functions.Function0<kotlin.Unit> timeText, optional kotlin.jvm.functions.Function0<kotlin.Unit> positionIndicator, kotlin.jvm.functions.Function0<kotlin.Unit> content);
   }
 
   public final class WearPreviewThemes implements androidx.compose.ui.tooling.preview.PreviewParameterProvider<com.google.android.horologist.compose.tools.ThemeValues> {

--- a/compose-tools/src/main/java/com/google/android/horologist/compose/tools/WearPreviewScreenScaffold.kt
+++ b/compose-tools/src/main/java/com/google/android/horologist/compose/tools/WearPreviewScreenScaffold.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.compose.tools
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.wear.compose.foundation.lazy.ScalingLazyListState
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.PositionIndicator
+import androidx.wear.compose.material.Scaffold
+import androidx.wear.compose.material.TimeSource
+import androidx.wear.compose.material.TimeText
+
+public object PinnedTimeSource : TimeSource {
+  override val currentTime: String
+    @Composable get() = "10:10"
+}
+
+public class FixedTimeSource(private val time: String = "10:10") : TimeSource {
+  override val currentTime: String
+    @Composable get() = time
+}
+
+@Composable
+public fun WearPreviewScreenScaffold(
+  modifier: Modifier = Modifier,
+  scrollState: ScalingLazyListState? = null,
+  timeText: @Composable () -> Unit = { TimeText(timeSource = PinnedTimeSource) },
+  positionIndicator: @Composable () -> Unit = {
+    scrollState?.let { PositionIndicator(scalingLazyListState = it) }
+  },
+  content: @Composable () -> Unit,
+) {
+  MaterialTheme {
+    Scaffold(
+      modifier = modifier.fillMaxSize().background(Color.Black),
+      timeText = timeText,
+      positionIndicator = positionIndicator,
+    ) {
+      content()
+    }
+  }
+}

--- a/datalayer/phone-ui/build.gradle.kts
+++ b/datalayer/phone-ui/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
   alias(libs.plugins.metalavaGradle)
   alias(libs.plugins.dependencyAnalysis)
   alias(libs.plugins.compose.compiler)
+  alias(libs.plugins.composeAiPreview)
 }
 
 android {

--- a/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/installapp/InstallAppBottomSheet.kt
+++ b/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/installapp/InstallAppBottomSheet.kt
@@ -235,3 +235,35 @@ private fun InstallAppBottomSheetContentPreviewNoIcon() {
     onConfirmation = {},
   )
 }
+
+@Preview(
+  name = "Install App Bottom Sheet - Landscape",
+  device = "spec:parent=pixel_5,orientation=landscape",
+  showBackground = true,
+)
+@Composable
+private fun InstallAppBottomSheetLandscapeContentPreview() {
+  InstallAppBottomSheetLandscapeContent(
+    image = { Icon(Icons.Default.Email, contentDescription = null) },
+    topMessage = "Stay productive and manage emails right from your wrist.",
+    bottomMessage = "Add the Gmail app to your Wear OS watch for easy access wherever you are.",
+    onDismissRequest = {},
+    onConfirmation = {},
+  )
+}
+
+@Preview(
+  name = "Install App Bottom Sheet - Landscape - No Icon",
+  device = "spec:parent=pixel_5,orientation=landscape",
+  showBackground = true,
+)
+@Composable
+private fun InstallAppBottomSheetLandscapeContentPreviewNoIcon() {
+  InstallAppBottomSheetLandscapeContent(
+    image = null,
+    topMessage = "Stay productive and manage emails right from your wrist.",
+    bottomMessage = "Add the Gmail app to your Wear OS watch for easy access wherever you are.",
+    onDismissRequest = {},
+    onConfirmation = {},
+  )
+}

--- a/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/installtile/InstallTileBottomSheet.kt
+++ b/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/installtile/InstallTileBottomSheet.kt
@@ -235,3 +235,35 @@ private fun InstallTileBottomSheetContentPreviewNoIcon() {
     onConfirmation = {},
   )
 }
+
+@Preview(
+  name = "Install Tile Bottom Sheet - Landscape",
+  device = "spec:parent=pixel_5,orientation=landscape",
+  showBackground = true,
+)
+@Composable
+private fun InstallTileBottomSheetLandscapeContentPreview() {
+  InstallTileBottomSheetLandscapeContent(
+    image = { Icon(Icons.Default.Email, contentDescription = null) },
+    topMessage = "Find useful content from your app with a glance.",
+    bottomMessage = "Add the Tile to your Wear OS app for accessing data with a glance.",
+    onDismissRequest = {},
+    onConfirmation = {},
+  )
+}
+
+@Preview(
+  name = "Install Tile Bottom Sheet - Landscape - No Icon",
+  device = "spec:parent=pixel_5,orientation=landscape",
+  showBackground = true,
+)
+@Composable
+private fun InstallTileBottomSheetLandscapeContentPreviewNoIcon() {
+  InstallTileBottomSheetLandscapeContent(
+    image = null,
+    topMessage = "Find useful content from your app with a glance.",
+    bottomMessage = "Add the Tile to your Wear OS app for accessing data with a glance.",
+    onDismissRequest = {},
+    onConfirmation = {},
+  )
+}

--- a/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/reengage/ReEngageBottomSheet.kt
+++ b/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/reengage/ReEngageBottomSheet.kt
@@ -253,3 +253,39 @@ private fun ReEngageBottomSheetContentPreviewNoIcon() {
     onConfirmation = {},
   )
 }
+
+@Preview(
+  name = "Re-engage Bottom Sheet - Landscape",
+  device = "spec:parent=pixel_5,orientation=landscape",
+  showBackground = true,
+)
+@Composable
+private fun ReEngageBottomSheetLandscapeContentPreview() {
+  ReEngageBottomSheetLandscapeContent(
+    image = { Icon(Icons.Default.Email, contentDescription = null) },
+    topMessage = "Stay productive and manage emails right from your wrist.",
+    bottomMessage = "Add the Gmail app to your Wear OS watch for easy access wherever you are.",
+    positiveButtonLabel = "Try on watch",
+    negativeButtonLabel = "Now now",
+    onDismissRequest = {},
+    onConfirmation = {},
+  )
+}
+
+@Preview(
+  name = "Re-engage Bottom Sheet - Landscape - No Icon",
+  device = "spec:parent=pixel_5,orientation=landscape",
+  showBackground = true,
+)
+@Composable
+private fun ReEngageBottomSheetLandscapeContentPreviewNoIcon() {
+  ReEngageBottomSheetLandscapeContent(
+    image = null,
+    topMessage = "Stay productive and manage emails right from your wrist.",
+    bottomMessage = "Add the Gmail app to your Wear OS watch for easy access wherever you are.",
+    positiveButtonLabel = "Try on watch",
+    negativeButtonLabel = "Now now",
+    onDismissRequest = {},
+    onConfirmation = {},
+  )
+}

--- a/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/signin/SignInBottomSheet.kt
+++ b/datalayer/phone-ui/src/main/java/com/google/android/horologist/datalayer/phone/ui/prompt/signin/SignInBottomSheet.kt
@@ -253,3 +253,39 @@ private fun SignInBottomSheetContentPreviewNoIcon() {
     onConfirmation = {},
   )
 }
+
+@Preview(
+  name = "Sign In Bottom Sheet - Landscape",
+  device = "spec:parent=pixel_5,orientation=landscape",
+  showBackground = true,
+)
+@Composable
+private fun SignInBottomSheetLandscapeContentPreview() {
+  SignInBottomSheetLandscapeContent(
+    image = { Icon(Icons.Default.Email, contentDescription = null) },
+    topMessage = "Stay productive and manage emails right from your wrist.",
+    bottomMessage = "Add the Gmail app to your Wear OS watch for easy access wherever you are.",
+    positiveButtonLabel = "Try on watch",
+    negativeButtonLabel = "Now now",
+    onDismissRequest = {},
+    onConfirmation = {},
+  )
+}
+
+@Preview(
+  name = "Sign In Bottom Sheet - Landscape - No Icon",
+  device = "spec:parent=pixel_5,orientation=landscape",
+  showBackground = true,
+)
+@Composable
+private fun SignInBottomSheetLandscapeContentPreviewNoIcon() {
+  SignInBottomSheetLandscapeContent(
+    image = null,
+    topMessage = "Stay productive and manage emails right from your wrist.",
+    bottomMessage = "Add the Gmail app to your Wear OS watch for easy access wherever you are.",
+    positiveButtonLabel = "Try on watch",
+    negativeButtonLabel = "Now now",
+    onDismissRequest = {},
+    onConfirmation = {},
+  )
+}

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodesActionsScreen.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/screens/nodesactions/NodesActionsScreen.kt
@@ -40,6 +40,7 @@ import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
 import com.google.android.horologist.compose.material.Chip
 import com.google.android.horologist.compose.material.CompactChip
+import com.google.android.horologist.compose.tools.WearPreviewScreenScaffold
 import com.google.android.horologist.datalayer.sample.R
 import com.google.android.horologist.images.base.paintable.ImageVectorPaintable
 
@@ -132,54 +133,63 @@ fun NodesActionsScreen(
 @WearPreviewDevices
 @Composable
 fun NodesActionsScreenPreviewLoaded() {
-  NodesActionsScreen(
-    state =
-      NodesActionScreenState.Loaded(
-        listOf(
-          NodeUiModel(
-            id = "123",
-            name = "Pixel Watch",
-            appInstalled = true,
-            type = NodeTypeUiModel.WATCH,
-          ),
-          NodeUiModel(
-            id = "123",
-            name = "Pixel 6 Pro",
-            appInstalled = true,
-            type = NodeTypeUiModel.PHONE,
-          ),
-          NodeUiModel(
-            id = "123",
-            name = "Unknown",
-            appInstalled = false,
-            type = NodeTypeUiModel.UNKNOWN,
-          ),
-        )
-      ),
-    onNodeClick = { _, _ -> },
-    onRefreshClick = {},
-    columnState = rememberResponsiveColumnState(),
-  )
+  val columnState = rememberResponsiveColumnState()
+  WearPreviewScreenScaffold(scrollState = columnState.state) {
+    NodesActionsScreen(
+      state =
+        NodesActionScreenState.Loaded(
+          listOf(
+            NodeUiModel(
+              id = "123",
+              name = "Pixel Watch",
+              appInstalled = true,
+              type = NodeTypeUiModel.WATCH,
+            ),
+            NodeUiModel(
+              id = "123",
+              name = "Pixel 6 Pro",
+              appInstalled = true,
+              type = NodeTypeUiModel.PHONE,
+            ),
+            NodeUiModel(
+              id = "123",
+              name = "Unknown",
+              appInstalled = false,
+              type = NodeTypeUiModel.UNKNOWN,
+            ),
+          )
+        ),
+      onNodeClick = { _, _ -> },
+      onRefreshClick = {},
+      columnState = columnState,
+    )
+  }
 }
 
 @WearPreviewDevices
 @Composable
 fun NodesActionsScreenPreviewEmptyNodes() {
-  NodesActionsScreen(
-    state = NodesActionScreenState.Loaded(emptyList()),
-    onNodeClick = { _, _ -> },
-    onRefreshClick = {},
-    columnState = rememberResponsiveColumnState(),
-  )
+  val columnState = rememberResponsiveColumnState()
+  WearPreviewScreenScaffold(scrollState = columnState.state) {
+    NodesActionsScreen(
+      state = NodesActionScreenState.Loaded(emptyList()),
+      onNodeClick = { _, _ -> },
+      onRefreshClick = {},
+      columnState = columnState,
+    )
+  }
 }
 
 @WearPreviewDevices
 @Composable
 fun NodesActionsScreenPreviewApiNotAvailable() {
-  NodesActionsScreen(
-    state = NodesActionScreenState.ApiNotAvailable,
-    onNodeClick = { _, _ -> },
-    onRefreshClick = {},
-    columnState = rememberResponsiveColumnState(),
-  )
+  val columnState = rememberResponsiveColumnState()
+  WearPreviewScreenScaffold(scrollState = columnState.state) {
+    NodesActionsScreen(
+      state = NodesActionScreenState.ApiNotAvailable,
+      onNodeClick = { _, _ -> },
+      onRefreshClick = {},
+      columnState = columnState,
+    )
+  }
 }

--- a/health/composables/src/debug/java/com/google/android/horologist/health/composables/screens/MetricsScreenPreview.kt
+++ b/health/composables/src/debug/java/com/google/android/horologist/health/composables/screens/MetricsScreenPreview.kt
@@ -19,6 +19,7 @@ package com.google.android.horologist.health.composables.screens
 import androidx.compose.runtime.Composable
 import androidx.wear.compose.material.PositionIndicator
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
+import com.google.android.horologist.compose.tools.WearPreviewScreenScaffold
 import com.google.android.horologist.health.composables.model.MetricUiModel
 import com.google.android.horologist.health.composables.theme.HR_HARD
 import com.google.android.horologist.health.composables.theme.HR_MAXIMUM
@@ -26,41 +27,49 @@ import com.google.android.horologist.health.composables.theme.HR_MAXIMUM
 @WearPreviewDevices
 @Composable
 fun MetricsScreenPreviewOneMetric() {
-  MetricsScreen(
-    firstMetric = MetricUiModel(text = "21:34", bottomRightText = "6"),
-    positionIndicator = { PositionIndicator(value = { 0.25f }) },
-  )
+  WearPreviewScreenScaffold {
+    MetricsScreen(
+      firstMetric = MetricUiModel(text = "21:34", bottomRightText = "6"),
+      positionIndicator = { PositionIndicator(value = { 0.25f }) },
+    )
+  }
 }
 
 @WearPreviewDevices
 @Composable
 fun MetricsScreenPreviewTwoMetrics() {
-  MetricsScreen(
-    firstMetric = MetricUiModel(text = "21:34", bottomRightText = "6"),
-    secondMetric = MetricUiModel(text = "138", bottomRightText = "cal"),
-    positionIndicator = { PositionIndicator(value = { 0.5f }) },
-  )
+  WearPreviewScreenScaffold {
+    MetricsScreen(
+      firstMetric = MetricUiModel(text = "21:34", bottomRightText = "6"),
+      secondMetric = MetricUiModel(text = "138", bottomRightText = "cal"),
+      positionIndicator = { PositionIndicator(value = { 0.5f }) },
+    )
+  }
 }
 
 @WearPreviewDevices
 @Composable
 fun MetricsScreenPreviewThreeMetrics() {
-  MetricsScreen(
-    firstMetric = MetricUiModel(text = "164", bottomRightText = "Vigorous", color = HR_HARD),
-    secondMetric = MetricUiModel(text = "2.7", bottomRightText = "mi"),
-    thirdMetric = MetricUiModel(text = "21:34", bottomRightText = "6"),
-    positionIndicator = { PositionIndicator(value = { 0.75f }) },
-  )
+  WearPreviewScreenScaffold {
+    MetricsScreen(
+      firstMetric = MetricUiModel(text = "164", bottomRightText = "Vigorous", color = HR_HARD),
+      secondMetric = MetricUiModel(text = "2.7", bottomRightText = "mi"),
+      thirdMetric = MetricUiModel(text = "21:34", bottomRightText = "6"),
+      positionIndicator = { PositionIndicator(value = { 0.75f }) },
+    )
+  }
 }
 
 @WearPreviewDevices
 @Composable
 fun MetricsScreenPreviewFourMetrics() {
-  MetricsScreen(
-    firstMetric = MetricUiModel(text = "198", bottomRightText = "Peak", color = HR_MAXIMUM),
-    secondMetric = MetricUiModel(text = "2.7", bottomRightText = "mi"),
-    thirdMetric = MetricUiModel(text = "8'51\"", bottomRightText = "pace"),
-    fourthMetric = MetricUiModel(text = "21:34", bottomRightText = "6"),
-    positionIndicator = { PositionIndicator(value = { 1f }) },
-  )
+  WearPreviewScreenScaffold {
+    MetricsScreen(
+      firstMetric = MetricUiModel(text = "198", bottomRightText = "Peak", color = HR_MAXIMUM),
+      secondMetric = MetricUiModel(text = "2.7", bottomRightText = "mi"),
+      thirdMetric = MetricUiModel(text = "8'51\"", bottomRightText = "pace"),
+      fourthMetric = MetricUiModel(text = "21:34", bottomRightText = "6"),
+      positionIndicator = { PositionIndicator(value = { 1f }) },
+    )
+  }
 }

--- a/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreenPreview.kt
+++ b/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/browse/BrowseScreenPreview.kt
@@ -18,6 +18,8 @@
 
 package com.google.android.horologist.media.ui.screens.browse
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Login
 import androidx.compose.material.icons.automirrored.filled.PlaylistPlay
@@ -25,13 +27,18 @@ import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Podcasts
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.ExperimentalWearMaterialApi
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import com.google.android.horologist.composables.PlaceholderChip
 import com.google.android.horologist.composables.Section
+import com.google.android.horologist.compose.layout.AppScaffold
+import com.google.android.horologist.compose.layout.ResponsiveTimeText
 import com.google.android.horologist.compose.material.Chip
+import com.google.android.horologist.compose.tools.PinnedTimeSource
 import com.google.android.horologist.images.base.paintable.ImageVectorPaintable.Companion.asPaintable
 import com.google.android.horologist.media.ui.R
 
@@ -71,69 +78,74 @@ private fun BrowseScreenPreviewSample(
   trendingSectionState: Section.State<String>,
   downloadsSectionState: Section.State<Pair<String, String>>,
 ) {
-  BrowseScreen {
-    button(
-      BrowseScreenPlaylistsSectionButton(
-        textId = R.string.horologist_browse_screen_preview_sign_in,
-        icon = Icons.AutoMirrored.Default.Login,
-        onClick = {},
+  AppScaffold(
+    modifier = Modifier.fillMaxSize().background(Color.Black),
+    timeText = { ResponsiveTimeText(timeSource = PinnedTimeSource) },
+  ) {
+    BrowseScreen {
+      button(
+        BrowseScreenPlaylistsSectionButton(
+          textId = R.string.horologist_browse_screen_preview_sign_in,
+          icon = Icons.AutoMirrored.Default.Login,
+          onClick = {},
+        )
       )
-    )
 
-    section(
-      state = trendingSectionState,
-      titleId = R.string.horologist_browse_screen_preview_trending_title,
-      emptyMessageId = R.string.horologist_browse_screen_preview_trending_empty,
-      failedMessageId = R.string.horologist_browse_screen_preview_trending_failed,
-    ) {
-      loaded { item: String ->
-        Chip(
-          label = item,
-          onClick = {},
-          icon = Icons.Default.Person.asPaintable(),
-          colors = ChipDefaults.secondaryChipColors(),
-        )
-      }
-
-      loading { PlaceholderChip(colors = ChipDefaults.secondaryChipColors()) }
-    }
-
-    downloadsSection(state = downloadsSectionState) {
-      loaded { item ->
-        Chip(
-          label = item.first,
-          onClick = {},
-          secondaryLabel = item.second,
-          icon = Icons.Default.MusicNote.asPaintable(),
-          colors = ChipDefaults.secondaryChipColors(),
-        )
-      }
-
-      loading { PlaceholderChip(colors = ChipDefaults.secondaryChipColors()) }
-
-      footer {
-        Chip(
-          label = stringResource(id = R.string.horologist_browse_screen_preview_see_more_button),
-          onClick = {},
-          colors = ChipDefaults.secondaryChipColors(),
-        )
-      }
-    }
-
-    playlistsSection(
-      buttons =
-        listOf(
-          BrowseScreenPlaylistsSectionButton(
-            textId = R.string.horologist_browse_screen_preview_playlists_button,
-            icon = Icons.AutoMirrored.Default.PlaylistPlay,
+      section(
+        state = trendingSectionState,
+        titleId = R.string.horologist_browse_screen_preview_trending_title,
+        emptyMessageId = R.string.horologist_browse_screen_preview_trending_empty,
+        failedMessageId = R.string.horologist_browse_screen_preview_trending_failed,
+      ) {
+        loaded { item: String ->
+          Chip(
+            label = item,
             onClick = {},
-          ),
-          BrowseScreenPlaylistsSectionButton(
-            textId = R.string.horologist_browse_screen_preview_podcasts_button,
-            icon = Icons.Default.Podcasts,
+            icon = Icons.Default.Person.asPaintable(),
+            colors = ChipDefaults.secondaryChipColors(),
+          )
+        }
+
+        loading { PlaceholderChip(colors = ChipDefaults.secondaryChipColors()) }
+      }
+
+      downloadsSection(state = downloadsSectionState) {
+        loaded { item ->
+          Chip(
+            label = item.first,
             onClick = {},
-          ),
-        )
-    )
+            secondaryLabel = item.second,
+            icon = Icons.Default.MusicNote.asPaintable(),
+            colors = ChipDefaults.secondaryChipColors(),
+          )
+        }
+
+        loading { PlaceholderChip(colors = ChipDefaults.secondaryChipColors()) }
+
+        footer {
+          Chip(
+            label = stringResource(id = R.string.horologist_browse_screen_preview_see_more_button),
+            onClick = {},
+            colors = ChipDefaults.secondaryChipColors(),
+          )
+        }
+      }
+
+      playlistsSection(
+        buttons =
+          listOf(
+            BrowseScreenPlaylistsSectionButton(
+              textId = R.string.horologist_browse_screen_preview_playlists_button,
+              icon = Icons.AutoMirrored.Default.PlaylistPlay,
+              onClick = {},
+            ),
+            BrowseScreenPlaylistsSectionButton(
+              textId = R.string.horologist_browse_screen_preview_podcasts_button,
+              icon = Icons.Default.Podcasts,
+              onClick = {},
+            ),
+          )
+      )
+    }
   }
 }

--- a/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/EntityScreenPreview.kt
+++ b/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/entity/EntityScreenPreview.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -48,102 +49,125 @@ import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import com.google.android.horologist.composables.PlaceholderChip
+import com.google.android.horologist.compose.layout.AppScaffold
+import com.google.android.horologist.compose.layout.ResponsiveTimeText
 import com.google.android.horologist.compose.material.Button
 import com.google.android.horologist.compose.material.Chip
+import com.google.android.horologist.compose.tools.PinnedTimeSource
 
 @WearPreviewDevices
 @Composable
 fun EntityScreenPreview() {
-  EntityScreen(
-    headerContent = {
-      Box(
-        modifier =
-          Modifier.fillMaxWidth()
-            .height(100.dp)
-            .background(
-              Brush.radialGradient(listOf((Color.Green).copy(alpha = 0.3f), Color.Transparent))
-            ),
-        contentAlignment = Alignment.Center,
-      ) {
-        Text("Playlist name")
-      }
-    },
-    buttonsContent = {
-      Row(
-        modifier = Modifier.padding(bottom = 16.dp).height(52.dp),
-        verticalAlignment = Alignment.CenterVertically,
-      ) {
-        Button(
-          imageVector = Icons.Default.Favorite,
-          contentDescription = "Favorite",
-          onClick = {},
-          modifier = Modifier.padding(start = 6.dp).weight(weight = 0.3F, fill = false),
-        )
+  AppScaffold(
+    modifier = Modifier.fillMaxSize().background(Color.Black),
+    timeText = { ResponsiveTimeText(timeSource = PinnedTimeSource) },
+  ) {
+    EntityScreen(
+      headerContent = {
+        Box(
+          modifier =
+            Modifier.fillMaxWidth()
+              .height(100.dp)
+              .background(
+                Brush.radialGradient(listOf((Color.Green).copy(alpha = 0.3f), Color.Transparent))
+              ),
+          contentAlignment = Alignment.Center,
+        ) {
+          Text("Playlist name")
+        }
+      },
+      buttonsContent = {
+        Row(
+          modifier = Modifier.padding(bottom = 16.dp).height(52.dp),
+          verticalAlignment = Alignment.CenterVertically,
+        ) {
+          Button(
+            imageVector = Icons.Default.Favorite,
+            contentDescription = "Favorite",
+            onClick = {},
+            modifier = Modifier.padding(start = 6.dp).weight(weight = 0.3F, fill = false),
+          )
 
-        Button(
-          imageVector = Icons.AutoMirrored.Default.PlaylistPlay,
-          contentDescription = "Play",
-          onClick = {},
-          modifier = Modifier.padding(start = 6.dp).weight(weight = 0.3F, fill = false),
-        )
-      }
-    },
-    content = {
-      item { Chip(label = "Song 1", onClick = {}) }
-      item { Chip(label = "Song 2", onClick = {}) }
-    },
-  )
+          Button(
+            imageVector = Icons.AutoMirrored.Default.PlaylistPlay,
+            contentDescription = "Play",
+            onClick = {},
+            modifier = Modifier.padding(start = 6.dp).weight(weight = 0.3F, fill = false),
+          )
+        }
+      },
+      content = {
+        item { Chip(label = "Song 1", onClick = {}) }
+        item { Chip(label = "Song 2", onClick = {}) }
+      },
+    )
+  }
 }
 
 @WearPreviewDevices
 @Composable
 fun EntityScreenPreviewLoadedState() {
-  EntityScreen(
-    entityScreenState = EntityScreenState.Loaded(listOf("Song 1", "Song 2")),
-    headerContent = { DefaultEntityScreenHeader(title = "Playlist name") },
-    loadingContent = {},
-    mediaContent = { song -> Chip(label = song, onClick = {}) },
-    buttonsContent = { ButtonContentForStatePreview() },
-  )
+  AppScaffold(
+    modifier = Modifier.fillMaxSize().background(Color.Black),
+    timeText = { ResponsiveTimeText(timeSource = PinnedTimeSource) },
+  ) {
+    EntityScreen(
+      entityScreenState = EntityScreenState.Loaded(listOf("Song 1", "Song 2")),
+      headerContent = { DefaultEntityScreenHeader(title = "Playlist name") },
+      loadingContent = {},
+      mediaContent = { song -> Chip(label = song, onClick = {}) },
+      buttonsContent = { ButtonContentForStatePreview() },
+    )
+  }
 }
 
 @WearPreviewDevices
 @Composable
 fun EntityScreenPreviewLoadingState() {
-  EntityScreen(
-    entityScreenState = EntityScreenState.Loading,
-    headerContent = { DefaultEntityScreenHeader(title = "Playlist name") },
-    loadingContent = {
-      items(count = 2) { PlaceholderChip(colors = ChipDefaults.secondaryChipColors()) }
-    },
-    mediaContent = {},
-    buttonsContent = { ButtonContentForStatePreview() },
-  )
+  AppScaffold(
+    modifier = Modifier.fillMaxSize().background(Color.Black),
+    timeText = { ResponsiveTimeText(timeSource = PinnedTimeSource) },
+  ) {
+    EntityScreen(
+      entityScreenState = EntityScreenState.Loading,
+      headerContent = { DefaultEntityScreenHeader(title = "Playlist name") },
+      loadingContent = {
+        items(count = 2) { PlaceholderChip(colors = ChipDefaults.secondaryChipColors()) }
+      },
+      mediaContent = {},
+      buttonsContent = { ButtonContentForStatePreview() },
+    )
+  }
 }
 
 @WearPreviewDevices
 @Composable
 fun EntityScreenPreviewFailedState() {
-  EntityScreen(
-    entityScreenState = EntityScreenState.Failed,
-    headerContent = { DefaultEntityScreenHeader(title = "Playlist name") },
-    loadingContent = {},
-    mediaContent = {},
-    buttonsContent = { ButtonContentForStatePreview() },
-    failedContent = {
-      Column(
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally,
-      ) {
-        Icon(
-          imageVector = Icons.Default.CloudOff,
-          contentDescription = null,
-          modifier = Modifier.size(24.dp).wrapContentSize(align = Alignment.Center),
-        )
-        Text(text = "Could not retrieve the playlist.", textAlign = TextAlign.Center)
-      }
-    },
-  )
+  AppScaffold(
+    modifier = Modifier.fillMaxSize().background(Color.Black),
+    timeText = { ResponsiveTimeText(timeSource = PinnedTimeSource) },
+  ) {
+    EntityScreen(
+      entityScreenState = EntityScreenState.Failed,
+      headerContent = { DefaultEntityScreenHeader(title = "Playlist name") },
+      loadingContent = {},
+      mediaContent = {},
+      buttonsContent = { ButtonContentForStatePreview() },
+      failedContent = {
+        Column(
+          verticalArrangement = Arrangement.Center,
+          horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+          Icon(
+            imageVector = Icons.Default.CloudOff,
+            contentDescription = null,
+            modifier = Modifier.size(24.dp).wrapContentSize(align = Alignment.Center),
+          )
+          Text(text = "Could not retrieve the playlist.", textAlign = TextAlign.Center)
+        }
+      },
+    )
+  }
 }
 
 @Composable

--- a/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/MenuScreen.kt
@@ -16,13 +16,17 @@
 
 package com.google.android.horologist.sample
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.wear.compose.material.ListHeader
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
+import com.google.android.horologist.compose.layout.AppScaffold
+import com.google.android.horologist.compose.layout.ResponsiveTimeText
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults.padding
@@ -30,6 +34,7 @@ import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
 import com.google.android.horologist.compose.material.Chip
 import com.google.android.horologist.compose.material.SecondaryTitle
+import com.google.android.horologist.compose.tools.PinnedTimeSource
 
 @Composable
 fun MenuScreen(modifier: Modifier = Modifier, navigateToRoute: (String) -> Unit) {
@@ -219,5 +224,10 @@ fun MenuScreen(modifier: Modifier = Modifier, navigateToRoute: (String) -> Unit)
 @WearPreviewDevices
 @Composable
 fun MenuScreenPreview() {
-  MenuScreen(modifier = Modifier.fillMaxSize(), navigateToRoute = {})
+  AppScaffold(
+    modifier = Modifier.fillMaxSize().background(Color.Black),
+    timeText = { ResponsiveTimeText(timeSource = PinnedTimeSource) },
+  ) {
+    MenuScreen(modifier = Modifier.fillMaxSize(), navigateToRoute = {})
+  }
 }

--- a/sample/src/main/java/com/google/android/horologist/sample/ScrollAwayScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/sample/ScrollAwayScreen.kt
@@ -49,6 +49,8 @@ import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
 import com.google.android.horologist.compose.layout.ResponsiveTimeText
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.tools.PinnedTimeSource
+import com.google.android.horologist.compose.tools.WearPreviewScreenScaffold
 
 @Composable
 fun ScrollScreenLazyColumn(scrollState: LazyListState) {
@@ -79,7 +81,9 @@ fun ScrollAwayScreenScalingLazyColumn(columnState: ScalingLazyColumnState) {
 fun ScrollAwayScreenColumn(scrollState: ScrollState) {
   Scaffold(
     modifier = Modifier.fillMaxSize(),
-    timeText = { ResponsiveTimeText(modifier = Modifier.scrollAway(scrollState)) },
+    timeText = {
+      ResponsiveTimeText(timeSource = PinnedTimeSource, modifier = Modifier.scrollAway(scrollState))
+    },
     positionIndicator = { PositionIndicator(scrollState = scrollState) },
   ) {
     Column(
@@ -112,5 +116,6 @@ private fun ExampleCard(modifier: Modifier, i: Int) {
 @WearPreviewLargeRound
 @Composable
 fun ScrollAwayScreenPreview() {
-  ScrollScreenLazyColumn(rememberLazyListState())
+  val scrollState = rememberLazyListState()
+  WearPreviewScreenScaffold { ScrollScreenLazyColumn(scrollState) }
 }


### PR DESCRIPTION
#### WHAT

…previews

- Add WearPreviewScreenScaffold, PinnedTimeSource, and FixedTimeSource to compose-tools
- Wrap naked screen previews in media:ui, health:composables, datalayer:sample:wear, and sample in scaffolding with solid black backgrounds and pinned time (10:10)
- Add missing phone landscape previews in datalayer:phone-ui bottom sheets

#### WHY


#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
