### PR TITLE
Document ApiException throw behavior for AppHelper node queries

### DIFF
--- a/datalayer/core/src/main/java/com/google/android/horologist/data/apphelper/DataLayerAppHelper.kt
+++ b/datalayer/core/src/main/java/com/google/android/horologist/data/apphelper/DataLayerAppHelper.kt
@@ -62,7 +62,12 @@ abstract class DataLayerAppHelper(
   protected val playStoreUri: String = "market://details?id=${context.packageName}"
   protected val remoteActivityHelper: RemoteActivityHelper by lazy { RemoteActivityHelper(context) }
 
-  /** Provides a list of connected nodes and the installation status of the app on these nodes. */
+  /**
+   * Provides a list of connected nodes and the installation status of the app on these nodes.
+   *
+   * @throws [ApiException] if the Wearable API is not available on this device. Call [isAvailable]
+   *   first to check whether the data layer can be used.
+   */
   public suspend fun connectedNodes(): List<AppHelperNodeStatus> {
     val connectedNodes = registry.nodeClient.connectedNodes.await()
     val capabilities =
@@ -111,6 +116,9 @@ abstract class DataLayerAppHelper(
    * When called from a phone device, multiple watches can be connected to it.
    *
    * When called from a watch device, usually only a single phone device will be connected to it.
+   *
+   * Collecting this flow may throw [ApiException] if the Wearable API is not available on this
+   * device. Call [isAvailable] first to check whether the data layer can be used.
    */
   public abstract val connectedAndInstalledNodes: Flow<Set<Node>>
 


### PR DESCRIPTION
## Problem

`connectedAndInstalledNodes` and `connectedNodes()` both hit the Wearable API (`CapabilityClient` / `NodeClient`) via `.await()`. When the Wearable API is not available on a device, these calls throw `ApiException: 17: API: Wearable.API is not available on this device`, but this throw behavior was completely undocumented. Library users discovered this the hard way (see #2596) because the failure surfaces as an opaque GMS stack trace with no Horologist frame in sight.

`isAvailable()` exists precisely to guard against this, but nothing in the doc pointed users to it.

## Change

Add `@throws ApiException` KDoc to the two public entry points (`connectedNodes()` and the abstract `connectedAndInstalledNodes` property), both referencing `isAvailable()` as the way to check before use. No behavioral change — documentation only.

## Verification

- The throw path is real and reachable: both methods call `CapabilityClient`/`NodeClient` GMS tasks via `await()`, which fail with `ApiException` when the API is unavailable (confirmed by the stack trace in #2596).
- `ApiException` is already imported in the file.

Fixes #2596