### PR TITLE
Demonstrate Robolectric 4.17 screenshot non-determinism (Left)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -180,6 +180,16 @@ subprojects {
   }
 
   tasks.withType<Test>().configureEach {
+    // TODO: remove once Robolectric no longer needs deep reflection into java.base internals.
+    // https://github.com/robolectric/robolectric/issues/11434
+    // Robolectric 4.17 emulates com.android.internal.os.ApplicationSharedMemory, which reflects
+    // into jdk.internal.access.SharedSecrets. That package isn't open to the unnamed module on
+    // JDK 17+, so without this every Robolectric test fails with
+    // "Failed to interact with raw FileDescriptor internals; perhaps JRE has changed?".
+    // Robolectric's own build sets the same flag in
+    // build-logic/.../gradle/TestTaskConfiguration.kt (DefaultJvmArgumentsProvider).
+    jvmArgs("--add-opens=java.base/jdk.internal.access=ALL-UNNAMED")
+
     val shardIndex =
       (project.findProperty("shardIndex") as? String)
         ?: (project.findProperty("test.shardIndex") as? String)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,9 +56,7 @@ material = "1.14.0"
 metalava = "0.5.1"
 moshi = "1.15.2"
 okio = "3.18.2"
-# 4.17 renders DatePickerA11yTest.interactionTest non-deterministically: identical runs produce
-# different anti-aliasing on the "Next" button edge, so verifyRoborazziDebug flakes.
-org-robolectric = "4.16.1"
+org-robolectric = "4.17"
 ossLicensesPlugin = "0.13.0"
 osslicenses = "0.10.0"
 # 22.0.0 removed legacy GoogleSignIn APIs used by auth:data and auth:ui

--- a/renovate.json
+++ b/renovate.json
@@ -123,13 +123,6 @@
       ],
       "allowedVersions": "<5.5.0",
       "description": "Requires compileSdk 37"
-    },
-    {
-      "matchPackagePatterns": [
-        "org.robolectric:*"
-      ],
-      "allowedVersions": "<4.17",
-      "description": "4.17 renders DatePickerA11yTest.interactionTest non-deterministically (the 'Next' button edge is anti-aliased differently between identical runs), so verifyRoborazziDebug flakes. It also needs --add-opens=java.base/jdk.internal.access=ALL-UNNAMED on the unit test JVM."
     }
   ]
 }


### PR DESCRIPTION
#### WHAT

Bumps Robolectric 4.16.1 -> 4.17, adds the --add-opens flag it requires, and drops the Renovate hold-back, with no test-side workaround, so CI shows the failure. This branch is a reproduction for an upstream bug report and is not intended to be merged.

--add-opens=java.base/jdk.internal.access=ALL-UNNAMED is required because 4.17 emulates com.android.internal.os.ApplicationSharedMemory, which reflects into jdk.internal.access.SharedSecrets. Without it every Robolectric test fails with "Failed to interact with raw FileDescriptor internals; perhaps JRE has changed?". That is upstream issue robolectric/robolectric#11434, and Robolectric's own build sets the same flag in build-logic/.../gradle/TestTaskConfiguration.kt.

Expected CI failure: :composables:verifyRoborazziDebug, DatePickerA11yTest.interactionTest capture _2.

Measured in an isolated environment (real ext4 disk, private GRADLE_USER_HOME, --no-daemon --no-build-cache --rerun-tasks, one CI job per Gradle invocation), three runs each:

  4.16.1   pass, pass, pass -- matches the golden every time
  4.17     fail, fail, fail -- three distinct images

The difference is confined to a 104x104 box at +175+334 of the 908x454 screen, containing only the circular "Next" button, which is captured mid press/scale animation at a varying phase:

  4.17 vs golden          6518-7012 differing px (~1.6%)
  4.17 run vs 4.17 run     516-723 differing px

Settling the animation from the test side does not work; the render never converges:

  composeRule.waitForIdle()                      3 distinct images
  mainClock.advanceTimeBy(2000) + waitForIdle()  3 distinct images

All other CI jobs pass on 4.17: metalavaCheckCompatibility, metalavaCheckCompatibilityRelease, ktfmtCheck and testDebug.

TAG=agy
CONV=709d690e-2237-4eaa-bef0-ab88bbe85909

#### WHY


#### HOW


#### Checklist :clipboard:
- [ ] Add explicit visibility modifier and explicit return types for public declarations
- [ ] Run spotless check
- [ ] Run tests
- [ ] Update metalava's signature text files
