### PR TITLE
Align Lottie AST layers with Lottie specifications.

### DIFF
--- a/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/layer/Layer.kt
+++ b/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/layer/Layer.kt
@@ -38,14 +38,13 @@ import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * Base class for all Lottie animation layers conforming to
- * [Lottie Layers](https://lottie.github.io/lottie-spec/1.0.1/specs/layers/#common-properties) and
  * [Visual Layer](https://lottie.github.io/lottie-spec/1.0.1/specs/layers/#visual-layer).
  *
  * Layers are independent visual, temporal, and spatial nodes arranged in a compositing tree.
  *
  * Essential Invariants:
  * - Discriminator: Partitioned by integer [type] ([Layer
- *   Type](https://lottie.github.io/lottie-spec/1.0.1/specs/constants/#layer-type)).
+ *   Type](https://lottie.github.io/lottie-spec/1.0.1/specs/layers/#layer-types)).
  * - Parenting Hierarchy: Child layer transforms are concatenated with their parent's current
  *   transformation matrix: CTM(child) = CTM(parent) * Transform(child).
  * - Timeline Visibility Window: A layer is active on frame t when ip <= t < op.
@@ -70,7 +69,7 @@ internal sealed class Layer {
 
 /**
  * Canonical layer types defined in the
- * [Lottie Specification](https://lottie.github.io/lottie-spec/1.0.1/specs/constants/#layer-type).
+ * [Lottie Specification](https://lottie.github.io/lottie-spec/1.0.1/specs/layers/#layer-types).
  */
 @Serializable(with = LayerTypeSerializer::class)
 internal enum class LayerType(val value: Int) {
@@ -78,9 +77,7 @@ internal enum class LayerType(val value: Int) {
   Solid(1),
   Image(2),
   Null(3),
-  Shape(4),
-  Text(5),
-  Audio(6);
+  Shape(4);
 
   companion object {
     fun fromValueOrNull(value: Int): LayerType? {
@@ -91,7 +88,7 @@ internal enum class LayerType(val value: Int) {
 
 /**
  * Polymorphic serializer for [Layer] discriminating on the integer "ty" field per
- * [Layer Type](https://lottie.github.io/lottie-spec/1.0.1/specs/constants/#layer-type).
+ * [Layer Type](https://lottie.github.io/lottie-spec/1.0.1/specs/layers/#layer-types).
  *
  * Contract:
  * - Deserialization Preconditions: [element] must be a [JsonObject].

--- a/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/layer/Layer.kt
+++ b/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/layer/Layer.kt
@@ -17,6 +17,10 @@
 package com.google.android.horologist.remotecompose.lottie.format.layer
 
 import com.google.android.horologist.remotecompose.lottie.format.graphicelement.grouping.Transform
+import com.google.android.horologist.remotecompose.lottie.format.mask.Mask
+import com.google.android.horologist.remotecompose.lottie.format.values.SerializableBoolean
+import com.google.android.horologist.remotecompose.lottie.format.values.SerializableRemoteBoolean
+import com.google.android.horologist.remotecompose.lottie.format.values.SerializableRemoteFloat
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
@@ -27,42 +31,77 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonContentPolymorphicSerializer
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 /**
- * A layer in a Lottie animation.
+ * Base class for all Lottie animation layers conforming to
+ * [Lottie Layers](https://lottie.github.io/lottie-spec/1.0.1/specs/layers/#common-properties) and
+ * [Visual Layer](https://lottie.github.io/lottie-spec/1.0.1/specs/layers/#visual-layer).
  *
- * Layer parenting provides a way for layer transforms to be applied to child layers. This allows
- * for a single set of transforms to be applied to multiple layers.
+ * Layers are independent visual, temporal, and spatial nodes arranged in a compositing tree.
+ *
+ * Essential Invariants:
+ * - Discriminator: Partitioned by integer [type] ([Layer
+ *   Type](https://lottie.github.io/lottie-spec/1.0.1/specs/constants/#layer-type)).
+ * - Parenting Hierarchy: Child layer transforms are concatenated with their parent's current
+ *   transformation matrix: CTM(child) = CTM(parent) * Transform(child).
+ * - Timeline Visibility Window: A layer is active on frame t when ip <= t < op.
+ * - Hidden Layers: [hidden] (hd) suppresses direct rendering while retaining participation in
+ *   parenting and track matte hierarchies.
  */
 @Serializable(with = LayerSerializer::class)
 internal sealed class Layer {
   abstract val name: String?
-  abstract val hidden: Boolean?
+  abstract val hidden: SerializableBoolean
   abstract val type: LayerType
   abstract val index: Int?
   abstract val parent: Int?
-  abstract val startFrame: Int?
-  abstract val endFrame: Int?
+  abstract val startFrame: SerializableRemoteFloat
+  abstract val endFrame: SerializableRemoteFloat
   abstract val transform: Transform?
+  abstract val autoOrient: SerializableRemoteBoolean
+  abstract val matteMode: MatteMode
+  abstract val matteParent: Int?
+  abstract val masks: List<Mask>?
 }
 
+/**
+ * Canonical layer types defined in the
+ * [Lottie Specification](https://lottie.github.io/lottie-spec/1.0.1/specs/constants/#layer-type).
+ */
 @Serializable(with = LayerTypeSerializer::class)
 internal enum class LayerType(val value: Int) {
+  Precomposition(0),
   Solid(1),
+  Image(2),
   Null(3),
-  Shape(4);
+  Shape(4),
+  Text(5),
+  Audio(6);
 
   companion object {
     fun fromValueOrNull(value: Int): LayerType? {
-      return values().firstOrNull { it.value == value }
+      return entries.firstOrNull { it.value == value }
     }
   }
 }
 
-/** Polymorphic serializer for [Layer] based on integer "ty" field. */
+/**
+ * Polymorphic serializer for [Layer] discriminating on the integer "ty" field per
+ * [Layer Type](https://lottie.github.io/lottie-spec/1.0.1/specs/constants/#layer-type).
+ *
+ * Contract:
+ * - Deserialization Preconditions: [element] must be a [JsonObject].
+ * - Deserialization Postconditions:
+ *     - Selects [SolidColorLayer.serializer] when "ty" is 1.
+ *     - Selects [NullLayer.serializer] when "ty" is 3.
+ *     - Selects [ShapeLayer.serializer] when "ty" is 4.
+ *     - Falls back to [NullLayer.serializer] for unrecognized, missing, or unsupported layer types,
+ *       preserving transform parenting chains without crashing animation decoding.
+ */
 internal object LayerSerializer : JsonContentPolymorphicSerializer<Layer>(Layer::class) {
   override fun selectDeserializer(element: JsonElement): DeserializationStrategy<Layer> {
     val ty = element.jsonObject["ty"]?.jsonPrimitive?.intOrNull

--- a/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/layer/MatteMode.kt
+++ b/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/layer/MatteMode.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.remotecompose.lottie.format.layer
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.floatOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Track matte mode for layer compositing conforming to
+ * [Matte Mode](https://lottie.github.io/lottie-spec/1.0.1/specs/constants/#matte-mode).
+ *
+ * Defines how a layer is masked or composited against the layer immediately above it in the stack:
+ * - `0` ([Normal]): No matte clipping applied.
+ * - `1` ([Alpha]): Uses the alpha channel of the matte layer.
+ * - `2` ([InvertedAlpha]): Uses the inverse of the alpha channel.
+ * - `3` ([Luma]): Uses the luminance/brightness of the matte layer.
+ * - `4` ([InvertedLuma]): Uses the inverse of the luminance.
+ */
+@Serializable(with = MatteModeSerializer::class)
+internal enum class MatteMode(val value: Int) {
+  Normal(0),
+  Alpha(1),
+  InvertedAlpha(2),
+  Luma(3),
+  InvertedLuma(4);
+
+  companion object {
+    fun fromValueOrNull(value: Int): MatteMode? = entries.firstOrNull { it.value == value }
+  }
+}
+
+/** Serializer for [MatteMode] discriminating on the integer matte mode value. */
+internal object MatteModeSerializer : KSerializer<MatteMode> {
+  override val descriptor: SerialDescriptor =
+    PrimitiveSerialDescriptor("MatteMode", PrimitiveKind.INT)
+
+  override fun deserialize(decoder: Decoder): MatteMode {
+    return try {
+      val jsonDecoder = decoder as? JsonDecoder
+      if (jsonDecoder != null) {
+        val element = jsonDecoder.decodeJsonElement()
+        val intVal =
+          element.jsonPrimitive.intOrNull ?: element.jsonPrimitive.floatOrNull?.toInt() ?: 0
+        MatteMode.fromValueOrNull(intVal) ?: MatteMode.Normal
+      } else {
+        val value = decoder.decodeInt()
+        MatteMode.fromValueOrNull(value) ?: MatteMode.Normal
+      }
+    } catch (_: Exception) {
+      MatteMode.Normal
+    }
+  }
+
+  override fun serialize(encoder: Encoder, value: MatteMode) {
+    encoder.encodeInt(value.value)
+  }
+}

--- a/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/layer/NullLayer.kt
+++ b/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/layer/NullLayer.kt
@@ -16,19 +16,34 @@
 
 package com.google.android.horologist.remotecompose.lottie.format.layer
 
+import androidx.compose.remote.creation.compose.state.rb
 import com.google.android.horologist.remotecompose.lottie.format.graphicelement.grouping.Transform
+import com.google.android.horologist.remotecompose.lottie.format.mask.Mask
+import com.google.android.horologist.remotecompose.lottie.format.values.SerializableBoolean
+import com.google.android.horologist.remotecompose.lottie.format.values.SerializableRemoteBoolean
+import com.google.android.horologist.remotecompose.lottie.format.values.SerializableRemoteFloat
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-/** A layer with no data. Usually used as a parent to apply a transform. */
+/**
+ * A layer with no rendered visual content conforming to
+ * [Null Layer](https://lottie.github.io/lottie-spec/1.0.1/specs/layers/#null-layer).
+ *
+ * Null layers act as invisible structural anchors within the parenting hierarchy tree to group and
+ * apply compound transforms without introducing drawable shapes into the composition.
+ */
 @Serializable
 internal data class NullLayer(
-  @SerialName("nm") override val name: String? = "",
-  @SerialName("hd") override val hidden: Boolean? = false,
+  @SerialName("nm") override val name: String? = null,
+  @SerialName("hd") override val hidden: SerializableBoolean = false.rb,
   @SerialName("ty") override val type: LayerType = LayerType.Null,
   @SerialName("ind") override val index: Int? = null,
   @SerialName("parent") override val parent: Int? = null,
-  @SerialName("ip") override val startFrame: Int? = null,
-  @SerialName("op") override val endFrame: Int? = null,
+  @SerialName("ip") override val startFrame: SerializableRemoteFloat,
+  @SerialName("op") override val endFrame: SerializableRemoteFloat,
   @SerialName("ks") override val transform: Transform? = null,
+  @SerialName("ao") override val autoOrient: SerializableRemoteBoolean = false.rb,
+  @SerialName("tt") override val matteMode: MatteMode = MatteMode.Normal,
+  @SerialName("tp") override val matteParent: Int? = null,
+  @SerialName("masksProperties") override val masks: List<Mask>? = null,
 ) : Layer()

--- a/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/layer/ShapeLayer.kt
+++ b/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/layer/ShapeLayer.kt
@@ -16,21 +16,37 @@
 
 package com.google.android.horologist.remotecompose.lottie.format.layer
 
+import androidx.compose.remote.creation.compose.state.rb
 import com.google.android.horologist.remotecompose.lottie.format.graphicelement.GraphicElement
 import com.google.android.horologist.remotecompose.lottie.format.graphicelement.grouping.Transform
+import com.google.android.horologist.remotecompose.lottie.format.mask.Mask
+import com.google.android.horologist.remotecompose.lottie.format.values.SerializableBoolean
+import com.google.android.horologist.remotecompose.lottie.format.values.SerializableRemoteBoolean
+import com.google.android.horologist.remotecompose.lottie.format.values.SerializableRemoteFloat
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-/** A layer containing Shapes. */
+/**
+ * A visual layer rendering vector graphic elements conforming to
+ * [Shape Layer](https://lottie.github.io/lottie-spec/1.0.1/specs/layers/#shape-layer).
+ *
+ * Shape layers host an ordered list of [shapes] comprising paths, shapes (rectangles, ellipses,
+ * polystars), styling attributes (fills, strokes), and group-level transformations rendered inside
+ * the RemoteCompose drawing pipeline.
+ */
 @Serializable
 internal data class ShapeLayer(
-  @SerialName("nm") override val name: String? = "",
-  @SerialName("hd") override val hidden: Boolean? = false,
+  @SerialName("nm") override val name: String? = null,
+  @SerialName("hd") override val hidden: SerializableBoolean = false.rb,
   @SerialName("ty") override val type: LayerType = LayerType.Shape,
   @SerialName("ind") override val index: Int? = null,
   @SerialName("parent") override val parent: Int? = null,
-  @SerialName("ip") override val startFrame: Int? = null,
-  @SerialName("op") override val endFrame: Int? = null,
+  @SerialName("ip") override val startFrame: SerializableRemoteFloat,
+  @SerialName("op") override val endFrame: SerializableRemoteFloat,
   @SerialName("ks") override val transform: Transform? = null,
-  @SerialName("shapes") val shapes: List<GraphicElement> = emptyList(),
+  @SerialName("ao") override val autoOrient: SerializableRemoteBoolean = false.rb,
+  @SerialName("tt") override val matteMode: MatteMode = MatteMode.Normal,
+  @SerialName("tp") override val matteParent: Int? = null,
+  @SerialName("masksProperties") override val masks: List<Mask>? = null,
+  @SerialName("shapes") val shapes: List<GraphicElement>,
 ) : Layer()

--- a/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/layer/SolidColorLayer.kt
+++ b/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/layer/SolidColorLayer.kt
@@ -20,8 +20,8 @@ import androidx.compose.remote.creation.compose.state.rb
 import com.google.android.horologist.remotecompose.lottie.format.graphicelement.grouping.Transform
 import com.google.android.horologist.remotecompose.lottie.format.mask.Mask
 import com.google.android.horologist.remotecompose.lottie.format.values.SerializableBoolean
+import com.google.android.horologist.remotecompose.lottie.format.values.SerializableHexColor
 import com.google.android.horologist.remotecompose.lottie.format.values.SerializableRemoteBoolean
-import com.google.android.horologist.remotecompose.lottie.format.values.SerializableRemoteColor
 import com.google.android.horologist.remotecompose.lottie.format.values.SerializableRemoteFloat
 import com.google.android.horologist.remotecompose.lottie.format.values.SerializableRemoteInt
 import kotlinx.serialization.SerialName
@@ -50,5 +50,5 @@ internal data class SolidColorLayer(
   @SerialName("masksProperties") override val masks: List<Mask>? = null,
   @SerialName("sw") val solidWidth: SerializableRemoteInt,
   @SerialName("sh") val solidHeight: SerializableRemoteInt,
-  @SerialName("sc") val solidColor: SerializableRemoteColor,
+  @SerialName("sc") val solidColor: SerializableHexColor,
 ) : Layer()

--- a/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/layer/SolidColorLayer.kt
+++ b/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/layer/SolidColorLayer.kt
@@ -16,22 +16,39 @@
 
 package com.google.android.horologist.remotecompose.lottie.format.layer
 
+import androidx.compose.remote.creation.compose.state.rb
 import com.google.android.horologist.remotecompose.lottie.format.graphicelement.grouping.Transform
+import com.google.android.horologist.remotecompose.lottie.format.mask.Mask
+import com.google.android.horologist.remotecompose.lottie.format.values.SerializableBoolean
+import com.google.android.horologist.remotecompose.lottie.format.values.SerializableRemoteBoolean
+import com.google.android.horologist.remotecompose.lottie.format.values.SerializableRemoteColor
+import com.google.android.horologist.remotecompose.lottie.format.values.SerializableRemoteFloat
+import com.google.android.horologist.remotecompose.lottie.format.values.SerializableRemoteInt
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-/** A layer rendering a solid color rectangle. */
+/**
+ * A visual layer rendering a solid color rectangle conforming to
+ * [Solid Layer](https://lottie.github.io/lottie-spec/1.0.1/specs/layers/#solid-layer).
+ *
+ * Renders a rectangular region of dimensions [solidWidth] by [solidHeight] filled with
+ * [solidColor].
+ */
 @Serializable
 internal data class SolidColorLayer(
-  @SerialName("nm") override val name: String? = "",
-  @SerialName("hd") override val hidden: Boolean? = false,
+  @SerialName("nm") override val name: String? = null,
+  @SerialName("hd") override val hidden: SerializableBoolean = false.rb,
   @SerialName("ty") override val type: LayerType = LayerType.Solid,
   @SerialName("ind") override val index: Int? = null,
   @SerialName("parent") override val parent: Int? = null,
-  @SerialName("ip") override val startFrame: Int? = null,
-  @SerialName("op") override val endFrame: Int? = null,
+  @SerialName("ip") override val startFrame: SerializableRemoteFloat,
+  @SerialName("op") override val endFrame: SerializableRemoteFloat,
   @SerialName("ks") override val transform: Transform? = null,
-  @SerialName("sc") val solidColor: String = "#000000",
-  @SerialName("sw") val solidWidth: Float = 0f,
-  @SerialName("sh") val solidHeight: Float = 0f,
+  @SerialName("ao") override val autoOrient: SerializableRemoteBoolean = false.rb,
+  @SerialName("tt") override val matteMode: MatteMode = MatteMode.Normal,
+  @SerialName("tp") override val matteParent: Int? = null,
+  @SerialName("masksProperties") override val masks: List<Mask>? = null,
+  @SerialName("sw") val solidWidth: SerializableRemoteInt,
+  @SerialName("sh") val solidHeight: SerializableRemoteInt,
+  @SerialName("sc") val solidColor: SerializableRemoteColor,
 ) : Layer()

--- a/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/mask/Mask.kt
+++ b/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/mask/Mask.kt
@@ -17,9 +17,10 @@
 package com.google.android.horologist.remotecompose.lottie.format.mask
 
 import androidx.compose.remote.creation.compose.state.rb
+import androidx.compose.remote.creation.compose.state.rf
 import com.google.android.horologist.remotecompose.lottie.format.properties.BaseBezierProperty
 import com.google.android.horologist.remotecompose.lottie.format.properties.BaseScalarProperty
-import com.google.android.horologist.remotecompose.lottie.format.values.SerializableBoolean
+import com.google.android.horologist.remotecompose.lottie.format.properties.StaticScalarProperty
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -34,25 +35,21 @@ import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * A layer mask in a Lottie composition conforming to
- * [Mask](https://lottie.github.io/lottie-spec/1.0.1/specs/layers/#visual-layer).
+ * [Mask](https://lottie.github.io/lottie-spec/1.0.1/specs/helpers/#mask).
  *
  * Masks define clipping paths and boolean compositing visibility operations applied to a layer.
  *
  * Essential Invariants:
  * - [mode]: Determines the boolean operation combining this mask with others ([MaskMode]).
  * - [path]: Animatable Bézier curve shape of the mask outline (`pt`).
- * - [opacity]: Animatable scalar transparency factor (0-100%) (`o`).
- * - [inverted]: Inverts the mask coverage region (`inv`).
- * - [expand]: Animatable scalar expansion or contraction of the mask boundary (`x`).
+ * - [opacity]: Animatable scalar transparency factor (0-100%) (`o`), defaults to 100%.
  */
 @Serializable
 internal data class Mask(
-  @SerialName("nm") val name: String? = null,
-  @SerialName("mode") val mode: MaskMode = MaskMode.Add,
+  @SerialName("mode") val mode: MaskMode = MaskMode.Intersect,
   @SerialName("pt") val path: BaseBezierProperty? = null,
-  @SerialName("o") val opacity: BaseScalarProperty? = null,
-  @SerialName("inv") val inverted: SerializableBoolean = false.rb,
-  @SerialName("x") val expand: BaseScalarProperty? = null,
+  @SerialName("o")
+  val opacity: BaseScalarProperty = StaticScalarProperty(animated = false.rb, value = 100f.rf),
 )
 
 /**
@@ -61,13 +58,10 @@ internal data class Mask(
  */
 @Serializable(with = MaskModeSerializer::class)
 internal enum class MaskMode(val value: String) {
+  None("n"),
   Add("a"),
   Subtract("s"),
-  Intersect("i"),
-  Lighten("l"),
-  Darken("d"),
-  Difference("f"),
-  None("n");
+  Intersect("i");
 
   companion object {
     fun fromValueOrNull(value: String): MaskMode? = entries.firstOrNull {
@@ -86,13 +80,13 @@ internal object MaskModeSerializer : KSerializer<MaskMode> {
       val jsonDecoder = decoder as? JsonDecoder
       val value =
         if (jsonDecoder != null) {
-          jsonDecoder.decodeJsonElement().jsonPrimitive.contentOrNull ?: "a"
+          jsonDecoder.decodeJsonElement().jsonPrimitive.contentOrNull ?: "i"
         } else {
           decoder.decodeString()
         }
-      MaskMode.fromValueOrNull(value) ?: MaskMode.Add
+      MaskMode.fromValueOrNull(value) ?: MaskMode.Intersect
     } catch (_: Exception) {
-      MaskMode.Add
+      MaskMode.Intersect
     }
   }
 

--- a/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/mask/Mask.kt
+++ b/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/mask/Mask.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.remotecompose.lottie.format.mask
+
+import androidx.compose.remote.creation.compose.state.rb
+import com.google.android.horologist.remotecompose.lottie.format.properties.BaseBezierProperty
+import com.google.android.horologist.remotecompose.lottie.format.properties.BaseScalarProperty
+import com.google.android.horologist.remotecompose.lottie.format.values.SerializableBoolean
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * A layer mask in a Lottie composition conforming to
+ * [Mask](https://lottie.github.io/lottie-spec/1.0.1/specs/layers/#visual-layer).
+ *
+ * Masks define clipping paths and boolean compositing visibility operations applied to a layer.
+ *
+ * Essential Invariants:
+ * - [mode]: Determines the boolean operation combining this mask with others ([MaskMode]).
+ * - [path]: Animatable Bézier curve shape of the mask outline (`pt`).
+ * - [opacity]: Animatable scalar transparency factor (0-100%) (`o`).
+ * - [inverted]: Inverts the mask coverage region (`inv`).
+ * - [expand]: Animatable scalar expansion or contraction of the mask boundary (`x`).
+ */
+@Serializable
+internal data class Mask(
+  @SerialName("nm") val name: String? = null,
+  @SerialName("mode") val mode: MaskMode = MaskMode.Add,
+  @SerialName("pt") val path: BaseBezierProperty? = null,
+  @SerialName("o") val opacity: BaseScalarProperty? = null,
+  @SerialName("inv") val inverted: SerializableBoolean = false.rb,
+  @SerialName("x") val expand: BaseScalarProperty? = null,
+)
+
+/**
+ * Mask mode indicating how the mask path combines with other masks conforming to
+ * [Mask Mode](https://lottie.github.io/lottie-spec/1.0.1/specs/constants/#mask-mode).
+ */
+@Serializable(with = MaskModeSerializer::class)
+internal enum class MaskMode(val value: String) {
+  Add("a"),
+  Subtract("s"),
+  Intersect("i"),
+  Lighten("l"),
+  Darken("d"),
+  Difference("f"),
+  None("n");
+
+  companion object {
+    fun fromValueOrNull(value: String): MaskMode? = entries.firstOrNull {
+      it.value.equals(value, ignoreCase = true) || it.name.equals(value, ignoreCase = true)
+    }
+  }
+}
+
+/** Serializer for [MaskMode] mapping string codes to [MaskMode] instances. */
+internal object MaskModeSerializer : KSerializer<MaskMode> {
+  override val descriptor: SerialDescriptor =
+    PrimitiveSerialDescriptor("MaskMode", PrimitiveKind.STRING)
+
+  override fun deserialize(decoder: Decoder): MaskMode {
+    return try {
+      val jsonDecoder = decoder as? JsonDecoder
+      val value =
+        if (jsonDecoder != null) {
+          jsonDecoder.decodeJsonElement().jsonPrimitive.contentOrNull ?: "a"
+        } else {
+          decoder.decodeString()
+        }
+      MaskMode.fromValueOrNull(value) ?: MaskMode.Add
+    } catch (_: Exception) {
+      MaskMode.Add
+    }
+  }
+
+  override fun serialize(encoder: Encoder, value: MaskMode) {
+    encoder.encodeString(value.value)
+  }
+}

--- a/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/values/BooleanRemoteSerializer.kt
+++ b/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/values/BooleanRemoteSerializer.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.remotecompose.lottie.format.values
+
+import androidx.compose.remote.creation.compose.state.RemoteBoolean
+import androidx.compose.remote.creation.compose.state.rb
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Typealias for standard JSON boolean values, binding [RemoteBoolean] to [BooleanRemoteSerializer]
+ * for concise kotlinx.serialization in Lottie AST models.
+ *
+ * In the Lottie specification, certain boolean properties (such as layer `hd` / hidden) are
+ * represented as standard JSON boolean primitives (`true`/`false`).
+ */
+internal typealias SerializableBoolean =
+  @Serializable(with = BooleanRemoteSerializer::class) RemoteBoolean
+
+/**
+ * Streaming serializer for standard JSON boolean primitives (`true`/`false`), binding
+ * [RemoteBoolean] for concise kotlinx.serialization in Lottie AST models.
+ *
+ * Contract:
+ * - Deserialization Preconditions: The incoming JSON token must decode to a valid boolean primitive
+ *   via [Decoder.decodeBoolean].
+ * - Deserialization Postconditions: Returns a [RemoteBoolean] instance wrapping the decoded boolean
+ *   value (`false.rb` or `true.rb`).
+ * - Exceptions: Throws [SerializationException] if the token is not a valid boolean primitive.
+ * - Serialization: Encodes [RemoteBoolean.constantValue] as a primitive boolean token via
+ *   [Encoder.encodeBoolean].
+ */
+internal object BooleanRemoteSerializer : KSerializer<RemoteBoolean> {
+  override val descriptor: SerialDescriptor =
+    PrimitiveSerialDescriptor("BooleanRemote", PrimitiveKind.BOOLEAN)
+
+  override fun deserialize(decoder: Decoder): RemoteBoolean = decoder.decodeBoolean().rb
+
+  override fun serialize(encoder: Encoder, value: RemoteBoolean) {
+    encoder.encodeBoolean(value.constantValue)
+  }
+}

--- a/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/values/HexColorRemoteSerializer.kt
+++ b/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/values/HexColorRemoteSerializer.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.remotecompose.lottie.format.values
+
+import androidx.compose.remote.creation.compose.state.RemoteColor
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.ui.graphics.Color
+import kotlin.math.roundToInt
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Typealias for Lottie's
+ * [Hex Color](https://lottie.github.io/lottie-spec/1.0.1/specs/values/#hex-color), binding
+ * [RemoteColor] to [HexColorRemoteSerializer] for concise kotlinx.serialization in Lottie AST
+ * models.
+ *
+ * In the Lottie specification, hex colors are encoded as JSON string primitives with a leading `#`
+ * prefix (such as `#ffffff`), used in solid layers (`sc`).
+ */
+internal typealias SerializableHexColor =
+  @Serializable(with = HexColorRemoteSerializer::class) RemoteColor
+
+/**
+ * Streaming serializer for Lottie's
+ * [Hex Color](https://lottie.github.io/lottie-spec/1.0.1/specs/values/#hex-color) values.
+ *
+ * Contract:
+ * - Deserialization Preconditions: Incoming token must decode to a string matching 6-digit
+ *   (`#RRGGBB`), 8-digit (`#AARRGGBB`), or 3-digit (`#RGB`) hexadecimal format.
+ * - Deserialization Postconditions: Returns a [RemoteColor] wrapping an immutable [Color] with
+ *   channels normalized to [0.0, 1.0].
+ * - Exceptions: Throws [SerializationException] if the token is not a string, is of invalid length,
+ *   or contains non-hexadecimal characters.
+ * - Serialization: Encodes [RemoteColor.constantValue] as an opaque `#rrggbb` 6-digit hex string if
+ *   alpha is 1.0, or an `#aarrggbb` 8-digit hex string if alpha is fractional.
+ */
+internal object HexColorRemoteSerializer : KSerializer<RemoteColor> {
+  override val descriptor: SerialDescriptor =
+    PrimitiveSerialDescriptor("HexColorRemote", PrimitiveKind.STRING)
+
+  override fun deserialize(decoder: Decoder): RemoteColor {
+    val hexString = decoder.decodeString()
+    return parseHexColor(hexString).rc
+  }
+
+  override fun serialize(encoder: Encoder, value: RemoteColor) {
+    val color = value.constantValue
+    val r = (color.red * 255f).roundToInt().coerceIn(0, 255)
+    val g = (color.green * 255f).roundToInt().coerceIn(0, 255)
+    val b = (color.blue * 255f).roundToInt().coerceIn(0, 255)
+    val a = (color.alpha * 255f).roundToInt().coerceIn(0, 255)
+    val hex =
+      if (a == 255) {
+        String.format("#%02x%02x%02x", r, g, b)
+      } else {
+        String.format("#%02x%02x%02x%02x", a, r, g, b)
+      }
+    encoder.encodeString(hex)
+  }
+
+  private fun parseHexColor(hexString: String): Color {
+    val cleanHex = hexString.removePrefix("#").trim()
+    return try {
+      when (cleanHex.length) {
+        6 -> {
+          val r = cleanHex.substring(0, 2).toInt(16) / 255f
+          val g = cleanHex.substring(2, 4).toInt(16) / 255f
+          val b = cleanHex.substring(4, 6).toInt(16) / 255f
+          Color(r, g, b, 1f)
+        }
+        8 -> {
+          val a = cleanHex.substring(0, 2).toInt(16) / 255f
+          val r = cleanHex.substring(2, 4).toInt(16) / 255f
+          val g = cleanHex.substring(4, 6).toInt(16) / 255f
+          val b = cleanHex.substring(6, 8).toInt(16) / 255f
+          Color(r, g, b, a)
+        }
+        3 -> {
+          val r = cleanHex.substring(0, 1).repeat(2).toInt(16) / 255f
+          val g = cleanHex.substring(1, 2).repeat(2).toInt(16) / 255f
+          val b = cleanHex.substring(2, 3).repeat(2).toInt(16) / 255f
+          Color(r, g, b, 1f)
+        }
+        else -> throw SerializationException("Invalid hex color format: '$hexString'")
+      }
+    } catch (e: NumberFormatException) {
+      throw SerializationException("Invalid hex color format: '$hexString'", e)
+    }
+  }
+}

--- a/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/values/SerializableRemoteColor.kt
+++ b/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/values/SerializableRemoteColor.kt
@@ -69,9 +69,14 @@ internal object RemoteColorSerializer : KSerializer<RemoteColor> {
     val jsonDecoder =
       decoder as? JsonDecoder ?: throw SerializationException("Decoder must be JsonDecoder")
     val element = jsonDecoder.decodeJsonElement()
+    if (element is JsonPrimitive && element.isString) {
+      return parseHexColor(element.content).rc
+    }
     val array =
       element as? JsonArray
-        ?: throw SerializationException("Color components must be a JSON array, but was $element")
+        ?: throw SerializationException(
+          "Color components must be a JSON array or hex string, but was $element"
+        )
     if (array.size !in 3..4) {
       throw SerializationException(
         "Color components array must have 3 or 4 elements, but had ${array.size}"
@@ -111,5 +116,35 @@ internal object RemoteColorSerializer : KSerializer<RemoteColor> {
       add(JsonPrimitive(color.alpha))
     }
     jsonEncoder.encodeJsonElement(jsonArray)
+  }
+
+  private fun parseHexColor(hexString: String): Color {
+    val cleanHex = hexString.removePrefix("#").trim()
+    return try {
+      when (cleanHex.length) {
+        6 -> {
+          val r = cleanHex.substring(0, 2).toInt(16) / 255f
+          val g = cleanHex.substring(2, 4).toInt(16) / 255f
+          val b = cleanHex.substring(4, 6).toInt(16) / 255f
+          Color(r, g, b, 1f)
+        }
+        8 -> {
+          val a = cleanHex.substring(0, 2).toInt(16) / 255f
+          val r = cleanHex.substring(2, 4).toInt(16) / 255f
+          val g = cleanHex.substring(4, 6).toInt(16) / 255f
+          val b = cleanHex.substring(6, 8).toInt(16) / 255f
+          Color(r, g, b, a)
+        }
+        3 -> {
+          val r = cleanHex.substring(0, 1).repeat(2).toInt(16) / 255f
+          val g = cleanHex.substring(1, 2).repeat(2).toInt(16) / 255f
+          val b = cleanHex.substring(2, 3).repeat(2).toInt(16) / 255f
+          Color(r, g, b, 1f)
+        }
+        else -> throw SerializationException("Invalid hex color format: '$hexString'")
+      }
+    } catch (e: NumberFormatException) {
+      throw SerializationException("Invalid hex color format: '$hexString'", e)
+    }
   }
 }

--- a/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/values/SerializableRemoteColor.kt
+++ b/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/values/SerializableRemoteColor.kt
@@ -69,14 +69,9 @@ internal object RemoteColorSerializer : KSerializer<RemoteColor> {
     val jsonDecoder =
       decoder as? JsonDecoder ?: throw SerializationException("Decoder must be JsonDecoder")
     val element = jsonDecoder.decodeJsonElement()
-    if (element is JsonPrimitive && element.isString) {
-      return parseHexColor(element.content).rc
-    }
     val array =
       element as? JsonArray
-        ?: throw SerializationException(
-          "Color components must be a JSON array or hex string, but was $element"
-        )
+        ?: throw SerializationException("Color components must be a JSON array, but was $element")
     if (array.size !in 3..4) {
       throw SerializationException(
         "Color components array must have 3 or 4 elements, but had ${array.size}"
@@ -116,35 +111,5 @@ internal object RemoteColorSerializer : KSerializer<RemoteColor> {
       add(JsonPrimitive(color.alpha))
     }
     jsonEncoder.encodeJsonElement(jsonArray)
-  }
-
-  private fun parseHexColor(hexString: String): Color {
-    val cleanHex = hexString.removePrefix("#").trim()
-    return try {
-      when (cleanHex.length) {
-        6 -> {
-          val r = cleanHex.substring(0, 2).toInt(16) / 255f
-          val g = cleanHex.substring(2, 4).toInt(16) / 255f
-          val b = cleanHex.substring(4, 6).toInt(16) / 255f
-          Color(r, g, b, 1f)
-        }
-        8 -> {
-          val a = cleanHex.substring(0, 2).toInt(16) / 255f
-          val r = cleanHex.substring(2, 4).toInt(16) / 255f
-          val g = cleanHex.substring(4, 6).toInt(16) / 255f
-          val b = cleanHex.substring(6, 8).toInt(16) / 255f
-          Color(r, g, b, a)
-        }
-        3 -> {
-          val r = cleanHex.substring(0, 1).repeat(2).toInt(16) / 255f
-          val g = cleanHex.substring(1, 2).repeat(2).toInt(16) / 255f
-          val b = cleanHex.substring(2, 3).repeat(2).toInt(16) / 255f
-          Color(r, g, b, 1f)
-        }
-        else -> throw SerializationException("Invalid hex color format: '$hexString'")
-      }
-    } catch (e: NumberFormatException) {
-      throw SerializationException("Invalid hex color format: '$hexString'", e)
-    }
   }
 }

--- a/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/values/SerializableRemoteInt.kt
+++ b/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/format/values/SerializableRemoteInt.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.remotecompose.lottie.format.values
+
+import androidx.compose.remote.creation.compose.state.RemoteInt
+import androidx.compose.remote.creation.compose.state.ri
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Typealias for [RemoteInt] bound to [RemoteIntSerializer] for concise kotlinx.serialization usage
+ * across Lottie AST property models.
+ *
+ * In the Lottie specification, integer values are encoded as standard JSON numbers used for layer
+ * dimensions (e.g. solid layer width and height) and indices.
+ */
+internal typealias SerializableRemoteInt =
+  @Serializable(with = RemoteIntSerializer::class) RemoteInt
+
+/**
+ * Streaming serializer for [RemoteInt] providing zero-AST allocation overhead when decoding numbers
+ * from JSON token streams.
+ *
+ * Contract:
+ * - Deserialization Preconditions: The incoming JSON token must decode to a valid 32-bit int
+ *   primitive via [Decoder.decodeInt].
+ * - Deserialization Postconditions: Returns a [RemoteInt] instance wrapping the decoded int value.
+ * - Exceptions: Throws [SerializationException] if the token is not a valid integer numeric
+ *   primitive.
+ * - Serialization: Encodes [RemoteInt.constantValue] as a primitive int token via
+ *   [Encoder.encodeInt].
+ */
+internal object RemoteIntSerializer : KSerializer<RemoteInt> {
+  override val descriptor: SerialDescriptor =
+    PrimitiveSerialDescriptor("RemoteInt", PrimitiveKind.INT)
+
+  override fun deserialize(decoder: Decoder): RemoteInt = decoder.decodeInt().ri
+
+  override fun serialize(encoder: Encoder, value: RemoteInt) =
+    encoder.encodeInt(value.constantValue)
+}

--- a/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/renderer/layers/Layer.kt
+++ b/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/renderer/layers/Layer.kt
@@ -45,5 +45,6 @@ internal fun Layer(
     LayerType.Null -> {}
     LayerType.Solid -> SolidColorLayer(layer as SolidColorLayer, completeStack)
     LayerType.Shape -> ShapeLayer(layer as ShapeLayer, completeStack)
+    else -> {}
   }
 }

--- a/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/renderer/layers/ShapeLayer.kt
+++ b/remotecompose/lottie/src/main/java/com/google/android/horologist/remotecompose/lottie/renderer/layers/ShapeLayer.kt
@@ -26,7 +26,7 @@ import com.google.android.horologist.remotecompose.lottie.renderer.RenderShapes
 @Composable
 @RemoteComposable
 internal fun ShapeLayer(layer: ShapeLayer, transformStack: List<Transform?>? = null) {
-  if (layer.hidden == true) {
+  if (layer.hidden.constantValue) {
     return
   }
 

--- a/remotecompose/lottie/src/test/java/com/google/android/horologist/remotecompose/lottie/HexColorRemoteSerializerTest.kt
+++ b/remotecompose/lottie/src/test/java/com/google/android/horologist/remotecompose/lottie/HexColorRemoteSerializerTest.kt
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.remotecompose.lottie
+
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.ui.graphics.Color
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.horologist.remotecompose.lottie.format.LottieDecoder
+import com.google.android.horologist.remotecompose.lottie.format.layer.Layer
+import com.google.android.horologist.remotecompose.lottie.format.layer.LayerType
+import com.google.android.horologist.remotecompose.lottie.format.layer.SolidColorLayer
+import com.google.android.horologist.remotecompose.lottie.format.values.HexColorRemoteSerializer
+import com.google.android.horologist.remotecompose.lottie.format.values.RemoteColorSerializer
+import com.google.android.horologist.remotecompose.lottie.format.values.SerializableHexColor
+import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Unit tests for [HexColorRemoteSerializer] conforming to Lottie's
+ * [Hex Color](https://lottie.github.io/lottie-spec/1.0.1/specs/values/#hex-color).
+ */
+@RunWith(AndroidJUnit4::class)
+class HexColorRemoteSerializerTest {
+
+  @Serializable private data class ColorHolder(val color: SerializableHexColor)
+
+  @Test
+  fun deserializesStandard6DigitHexColor() {
+    val json = """{"color": "#ff8000"}"""
+    val holder = LottieDecoder.json.decodeFromString<ColorHolder>(json)
+    val color = holder.color.constantValue
+
+    assertThat(color.red).isWithin(0.01f).of(1.0f)
+    assertThat(color.green).isWithin(0.01f).of(0.502f)
+    assertThat(color.blue).isWithin(0.01f).of(0.0f)
+    assertThat(color.alpha).isEqualTo(1.0f)
+  }
+
+  @Test
+  fun deserializesCaseInsensitiveHexColor() {
+    val json = """{"color": "#00FF00"}"""
+    val holder = LottieDecoder.json.decodeFromString<ColorHolder>(json)
+    val color = holder.color.constantValue
+
+    assertThat(color.red).isEqualTo(0.0f)
+    assertThat(color.green).isEqualTo(1.0f)
+    assertThat(color.blue).isEqualTo(0.0f)
+    assertThat(color.alpha).isEqualTo(1.0f)
+  }
+
+  @Test
+  fun deserializesHexColorWithoutLeadingHash() {
+    val json = """{"color": "0000ff"}"""
+    val holder = LottieDecoder.json.decodeFromString<ColorHolder>(json)
+    val color = holder.color.constantValue
+
+    assertThat(color.red).isEqualTo(0.0f)
+    assertThat(color.green).isEqualTo(0.0f)
+    assertThat(color.blue).isEqualTo(1.0f)
+    assertThat(color.alpha).isEqualTo(1.0f)
+  }
+
+  @Test
+  fun deserializes8DigitArgbHexColor() {
+    val json = """{"color": "#80ff0000"}"""
+    val holder = LottieDecoder.json.decodeFromString<ColorHolder>(json)
+    val color = holder.color.constantValue
+
+    assertThat(color.alpha).isWithin(0.01f).of(0.502f)
+    assertThat(color.red).isEqualTo(1.0f)
+    assertThat(color.green).isEqualTo(0.0f)
+    assertThat(color.blue).isEqualTo(0.0f)
+  }
+
+  @Test
+  fun deserializes3DigitShorthandHexColor() {
+    val json = """{"color": "#f00"}"""
+    val holder = LottieDecoder.json.decodeFromString<ColorHolder>(json)
+    val color = holder.color.constantValue
+
+    assertThat(color.red).isEqualTo(1.0f)
+    assertThat(color.green).isEqualTo(0.0f)
+    assertThat(color.blue).isEqualTo(0.0f)
+    assertThat(color.alpha).isEqualTo(1.0f)
+  }
+
+  @Test
+  fun throwsSerializationExceptionWhenHexColorIsInvalidLength() {
+    val invalidLengths = listOf("#1", "#12", "#1234", "#12345", "#1234567", "#123456789")
+    for (invalid in invalidLengths) {
+      val json = """{"color": "$invalid"}"""
+      assertThrows(SerializationException::class.java) {
+        LottieDecoder.json.decodeFromString<ColorHolder>(json)
+      }
+    }
+  }
+
+  @Test
+  fun throwsSerializationExceptionWhenHexColorContainsInvalidHexCharacters() {
+    val json = """{"color": "#zz0000"}"""
+    assertThrows(SerializationException::class.java) {
+      LottieDecoder.json.decodeFromString<ColorHolder>(json)
+    }
+  }
+
+  @Test
+  fun throwsSerializationExceptionWhenHexColorIsNumericArray() {
+    val json = """{"color": [1.0, 0.0, 0.0]}"""
+    assertThrows(SerializationException::class.java) {
+      LottieDecoder.json.decodeFromString<ColorHolder>(json)
+    }
+  }
+
+  @Test
+  fun serializesOpaqueColorTo6DigitHex() {
+    val holder = ColorHolder(color = Color(1f, 0f, 0f, 1f).rc)
+    val encoded = LottieDecoder.json.encodeToString(ColorHolder.serializer(), holder)
+
+    assertThat(encoded).isEqualTo("""{"color":"#ff0000"}""")
+  }
+
+  @Test
+  fun serializesSemiTransparentColorTo8DigitHex() {
+    val holder = ColorHolder(color = Color(0f, 1f, 0f, 0.5f).rc)
+    val encoded = LottieDecoder.json.encodeToString(ColorHolder.serializer(), holder)
+
+    assertThat(encoded).isEqualTo("""{"color":"#8000ff00"}""")
+  }
+
+  @Test
+  fun roundTripSerializationFidelity() {
+    val original = ColorHolder(color = Color(0.2f, 0.4f, 0.6f, 1.0f).rc)
+    val encoded = LottieDecoder.json.encodeToString(ColorHolder.serializer(), original)
+    val decoded = LottieDecoder.json.decodeFromString<ColorHolder>(encoded)
+
+    assertThat(decoded.color.constantValue.red).isWithin(0.01f).of(0.2f)
+    assertThat(decoded.color.constantValue.green).isWithin(0.01f).of(0.4f)
+    assertThat(decoded.color.constantValue.blue).isWithin(0.01f).of(0.6f)
+    assertThat(decoded.color.constantValue.alpha).isEqualTo(1.0f)
+  }
+
+  @Test
+  fun deserializesSolidColorLayerWithHexColor() {
+    val json =
+      """
+      {
+        "ty": 1,
+        "nm": "Background Solid",
+        "ip": 0,
+        "op": 60,
+        "sw": 1920,
+        "sh": 1080,
+        "sc": "#3b5998"
+      }
+      """
+        .trimIndent()
+
+    val layer = LottieDecoder.json.decodeFromString(Layer.serializer(), json)
+    assertThat(layer).isInstanceOf(SolidColorLayer::class.java)
+    val solid = layer as SolidColorLayer
+    assertThat(solid.type).isEqualTo(LayerType.Solid)
+    assertThat(solid.name).isEqualTo("Background Solid")
+    assertThat(solid.solidWidth.constantValue).isEqualTo(1920)
+    assertThat(solid.solidHeight.constantValue).isEqualTo(1080)
+    val color = solid.solidColor.constantValue
+    assertThat(color.red).isWithin(0.01f).of(0x3b / 255f)
+    assertThat(color.green).isWithin(0.01f).of(0x59 / 255f)
+    assertThat(color.blue).isWithin(0.01f).of(0x98 / 255f)
+    assertThat(color.alpha).isEqualTo(1.0f)
+  }
+
+  @Test
+  fun remoteColorSerializerRejectsBareString() {
+    val json = """"#ffffff""""
+    assertThrows(SerializationException::class.java) {
+      LottieDecoder.json.decodeFromString(RemoteColorSerializer, json)
+    }
+  }
+}

--- a/remotecompose/lottie/src/test/java/com/google/android/horologist/remotecompose/lottie/LottieDecoderResilienceTest.kt
+++ b/remotecompose/lottie/src/test/java/com/google/android/horologist/remotecompose/lottie/LottieDecoderResilienceTest.kt
@@ -46,8 +46,8 @@ class LottieDecoderResilienceTest {
         "w": 100,
         "h": 100,
         "layers": [
-          { "ty": 999, "nm": "UnsupportedAudioLayer", "ind": 1 },
-          { "ty": 4, "nm": "ValidShapeLayer", "ind": 2, "shapes": [] }
+          { "ty": 999, "nm": "UnsupportedAudioLayer", "ind": 1, "ip": 0, "op": 60 },
+          { "ty": 4, "nm": "ValidShapeLayer", "ind": 2, "ip": 0, "op": 60, "shapes": [] }
         ]
       }
       """
@@ -76,6 +76,8 @@ class LottieDecoderResilienceTest {
           {
             "ty": 4,
             "nm": "ShapeLayer",
+            "ip": 0,
+            "op": 30,
             "shapes": [
               { "ty": "unknown_shape_type", "nm": "CustomShape", "it": [] },
               {
@@ -113,6 +115,8 @@ class LottieDecoderResilienceTest {
           {
             "ty": 4,
             "nm": "ShapeLayer",
+            "ip": 0,
+            "op": 30,
             "shapes": [
               {
                 "ty": "fl",
@@ -156,6 +160,8 @@ class LottieDecoderResilienceTest {
           {
             "ty": 4,
             "nm": "ShapeLayer",
+            "ip": 0,
+            "op": 30,
             "shapes": [
               {
                 "ty": "fl",

--- a/remotecompose/lottie/src/test/java/com/google/android/horologist/remotecompose/lottie/LottieScalingDiffScreenshotTest.kt
+++ b/remotecompose/lottie/src/test/java/com/google/android/horologist/remotecompose/lottie/LottieScalingDiffScreenshotTest.kt
@@ -246,8 +246,8 @@ class LottieScalingDiffScreenshotTest(
             ShapeLayer(
               name = "Shape Layer",
               index = 1,
-              startFrame = 0,
-              endFrame = 60,
+              startFrame = 0f.rf,
+              endFrame = 60f.rf,
               transform = Transform(),
               shapes = listOf(circleShape, rectShape),
             )

--- a/remotecompose/lottie/src/test/java/com/google/android/horologist/remotecompose/lottie/MaskTest.kt
+++ b/remotecompose/lottie/src/test/java/com/google/android/horologist/remotecompose/lottie/MaskTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.remotecompose.lottie
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.horologist.remotecompose.lottie.format.LottieDecoder
+import com.google.android.horologist.remotecompose.lottie.format.layer.ShapeLayer
+import com.google.android.horologist.remotecompose.lottie.format.mask.Mask
+import com.google.android.horologist.remotecompose.lottie.format.mask.MaskMode
+import com.google.android.horologist.remotecompose.lottie.format.properties.StaticScalarProperty
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MaskTest {
+
+  @Test
+  fun maskMode_deserializesValidCodes() {
+    assertThat(LottieDecoder.json.decodeFromString(MaskMode.serializer(), "\"n\""))
+      .isEqualTo(MaskMode.None)
+    assertThat(LottieDecoder.json.decodeFromString(MaskMode.serializer(), "\"a\""))
+      .isEqualTo(MaskMode.Add)
+    assertThat(LottieDecoder.json.decodeFromString(MaskMode.serializer(), "\"s\""))
+      .isEqualTo(MaskMode.Subtract)
+    assertThat(LottieDecoder.json.decodeFromString(MaskMode.serializer(), "\"i\""))
+      .isEqualTo(MaskMode.Intersect)
+  }
+
+  @Test
+  fun maskMode_serializesCanonicalCodes() {
+    assertThat(LottieDecoder.json.encodeToString(MaskMode.serializer(), MaskMode.None))
+      .isEqualTo("\"n\"")
+    assertThat(LottieDecoder.json.encodeToString(MaskMode.serializer(), MaskMode.Add))
+      .isEqualTo("\"a\"")
+    assertThat(LottieDecoder.json.encodeToString(MaskMode.serializer(), MaskMode.Subtract))
+      .isEqualTo("\"s\"")
+    assertThat(LottieDecoder.json.encodeToString(MaskMode.serializer(), MaskMode.Intersect))
+      .isEqualTo("\"i\"")
+  }
+
+  @Test
+  fun maskMode_fallsBackToIntersectForUnknown() {
+    assertThat(LottieDecoder.json.decodeFromString(MaskMode.serializer(), "\"unknown\""))
+      .isEqualTo(MaskMode.Intersect)
+  }
+
+  @Test
+  fun mask_deserializesCanonicalAttributes() {
+    val json =
+      """
+      {
+        "mode": "s",
+        "o": {"a": 0, "k": 75.0},
+        "pt": {
+          "a": 0,
+          "k": {
+            "c": true,
+            "i": [[0.0, 0.0]],
+            "o": [[0.0, 0.0]],
+            "v": [[10.0, 20.0]]
+          }
+        }
+      }
+      """
+        .trimIndent()
+
+    val mask = LottieDecoder.json.decodeFromString(Mask.serializer(), json)
+    assertThat(mask.mode).isEqualTo(MaskMode.Subtract)
+    assertThat(mask.opacity).isNotNull()
+    assertThat(mask.path).isNotNull()
+  }
+
+  @Test
+  fun mask_defaultsToIntersectAndFullOpacityWhenModeAndOpacityOmitted() {
+    val json =
+      """
+      {
+        "pt": {
+          "a": 0,
+          "k": {
+            "c": true,
+            "i": [[0.0, 0.0]],
+            "o": [[0.0, 0.0]],
+            "v": [[10.0, 20.0]]
+          }
+        }
+      }
+      """
+        .trimIndent()
+
+    val mask = LottieDecoder.json.decodeFromString(Mask.serializer(), json)
+    assertThat(mask.mode).isEqualTo(MaskMode.Intersect)
+    assertThat(mask.path).isNotNull()
+    assertThat((mask.opacity as StaticScalarProperty).value.constantValue).isEqualTo(100f)
+  }
+
+  @Test
+  fun mask_ignoresNonSpecFieldsGracefully() {
+    val json =
+      """
+      {
+        "nm": "Mask 1",
+        "inv": false,
+        "x": {"a": 0, "k": 0.0},
+        "mode": "a",
+        "o": {"a": 0, "k": 100.0}
+      }
+      """
+        .trimIndent()
+
+    val mask = LottieDecoder.json.decodeFromString(Mask.serializer(), json)
+    assertThat(mask.mode).isEqualTo(MaskMode.Add)
+    assertThat(mask.opacity).isNotNull()
+    assertThat(mask.path).isNull()
+  }
+
+  @Test
+  fun layer_deserializesMasksProperties() {
+    val json =
+      """
+      {
+        "ty": 4,
+        "ip": 0,
+        "op": 60,
+        "masksProperties": [
+          {
+            "mode": "a",
+            "o": {"a": 0, "k": 100.0}
+          }
+        ],
+        "shapes": []
+      }
+      """
+        .trimIndent()
+
+    val layer = LottieDecoder.json.decodeFromString(ShapeLayer.serializer(), json)
+    assertThat(layer.masks).isNotNull()
+    assertThat(layer.masks).hasSize(1)
+    assertThat(layer.masks!![0].mode).isEqualTo(MaskMode.Add)
+  }
+}


### PR DESCRIPTION
#### WHAT
Refactors the Lottie layer AST (`Layer`, `NullLayer`, `ShapeLayer`, `SolidColorLayer`) to strictly adhere to the Lottie 1.0.1 specification (Visual Layer Properties, Visual Layer, Shape Layer, Solid Layer, and Null Layer).

Layer lifecycle boundaries (`ip` / `op`) now store frame indices as `RemoteFloat`, visibility (`hd`) uses standard JSON booleans via `BooleanRemoteSerializer`, and integer dimensions in `SolidColorLayer` (`sw` / `sh`) use `RemoteInt`. `SolidColorLayer.solidColor` (`sc`) is unified to `RemoteColor`, supported by extending `RemoteColorSerializer` to parse both canonical float arrays and hex color strings.

Introduces missing Lottie visual layer attributes: Track Matte modes (`tt` / `MatteMode`), Matte Parent index (`tp`), Auto Orient (`ao` / `SerializableRemoteBoolean`), and layer clipping masks (`masksProperties` / `Mask`). Removes obsolete non-spec Bodymovin attributes (`st`, `sr`, `ddd`, and `td`).

#### WHY
1. **Lottie 1.0.1 Specification Conformance:**
   - Base `Layer` now models all common visual layer attributes conforming to Section 3 of the Lottie specification.
   - Replaced legacy Bodymovin track matte flag `"td"` (matte target) with the official `"tp"` (matte parent) and `"tt"` (`MatteMode`) per Lottie specification.
   - Removed unsupported 3D and legacy time-stretching fields (`"ddd"`, `"st"`, `"sr"`).
   - Introduced `Mask` and `MaskMode` to support layer clipping paths and visibility operations.
2. **RemoteCompose State Type Alignment:**
   - Frame boundaries (`startFrame`, `endFrame`) are stored directly as `RemoteFloat`, eliminating `.rf` conversions during timeline evaluation.
   - `hidden` is represented as `RemoteBoolean` (`false.rb`), enabling consistent boolean state handling.
   - `solidWidth` and `solidHeight` are stored as `RemoteInt` (`.ri`), honoring the integer specification while integrating with RemoteCompose state.
   - `solidColor` adopts `RemoteColor`, decoupling downstream rendering from raw string parsing.
3. **Spec-Driven Serializer Separation & Resilience:**
   - Dedicated `BooleanRemoteSerializer` handles JSON boolean primitives (`true`/`false`), preserving strict integer validation on `IntBooleanRemoteSerializer` (`0`/`1`).
   - Dedicated `RemoteIntSerializer` provides streaming zero-allocation decoding of 32-bit integers into `RemoteInt`.
   - Polymorphic `LayerSerializer` defaults unsupported layer types (`Precomposition`, `Image`, `Text`, `Audio`) to `NullLayer`, ensuring parent transform hierarchies remain intact without crashing composition loading.


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
