### PR TITLE
Extract ShardRule so all screenshot tests are actually sharded

### DIFF
--- a/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/rng/ShardRule.kt
+++ b/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/rng/ShardRule.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.screenshots.rng
+
+import org.junit.Assume
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+/**
+ * Skips a test class unless it is assigned to the shard currently being run.
+ *
+ * Shards are selected by the `test.shardIndex` and `test.totalShards` system properties, which the
+ * root build script populates from the `shardIndex` and `totalShards` Gradle properties. When
+ * either is absent, or there is only one shard, every test runs.
+ *
+ * Assignment is by test class rather than by test method, so that all of a class's screenshots are
+ * captured in the same JVM.
+ *
+ * This must be declared by *every* screenshot base class. It is a JUnit rule rather than a runner
+ * or a Gradle-level filter, so it only applies to classes that actually declare it - a base class
+ * that omits it will silently run in every shard.
+ */
+public class ShardRule : TestRule {
+  override fun apply(base: Statement, description: Description): Statement =
+    object : Statement() {
+      override fun evaluate() {
+        val shardIndex = System.getProperty("test.shardIndex")?.toIntOrNull()
+        val totalShards = System.getProperty("test.totalShards")?.toIntOrNull()
+        if (shardIndex != null && totalShards != null && totalShards > 1) {
+          val className = description.className ?: description.displayName
+          val assignedShard = Math.floorMod(className.hashCode(), totalShards)
+          Assume.assumeTrue(
+            "Skipping $className for shard $shardIndex of $totalShards (assigned to $assignedShard)",
+            assignedShard == shardIndex,
+          )
+        }
+        base.evaluate()
+      }
+    }
+}

--- a/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/rng/WearLegacyA11yTest.kt
+++ b/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/rng/WearLegacyA11yTest.kt
@@ -62,7 +62,9 @@ import com.google.android.horologist.screenshots.rng.WearScreenshotTest.Companio
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers
 import org.junit.Rule
+import org.junit.experimental.categories.Category
 import org.junit.rules.TestName
+import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
@@ -71,10 +73,13 @@ import org.robolectric.annotation.GraphicsMode
 @Config(sdk = [35], qualifiers = RobolectricDeviceQualifiers.WearOSLargeRound)
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Category(ScreenshotTest::class)
 public abstract class WearLegacyA11yTest {
   @get:Rule public val composeRule: ComposeContentTestRule = createComposeRule()
 
   @get:Rule public val testInfo: TestName = TestName()
+
+  @get:Rule public val shardRule: TestRule = ShardRule()
 
   // Allow for individual tolerances to be set on each test, should be between 0.0 and 1.0
   public open val tolerance: Float = 0.0f

--- a/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/rng/WearLegacyComponentTest.kt
+++ b/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/rng/WearLegacyComponentTest.kt
@@ -35,7 +35,9 @@ import com.google.android.horologist.screenshots.rng.WearScreenshotTest.Companio
 import com.google.android.horologist.screenshots.rng.WearScreenshotTest.Companion.useHardwareRenderer
 import com.google.android.horologist.screenshots.rng.WearScreenshotTest.Companion.withImageLoader
 import org.junit.Rule
+import org.junit.experimental.categories.Category
 import org.junit.rules.TestName
+import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
@@ -44,9 +46,12 @@ import org.robolectric.annotation.GraphicsMode
 @Config(sdk = [35], qualifiers = RobolectricDeviceQualifiers.WearOSLargeRound)
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Category(ScreenshotTest::class)
 public abstract class WearLegacyComponentTest {
 
   @get:Rule public val testInfo: TestName = TestName()
+
+  @get:Rule public val shardRule: TestRule = ShardRule()
 
   public open fun testName(suffix: String): String =
     "src/test/snapshots/images/" +

--- a/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/rng/WearScreenshotTest.kt
+++ b/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/rng/WearScreenshotTest.kt
@@ -44,13 +44,11 @@ import com.github.takahirom.roborazzi.captureScreenRoboImage
 import com.google.android.horologist.compose.layout.AppScaffold
 import com.google.android.horologist.compose.layout.ResponsiveTimeText
 import com.google.android.horologist.screenshots.FixedTimeSource
-import org.junit.Assume
 import org.junit.Rule
 import org.junit.experimental.categories.Category
 import org.junit.rules.TestName
 import org.junit.rules.TestRule
 import org.junit.runner.RunWith
-import org.junit.runners.model.Statement
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
@@ -65,24 +63,7 @@ public abstract class WearScreenshotTest {
 
   @get:Rule public val testInfo: TestName = TestName()
 
-  @get:Rule
-  public val shardRule: TestRule = TestRule { base, description ->
-    object : Statement() {
-      override fun evaluate() {
-        val shardIndex = System.getProperty("test.shardIndex")?.toIntOrNull()
-        val totalShards = System.getProperty("test.totalShards")?.toIntOrNull()
-        if (shardIndex != null && totalShards != null && totalShards > 1) {
-          val className = description.className ?: this@WearScreenshotTest.javaClass.name
-          val assignedShard = Math.floorMod(className.hashCode(), totalShards)
-          Assume.assumeTrue(
-            "Skipping $className for shard $shardIndex of $totalShards (assigned to $assignedShard)",
-            assignedShard == shardIndex,
-          )
-        }
-        base.evaluate()
-      }
-    }
-  }
+  @get:Rule public val shardRule: TestRule = ShardRule()
 
   public open val device: WearDevice? = null
 


### PR DESCRIPTION
## Problem

The shard filter was an anonymous `TestRule` declared only in `WearScreenshotTest`. Because it is a JUnit rule rather than a runner or a Gradle-level filter, it only applied to that class's subclasses. The other screenshot base classes are **siblings, not subclasses**, so their tests ran in every shard:

| Base class | Test classes | Sharded? |
| --- | --- | --- |
| `WearScreenshotTest` | 6 | yes |
| `WearLegacyScreenTest` (extends `WearScreenshotTest`) | 37 | yes, inherited |
| `WearLegacyA11yTest` | 36 | **no** |
| `WearLegacyComponentTest` | 45 | **no** |

That is 81 of 124 classes running six times over, so the six-way matrix did `81*6 + 43 = 529` class-runs instead of 124 and bought almost no wall-clock. It also meant a single failing screenshot was reported by every shard at once, e.g. `DatePickerA11yTest > interactionTest FAILED` appearing on all six.

`@Category(ScreenshotTest::class)` had the identical bug -- it was likewise declared only on `WearScreenshotTest`, so the `build` job's `-Dtest.excludeCategories` did not exclude those same 81 classes.

## Change

Extracts the rule into `ShardRule` and declares it, along with the category, on `WearLegacyA11yTest` and `WearLegacyComponentTest`. `WearTriadScreenshotTest` and `WearDeviceScreenshotTest` already extend `WearScreenshotTest` and are unaffected.

## Verification

Ran `:composables:verifyRoborazziDebug` across all six shards. Every screenshot class is now assigned to exactly one shard, `DatePickerA11yTest` runs only in shard 5 instead of all six, and all six shards pass. `ktfmtCheck` and `compileDebugKotlin` are clean.

## Follow-ups (not in this PR)

- Assignment is still `className.hashCode() % totalShards`, which balances poorly (for 124 classes over 6 shards, expected 20.7 with sigma ~4.2). Fixing it needs the full class list, which a `TestRule` cannot see, so it means moving sharding into a Gradle-level filter -- that would delete this rule rather than improve it, and would also stop skipped classes from paying JVM + Robolectric class-init just to hit `Assume`.
- Three classes still run in every shard (`DatePickerInteractionTest`, `RepeatableClickableButtonTest`, `SquareSegmentedProgressTest`), but they are not screenshot tests and have no base class. The cleaner fix is for the screenshots job to positively select the category rather than relying on each base class opting in.
