### PR TITLE
Update Robolectric to 4.17 and fix screenshot test flakiness (Right)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -180,6 +180,10 @@ subprojects {
   }
 
   tasks.withType<Test>().configureEach {
+    // Required by Robolectric 4.17+ on JDK 17+ for ApplicationSharedMemory emulation
+    // which reflects into jdk.internal.access.SharedSecrets (see robolectric/robolectric#11434).
+    jvmArgs("--add-opens=java.base/jdk.internal.access=ALL-UNNAMED")
+
     val shardIndex =
       (project.findProperty("shardIndex") as? String)
         ?: (project.findProperty("test.shardIndex") as? String)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,9 +56,7 @@ material = "1.14.0"
 metalava = "0.5.1"
 moshi = "1.15.2"
 okio = "3.18.2"
-# 4.17 renders DatePickerA11yTest.interactionTest non-deterministically: identical runs produce
-# different anti-aliasing on the "Next" button edge, so verifyRoborazziDebug flakes.
-org-robolectric = "4.16.1"
+org-robolectric = "4.17"
 ossLicensesPlugin = "0.13.0"
 osslicenses = "0.10.0"
 # 22.0.0 removed legacy GoogleSignIn APIs used by auth:data and auth:ui

--- a/renovate.json
+++ b/renovate.json
@@ -123,13 +123,6 @@
       ],
       "allowedVersions": "<5.5.0",
       "description": "Requires compileSdk 37"
-    },
-    {
-      "matchPackagePatterns": [
-        "org.robolectric:*"
-      ],
-      "allowedVersions": "<4.17",
-      "description": "4.17 renders DatePickerA11yTest.interactionTest non-deterministically (the 'Next' button edge is anti-aliased differently between identical runs), so verifyRoborazziDebug flakes. It also needs --add-opens=java.base/jdk.internal.access=ALL-UNNAMED on the unit test JVM."
     }
   ]
 }


### PR DESCRIPTION
#### WHAT

- Bump org-robolectric to 4.17 in libs.versions.toml and remove restriction in renovate.json.
- Add --add-opens=java.base/jdk.internal.access=ALL-UNNAMED to test JVM args in root build.gradle.kts. Robolectric 4.17+ on JDK 17+ reflects into jdk.internal.access.SharedSecrets for ApplicationSharedMemory emulation (see upstream robolectric/robolectric#11434).
- Advance Compose clock and wait for idle in WearLegacyA11yTest.captureScreenA11yRoboImage to ensure Compose animations/ripples settle before capturing screenshots.
- Set tolerance to 0.03f in DatePickerA11yTest to account for minor native Skia alpha-blending variations across the circular button in Roborazzi comparison images.
- Update golden images for DatePickerA11yTest.

#### WHY


#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
